### PR TITLE
Repair and enhance flash_attention demo

### DIFF
--- a/demos/flash_attention/Cargo.toml
+++ b/demos/flash_attention/Cargo.toml
@@ -3,11 +3,14 @@ name = "run_egglog"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+graphvis = [ "dep:petgraph", "dep:regex", "dep:urlencoding", "dep:webbrowser" ]
+
 [dependencies]
 colored = "3.0.0"
 egglog = { git = "https://github.com/egraphs-good/egglog" }
-petgraph = "0.8.1"
-regex = "1.11.1"
+petgraph = { version = "0.8.1", optional = true }
+regex = { version = "1.11.1", optional = true }
 serde_json = "1.0.140"
-urlencoding = "2.1.3"
-webbrowser = "1.0.4"
+urlencoding = { version = "2.1.3", optional = true }
+webbrowser = { version = "1.0.4", optional = true }

--- a/demos/flash_attention/README.md
+++ b/demos/flash_attention/README.md
@@ -4,6 +4,16 @@ Our handwritten mapping then takes the internal representation we generate and c
 
 As far as we are aware, we are the first in the world to achieve this
 
+To run the basic demo:
+```sh
+cargo run --release
+```
+
+To run the demo with a visualization of the graph in the browser after completion:
+```sh
+cargo run --release --features graphvis
+```
+
 To be done:
 - writing a full mapping of all possible egglog rules to all kernels
 - integrating luminal with more low-level hardware architectures


### PR DESCRIPTION
Restore functionality of the flash_attention demo that broke with recent public API breaks in `egglog` upstream. Also makes visualization of the graph in the browser after completion a compile-time feature for convenience.