### PR TITLE
Search: early-stop candidate profiling against the best-so-far metric

### DIFF
--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -3095,6 +3095,7 @@ impl CudaRuntime {
         dyn_map: &FxHashMap<char, usize>,
         trials: usize,
         timeout: Option<std::time::Duration>,
+        early_stop: Option<(Duration, f64)>,
     ) -> (Duration, String) {
         self.profiling = true;
         let profile_start = std::time::Instant::now();
@@ -3125,6 +3126,18 @@ impl CudaRuntime {
             self.execute(dyn_map);
             durations.push(start.elapsed());
             if timeout.is_some_and(|timeout| profile_start.elapsed() >= timeout) {
+                break;
+            }
+            // Early stop against the search's best-so-far: once this
+            // candidate's running mean has lost by the configured margin,
+            // remaining trials can't change the outcome — return the partial
+            // mean and let ranking handle it. Deliberately checked only on
+            // timed trials: the warmup above absorbs one-time costs, and a
+            // slow warmup must not disqualify a fast steady-state candidate.
+            if early_stop.is_some_and(|(best, factor)| {
+                let mean = durations.iter().sum::<Duration>() / durations.len() as u32;
+                luminal::op::early_stop_exceeded(mean, best, factor)
+            }) {
                 break;
             }
         }
@@ -3586,6 +3599,7 @@ impl Runtime for CudaRuntime {
         dyn_map: &FxHashMap<char, usize>,
         trials: usize,
         timeout: Option<std::time::Duration>,
+        early_stop: Option<(Self::ProfileMetric, f64)>,
     ) -> (Self::ProfileMetric, String) {
         Self::dump_candidate_llir_for_postmortem(llir_graph, dyn_map);
         // Clear active bucket's arena before loading new LLIR for profiling.
@@ -3598,7 +3612,7 @@ impl Runtime for CudaRuntime {
         if let Err(e) = self.try_load_llir(llir_graph) {
             return Self::invalid_profile_metric(e);
         }
-        self.profile_loaded_llir(llir_graph, dyn_map, trials, timeout)
+        self.profile_loaded_llir(llir_graph, dyn_map, trials, timeout, early_stop)
     }
 
     fn profile_with_bucket_context(
@@ -3607,12 +3621,13 @@ impl Runtime for CudaRuntime {
         dyn_map: &FxHashMap<char, usize>,
         trials: usize,
         timeout: Option<std::time::Duration>,
+        early_stop: Option<(Self::ProfileMetric, f64)>,
         bucket_context: luminal::op::ProfileBucketContext<'_>,
     ) -> (Self::ProfileMetric, String) {
         // Profile with the same bucket metadata that final bucket compilation
         // uses, so bucket-sensitive graph packaging decisions match search.
         if bucket_context.dim_buckets.is_empty() {
-            return self.profile(llir_graph, dyn_map, trials, timeout);
+            return self.profile(llir_graph, dyn_map, trials, timeout, early_stop);
         }
         Self::dump_candidate_llir_for_postmortem(llir_graph, dyn_map);
         if !self.compiled_buckets.is_empty() {
@@ -3629,7 +3644,7 @@ impl Runtime for CudaRuntime {
         if let Err(e) = self.try_load_llir_buckets(bucket_context.dim_buckets, &bucket_llirs) {
             return Self::invalid_profile_metric(e);
         }
-        self.profile_loaded_llir(llir_graph, dyn_map, trials, timeout)
+        self.profile_loaded_llir(llir_graph, dyn_map, trials, timeout, early_stop)
     }
 
     #[tracing::instrument(skip_all)]

--- a/crates/luminal_metal/src/runtime.rs
+++ b/crates/luminal_metal/src/runtime.rs
@@ -383,6 +383,7 @@ impl Runtime for MetalRuntime {
         dyn_map: &FxHashMap<char, usize>,
         trials: usize,
         timeout: Option<std::time::Duration>,
+        early_stop: Option<(Self::ProfileMetric, f64)>,
     ) -> (Self::ProfileMetric, String) {
         self.load_llir(llir_graph);
         self.allocate_intermediate_buffers(dyn_map);
@@ -397,6 +398,14 @@ impl Runtime for MetalRuntime {
             duration += start.elapsed();
             completed_trials += 1;
             if timeout.is_some_and(|timeout| profile_start.elapsed() >= timeout) {
+                break;
+            }
+            // A candidate whose running mean has already lost by the
+            // early-stop margin keeps its partial mean; further trials
+            // can only refine a metric that is out of contention.
+            if early_stop.is_some_and(|(best, factor)| {
+                luminal::op::early_stop_exceeded(duration / completed_trials as u32, best, factor)
+            }) {
                 break;
             }
         }

--- a/examples/llama/src/main.rs
+++ b/examples/llama/src/main.rs
@@ -342,7 +342,11 @@ fn main() {
         )
         .search_graph_limit(SEARCH_GRAPHS)
         .trials(SEARCH_TRIALS)
-        .keep_best(SEARCH_KEEP_BEST);
+        .keep_best(SEARCH_KEEP_BEST)
+        // Candidates whose running mean has already lost by 2x stop trialing
+        // early; their partial mean is still ranked. Cuts profiling time spent
+        // on losers without changing which candidate wins.
+        .early_stop_factor(2.0);
 
     println!("Loading weights...");
     let load_start = std::time::Instant::now();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -229,6 +229,12 @@ pub struct CompileOptions {
     pub candidate_timeout: Option<std::time::Duration>,
     /// Caps how long profiling runs a single trial; not a rejection criterion.
     pub execution_timeout: Option<std::time::Duration>,
+    /// Stop profiling a candidate early once its running mean exceeds
+    /// `factor ×` the best candidate's metric. The partial mean is still
+    /// returned and ranked normally, so this never changes which candidates
+    /// are eligible — it only stops spending trials on candidates that have
+    /// already lost by at least this margin. `None` disables (default).
+    pub early_stop_factor: Option<f64>,
     /// Dynamic dimension values applied after search-space construction and
     /// before search. These values persist in [`Graph::dyn_map`] and provide
     /// the base representative values for unbucketed dimensions. Per-bucket
@@ -305,6 +311,17 @@ impl CompileOptions {
         self
     }
 
+    /// Stop profiling a candidate once its running mean exceeds `factor ×`
+    /// the current best. See [`CompileOptions::early_stop_factor`].
+    pub fn early_stop_factor(mut self, factor: f64) -> Self {
+        assert!(
+            factor >= 1.0,
+            "early_stop_factor below 1.0 would truncate candidates still in contention"
+        );
+        self.early_stop_factor = Some(factor);
+        self
+    }
+
     /// Set a dynamic dimension after search-space construction and before
     /// search. This is equivalent to calling [`Graph::set_dim`] between
     /// [`Graph::build_search_space`] and [`Graph::search`], while still using
@@ -377,6 +394,7 @@ impl Default for CompileOptions {
             restart_stagnation: 0,
             candidate_timeout: Some(std::time::Duration::from_secs(5)),
             execution_timeout: Some(std::time::Duration::from_secs(1)),
+            early_stop_factor: None,
             search_dims: FxHashMap::default(),
             profile_dims: FxHashMap::default(),
             dim_buckets: FxHashMap::default(),
@@ -2318,6 +2336,9 @@ impl Graph {
                                 &profile_dyn_map,
                                 options.trials,
                                 options.execution_timeout,
+                                // No best exists yet — the initial genome
+                                // establishes the early-stop baseline.
+                                None,
                                 ProfileBucketContext {
                                     dim_buckets: &bucket_context.dim_buckets,
                                     bucket_indices: &bucket_context.bucket_indices,
@@ -2330,6 +2351,7 @@ impl Graph {
                                 &profile_dyn_map,
                                 options.trials,
                                 options.execution_timeout,
+                                None,
                             )
                         };
                     let timed_out = candidate_timed_out(profile_start.elapsed());
@@ -2507,6 +2529,13 @@ impl Graph {
                 let filter_display = filter_result.display;
 
                 n_graphs += 1;
+                // Losers are the most expensive candidates to profile: a
+                // candidate whose running mean is already `factor ×` worse
+                // than the best can stop trialing — its partial mean is
+                // ranked normally and cannot win.
+                let early_stop = options
+                    .early_stop_factor
+                    .map(|factor| (best_metric.clone(), factor));
                 let profile_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     runtime.clear_intermediate_buffers();
                     let profile_start = std::time::Instant::now();
@@ -2517,6 +2546,7 @@ impl Graph {
                                 &profile_dyn_map,
                                 options.trials,
                                 options.execution_timeout,
+                                early_stop,
                                 ProfileBucketContext {
                                     dim_buckets: &bucket_context.dim_buckets,
                                     bucket_indices: &bucket_context.bucket_indices,
@@ -2529,6 +2559,7 @@ impl Graph {
                                 &profile_dyn_map,
                                 options.trials,
                                 options.execution_timeout,
+                                early_stop,
                             )
                         };
                     let timed_out = candidate_timed_out(profile_start.elapsed());
@@ -4316,6 +4347,7 @@ mod tests {
             dyn_map: &FxHashMap<char, usize>,
             _: usize,
             _: Option<std::time::Duration>,
+            _: Option<(Self::ProfileMetric, f64)>,
         ) -> (Self::ProfileMetric, String) {
             self.profile_dyn_maps.push(dyn_map.clone());
             (0, "0 ms".to_string())
@@ -4347,6 +4379,7 @@ mod tests {
             _: &FxHashMap<char, usize>,
             _: usize,
             _: Option<std::time::Duration>,
+            _: Option<(Self::ProfileMetric, f64)>,
         ) -> (Self::ProfileMetric, String) {
             (0, "0 ms".to_string())
         }
@@ -4391,6 +4424,7 @@ mod tests {
             _: &FxHashMap<char, usize>,
             _: usize,
             _: Option<std::time::Duration>,
+            _: Option<(Self::ProfileMetric, f64)>,
         ) -> (Self::ProfileMetric, String) {
             let count = PROFILE_CALLS.fetch_add(1, Ordering::SeqCst);
             (count, format!("{count} ms"))
@@ -4531,6 +4565,7 @@ mod tests {
             _: &FxHashMap<char, usize>,
             _: usize,
             _: Option<std::time::Duration>,
+            _: Option<(Self::ProfileMetric, f64)>,
         ) -> (Self::ProfileMetric, String) {
             let (fast, safe, _) = Self::signature(llir);
             assert_eq!(
@@ -4602,6 +4637,7 @@ mod tests {
             dyn_map: &FxHashMap<char, usize>,
             _: usize,
             _: Option<std::time::Duration>,
+            _: Option<(Self::ProfileMetric, f64)>,
         ) -> (Self::ProfileMetric, String) {
             let (fast, safe, _) = FinalFilterRuntime::signature(llir);
             assert_eq!(
@@ -4688,6 +4724,7 @@ mod tests {
             _: &FxHashMap<char, usize>,
             _: usize,
             _: Option<std::time::Duration>,
+            _: Option<(Self::ProfileMetric, f64)>,
         ) -> (Self::ProfileMetric, String) {
             let (fast, safe, _) = FinalFilterRuntime::signature(llir);
             if fast > 0 {
@@ -4772,6 +4809,7 @@ mod tests {
             _: &FxHashMap<char, usize>,
             _: usize,
             _: Option<std::time::Duration>,
+            _: Option<(Self::ProfileMetric, f64)>,
         ) -> (Self::ProfileMetric, String) {
             let profile_call = SEARCH_BUDGET_PROFILE_CALLS.fetch_add(1, Ordering::SeqCst);
             if profile_call == 1 {
@@ -4837,6 +4875,7 @@ mod tests {
             _: &FxHashMap<char, usize>,
             _: usize,
             _: Option<std::time::Duration>,
+            _: Option<(Self::ProfileMetric, f64)>,
         ) -> (Self::ProfileMetric, String) {
             let (fast, _, _) = FinalFilterRuntime::signature(llir);
             if fast == 1 {
@@ -5015,6 +5054,76 @@ mod tests {
             safe > 1,
             "the loaded fallback should be the fully unrolled safe graph"
         );
+    }
+
+    #[derive(Default)]
+    struct EarlyStopRecordingRuntime {
+        early_stop_args: Vec<Option<(usize, f64)>>,
+        profile_calls: usize,
+    }
+
+    impl Runtime for EarlyStopRecordingRuntime {
+        // Two competing ops so the e-graph has real choices and the search
+        // actually produces offspring after the initial genome.
+        type Ops = (FastButInvalidAfterUnroll, SlowerValidAfterUnroll);
+        type CompileArg = ();
+        type ExecReturn = ();
+        type ProfileMetric = usize;
+
+        fn initialize(_: Self::CompileArg) -> Self {
+            Self::default()
+        }
+
+        fn load_llir(&mut self, _: &LLIRGraph) {}
+
+        fn execute(&mut self, _: &FxHashMap<char, usize>) -> Self::ExecReturn {}
+
+        fn profile(
+            &mut self,
+            _: &LLIRGraph,
+            _: &FxHashMap<char, usize>,
+            _: usize,
+            _: Option<std::time::Duration>,
+            early_stop: Option<(Self::ProfileMetric, f64)>,
+        ) -> (Self::ProfileMetric, String) {
+            self.early_stop_args.push(early_stop);
+            // Strictly increasing metrics: the initial genome (metric 0)
+            // stays the running best for the whole search.
+            let metric = self.profile_calls;
+            self.profile_calls += 1;
+            (metric, format!("{metric} ms"))
+        }
+    }
+
+    #[test]
+    fn search_passes_best_so_far_to_profile_early_stop() {
+        let mut cx = Graph::new();
+        let input = cx.tensor(8);
+        let _ = input.sin().sin().sin().output();
+
+        let options = CompileOptions::default()
+            .search_graph_limit(16)
+            .generation_size(4)
+            .mutations(2)
+            .early_stop_factor(2.0)
+            .search_log(false);
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0xEA51_5709);
+        let runtime = cx.compile_with_rng(EarlyStopRecordingRuntime::default(), options, &mut rng);
+
+        assert!(
+            runtime.early_stop_args.len() > 1,
+            "search should profile more candidates than the initial genome"
+        );
+        assert_eq!(
+            runtime.early_stop_args[0], None,
+            "no best exists before the initial genome is profiled"
+        );
+        for arg in &runtime.early_stop_args[1..] {
+            let (best, factor) =
+                arg.expect("offspring profiling should receive the best-so-far cutoff");
+            assert_eq!(best, 0, "the initial genome's metric is the running best");
+            assert_eq!(factor, 2.0);
+        }
     }
 
     #[test]

--- a/src/hlir.rs
+++ b/src/hlir.rs
@@ -2983,6 +2983,7 @@ impl Runtime for ReferenceRuntime {
         _: &FxHashMap<char, usize>,
         _: usize,
         _: Option<std::time::Duration>,
+        _: Option<(Self::ProfileMetric, f64)>,
     ) -> (Self::ProfileMetric, String) {
         (0, "0 ms".to_string())
     }

--- a/src/op.rs
+++ b/src/op.rs
@@ -89,12 +89,20 @@ pub trait Runtime {
     fn initialize(arg: Self::CompileArg) -> Self;
     fn load_llir(&mut self, llir_graph: &LLIRGraph);
     fn execute(&mut self, dyn_map: &FxHashMap<char, usize>) -> Self::ExecReturn;
+    /// `early_stop` is `Some((best_metric, factor))` when the search already
+    /// holds a best candidate: once this candidate's running mean exceeds
+    /// `best * factor`, the runtime may stop remaining trials and return the
+    /// partial mean. The truncated metric is still returned and ranked
+    /// normally — early stop never changes which candidates are eligible,
+    /// only how much profiling time is spent on ones that have already lost.
+    /// Runtimes are free to ignore it.
     fn profile(
         &mut self,
         llir_graph: &LLIRGraph,
         dyn_map: &FxHashMap<char, usize>,
         trials: usize,
         timeout: Option<std::time::Duration>,
+        early_stop: Option<(Self::ProfileMetric, f64)>,
     ) -> (Self::ProfileMetric, String);
     /// Profile one candidate in the context of a specific dynamic-dimension
     /// bucket. Runtimes with bucket-sensitive lowering can override this so
@@ -106,9 +114,10 @@ pub trait Runtime {
         dyn_map: &FxHashMap<char, usize>,
         trials: usize,
         timeout: Option<std::time::Duration>,
+        early_stop: Option<(Self::ProfileMetric, f64)>,
         _bucket_context: ProfileBucketContext<'_>,
     ) -> (Self::ProfileMetric, String) {
-        self.profile(llir_graph, dyn_map, trials, timeout)
+        self.profile(llir_graph, dyn_map, trials, timeout, early_stop)
     }
     /// Aggregate multiple profile metrics into one comparable metric.
     /// Used for regionalized profiling and best-first bucket-set selection.
@@ -182,6 +191,18 @@ pub trait Runtime {
 /// Optional runtime instrumentation for collecting execution statistics.
 pub trait RuntimeStats: Runtime {
     fn execute_with_stats(&mut self, dyn_map: &FxHashMap<char, usize>) -> Option<ExecutionStats>;
+}
+
+/// Shared early-stop predicate for duration-metric runtimes: true once a
+/// candidate's running mean trial time exceeds `best * factor`, i.e. the
+/// candidate has already lost by at least the configured margin and further
+/// trials can only refine a metric that is out of contention.
+pub fn early_stop_exceeded(
+    mean: std::time::Duration,
+    best: std::time::Duration,
+    factor: f64,
+) -> bool {
+    mean.as_secs_f64() > best.as_secs_f64() * factor
 }
 
 /// Timing method used for execution statistics.
@@ -497,4 +518,22 @@ macro_rules! impl_into_ops {
         $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y);
         $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
     };
+}
+
+#[cfg(test)]
+mod early_stop_tests {
+    use super::early_stop_exceeded;
+    use std::time::Duration;
+
+    #[test]
+    fn test_early_stop_exceeded() {
+        let best = Duration::from_millis(5);
+        // 2x cutoff: 10ms mean is at the boundary, not over it.
+        assert!(!early_stop_exceeded(Duration::from_millis(10), best, 2.0));
+        assert!(early_stop_exceeded(Duration::from_millis(11), best, 2.0));
+        // A candidate faster than best never stops early.
+        assert!(!early_stop_exceeded(Duration::from_millis(4), best, 2.0));
+        // Factor 1.0 stops anything slower than best.
+        assert!(early_stop_exceeded(Duration::from_millis(6), best, 1.0));
+    }
 }


### PR DESCRIPTION
## What

Opt-in early stopping for candidate profiling during search: once a candidate's running mean exceeds `factor ×` the best-so-far metric, remaining trials are skipped and the partial mean is returned and ranked normally.

```rust
CompileOptions::default().early_stop_factor(2.0)
```

## Why

Losers are the most expensive candidates to profile — `profile_loaded_llir` already says exactly this about the warmup bail ("Bad candidates are the most expensive ones to run"). But the fixed 1s `execution_timeout` only catches catastrophic candidates: with a 5ms best and 10 trials, a 12ms/trial candidate never trips it and pays all 10 trials despite being out of contention after the first. With a 2× cutoff it pays one trial (~80% less profiling time on that candidate). Searches that evaluate hundreds of candidates spend most of their profiling time on exactly these mid-range losers.

## Invariants

- **Selection semantics unchanged.** The truncated metric is still returned and ranked; early stop never changes which candidates are eligible, only how much time is spent timing ones that have already lost by the configured margin.
- **Default off.** `early_stop_factor: None` — zero behavior change unless opted in. The llama example opts in at 2.0. Happy to change the default (or the example factor) based on your H100 runs.
- **CUDA warmup bail untouched.** The check runs only on timed trials, so a slow-warmup/fast-steady-state candidate is never disqualified by its one-time costs.

## Changes

- `Runtime::profile` / `profile_with_bucket_context` gain `early_stop: Option<(Self::ProfileMetric, f64)>` (breaking trait change; all in-repo impls updated).
- Shared predicate `luminal::op::early_stop_exceeded` used by Metal and CUDA (both `ProfileMetric = Duration`).
- Search wiring: initial genome passes `None` (it establishes the baseline), offspring pass `Some((best, factor))`.
- Regression test with fixed seed: asserts the search passes `None` first and the running best to every subsequent profile call.

## Testing

- Core: 149/149 pass (`cargo test --lib`), including the new regression test and predicate unit test.
- Metal: 45/45 pass on an Apple GPU — exercises the real early-stop trial loop.
- `cargo fmt` + clippy clean on core and Metal.
- CUDA changes are mechanical (param threading + the same 5-line loop check) but I don't have NVIDIA hardware — relying on `test-cuda.yml` / `cuda-clippy.yml` here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
