### PR TITLE
Improving our d-type promotion to match pytorch accumulation behavior + fix bug in expand op

### DIFF
--- a/crates/luminal_python/rust/src/pt2_util.rs
+++ b/crates/luminal_python/rust/src/pt2_util.rs
@@ -83,8 +83,22 @@ pub fn ensure_same_dtype(a: GraphTensor, b: GraphTensor) -> (GraphTensor, GraphT
     if a.dtype == b.dtype {
         return (a, b);
     }
+    // Promotion lattice mirroring torch's type-promotion rules, as
+    // implemented by `torch.promote_types` (documented under "Type
+    // promotion",
+    // https://docs.pytorch.org/docs/stable/tensor_attributes.html#type-promotion-doc):
+    // wider wins, floats
+    // beat ints, and a mixed f16/bf16 pair promotes to f32 — verifiable
+    // directly: promote_types(int32, int64) == int64,
+    // promote_types(float16, bfloat16) == float32. The old table promoted
+    // (Int, I64) to Int, silently truncating the 64-bit side.
     let target = match (a.dtype, b.dtype) {
+        (DType::F64, _) | (_, DType::F64) => DType::F64,
         (DType::F32, _) | (_, DType::F32) => DType::F32,
+        (DType::F16, DType::Bf16) | (DType::Bf16, DType::F16) => DType::F32,
+        (DType::F16, _) | (_, DType::F16) => DType::F16,
+        (DType::Bf16, _) | (_, DType::Bf16) => DType::Bf16,
+        (DType::I64, _) | (_, DType::I64) => DType::I64,
         (DType::Int, _) | (_, DType::Int) => DType::Int,
         _ => DType::F32,
     };

--- a/crates/luminal_python/rust/src/translator/dispatch.rs
+++ b/crates/luminal_python/rust/src/translator/dispatch.rs
@@ -134,7 +134,9 @@ impl<'a> Translator<'a> {
                 let mat2 = self.get_input_tensor(node, 2)?;
                 let beta = self.get_float_arg(node, 3).unwrap_or(1.0) as f32;
                 let alpha = self.get_float_arg(node, 4).unwrap_or(1.0) as f32;
+                let (mat1, mat2) = ensure_same_dtype(mat1, mat2);
                 let mm = mat1.matmul(mat2);
+                let (input, mm) = ensure_same_dtype(input, mm);
                 let (input, mm) = broadcast_binary(input, mm);
                 input * beta + mm * alpha
             }
@@ -381,12 +383,14 @@ impl<'a> Translator<'a> {
             "torch.ops.aten.maximum.default" => {
                 let a = self.get_input_tensor(node, 0)?;
                 let b = self.get_input_tensor(node, 1)?;
+                let (a, b) = ensure_same_dtype(a, b);
                 let (a, b) = broadcast_binary(a, b);
                 a.maximum(b)
             }
             "torch.ops.aten.minimum.default" => {
                 let a = self.get_input_tensor(node, 0)?;
                 let b = self.get_input_tensor(node, 1)?;
+                let (a, b) = ensure_same_dtype(a, b);
                 let (a, b) = broadcast_binary(a, b);
                 a.minimum(b)
             }

--- a/crates/luminal_python/rust/src/translator/movement.rs
+++ b/crates/luminal_python/rust/src/translator/movement.rs
@@ -199,13 +199,17 @@ impl<'a> Translator<'a> {
     pub(crate) fn translate_expand(&mut self, node: &Node) -> Result<GraphTensor> {
         let mut a = self.get_input_tensor(node, 0)?;
         let neg1_expr = Expression::from(-1i32);
-        let target_shape: Vec<Expression> = if let Ok(sizes) = self.get_ints_arg(node, 1) {
+        // torch's expand PREPENDS new dims when the target rank exceeds the
+        // source rank, so `-1`/existing sizes resolve RIGHT-aligned against
+        // the source shape (`class_embedding.expand(B, 1, -1)`: 1-D -> 3-D).
+        // Unsqueeze leading dims first so the ShapeTracker expand sees
+        // matching ranks; left-aligned indexing walks off the source shape.
+        let raw: Vec<Expression> = if let Ok(sizes) = self.get_ints_arg(node, 1) {
             sizes
                 .iter()
-                .enumerate()
-                .map(|(i, &s)| {
+                .map(|&s| {
                     if s == -1 {
-                        a.shape.dims[i]
+                        neg1_expr
                     } else {
                         Expression::from(s as usize)
                     }
@@ -213,11 +217,32 @@ impl<'a> Translator<'a> {
                 .collect()
         } else {
             self.get_exprs_arg(node, 1)?
-                .into_iter()
-                .enumerate()
-                .map(|(i, e)| if e == neg1_expr { a.shape.dims[i] } else { e })
-                .collect()
         };
+        anyhow::ensure!(
+            raw.len() >= a.shape.len(),
+            "expand: target rank {} below source rank {}",
+            raw.len(),
+            a.shape.len()
+        );
+        let offset = raw.len() - a.shape.len();
+        for _ in 0..offset {
+            a = a.unsqueeze(0);
+        }
+        let target_shape: Vec<Expression> = raw
+            .into_iter()
+            .enumerate()
+            .map(|(i, e)| {
+                if e == neg1_expr {
+                    anyhow::ensure!(
+                        i >= offset,
+                        "expand: -1 is only valid for existing (right-aligned) dims"
+                    );
+                    Ok(a.shape.dims[i])
+                } else {
+                    Ok(e)
+                }
+            })
+            .collect::<Result<_>>()?;
         a.shape.expand(target_shape);
         Ok(a)
     }

--- a/crates/luminal_python/rust/src/translator/unary.rs
+++ b/crates/luminal_python/rust/src/translator/unary.rs
@@ -114,23 +114,32 @@ impl<'a> Translator<'a> {
         // eps is arg 4 (after input, normalized_shape, weight, bias), default 1e-5
         let eps = self.get_float_arg(node, 4).unwrap_or(1e-5) as f32;
 
-        let mut result = input.layer_norm(axes, eps);
+        // torch computes LN statistics in fp32 (opmath) even for fp16/bf16
+        // inputs — "For FP16 or BFloat16 inputs, ops should perform internal
+        // math in FP32" (aten/src/ATen/OpMathType.h; used by
+        // layer_norm_kernel.cpp as `opmath_t`). fp16 statistics overflow on
+        // outlier activations (x^2 > 65504 at |x| > ~256 — the OPT-family
+        // residual-stream profile).
+        // Mirror translate_fused_rms_norm: normalize + affine in F32, cast
+        // the result back to the input dtype.
+        let out_dtype = input.dtype;
+        let mut result = input.cast(DType::F32).layer_norm(axes, eps);
 
         // Apply weight (arg 2) if present and not None
         if let Some(weight_name) = node.inputs.get(2).and_then(|i| i.arg.as_tensor_name()) {
-            let w = self.get_tensor(weight_name)?;
+            let w = self.get_tensor(weight_name)?.cast(DType::F32);
             let (r, w) = broadcast_binary(result, w);
             result = r * w;
         }
 
         // Apply bias (arg 3) if present and not None
         if let Some(bias_name) = node.inputs.get(3).and_then(|i| i.arg.as_tensor_name()) {
-            let b = self.get_tensor(bias_name)?;
+            let b = self.get_tensor(bias_name)?.cast(DType::F32);
             let (r, b) = broadcast_binary(result, b);
             result = r + b;
         }
 
-        Ok(result)
+        Ok(result.cast(out_dtype))
     }
 
     /// `aten._fused_rms_norm` (F.rms_norm on CUDA): frontend `std_norm` +
@@ -213,9 +222,13 @@ impl<'a> Translator<'a> {
         let spatial: Expression = orig_dims[2..].iter().cloned().product();
         let group_volume = spatial * Expression::from(group_size);
 
+        // torch computes group-norm statistics in fp32 (opmath); fp16 stats
+        // overflow on outlier activations. Normalize + affine in F32 and
+        // cast back at the end (mirrors translate_fused_rms_norm).
+        let out_dtype = input.dtype;
         // Flatten everything after the batch dim into one axis: (N, C, ...) -> (N, M),
         // where M = C * spatial. Group volumes are contiguous in this layout.
-        let mut t = input;
+        let mut t = input.cast(DType::F32);
         while t.shape.len() > 2 {
             t = t.merge_dims(1, 2);
         }
@@ -239,19 +252,19 @@ impl<'a> Translator<'a> {
         // broadcast them onto every axis except the channel axis.
         let non_channel_axes: Vec<usize> = (0..ndim).filter(|&a| a != 1).collect();
         if let Some(weight_name) = node.inputs.get(1).and_then(|i| i.arg.as_tensor_name()) {
-            let w = self.get_tensor(weight_name)?;
+            let w = self.get_tensor(weight_name)?.cast(DType::F32);
             let w = w.expand_to_shape_on_axes(t.shape, non_channel_axes.clone());
             let (r, w) = broadcast_binary(t, w);
             t = r * w;
         }
         if let Some(bias_name) = node.inputs.get(2).and_then(|i| i.arg.as_tensor_name()) {
-            let b = self.get_tensor(bias_name)?;
+            let b = self.get_tensor(bias_name)?.cast(DType::F32);
             let b = b.expand_to_shape_on_axes(t.shape, non_channel_axes);
             let (r, b) = broadcast_binary(t, b);
             t = r + b;
         }
 
-        Ok(t)
+        Ok(t.cast(out_dtype))
     }
 
     pub(crate) fn translate_sign(&mut self, node: &Node) -> Result<GraphTensor> {

--- a/crates/luminal_python/tests/test_hlir_ops.py
+++ b/crates/luminal_python/tests/test_hlir_ops.py
@@ -2161,6 +2161,95 @@ def test_sdpa_f32_unaffected_by_upcast(device: torch.device):
     )
 
 
+# ---- mixed-dtype operand unification ---------------------------------------
+
+
+@pytest.mark.parametrize("op", ["sum", "mean", "softmax", "cumsum", "amax"])
+def test_reduction_fp16_opmath_parity(op: str, device: torch.device):
+    """Reduction-class ops at fp16 outlier scale must match eager (which
+    accumulates in fp32 opmath). Guards against input-dtype statistic
+    chains — the layer_norm/sdpa overflow class."""
+    from test_models import ReductionParityModel
+
+    torch.manual_seed(0)
+    model = ReductionParityModel(op).to(device)
+    compiled: Callable = torch.compile(model, backend=luminal_backend)
+    if op in ("sum", "mean", "cumsum"):
+        x = (torch.rand(2, 8, 2048) * 30 + 1).half().to(device)  # big positive sums
+    else:
+        x = (torch.randn(2, 8, 2048) * 40).half().to(device)  # ~300-magnitude tails
+    expected = model(x)
+    actual = compiled(x)
+    assert torch.isfinite(actual).all(), f"{op}: non-finite output"
+    rel = (
+        (actual.double() - expected.double()).abs().max()
+        / expected.double().abs().max().clamp(min=1e-9)
+    ).item()
+    assert rel < 0.01, f"{op}: rel_err={rel:.4f} vs eager"
+
+
+def test_layer_norm_fp16_outliers(device: torch.device):
+    """LN statistics must be computed in fp32 for low-precision inputs —
+    fp16 stats overflow on outlier activations (x^2 > fp16 max)."""
+    from test_models import LayerNormOutlierModel
+
+    torch.manual_seed(0)
+    model = LayerNormOutlierModel().to(device).half()
+    compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = (torch.randn(1, 8, 64) * 40.0).half().to(device)
+    x[..., 0] = 350.0  # outlier channel: 350^2 overflows fp16
+    expected: torch.Tensor = model(x)
+    actual: torch.Tensor = compiled(x)
+    assert torch.isfinite(actual).all(), "LN produced non-finite output"
+    assert torch.allclose(actual.float(), expected.float(), atol=2e-2), (
+        f"max_diff={torch.max(torch.abs(actual.float() - expected.float())).item():.4f}"
+    )
+
+
+def test_expand_rank_extending(device: torch.device):
+    """1-D -> 3-D expand with -1 must resolve source dims right-aligned
+    (torch prepends new dims); left-aligned indexing walks off the end."""
+    from test_models import ExpandRankExtendModel
+
+    model: torch.nn.Module = ExpandRankExtendModel().to(device)
+    compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.randn(2, 3, 16, device=device)
+    expected: torch.Tensor = model(x)
+    actual: torch.Tensor = compiled(x)
+    assert torch.allclose(actual, expected, atol=1e-5), (
+        f"max_diff={torch.max(torch.abs(actual - expected)).item():.2e}"
+    )
+
+
+def test_minimum_mixed_int_widths(device: torch.device):
+    """`torch.minimum(int64, int32)`: operands must be dtype-unified before
+    the core compare (panics with "Dtypes must match" otherwise). The
+    T5-family relative-position bucketing hits exactly this."""
+    from test_models import MixedIntMinimumModel
+
+    model: torch.nn.Module = MixedIntMinimumModel().to(device)
+    compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.tensor([[1, 3, 7, 9]], dtype=torch.int64, device=device)
+    expected: torch.Tensor = model(x)
+    actual: torch.Tensor = compiled(x)
+    assert torch.equal(actual, expected)
+
+
+def test_compare_promotes_to_int64(device: torch.device):
+    """Mixed int widths must promote UP to int64 (torch semantics) — an
+    int64 operand beyond i32 range flips the comparison if truncated."""
+    from test_models import WideIntCompareModel
+
+    model: torch.nn.Module = WideIntCompareModel().to(device)
+    compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.tensor(
+        [[3_000_000_000, 2, 6_000_000_000]], dtype=torch.int64, device=device
+    )
+    expected: torch.Tensor = model(x)  # [1, 0, 1]
+    actual: torch.Tensor = compiled(x)
+    assert torch.equal(actual, expected), f"{actual=} {expected=}"
+
+
 def test_mlp_block(device: torch.device):
     """Test two-layer MLP: Linear(8,16) -> ReLU -> Linear(16,4) on input (2,8)."""
     model: torch.nn.Module = MLPBlockModel().to(device)

--- a/crates/luminal_python/tests/test_models.py
+++ b/crates/luminal_python/tests/test_models.py
@@ -2497,6 +2497,76 @@ class SdpaGqaModel(torch.nn.Module):
         )
 
 
+class ReductionParityModel(torch.nn.Module):
+    """One reduction-class op, for the fp16 opmath parity battery: torch
+    accumulates reductions in fp32 for half inputs; these pin luminal to the
+    same contract at outlier magnitudes."""
+
+    OPS = {
+        "sum": lambda x: x.sum(-1),
+        "mean": lambda x: x.mean(-1),
+        "softmax": lambda x: torch.softmax(x, -1),
+        "cumsum": lambda x: x.cumsum(-1),
+        "amax": lambda x: x.amax(-1),
+    }
+
+    def __init__(self, op: str) -> None:
+        super().__init__()
+        self.op = op
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.OPS[self.op](x)
+
+
+class LayerNormOutlierModel(torch.nn.Module):
+    """LayerNorm over fp16 activations with outlier magnitudes (~350, the
+    OPT-family residual-stream profile). torch computes LN statistics in
+    fp32 (opmath); fp16 statistics overflow at |x| > ~256 since x^2
+    exceeds fp16 max (65504)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.ln = torch.nn.LayerNorm(64)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.ln(x)
+
+
+class ExpandRankExtendModel(torch.nn.Module):
+    """Rank-extending `expand` with `-1`: a 1-D parameter grown to 3-D
+    (`class_embedding.expand(B, 1, -1)` — the CLIP vision-tower pattern).
+    torch prepends the new dims, so `-1`/existing sizes resolve
+    RIGHT-aligned against the source shape."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.emb = torch.nn.Parameter(torch.randn(16))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        cls = self.emb.expand(x.shape[0], 1, -1)
+        return torch.cat([cls, x], dim=1)
+
+
+class MixedIntMinimumModel(torch.nn.Module):
+    """`torch.minimum` between int64 and int32 tensors — torch promotes to
+    int64 inside the kernel, so the exported graph carries mixed operand
+    dtypes with no explicit cast."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        cap = torch.full_like(x, 4, dtype=torch.int32)
+        return torch.minimum(x, cap).to(torch.float32)
+
+
+class WideIntCompareModel(torch.nn.Module):
+    """int64-vs-int32 comparison where the int64 side exceeds i32 range —
+    detects wrong-direction promotion (truncating i64 to i32 flips the
+    comparison for values beyond 2^31)."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        small = torch.full_like(x, 5, dtype=torch.int32)
+        return (x > small).to(torch.float32)
+
+
 class RepeatModel(torch.nn.Module):
     """`Tensor.repeat(*repeats)` — tiles `repeats[d]` copies along each dim;
     when `len(repeats) > ndim`, size-1 leading dims are prepended first."""


### PR DESCRIPTION
Better following the bf16 accumulation behavior in pytorch, following the behavior laid out by https://docs.pytorch.org/docs/stable/tensor_attributes.html#type-promotion-doc), and https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/OpMathType.h

OpMath is name given to the in house style of pytorch for how they handle type promotion to avoid accumulation errors 