### PR TITLE
Safely print empty tensors

### DIFF
--- a/src/graph_tensor.rs
+++ b/src/graph_tensor.rs
@@ -273,8 +273,13 @@ impl Debug for GraphTensor {
         let shape = shape.shape_usize();
         writeln!(f, "Tensor with Shape: {shape:?}")?;
 
-        // Print the data by going dimension by dimension, recursively
-        pretty_print_tensor_recursive(f, &self.data(), &shape, 0)
+        if self.graph().tensors.contains_key(&(self.id, 0)) {
+            // Print the data by going dimension by dimension, recursively
+            pretty_print_tensor_recursive(f, &self.data(), &shape, 0)
+        } else {
+            // Print for empty tensors
+            writeln!(f, "Tensor is empty.")
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds functionality to safely print empty graph tensors instead of panicking.

Current functionality:
```
thread 'main' panicked at src/graph_tensor.rs:94:14:
Tensor not found in the graph!
```

New functionality:
```
Tensor with Shape: [2]
Tensor is empty.
```