### PR TITLE
feat(bert): add BERT masked-LM example with CUDA compile support

### DIFF
--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -3683,7 +3683,7 @@ impl Runtime for CudaRuntime {
         // Materialize CUDA graphs before timed execution. The first real launch
         // should only patch an already-instantiated graph, not build it from scratch.
         let timer = std::time::Instant::now();
-        self.materialize_bucket_cuda_graphs(self.active_bucket, dyn_map, false)
+        self.materialize_bucket_cuda_graphs(self.active_bucket, dyn_map, self.profiling)
             .unwrap_or_else(|e| panic!("CUDA graph materialization failed: {e}"));
         materialize_time += timer.elapsed();
 

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -3683,7 +3683,7 @@ impl Runtime for CudaRuntime {
         // Materialize CUDA graphs before timed execution. The first real launch
         // should only patch an already-instantiated graph, not build it from scratch.
         let timer = std::time::Instant::now();
-        self.materialize_bucket_cuda_graphs(self.active_bucket, dyn_map, self.profiling)
+        self.materialize_bucket_cuda_graphs(self.active_bucket, dyn_map, false)
             .unwrap_or_else(|e| panic!("CUDA graph materialization failed: {e}"));
         materialize_time += timer.elapsed();
 

--- a/examples/bert/Cargo.toml
+++ b/examples/bert/Cargo.toml
@@ -28,3 +28,4 @@ serde_json = "1.0"
 half = { version = "2.7.1", features = ["bytemuck"] }
 bytemuck = "1.24.0"
 memmap2 = "0.9.9"
+rand = "0.9.2"

--- a/examples/bert/Cargo.toml
+++ b/examples/bert/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "bert"
+version = "0.1.0"
+edition = "2024"
+
+[features]
+
+[dependencies]
+luminal = { path = "../.." }
+tikv-jemallocator = { version = "0.7", features = [
+  "unprefixed_malloc_on_supported_platforms",
+] }
+luminal_nn = { path = "../../crates/luminal_nn" }
+luminal_cuda_lite = { path = "../../crates/luminal_cuda_lite" }
+luminal_tracing = { path = "../../crates/luminal_tracing" }
+tokenizers = "0.22.2"
+tracing = "0.1.43"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# HuggingFace model download
+hf-hub = { version = "0.4", default-features = false, features = [
+  "rustls-tls",
+  "ureq",
+] }
+safetensors = "0.7.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+half = { version = "2.7.1", features = ["bytemuck"] }
+bytemuck = "1.24.0"
+memmap2 = "0.9.9"

--- a/examples/bert/src/hf.rs
+++ b/examples/bert/src/hf.rs
@@ -1,0 +1,221 @@
+use half::{bf16, f16};
+use hf_hub::api::sync::Api;
+use memmap2::MmapOptions;
+use safetensors::{Dtype, SafeTensors, tensor::TensorView};
+use serde::Deserialize;
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::Write,
+    path::{Path, PathBuf},
+};
+use tracing::info;
+
+#[derive(Deserialize)]
+struct SafetensorsIndex {
+    weight_map: HashMap<String, String>,
+}
+
+struct StoredTensor {
+    shape: Vec<usize>,
+    dtype: Dtype,
+    data: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WeightFormat {
+    F32,
+    Bf16,
+}
+
+pub struct PreparedModel {
+    pub model_dir: PathBuf,
+    pub weight_files: Vec<PathBuf>,
+}
+
+pub fn download_hf_model(repo_id: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    info!("Downloading model from HuggingFace: {repo_id}");
+    let api = Api::new()?;
+    let repo = api.model(repo_id.to_string());
+    info!("Downloading tokenizer.json...");
+    let tokenizer_path = repo.get("tokenizer.json")?;
+    let model_dir = tokenizer_path.parent().unwrap().to_path_buf();
+    info!("Model cache directory: {}", model_dir.display());
+    info!("Checking for single-shard model...");
+    if repo.get("model.safetensors").is_ok() {
+        info!("Single-shard model downloaded successfully.");
+        return Ok(model_dir);
+    }
+    info!("Single shard not found, downloading sharded model index...");
+    let index_path = repo.get("model.safetensors.index.json")?;
+    let index_content = std::fs::read_to_string(&index_path)?;
+    let index: SafetensorsIndex = serde_json::from_str(&index_content)?;
+    let mut shard_files: Vec<String> = index.weight_map.values().cloned().collect();
+    shard_files.sort();
+    shard_files.dedup();
+    info!("Found {} shard files to download.", shard_files.len());
+    for (i, shard_file) in shard_files.iter().enumerate() {
+        info!(
+            "Downloading shard {}/{}: {shard_file}",
+            i + 1,
+            shard_files.len()
+        );
+        repo.get(shard_file)?;
+    }
+    info!("All shards downloaded successfully.");
+    Ok(model_dir)
+}
+
+fn tensor_to_f32(tensor: &safetensors::tensor::TensorView) -> Vec<f32> {
+    let dtype = tensor.dtype();
+    let data = tensor.data();
+    match dtype {
+        Dtype::F32 => bytemuck::cast_slice::<u8, f32>(data).to_vec(),
+        Dtype::F16 => {
+            let f16_slice: &[f16] = bytemuck::cast_slice(data);
+            f16_slice.iter().map(|x| x.to_f32()).collect()
+        }
+        Dtype::BF16 => {
+            let bf16_slice: &[bf16] = bytemuck::cast_slice(data);
+            bf16_slice.iter().map(|x| x.to_f32()).collect()
+        }
+        other => panic!("Unsupported dtype for conversion: {other:?}"),
+    }
+}
+
+fn tensor_to_f32_bytes(tensor: &safetensors::tensor::TensorView) -> Vec<u8> {
+    let fp32 = tensor_to_f32(tensor);
+    bytemuck::cast_slice(&fp32).to_vec()
+}
+
+fn tensor_to_bf16_bytes(tensor: &safetensors::tensor::TensorView) -> Vec<u8> {
+    match tensor.dtype() {
+        Dtype::BF16 => tensor.data().to_vec(),
+        _ => tensor_to_f32(tensor)
+            .into_iter()
+            .flat_map(|x| bf16::from_f32(x).to_le_bytes())
+            .collect(),
+    }
+}
+
+fn keep_f32_in_bf16_pipeline(name: &str) -> bool {
+    name.contains("LayerNorm")
+}
+
+fn stored_tensor_bf16(name: &str, tensor: &safetensors::tensor::TensorView) -> StoredTensor {
+    let shape = tensor.shape().to_vec();
+    if keep_f32_in_bf16_pipeline(name) {
+        StoredTensor {
+            shape,
+            dtype: Dtype::F32,
+            data: tensor_to_f32_bytes(tensor),
+        }
+    } else {
+        StoredTensor {
+            shape,
+            dtype: Dtype::BF16,
+            data: tensor_to_bf16_bytes(tensor),
+        }
+    }
+}
+
+fn stored_tensor_f32(_name: &str, tensor: &safetensors::tensor::TensorView) -> StoredTensor {
+    StoredTensor {
+        shape: tensor.shape().to_vec(),
+        dtype: Dtype::F32,
+        data: tensor_to_f32_bytes(tensor),
+    }
+}
+
+fn model_shard_files(model_dir: &Path) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    let index_path = model_dir.join("model.safetensors.index.json");
+    let single_shard_path = model_dir.join("model.safetensors");
+
+    if single_shard_path.exists() && !index_path.exists() {
+        Ok(vec![single_shard_path])
+    } else if index_path.exists() {
+        let index_content = std::fs::read_to_string(&index_path)?;
+        let index: SafetensorsIndex = serde_json::from_str(&index_content)?;
+        let mut files: Vec<String> = index.weight_map.values().cloned().collect();
+        files.sort();
+        files.dedup();
+        Ok(files.into_iter().map(|f| model_dir.join(f)).collect())
+    } else {
+        Err("No model.safetensors or model.safetensors.index.json found".into())
+    }
+}
+
+pub fn combine_safetensors(
+    model_dir: &Path,
+    convert_bf16: bool,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let suffix = if convert_bf16 { "bf16" } else { "f32" };
+    let output_path = model_dir.join(format!("model_combined_{suffix}.safetensors"));
+
+    if output_path.exists() {
+        return Ok(output_path);
+    }
+
+    let shard_files = model_shard_files(model_dir)?;
+    info!(
+        "Loading {} shard files (converting to {})...",
+        shard_files.len(),
+        if convert_bf16 { "BF16, norms F32" } else { "F32" }
+    );
+
+    let mut all_tensors: HashMap<String, StoredTensor> = HashMap::new();
+
+    for shard_path in &shard_files {
+        info!(
+            "  Loading {}...",
+            shard_path.file_name().unwrap().to_string_lossy()
+        );
+        let file = File::open(shard_path)?;
+        let mmap = unsafe { MmapOptions::new().map(&file)? };
+        let st = SafeTensors::deserialize(&mmap)?;
+
+        for name in st.names() {
+            let tensor = st.tensor(name)?;
+            all_tensors.insert(
+                name.to_string(),
+                if convert_bf16 {
+                    stored_tensor_bf16(name, &tensor)
+                } else {
+                    stored_tensor_f32(name, &tensor)
+                },
+            );
+        }
+    }
+
+    info!("Extracted {} tensors", all_tensors.len());
+    info!("Saving combined model to {}...", output_path.display());
+
+    let tensor_views: HashMap<String, TensorView<'_>> = all_tensors
+        .iter()
+        .map(|(name, stored)| {
+            let view = TensorView::new(stored.dtype, stored.shape.clone(), &stored.data).unwrap();
+            (name.clone(), view)
+        })
+        .collect();
+
+    let serialized = safetensors::serialize(&tensor_views, None)?;
+
+    let mut file = File::create(&output_path)?;
+    file.write_all(&serialized)?;
+
+    info!("Combined model saved successfully!");
+    Ok(output_path)
+}
+
+pub fn prepare_hf_model(
+    repo_id: &str,
+    weight_format: WeightFormat,
+) -> Result<PreparedModel, Box<dyn std::error::Error>> {
+    let model_dir = download_hf_model(repo_id)?;
+    let convert_bf16 = weight_format == WeightFormat::Bf16;
+    let weights_path = combine_safetensors(&model_dir, convert_bf16)?;
+    Ok(PreparedModel {
+        model_dir,
+        weight_files: vec![weights_path],
+    })
+}

--- a/examples/bert/src/hf.rs
+++ b/examples/bert/src/hf.rs
@@ -150,7 +150,9 @@ pub fn combine_safetensors(
     convert_bf16: bool,
 ) -> Result<PathBuf, Box<dyn std::error::Error>> {
     let suffix = if convert_bf16 { "bf16" } else { "f32" };
-    let output_path = model_dir.join(format!("model_combined_{suffix}.safetensors"));
+    // Bump the filename so existing cached combined files are regenerated
+    // after key-mapping changes (e.g. LayerNorm.gamma -> LayerNorm.weight).
+    let output_path = model_dir.join(format!("model_combined_v2_{suffix}.safetensors"));
 
     if output_path.exists() {
         return Ok(output_path);
@@ -160,7 +162,11 @@ pub fn combine_safetensors(
     info!(
         "Loading {} shard files (converting to {})...",
         shard_files.len(),
-        if convert_bf16 { "BF16, norms F32" } else { "F32" }
+        if convert_bf16 {
+            "BF16, norms F32"
+        } else {
+            "F32"
+        }
     );
 
     let mut all_tensors: HashMap<String, StoredTensor> = HashMap::new();
@@ -175,9 +181,18 @@ pub fn combine_safetensors(
         let st = SafeTensors::deserialize(&mmap)?;
 
         for name in st.names() {
+            // HF BERT checkpoints use LayerNorm.gamma / LayerNorm.beta, but the
+            // Luminal model declares them as LayerNorm.weight / LayerNorm.bias.
+            let mapped_name = if name.ends_with("LayerNorm.gamma") {
+                name.replace("LayerNorm.gamma", "LayerNorm.weight")
+            } else if name.ends_with("LayerNorm.beta") {
+                name.replace("LayerNorm.beta", "LayerNorm.bias")
+            } else {
+                name.to_string()
+            };
             let tensor = st.tensor(name)?;
             all_tensors.insert(
-                name.to_string(),
+                mapped_name,
                 if convert_bf16 {
                     stored_tensor_bf16(name, &tensor)
                 } else {

--- a/examples/bert/src/main.rs
+++ b/examples/bert/src/main.rs
@@ -9,7 +9,7 @@ use luminal::{dtype::DType, prelude::*};
 use luminal_cuda_lite::{cudarc::driver::CudaContext, runtime::CudaRuntime};
 use luminal_tracing::*;
 use model::*;
-use std::env;
+use std::{env, time::Duration};
 use tokenizers::Tokenizer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -17,6 +17,49 @@ const REPO_ID: &str = "google-bert/bert-base-uncased";
 const MAX_SEQ_LEN: usize = 128;
 const MASK_TOKEN: u32 = 103;
 const TOP_K: usize = 5;
+
+#[derive(Default, Clone)]
+struct StepProfile {
+    total: Duration,
+    set_inputs: Duration,
+    execute: Duration,
+    get_logits: Duration,
+}
+
+fn avg_ms(duration: Duration, n: usize) -> f64 {
+    if n == 0 {
+        0.0
+    } else {
+        duration.as_secs_f64() * 1e3 / n as f64
+    }
+}
+
+fn print_profile(label: &str, profile: &StepProfile, n: usize) {
+    println!(
+        "  {label}: n={n}, avg={:.2} ms [set={:.2}, exec={:.2}, logits_dtoh={:.2}]",
+        avg_ms(profile.total, n),
+        avg_ms(profile.set_inputs, n),
+        avg_ms(profile.execute, n),
+        avg_ms(profile.get_logits, n),
+    );
+}
+
+fn print_host_op_summary(runtime: &CudaRuntime, label: &str) {
+    let host_ops = runtime.host_ops();
+    let debug_ops = host_ops
+        .iter()
+        .map(|op| format!("{op:?}"))
+        .collect::<Vec<_>>();
+    let cublaslt = debug_ops
+        .iter()
+        .filter(|op| op.contains("CuBlasLt"))
+        .count();
+    println!(
+        "Host op summary ({label}): total={}, cublasLt={}",
+        debug_ops.len(),
+        cublaslt,
+    );
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BertWeightMode {
@@ -85,7 +128,7 @@ fn main() {
     let input_ids = cx.named_tensor("input_ids", 's').as_dtype(DType::Int);
     let token_type_ids = cx.named_tensor("token_type_ids", 's').as_dtype(DType::Int);
     let pos_ids = cx.named_tensor("pos_ids", 's').as_dtype(DType::Int);
-    let mask = cx.named_tensor("mask", (1, 's', 's'));
+    let mask = cx.named_tensor("mask", ('s', 's'));
 
     let bert = match weight_mode {
         BertWeightMode::F32 => BertForMaskedLM::init_f32(&mut cx),
@@ -110,7 +153,11 @@ fn main() {
     let compile_start = std::time::Instant::now();
     cx.set_dim('s', MAX_SEQ_LEN);
     runtime = cx.compile(runtime, CompileOptions::default());
-    println!("  Compile: {:.2} s", compile_start.elapsed().as_secs_f64());
+    println!(
+        "  Compile: {:.2} s",
+        compile_start.elapsed().as_secs_f64()
+    );
+    print_host_op_summary(&runtime, "post-compile");
 
     // Example: "The capital of France is [MASK]."
     let sentence = "The capital of France is [MASK].";
@@ -141,15 +188,15 @@ fn main() {
     let pos_ids_data: Vec<i32> = (0..seq_len as i32).collect();
     let token_type_ids_data: Vec<i32> = vec![0; seq_len];
 
-    // Build attention mask (causal not needed for BERT, just 1s for valid tokens)
-    let mut mask_data = vec![0f32; seq_len * seq_len];
-    for i in 0..seq_len {
-        for j in 0..seq_len {
-            mask_data[i * seq_len + j] = 0.0; // 0 = not masked (BERT uses 0/1, not -inf/0)
-        }
-    }
+    // Build attention mask (all zeros = no masking for BERT)
+    let mask_data = vec![0f32; seq_len * seq_len];
 
     cx.set_dim('s', seq_len);
+
+    let mut profile = StepProfile::default();
+    let start = std::time::Instant::now();
+
+    let set_start = std::time::Instant::now();
     runtime.set_data(
         input_ids,
         tokens.iter().map(|&t| t as i32).collect::<Vec<_>>(),
@@ -157,10 +204,21 @@ fn main() {
     runtime.set_data(token_type_ids, token_type_ids_data);
     runtime.set_data(pos_ids, pos_ids_data);
     runtime.set_data(mask, mask_data);
+    profile.set_inputs = set_start.elapsed();
 
+    let execute_start = std::time::Instant::now();
     runtime.execute(&cx.dyn_map);
+    profile.execute = execute_start.elapsed();
 
+    let logits_start = std::time::Instant::now();
     let logits_data = runtime.get_f32(logits);
+    profile.get_logits = logits_start.elapsed();
+
+    profile.total = start.elapsed();
+
+    print_host_op_summary(&runtime, "after forward");
+    println!("\nProfile:");
+    print_profile("forward", &profile, 1);
 
     // For each mask position, find top-k predictions
     for &mask_pos in &mask_positions {

--- a/examples/bert/src/main.rs
+++ b/examples/bert/src/main.rs
@@ -82,12 +82,10 @@ fn main() {
 
     // Build graph
     let mut cx = Graph::default();
-    let input_ids = cx.named_tensor("input_ids", (1, 's')).as_dtype(DType::Int);
-    let token_type_ids = cx
-        .named_tensor("token_type_ids", (1, 's'))
-        .as_dtype(DType::Int);
-    let pos_ids = cx.named_tensor("pos_ids", (1, 's')).as_dtype(DType::Int);
-    let mask = cx.named_tensor("mask", (1, 1, 's', 's'));
+    let input_ids = cx.named_tensor("input_ids", 's').as_dtype(DType::Int);
+    let token_type_ids = cx.named_tensor("token_type_ids", 's').as_dtype(DType::Int);
+    let pos_ids = cx.named_tensor("pos_ids", 's').as_dtype(DType::Int);
+    let mask = cx.named_tensor("mask", (1, 's', 's'));
 
     let bert = match weight_mode {
         BertWeightMode::F32 => BertForMaskedLM::init_f32(&mut cx),

--- a/examples/bert/src/main.rs
+++ b/examples/bert/src/main.rs
@@ -152,7 +152,7 @@ fn main() {
     println!("Compiling...");
     let compile_start = std::time::Instant::now();
     cx.set_dim('s', MAX_SEQ_LEN);
-    runtime = cx.compile(runtime, CompileOptions::default());
+    runtime = cx.compile(runtime, CompileOptions::default().search_graph_limit(1));
     println!(
         "  Compile: {:.2} s",
         compile_start.elapsed().as_secs_f64()

--- a/examples/bert/src/main.rs
+++ b/examples/bert/src/main.rs
@@ -1,0 +1,190 @@
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+mod hf;
+mod model;
+
+use hf::{WeightFormat, prepare_hf_model};
+use luminal::{dtype::DType, prelude::*};
+use luminal_cuda_lite::{cudarc::driver::CudaContext, runtime::CudaRuntime};
+use luminal_tracing::*;
+use model::*;
+use std::env;
+use tokenizers::Tokenizer;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+const REPO_ID: &str = "google-bert/bert-base-uncased";
+const MAX_SEQ_LEN: usize = 128;
+const MASK_TOKEN: u32 = 103;
+const TOP_K: usize = 5;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BertWeightMode {
+    F32,
+    Bf16,
+}
+
+impl BertWeightMode {
+    fn weight_format(self) -> WeightFormat {
+        match self {
+            Self::F32 => WeightFormat::F32,
+            Self::Bf16 => WeightFormat::Bf16,
+        }
+    }
+}
+
+fn print_usage(program: &str) {
+    println!("Usage: {program} [--bf16|--f32]");
+    println!();
+    println!("  --f32     Native f32 weights and activations (default)");
+    println!("  --bf16    Bf16 weights and activations (norms stay F32)");
+    println!("  -h,--help Show this help");
+}
+
+fn parse_args() -> BertWeightMode {
+    let mut mode = BertWeightMode::F32;
+    let mut args = env::args();
+    let program = args.next().unwrap_or_else(|| "bert".to_string());
+    for arg in args {
+        match arg.as_str() {
+            "--bf16" => mode = BertWeightMode::Bf16,
+            "--f32" => mode = BertWeightMode::F32,
+            "-h" | "--help" => {
+                print_usage(&program);
+                std::process::exit(0);
+            }
+            _ => {
+                eprintln!("Unknown argument: {arg}");
+                print_usage(&program);
+                std::process::exit(2);
+            }
+        }
+    }
+    mode
+}
+
+fn main() {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(luminal_filter())
+        .init();
+
+    let weight_mode = parse_args();
+    let ctx = CudaContext::new(0).unwrap();
+    let stream = ctx.default_stream();
+
+    let prepared =
+        prepare_hf_model(REPO_ID, weight_mode.weight_format()).expect("Failed to prepare model");
+    println!("Using model: {REPO_ID}");
+    println!("Using model directory: {}", prepared.model_dir.display());
+
+    let tokenizer = Tokenizer::from_file(prepared.model_dir.join("tokenizer.json")).unwrap();
+
+    // Build graph
+    let mut cx = Graph::default();
+    let input_ids = cx.named_tensor("input_ids", (1, 's')).as_dtype(DType::Int);
+    let token_type_ids = cx
+        .named_tensor("token_type_ids", (1, 's'))
+        .as_dtype(DType::Int);
+    let pos_ids = cx.named_tensor("pos_ids", (1, 's')).as_dtype(DType::Int);
+    let mask = cx.named_tensor("mask", (1, 1, 's', 's'));
+
+    let bert = match weight_mode {
+        BertWeightMode::F32 => BertForMaskedLM::init_f32(&mut cx),
+        BertWeightMode::Bf16 => BertForMaskedLM::init_bf16(&mut cx),
+    };
+    let logits = bert
+        .forward(input_ids, token_type_ids, pos_ids, mask)
+        .output();
+
+    cx.set_dim('s', 1);
+
+    println!("Loading weights...");
+    let load_start = std::time::Instant::now();
+    let mut runtime = CudaRuntime::initialize(stream.clone());
+    for weights_path in &prepared.weight_files {
+        println!("  Loading {}", weights_path.display());
+        runtime.load_safetensors(&cx, weights_path.to_str().unwrap());
+    }
+    println!("  Weight load: {:.2} s", load_start.elapsed().as_secs_f64());
+
+    println!("Compiling...");
+    let compile_start = std::time::Instant::now();
+    cx.set_dim('s', MAX_SEQ_LEN);
+    runtime = cx.compile(runtime, CompileOptions::default());
+    println!("  Compile: {:.2} s", compile_start.elapsed().as_secs_f64());
+
+    // Example: "The capital of France is [MASK]."
+    let sentence = "The capital of France is [MASK].";
+    let encoding = tokenizer.encode(sentence, true).unwrap();
+    let tokens = encoding.get_ids();
+    let seq_len = tokens.len().min(MAX_SEQ_LEN);
+    let tokens: Vec<u32> = tokens[..seq_len].to_vec();
+
+    // Find mask positions
+    let mask_positions: Vec<usize> = tokens
+        .iter()
+        .enumerate()
+        .filter(|&(_, t)| *t == MASK_TOKEN)
+        .map(|(i, _)| i)
+        .collect();
+
+    if mask_positions.is_empty() {
+        eprintln!("No [MASK] token found in input. Use the token [MASK] in your sentence.");
+        std::process::exit(1);
+    }
+
+    println!(
+        "Input: \"{sentence}\" ({} tokens, mask at positions {:?})",
+        seq_len, mask_positions
+    );
+
+    // Build position ids and token type ids
+    let pos_ids_data: Vec<i32> = (0..seq_len as i32).collect();
+    let token_type_ids_data: Vec<i32> = vec![0; seq_len];
+
+    // Build attention mask (causal not needed for BERT, just 1s for valid tokens)
+    let mut mask_data = vec![0f32; seq_len * seq_len];
+    for i in 0..seq_len {
+        for j in 0..seq_len {
+            mask_data[i * seq_len + j] = 0.0; // 0 = not masked (BERT uses 0/1, not -inf/0)
+        }
+    }
+
+    cx.set_dim('s', seq_len);
+    runtime.set_data(
+        input_ids,
+        tokens.iter().map(|&t| t as i32).collect::<Vec<_>>(),
+    );
+    runtime.set_data(token_type_ids, token_type_ids_data);
+    runtime.set_data(pos_ids, pos_ids_data);
+    runtime.set_data(mask, mask_data);
+
+    runtime.execute(&cx.dyn_map);
+
+    let logits_data = runtime.get_f32(logits);
+
+    // For each mask position, find top-k predictions
+    for &mask_pos in &mask_positions {
+        println!("\nTop {TOP_K} predictions at position {mask_pos}:");
+        let start = mask_pos * VOCAB_SIZE;
+        let end = start + VOCAB_SIZE;
+        let scores = &logits_data[start..end];
+
+        let mut indices: Vec<usize> = (0..VOCAB_SIZE).collect();
+        indices.sort_by(|&a, &b| scores[b].partial_cmp(&scores[a]).unwrap());
+
+        for (rank, &idx) in indices.iter().take(TOP_K).enumerate() {
+            let token_str = tokenizer
+                .decode(&[idx as u32], true)
+                .unwrap_or_else(|_| format!("<id {idx}>"));
+            println!(
+                "  {}. {} (id={}, score={:.4})",
+                rank + 1,
+                token_str.trim(),
+                idx,
+                scores[idx]
+            );
+        }
+    }
+}

--- a/examples/bert/src/main.rs
+++ b/examples/bert/src/main.rs
@@ -132,6 +132,7 @@ fn print_topk_predictions(logits_data: &[f32], mask_positions: &[usize], tokeniz
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_model_step(
     cx: &mut Graph,
     runtime: &mut CudaRuntime,
@@ -183,8 +184,6 @@ fn main() {
     println!("Using model: {REPO_ID}");
     println!("Using model directory: {}", prepared.model_dir.display());
 
-    let tokenizer = Tokenizer::from_file(prepared.model_dir.join("tokenizer.json")).unwrap();
-
     // Build graph
     let mut cx = Graph::default();
     let input_ids = cx.named_tensor("input_ids", 's').as_dtype(DType::Int);
@@ -196,6 +195,8 @@ fn main() {
         BertWeightMode::Bf16 => BertForMaskedLM::init_bf16(&mut cx),
     };
     let logits = bert.forward_with_topk(input_ids, token_type_ids, pos_ids);
+
+    let tokenizer = Tokenizer::from_file(prepared.model_dir.join("tokenizer.json")).unwrap();
 
     println!("Loading weights...");
     let load_start = std::time::Instant::now();
@@ -212,8 +213,16 @@ fn main() {
     runtime.set_data(input_ids, vec![0i32; MAX_SEQ_LEN]);
     runtime.set_data(token_type_ids, vec![0i32; MAX_SEQ_LEN]);
     runtime.set_data(pos_ids, (0..MAX_SEQ_LEN as i32).collect::<Vec<_>>());
+    let compile_options = CompileOptions::default()
+        .dim_buckets(
+            's',
+            &[DimBucket::new(1, MAX_SEQ_LEN).representative(MAX_SEQ_LEN)],
+        )
+        .search_graph_limit(500)
+        .generation_size(1)
+        .mutations(1);
     let mut rng = StdRng::seed_from_u64(0);
-    runtime = cx.compile_with_rng(runtime, CompileOptions::default(), &mut rng);
+    runtime = cx.compile_with_rng(runtime, compile_options, &mut rng);
     println!("  Compile: {:.2} s", compile_start.elapsed().as_secs_f64());
     print_host_op_summary(&runtime, "post-compile");
 

--- a/examples/bert/src/main.rs
+++ b/examples/bert/src/main.rs
@@ -9,6 +9,7 @@ use luminal::{dtype::DType, prelude::*};
 use luminal_cuda_lite::{cudarc::driver::CudaContext, runtime::CudaRuntime};
 use luminal_tracing::*;
 use model::*;
+use rand::{SeedableRng, rngs::StdRng};
 use std::{env, time::Duration};
 use tokenizers::Tokenizer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -106,6 +107,67 @@ fn parse_args() -> BertWeightMode {
     mode
 }
 
+fn print_topk_predictions(logits_data: &[f32], mask_positions: &[usize], tokenizer: &Tokenizer) {
+    for &mask_pos in mask_positions {
+        println!("\nTop {TOP_K} predictions at position {mask_pos}:");
+        let start = mask_pos * VOCAB_SIZE;
+        let end = start + VOCAB_SIZE;
+        let scores = &logits_data[start..end];
+
+        let mut indices: Vec<usize> = (0..VOCAB_SIZE).collect();
+        indices.sort_by(|&a, &b| scores[b].partial_cmp(&scores[a]).unwrap());
+
+        for (rank, &idx) in indices.iter().take(TOP_K).enumerate() {
+            let token_str = tokenizer
+                .decode(&[idx as u32], true)
+                .unwrap_or_else(|_| format!("<id {idx}>"));
+            println!(
+                "  {}. {} (id={}, score={:.4})",
+                rank + 1,
+                token_str.trim(),
+                idx,
+                scores[idx]
+            );
+        }
+    }
+}
+
+fn run_model_step(
+    cx: &mut Graph,
+    runtime: &mut CudaRuntime,
+    input_ids: GraphTensor,
+    token_type_ids: GraphTensor,
+    pos_ids: GraphTensor,
+    logits: GraphTensor,
+    tokens: &[i32],
+    token_type_ids_data: &[i32],
+    pos_ids_data: &[i32],
+    seq_len: usize,
+) -> (Vec<f32>, StepProfile) {
+    let start = std::time::Instant::now();
+    let mut profile = StepProfile::default();
+
+    cx.set_dim('s', seq_len);
+
+    let set_start = std::time::Instant::now();
+    runtime.set_data(input_ids, tokens.to_vec());
+    runtime.set_data(token_type_ids, token_type_ids_data.to_vec());
+    runtime.set_data(pos_ids, pos_ids_data.to_vec());
+    profile.set_inputs = set_start.elapsed();
+
+    let execute_start = std::time::Instant::now();
+    runtime.execute(&cx.dyn_map);
+    profile.execute = execute_start.elapsed();
+
+    let logits_start = std::time::Instant::now();
+    let logits_data = runtime.get_f32(logits);
+    profile.get_logits = logits_start.elapsed();
+
+    profile.total = start.elapsed();
+
+    (logits_data, profile)
+}
+
 fn main() {
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer())
@@ -128,17 +190,12 @@ fn main() {
     let input_ids = cx.named_tensor("input_ids", 's').as_dtype(DType::Int);
     let token_type_ids = cx.named_tensor("token_type_ids", 's').as_dtype(DType::Int);
     let pos_ids = cx.named_tensor("pos_ids", 's').as_dtype(DType::Int);
-    let mask = cx.named_tensor("mask", ('s', 's'));
 
     let bert = match weight_mode {
         BertWeightMode::F32 => BertForMaskedLM::init_f32(&mut cx),
         BertWeightMode::Bf16 => BertForMaskedLM::init_bf16(&mut cx),
     };
-    let logits = bert
-        .forward(input_ids, token_type_ids, pos_ids, mask)
-        .output();
-
-    cx.set_dim('s', 1);
+    let logits = bert.forward_with_topk(input_ids, token_type_ids, pos_ids);
 
     println!("Loading weights...");
     let load_start = std::time::Instant::now();
@@ -152,14 +209,14 @@ fn main() {
     println!("Compiling...");
     let compile_start = std::time::Instant::now();
     cx.set_dim('s', MAX_SEQ_LEN);
-    runtime = cx.compile(runtime, CompileOptions::default().search_graph_limit(1));
-    println!(
-        "  Compile: {:.2} s",
-        compile_start.elapsed().as_secs_f64()
-    );
+    runtime.set_data(input_ids, vec![0i32; MAX_SEQ_LEN]);
+    runtime.set_data(token_type_ids, vec![0i32; MAX_SEQ_LEN]);
+    runtime.set_data(pos_ids, (0..MAX_SEQ_LEN as i32).collect::<Vec<_>>());
+    let mut rng = StdRng::seed_from_u64(0);
+    runtime = cx.compile_with_rng(runtime, CompileOptions::default(), &mut rng);
+    println!("  Compile: {:.2} s", compile_start.elapsed().as_secs_f64());
     print_host_op_summary(&runtime, "post-compile");
 
-    // Example: "The capital of France is [MASK]."
     let sentence = "The capital of France is [MASK].";
     let encoding = tokenizer.encode(sentence, true).unwrap();
     let tokens = encoding.get_ids();
@@ -188,59 +245,22 @@ fn main() {
     let pos_ids_data: Vec<i32> = (0..seq_len as i32).collect();
     let token_type_ids_data: Vec<i32> = vec![0; seq_len];
 
-    // Build attention mask (all zeros = no masking for BERT)
-    let mask_data = vec![0f32; seq_len * seq_len];
-
-    cx.set_dim('s', seq_len);
-
-    let mut profile = StepProfile::default();
-    let start = std::time::Instant::now();
-
-    let set_start = std::time::Instant::now();
-    runtime.set_data(
+    let (logits_data, profile) = run_model_step(
+        &mut cx,
+        &mut runtime,
         input_ids,
-        tokens.iter().map(|&t| t as i32).collect::<Vec<_>>(),
+        token_type_ids,
+        pos_ids,
+        logits,
+        &tokens.iter().map(|&t| t as i32).collect::<Vec<_>>(),
+        &token_type_ids_data,
+        &pos_ids_data,
+        seq_len,
     );
-    runtime.set_data(token_type_ids, token_type_ids_data);
-    runtime.set_data(pos_ids, pos_ids_data);
-    runtime.set_data(mask, mask_data);
-    profile.set_inputs = set_start.elapsed();
-
-    let execute_start = std::time::Instant::now();
-    runtime.execute(&cx.dyn_map);
-    profile.execute = execute_start.elapsed();
-
-    let logits_start = std::time::Instant::now();
-    let logits_data = runtime.get_f32(logits);
-    profile.get_logits = logits_start.elapsed();
-
-    profile.total = start.elapsed();
 
     print_host_op_summary(&runtime, "after forward");
     println!("\nProfile:");
     print_profile("forward", &profile, 1);
 
-    // For each mask position, find top-k predictions
-    for &mask_pos in &mask_positions {
-        println!("\nTop {TOP_K} predictions at position {mask_pos}:");
-        let start = mask_pos * VOCAB_SIZE;
-        let end = start + VOCAB_SIZE;
-        let scores = &logits_data[start..end];
-
-        let mut indices: Vec<usize> = (0..VOCAB_SIZE).collect();
-        indices.sort_by(|&a, &b| scores[b].partial_cmp(&scores[a]).unwrap());
-
-        for (rank, &idx) in indices.iter().take(TOP_K).enumerate() {
-            let token_str = tokenizer
-                .decode(&[idx as u32], true)
-                .unwrap_or_else(|_| format!("<id {idx}>"));
-            println!(
-                "  {}. {} (id={}, score={:.4})",
-                rank + 1,
-                token_str.trim(),
-                idx,
-                scores[idx]
-            );
-        }
-    }
+    print_topk_predictions(&logits_data, &mask_positions, &tokenizer);
 }

--- a/examples/bert/src/model.rs
+++ b/examples/bert/src/model.rs
@@ -1,8 +1,4 @@
-use luminal::{
-    dtype::DType,
-    graph::Graph,
-    prelude::GraphTensor,
-};
+use luminal::{dtype::DType, graph::Graph, prelude::GraphTensor};
 use luminal_nn::LayerNorm;
 
 // BERT-base hyperparams
@@ -83,11 +79,7 @@ fn linear_weight(
         .persist()
 }
 
-fn linear_bias(
-    cx: &mut Graph,
-    prefix: impl ToString,
-    out: usize,
-) -> GraphTensor {
+fn linear_bias(cx: &mut Graph, prefix: impl ToString, out: usize) -> GraphTensor {
     cx.named_tensor(format!("{}.bias", prefix.to_string()), out)
         .persist()
 }
@@ -107,17 +99,8 @@ fn layer_linear_weight(
     )
 }
 
-fn layer_linear_bias(
-    cx: &mut Graph,
-    layer: usize,
-    suffix: &str,
-    out: usize,
-) -> GraphTensor {
-    linear_bias(
-        cx,
-        format!("bert.encoder.layer.{layer}.{suffix}"),
-        out,
-    )
+fn layer_linear_bias(cx: &mut Graph, layer: usize, suffix: &str, out: usize) -> GraphTensor {
+    linear_bias(cx, format!("bert.encoder.layer.{layer}.{suffix}"), out)
 }
 
 fn norm_in_f32(norm: &LayerNorm, x: GraphTensor, act: DType) -> GraphTensor {
@@ -214,16 +197,45 @@ pub struct BertSelfAttention {
 }
 
 impl BertSelfAttention {
-    pub fn init(cx: &mut Graph, layer: usize, config: &BertConfig, precision: BertPrecision) -> Self {
+    pub fn init(
+        cx: &mut Graph,
+        layer: usize,
+        config: &BertConfig,
+        precision: BertPrecision,
+    ) -> Self {
         let hidden = config.hidden;
         Self {
-            q_weight: layer_linear_weight(cx, layer, "attention.self.query", (hidden, hidden), precision),
+            q_weight: layer_linear_weight(
+                cx,
+                layer,
+                "attention.self.query",
+                (hidden, hidden),
+                precision,
+            ),
             q_bias: layer_linear_bias(cx, layer, "attention.self.query", hidden),
-            k_weight: layer_linear_weight(cx, layer, "attention.self.key", (hidden, hidden), precision),
+            k_weight: layer_linear_weight(
+                cx,
+                layer,
+                "attention.self.key",
+                (hidden, hidden),
+                precision,
+            ),
             k_bias: layer_linear_bias(cx, layer, "attention.self.key", hidden),
-            v_weight: layer_linear_weight(cx, layer, "attention.self.value", (hidden, hidden), precision),
+            v_weight: layer_linear_weight(
+                cx,
+                layer,
+                "attention.self.value",
+                (hidden, hidden),
+                precision,
+            ),
             v_bias: layer_linear_bias(cx, layer, "attention.self.value", hidden),
-            o_weight: layer_linear_weight(cx, layer, "attention.output.dense", (hidden, hidden), precision),
+            o_weight: layer_linear_weight(
+                cx,
+                layer,
+                "attention.output.dense",
+                (hidden, hidden),
+                precision,
+            ),
             o_bias: layer_linear_bias(cx, layer, "attention.output.dense", hidden),
             head_dim: config.hidden / config.n_heads,
             n_heads: config.n_heads,
@@ -261,7 +273,12 @@ pub struct BertLayer {
 }
 
 impl BertLayer {
-    pub fn init(cx: &mut Graph, layer: usize, config: &BertConfig, precision: BertPrecision) -> Self {
+    pub fn init(
+        cx: &mut Graph,
+        layer: usize,
+        config: &BertConfig,
+        precision: BertPrecision,
+    ) -> Self {
         let hidden = config.hidden;
         let intermediate = config.intermediate;
         Self {
@@ -269,34 +286,28 @@ impl BertLayer {
             attn_norm: {
                 let w = format!("bert.encoder.layer.{layer}.attention.output.LayerNorm.weight");
                 let b = format!("bert.encoder.layer.{layer}.attention.output.LayerNorm.bias");
-                LayerNorm::new(
-                    hidden,
-                    Some(w.as_str()),
-                    Some(b.as_str()),
-                    true,
-                    1e-12,
-                    cx,
-                )
+                LayerNorm::new(hidden, Some(w.as_str()), Some(b.as_str()), true, 1e-12, cx)
             },
             intermediate_weight: layer_linear_weight(
-                cx, layer, "intermediate.dense", (intermediate, hidden), precision,
+                cx,
+                layer,
+                "intermediate.dense",
+                (intermediate, hidden),
+                precision,
             ),
             intermediate_bias: layer_linear_bias(cx, layer, "intermediate.dense", intermediate),
             output_weight: layer_linear_weight(
-                cx, layer, "output.dense", (hidden, intermediate), precision,
+                cx,
+                layer,
+                "output.dense",
+                (hidden, intermediate),
+                precision,
             ),
             output_bias: layer_linear_bias(cx, layer, "output.dense", hidden),
             output_norm: {
                 let w = format!("bert.encoder.layer.{layer}.output.LayerNorm.weight");
                 let b = format!("bert.encoder.layer.{layer}.output.LayerNorm.bias");
-                LayerNorm::new(
-                    hidden,
-                    Some(w.as_str()),
-                    Some(b.as_str()),
-                    true,
-                    1e-12,
-                    cx,
-                )
+                LayerNorm::new(hidden, Some(w.as_str()), Some(b.as_str()), true, 1e-12, cx)
             },
         }
     }
@@ -343,7 +354,12 @@ impl BertLMPredictionHead {
     pub fn init(cx: &mut Graph, config: &BertConfig, precision: BertPrecision) -> Self {
         let hidden = config.hidden;
         Self {
-            dense_weight: linear_weight(cx, "cls.predictions.transform.dense", (hidden, hidden), precision),
+            dense_weight: linear_weight(
+                cx,
+                "cls.predictions.transform.dense",
+                (hidden, hidden),
+                precision,
+            ),
             dense_bias: linear_bias(cx, "cls.predictions.transform.dense", hidden),
             norm: LayerNorm::new(
                 hidden,
@@ -357,12 +373,20 @@ impl BertLMPredictionHead {
         }
     }
 
-    pub fn forward(&self, x: GraphTensor, embedding_weight: GraphTensor, act: DType) -> GraphTensor {
+    pub fn forward(
+        &self,
+        x: GraphTensor,
+        embedding_weight: GraphTensor,
+        act: DType,
+    ) -> GraphTensor {
         let h = linear(x, self.dense_weight, Some(self.dense_bias)).gelu();
         let h = norm_in_f32(&self.norm, h, act);
         // Weight tying: decoder weight = embedding weight
         let logits = h.matmul(embedding_weight.t());
-        logits + self.decoder_bias.expand_lhs(&logits.dims()[..logits.dims().len() - 1])
+        logits
+            + self
+                .decoder_bias
+                .expand_lhs(&logits.dims()[..logits.dims().len() - 1])
     }
 }
 
@@ -405,8 +429,121 @@ impl BertForMaskedLM {
         mask: GraphTensor,
     ) -> GraphTensor {
         let act = self.precision.act_dtype();
-        let emb = self.embeddings.forward(input_ids, token_type_ids, pos_ids, act, self.config.hidden);
+        let emb =
+            self.embeddings
+                .forward(input_ids, token_type_ids, pos_ids, act, self.config.hidden);
         let encoded = self.encoder.forward(emb, mask, act);
         self.head.forward(encoded, self.embeddings.token_embed, act)
     }
+
+    // pub fn parameter_tensors(&self) -> Vec<GraphTensor> {
+    //     let mut tensors = vec![
+    //         self.embeddings.token_embed,
+    //         self.embeddings.type_embed,
+    //         self.embeddings.position_embed,
+    //     ];
+    //     if let Some(w) = self.embeddings.norm.weight {
+    //         tensors.push(w);
+    //     }
+    //     if let Some(b) = self.embeddings.norm.bias {
+    //         tensors.push(b);
+    //     }
+    //     for layer in &self.encoder.layers {
+    //         tensors.push(layer.attention.q_weight);
+    //         tensors.push(layer.attention.q_bias);
+    //         tensors.push(layer.attention.k_weight);
+    //         tensors.push(layer.attention.k_bias);
+    //         tensors.push(layer.attention.v_weight);
+    //         tensors.push(layer.attention.v_bias);
+    //         tensors.push(layer.attention.o_weight);
+    //         tensors.push(layer.attention.o_bias);
+    //         if let Some(w) = layer.attn_norm.weight {
+    //             tensors.push(w);
+    //         }
+    //         if let Some(b) = layer.attn_norm.bias {
+    //             tensors.push(b);
+    //         }
+    //         tensors.push(layer.intermediate_weight);
+    //         tensors.push(layer.intermediate_bias);
+    //         tensors.push(layer.output_weight);
+    //         tensors.push(layer.output_bias);
+    //         if let Some(w) = layer.output_norm.weight {
+    //             tensors.push(w);
+    //         }
+    //         if let Some(b) = layer.output_norm.bias {
+    //             tensors.push(b);
+    //         }
+    //     }
+    //     tensors.push(self.head.dense_weight);
+    //     tensors.push(self.head.dense_bias);
+    //     if let Some(w) = self.head.norm.weight {
+    //         tensors.push(w);
+    //     }
+    //     if let Some(b) = self.head.norm.bias {
+    //         tensors.push(b);
+    //     }
+    //     tensors.push(self.head.decoder_bias);
+    //     tensors
+    // }
 }
+
+// #[cfg(test)]
+// mod tests {
+//     use luminal::prelude::*;
+
+//     use super::*;
+
+//     fn run_forward(seq_len: usize) {
+//         let mut cx = Graph::default();
+//         let input_ids = cx.named_tensor("input_ids", 's').as_dtype(DType::Int);
+//         let token_type_ids = cx.named_tensor("token_type_ids", 's').as_dtype(DType::Int);
+//         let pos_ids = cx.named_tensor("pos_ids", 's').as_dtype(DType::Int);
+//         let mask = cx.named_tensor("mask", ('s', 's'));
+
+//         let bert = BertForMaskedLM::init_f32(&mut cx);
+//         let logits = bert
+//             .forward(input_ids, token_type_ids, pos_ids, mask)
+//             .output();
+
+//         cx.set_dim('s', seq_len);
+//         let mut rt: ReferenceRuntime = cx.compile(
+//             ReferenceRuntime::default(),
+//             CompileOptions::default().search_graph_limit(1),
+//         );
+
+//         // Set input data
+//         rt.set_data(input_ids, vec![0i32; seq_len]);
+//         rt.set_data(token_type_ids, vec![0i32; seq_len]);
+//         rt.set_data(pos_ids, (0..seq_len as i32).collect::<Vec<_>>());
+//         rt.set_data(mask, vec![0f32; seq_len * seq_len]);
+
+//         // Set zero data for all weight tensors
+//         for t in bert.parameter_tensors() {
+//             let n: usize = t.shape.dims.iter().map(|e| e.to_usize().unwrap()).product();
+//             match t.dtype {
+//                 DType::F32 => rt.set_data(t, vec![0f32; n]),
+//                 DType::Bf16 => rt.set_data(t, vec![half::bf16::ZERO; n]),
+//                 _ => {}
+//             }
+//         }
+
+//         rt.execute(&cx.dyn_map);
+//         let out = rt.get_f32(logits);
+//         assert_eq!(out.len(), seq_len * VOCAB_SIZE);
+//     }
+
+//     // #[test]
+//     // fn forward_seq_1() {
+//     //     run_forward(1);
+//     // }
+
+//     #[test]
+//     fn forward_seq_4() {
+//         run_forward(4);
+//     }
+
+//     // #[test]
+//     // fn forward_seq_8() {
+//     //     run_forward(8);
+//     // }
+// }

--- a/examples/bert/src/model.rs
+++ b/examples/bert/src/model.rs
@@ -1,0 +1,410 @@
+use luminal::{
+    dtype::DType,
+    graph::Graph,
+    prelude::GraphTensor,
+};
+use luminal_nn::LayerNorm;
+
+// BERT-base hyperparams
+pub const LAYERS: usize = 12;
+pub const HIDDEN: usize = 768;
+pub const INTERMEDIATE: usize = 3072;
+pub const N_HEADS: usize = 12;
+#[allow(dead_code)]
+pub const HEAD_DIM: usize = HIDDEN / N_HEADS; // 64
+#[allow(dead_code)]
+pub const VOCAB_SIZE: usize = 30522;
+pub const MAX_SEQ: usize = 512;
+pub const TYPE_VOCAB_SIZE: usize = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BertPrecision {
+    F32,
+    Bf16,
+}
+
+impl BertPrecision {
+    fn weight_dtype(self) -> DType {
+        match self {
+            Self::F32 => DType::F32,
+            Self::Bf16 => DType::Bf16,
+        }
+    }
+
+    fn act_dtype(self) -> DType {
+        match self {
+            Self::F32 => DType::F32,
+            Self::Bf16 => DType::Bf16,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BertConfig {
+    pub layers: usize,
+    pub hidden: usize,
+    pub intermediate: usize,
+    pub n_heads: usize,
+    pub vocab_size: usize,
+    pub max_seq: usize,
+    pub type_vocab_size: usize,
+}
+
+impl Default for BertConfig {
+    fn default() -> Self {
+        Self {
+            layers: LAYERS,
+            hidden: HIDDEN,
+            intermediate: INTERMEDIATE,
+            n_heads: N_HEADS,
+            vocab_size: VOCAB_SIZE,
+            max_seq: MAX_SEQ,
+            type_vocab_size: TYPE_VOCAB_SIZE,
+        }
+    }
+}
+
+fn persist(
+    cx: &mut Graph,
+    name: impl ToString,
+    shape: impl luminal::prelude::ToShape,
+) -> GraphTensor {
+    cx.named_tensor(name, shape).persist()
+}
+
+fn linear_weight(
+    cx: &mut Graph,
+    prefix: impl ToString,
+    shape: impl luminal::prelude::ToShape,
+    precision: BertPrecision,
+) -> GraphTensor {
+    cx.named_tensor(format!("{}.weight", prefix.to_string()), shape)
+        .as_dtype(precision.weight_dtype())
+        .persist()
+}
+
+fn linear_bias(
+    cx: &mut Graph,
+    prefix: impl ToString,
+    out: usize,
+) -> GraphTensor {
+    cx.named_tensor(format!("{}.bias", prefix.to_string()), out)
+        .persist()
+}
+
+fn layer_linear_weight(
+    cx: &mut Graph,
+    layer: usize,
+    suffix: &str,
+    shape: impl luminal::prelude::ToShape,
+    precision: BertPrecision,
+) -> GraphTensor {
+    linear_weight(
+        cx,
+        format!("bert.encoder.layer.{layer}.{suffix}"),
+        shape,
+        precision,
+    )
+}
+
+fn layer_linear_bias(
+    cx: &mut Graph,
+    layer: usize,
+    suffix: &str,
+    out: usize,
+) -> GraphTensor {
+    linear_bias(
+        cx,
+        format!("bert.encoder.layer.{layer}.{suffix}"),
+        out,
+    )
+}
+
+fn norm_in_f32(norm: &LayerNorm, x: GraphTensor, act: DType) -> GraphTensor {
+    if act == DType::F32 {
+        norm.forward(x)
+    } else {
+        norm.forward(x.cast(DType::F32)).cast(act)
+    }
+}
+
+fn linear(input: GraphTensor, weight: GraphTensor, bias: Option<GraphTensor>) -> GraphTensor {
+    let out = input.matmul(weight.t());
+    if let Some(b) = bias {
+        out + b.expand_lhs(&out.dims()[..out.dims().len() - 1])
+    } else {
+        out
+    }
+}
+
+fn token_embedding(embedding: GraphTensor, token_ids: GraphTensor, hidden: usize) -> GraphTensor {
+    let seq = token_ids.dims1();
+    embedding.gather(
+        (token_ids * hidden).expand_dim(1, hidden)
+            + token_ids.graph().arange(hidden).expand_dim(0, seq),
+    )
+}
+
+pub struct BertEmbeddings {
+    token_embed: GraphTensor,
+    type_embed: GraphTensor,
+    position_embed: GraphTensor,
+    norm: LayerNorm,
+}
+
+impl BertEmbeddings {
+    pub fn init(cx: &mut Graph, config: &BertConfig, precision: BertPrecision) -> Self {
+        let table_dtype = precision.act_dtype();
+        Self {
+            token_embed: persist(
+                cx,
+                "bert.embeddings.word_embeddings.weight",
+                (config.vocab_size, config.hidden),
+            )
+            .as_dtype(table_dtype),
+            type_embed: persist(
+                cx,
+                "bert.embeddings.token_type_embeddings.weight",
+                (config.type_vocab_size, config.hidden),
+            )
+            .as_dtype(table_dtype),
+            position_embed: persist(
+                cx,
+                "bert.embeddings.position_embeddings.weight",
+                (config.max_seq, config.hidden),
+            )
+            .as_dtype(table_dtype),
+            norm: LayerNorm::new(
+                config.hidden,
+                Some("bert.embeddings.LayerNorm.weight"),
+                Some("bert.embeddings.LayerNorm.bias"),
+                true,
+                1e-12,
+                cx,
+            ),
+        }
+    }
+
+    pub fn forward(
+        &self,
+        input_ids: GraphTensor,
+        token_type_ids: GraphTensor,
+        pos_ids: GraphTensor,
+        act: DType,
+        hidden: usize,
+    ) -> GraphTensor {
+        let tok = token_embedding(self.token_embed, input_ids, hidden);
+        let typ = token_embedding(self.type_embed, token_type_ids, hidden);
+        let pos = token_embedding(self.position_embed, pos_ids, hidden);
+        norm_in_f32(&self.norm, tok + typ + pos, act)
+    }
+}
+
+pub struct BertSelfAttention {
+    q_weight: GraphTensor,
+    q_bias: GraphTensor,
+    k_weight: GraphTensor,
+    k_bias: GraphTensor,
+    v_weight: GraphTensor,
+    v_bias: GraphTensor,
+    o_weight: GraphTensor,
+    o_bias: GraphTensor,
+    head_dim: usize,
+}
+
+impl BertSelfAttention {
+    pub fn init(cx: &mut Graph, layer: usize, config: &BertConfig, precision: BertPrecision) -> Self {
+        let hidden = config.hidden;
+        Self {
+            q_weight: layer_linear_weight(cx, layer, "attention.self.query", (hidden, hidden), precision),
+            q_bias: layer_linear_bias(cx, layer, "attention.self.query", hidden),
+            k_weight: layer_linear_weight(cx, layer, "attention.self.key", (hidden, hidden), precision),
+            k_bias: layer_linear_bias(cx, layer, "attention.self.key", hidden),
+            v_weight: layer_linear_weight(cx, layer, "attention.self.value", (hidden, hidden), precision),
+            v_bias: layer_linear_bias(cx, layer, "attention.self.value", hidden),
+            o_weight: layer_linear_weight(cx, layer, "attention.output.dense", (hidden, hidden), precision),
+            o_bias: layer_linear_bias(cx, layer, "attention.output.dense", hidden),
+            head_dim: config.hidden / config.n_heads,
+        }
+    }
+
+    pub fn forward(&self, x: GraphTensor, mask: GraphTensor, _act: DType) -> GraphTensor {
+        let scale = 1.0 / (self.head_dim as f32).sqrt();
+
+        let q = linear(x, self.q_weight, Some(self.q_bias));
+        let k = linear(x, self.k_weight, Some(self.k_bias));
+        let v = linear(x, self.v_weight, Some(self.v_bias));
+
+        let q = q.split_dims(1, self.head_dim).transpose(0, 1);
+        let k = k.split_dims(1, self.head_dim).transpose(0, 1);
+        let v = v.split_dims(1, self.head_dim).transpose(0, 1);
+
+        let scores = q.matmul(k.permute((0, 1, 3, 2))) * scale;
+        let masked = scores + mask;
+        let weights = masked.softmax(3);
+
+        let out = weights.matmul(v).transpose(0, 1).merge_dims(1, 2);
+        linear(out, self.o_weight, Some(self.o_bias))
+    }
+}
+
+pub struct BertLayer {
+    attention: BertSelfAttention,
+    attn_norm: LayerNorm,
+    intermediate_weight: GraphTensor,
+    intermediate_bias: GraphTensor,
+    output_weight: GraphTensor,
+    output_bias: GraphTensor,
+    output_norm: LayerNorm,
+}
+
+impl BertLayer {
+    pub fn init(cx: &mut Graph, layer: usize, config: &BertConfig, precision: BertPrecision) -> Self {
+        let hidden = config.hidden;
+        let intermediate = config.intermediate;
+        Self {
+            attention: BertSelfAttention::init(cx, layer, config, precision),
+            attn_norm: {
+                let w = format!("bert.encoder.layer.{layer}.attention.output.LayerNorm.weight");
+                let b = format!("bert.encoder.layer.{layer}.attention.output.LayerNorm.bias");
+                LayerNorm::new(
+                    hidden,
+                    Some(w.as_str()),
+                    Some(b.as_str()),
+                    true,
+                    1e-12,
+                    cx,
+                )
+            },
+            intermediate_weight: layer_linear_weight(
+                cx, layer, "intermediate.dense", (intermediate, hidden), precision,
+            ),
+            intermediate_bias: layer_linear_bias(cx, layer, "intermediate.dense", intermediate),
+            output_weight: layer_linear_weight(
+                cx, layer, "output.dense", (hidden, intermediate), precision,
+            ),
+            output_bias: layer_linear_bias(cx, layer, "output.dense", hidden),
+            output_norm: {
+                let w = format!("bert.encoder.layer.{layer}.output.LayerNorm.weight");
+                let b = format!("bert.encoder.layer.{layer}.output.LayerNorm.bias");
+                LayerNorm::new(
+                    hidden,
+                    Some(w.as_str()),
+                    Some(b.as_str()),
+                    true,
+                    1e-12,
+                    cx,
+                )
+            },
+        }
+    }
+
+    pub fn forward(&self, x: GraphTensor, mask: GraphTensor, act: DType) -> GraphTensor {
+        let attn = self.attention.forward(x, mask, act);
+        let h = norm_in_f32(&self.attn_norm, x + attn, act);
+        let inter = linear(h, self.intermediate_weight, Some(self.intermediate_bias)).gelu();
+        let out = linear(inter, self.output_weight, Some(self.output_bias));
+        norm_in_f32(&self.output_norm, h + out, act)
+    }
+}
+
+pub struct BertEncoder {
+    layers: Vec<BertLayer>,
+}
+
+impl BertEncoder {
+    pub fn init(cx: &mut Graph, config: &BertConfig, precision: BertPrecision) -> Self {
+        Self {
+            layers: (0..config.layers)
+                .map(|l| BertLayer::init(cx, l, config, precision))
+                .collect(),
+        }
+    }
+
+    pub fn forward(&self, x: GraphTensor, mask: GraphTensor, act: DType) -> GraphTensor {
+        let mut h = x;
+        for layer in &self.layers {
+            h = layer.forward(h, mask, act);
+        }
+        h
+    }
+}
+
+pub struct BertLMPredictionHead {
+    dense_weight: GraphTensor,
+    dense_bias: GraphTensor,
+    norm: LayerNorm,
+    decoder_bias: GraphTensor,
+}
+
+impl BertLMPredictionHead {
+    pub fn init(cx: &mut Graph, config: &BertConfig, precision: BertPrecision) -> Self {
+        let hidden = config.hidden;
+        Self {
+            dense_weight: linear_weight(cx, "cls.predictions.transform.dense", (hidden, hidden), precision),
+            dense_bias: linear_bias(cx, "cls.predictions.transform.dense", hidden),
+            norm: LayerNorm::new(
+                hidden,
+                Some("cls.predictions.transform.LayerNorm.weight"),
+                Some("cls.predictions.transform.LayerNorm.bias"),
+                true,
+                1e-12,
+                cx,
+            ),
+            decoder_bias: persist(cx, "cls.predictions.bias", config.vocab_size),
+        }
+    }
+
+    pub fn forward(&self, x: GraphTensor, embedding_weight: GraphTensor, act: DType) -> GraphTensor {
+        let h = linear(x, self.dense_weight, Some(self.dense_bias)).gelu();
+        let h = norm_in_f32(&self.norm, h, act);
+        // Weight tying: decoder weight = embedding weight
+        let logits = h.matmul(embedding_weight.t());
+        logits + self.decoder_bias.expand_lhs(&logits.dims()[..logits.dims().len() - 1])
+    }
+}
+
+pub struct BertForMaskedLM {
+    config: BertConfig,
+    precision: BertPrecision,
+    embeddings: BertEmbeddings,
+    encoder: BertEncoder,
+    head: BertLMPredictionHead,
+}
+
+impl BertForMaskedLM {
+    pub fn init_f32(cx: &mut Graph) -> Self {
+        Self::init_with_precision(cx, BertConfig::default(), BertPrecision::F32)
+    }
+
+    pub fn init_bf16(cx: &mut Graph) -> Self {
+        Self::init_with_precision(cx, BertConfig::default(), BertPrecision::Bf16)
+    }
+
+    pub fn init_with_precision(
+        cx: &mut Graph,
+        config: BertConfig,
+        precision: BertPrecision,
+    ) -> Self {
+        Self {
+            config,
+            precision,
+            embeddings: BertEmbeddings::init(cx, &config, precision),
+            encoder: BertEncoder::init(cx, &config, precision),
+            head: BertLMPredictionHead::init(cx, &config, precision),
+        }
+    }
+
+    pub fn forward(
+        &self,
+        input_ids: GraphTensor,
+        token_type_ids: GraphTensor,
+        pos_ids: GraphTensor,
+        mask: GraphTensor,
+    ) -> GraphTensor {
+        let act = self.precision.act_dtype();
+        let emb = self.embeddings.forward(input_ids, token_type_ids, pos_ids, act, self.config.hidden);
+        let encoded = self.encoder.forward(emb, mask, act);
+        self.head.forward(encoded, self.embeddings.token_embed, act)
+    }
+}

--- a/examples/bert/src/model.rs
+++ b/examples/bert/src/model.rs
@@ -104,10 +104,35 @@ fn layer_linear_bias(cx: &mut Graph, layer: usize, suffix: &str, out: usize) -> 
 }
 
 fn norm_in_f32(norm: &LayerNorm, x: GraphTensor, act: DType) -> GraphTensor {
-    if act == DType::F32 {
-        norm.forward(x)
+    let x = if act == DType::F32 {
+        x
     } else {
-        norm.forward(x.cast(DType::F32)).cast(act)
+        x.cast(DType::F32)
+    };
+    // Manual LayerNorm: mean_norm + std_norm + weight + bias.
+    // mean_norm is decomposed as x - x.mean() rather than calling
+    // LayerNorm::forward with mean_norm=true, because the CUDA backend's
+    // KernelRMSNorm egglog rule only matches the RMS norm pattern (no mean
+    // subtraction). Writing the mean subtraction explicitly lets the std_norm
+    // chain still fuse into a single kernel.
+    let axis = x.shape.last_axis();
+    let mean = x.mean(axis).expand_to_shape_on_axes(x.shape, axis);
+    let h = x - mean;
+    let h = h.std_norm(axis, 1e-12);
+    let h = if let Some(w) = norm.weight {
+        h * w.expand_lhs(&h.dims()[..h.dims().len() - 1])
+    } else {
+        h
+    };
+    let h = if let Some(b) = norm.bias {
+        h + b.expand_lhs(&h.dims()[..h.dims().len() - 1])
+    } else {
+        h
+    };
+    if act == DType::F32 {
+        h
+    } else {
+        h.cast(act)
     }
 }
 

--- a/examples/bert/src/model.rs
+++ b/examples/bert/src/model.rs
@@ -239,9 +239,9 @@ impl BertSelfAttention {
         let k = k.split_dims(1, self.head_dim).transpose(0, 1);
         let v = v.split_dims(1, self.head_dim).transpose(0, 1);
 
-        let scores = q.matmul(k.permute((0, 1, 3, 2))) * scale;
+        let scores = q.matmul(k.permute((0, 2, 1))) * scale;
         let masked = scores + mask;
-        let weights = masked.softmax(3);
+        let weights = masked.softmax(2);
 
         let out = weights.matmul(v).transpose(0, 1).merge_dims(1, 2);
         linear(out, self.o_weight, Some(self.o_bias))

--- a/examples/bert/src/model.rs
+++ b/examples/bert/src/model.rs
@@ -104,35 +104,10 @@ fn layer_linear_bias(cx: &mut Graph, layer: usize, suffix: &str, out: usize) -> 
 }
 
 fn norm_in_f32(norm: &LayerNorm, x: GraphTensor, act: DType) -> GraphTensor {
-    let x = if act == DType::F32 {
-        x
-    } else {
-        x.cast(DType::F32)
-    };
-    // Manual LayerNorm: mean_norm + std_norm + weight + bias.
-    // mean_norm is decomposed as x - x.mean() rather than calling
-    // LayerNorm::forward with mean_norm=true, because the CUDA backend's
-    // KernelRMSNorm egglog rule only matches the RMS norm pattern (no mean
-    // subtraction). Writing the mean subtraction explicitly lets the std_norm
-    // chain still fuse into a single kernel.
-    let axis = x.shape.last_axis();
-    let mean = x.mean(axis).expand_to_shape_on_axes(x.shape, axis);
-    let h = x - mean;
-    let h = h.std_norm(axis, 1e-12);
-    let h = if let Some(w) = norm.weight {
-        h * w.expand_lhs(&h.dims()[..h.dims().len() - 1])
-    } else {
-        h
-    };
-    let h = if let Some(b) = norm.bias {
-        h + b.expand_lhs(&h.dims()[..h.dims().len() - 1])
-    } else {
-        h
-    };
     if act == DType::F32 {
-        h
+        norm.forward(x)
     } else {
-        h.cast(act)
+        norm.forward(x.cast(DType::F32)).cast(act)
     }
 }
 
@@ -218,7 +193,6 @@ pub struct BertSelfAttention {
     o_weight: GraphTensor,
     o_bias: GraphTensor,
     head_dim: usize,
-    n_heads: usize,
 }
 
 impl BertSelfAttention {
@@ -263,11 +237,10 @@ impl BertSelfAttention {
             ),
             o_bias: layer_linear_bias(cx, layer, "attention.output.dense", hidden),
             head_dim: config.hidden / config.n_heads,
-            n_heads: config.n_heads,
         }
     }
 
-    pub fn forward(&self, x: GraphTensor, mask: GraphTensor, _act: DType) -> GraphTensor {
+    pub fn forward(&self, x: GraphTensor, _act: DType) -> GraphTensor {
         let scale = 1.0 / (self.head_dim as f32).sqrt();
 
         let q = linear(x, self.q_weight, Some(self.q_bias));
@@ -279,8 +252,7 @@ impl BertSelfAttention {
         let v = v.split_dims(1, self.head_dim).transpose(0, 1);
 
         let scores = q.matmul(k.permute((0, 2, 1))) * scale;
-        let masked = scores + mask.expand_dim(0, self.n_heads);
-        let weights = masked.softmax(2);
+        let weights = scores.softmax(2);
 
         let out = weights.matmul(v).transpose(0, 1).merge_dims(1, 2);
         linear(out, self.o_weight, Some(self.o_bias))
@@ -337,8 +309,8 @@ impl BertLayer {
         }
     }
 
-    pub fn forward(&self, x: GraphTensor, mask: GraphTensor, act: DType) -> GraphTensor {
-        let attn = self.attention.forward(x, mask, act);
+    pub fn forward(&self, x: GraphTensor, act: DType) -> GraphTensor {
+        let attn = self.attention.forward(x, act);
         let h = norm_in_f32(&self.attn_norm, x + attn, act);
         let inter = linear(h, self.intermediate_weight, Some(self.intermediate_bias)).gelu();
         let out = linear(inter, self.output_weight, Some(self.output_bias));
@@ -359,10 +331,10 @@ impl BertEncoder {
         }
     }
 
-    pub fn forward(&self, x: GraphTensor, mask: GraphTensor, act: DType) -> GraphTensor {
+    pub fn forward(&self, x: GraphTensor, act: DType) -> GraphTensor {
         let mut h = x;
         for layer in &self.layers {
-            h = layer.forward(h, mask, act);
+            h = layer.forward(h, act);
         }
         h
     }
@@ -451,124 +423,21 @@ impl BertForMaskedLM {
         input_ids: GraphTensor,
         token_type_ids: GraphTensor,
         pos_ids: GraphTensor,
-        mask: GraphTensor,
     ) -> GraphTensor {
         let act = self.precision.act_dtype();
         let emb =
             self.embeddings
                 .forward(input_ids, token_type_ids, pos_ids, act, self.config.hidden);
-        let encoded = self.encoder.forward(emb, mask, act);
+        let encoded = self.encoder.forward(emb, act);
         self.head.forward(encoded, self.embeddings.token_embed, act)
     }
 
-    // pub fn parameter_tensors(&self) -> Vec<GraphTensor> {
-    //     let mut tensors = vec![
-    //         self.embeddings.token_embed,
-    //         self.embeddings.type_embed,
-    //         self.embeddings.position_embed,
-    //     ];
-    //     if let Some(w) = self.embeddings.norm.weight {
-    //         tensors.push(w);
-    //     }
-    //     if let Some(b) = self.embeddings.norm.bias {
-    //         tensors.push(b);
-    //     }
-    //     for layer in &self.encoder.layers {
-    //         tensors.push(layer.attention.q_weight);
-    //         tensors.push(layer.attention.q_bias);
-    //         tensors.push(layer.attention.k_weight);
-    //         tensors.push(layer.attention.k_bias);
-    //         tensors.push(layer.attention.v_weight);
-    //         tensors.push(layer.attention.v_bias);
-    //         tensors.push(layer.attention.o_weight);
-    //         tensors.push(layer.attention.o_bias);
-    //         if let Some(w) = layer.attn_norm.weight {
-    //             tensors.push(w);
-    //         }
-    //         if let Some(b) = layer.attn_norm.bias {
-    //             tensors.push(b);
-    //         }
-    //         tensors.push(layer.intermediate_weight);
-    //         tensors.push(layer.intermediate_bias);
-    //         tensors.push(layer.output_weight);
-    //         tensors.push(layer.output_bias);
-    //         if let Some(w) = layer.output_norm.weight {
-    //             tensors.push(w);
-    //         }
-    //         if let Some(b) = layer.output_norm.bias {
-    //             tensors.push(b);
-    //         }
-    //     }
-    //     tensors.push(self.head.dense_weight);
-    //     tensors.push(self.head.dense_bias);
-    //     if let Some(w) = self.head.norm.weight {
-    //         tensors.push(w);
-    //     }
-    //     if let Some(b) = self.head.norm.bias {
-    //         tensors.push(b);
-    //     }
-    //     tensors.push(self.head.decoder_bias);
-    //     tensors
-    // }
+    pub fn forward_with_topk(
+        &self,
+        input_ids: GraphTensor,
+        token_type_ids: GraphTensor,
+        pos_ids: GraphTensor,
+    ) -> GraphTensor {
+        self.forward(input_ids, token_type_ids, pos_ids).output()
+    }
 }
-
-// #[cfg(test)]
-// mod tests {
-//     use luminal::prelude::*;
-
-//     use super::*;
-
-//     fn run_forward(seq_len: usize) {
-//         let mut cx = Graph::default();
-//         let input_ids = cx.named_tensor("input_ids", 's').as_dtype(DType::Int);
-//         let token_type_ids = cx.named_tensor("token_type_ids", 's').as_dtype(DType::Int);
-//         let pos_ids = cx.named_tensor("pos_ids", 's').as_dtype(DType::Int);
-//         let mask = cx.named_tensor("mask", ('s', 's'));
-
-//         let bert = BertForMaskedLM::init_f32(&mut cx);
-//         let logits = bert
-//             .forward(input_ids, token_type_ids, pos_ids, mask)
-//             .output();
-
-//         cx.set_dim('s', seq_len);
-//         let mut rt: ReferenceRuntime = cx.compile(
-//             ReferenceRuntime::default(),
-//             CompileOptions::default().search_graph_limit(1),
-//         );
-
-//         // Set input data
-//         rt.set_data(input_ids, vec![0i32; seq_len]);
-//         rt.set_data(token_type_ids, vec![0i32; seq_len]);
-//         rt.set_data(pos_ids, (0..seq_len as i32).collect::<Vec<_>>());
-//         rt.set_data(mask, vec![0f32; seq_len * seq_len]);
-
-//         // Set zero data for all weight tensors
-//         for t in bert.parameter_tensors() {
-//             let n: usize = t.shape.dims.iter().map(|e| e.to_usize().unwrap()).product();
-//             match t.dtype {
-//                 DType::F32 => rt.set_data(t, vec![0f32; n]),
-//                 DType::Bf16 => rt.set_data(t, vec![half::bf16::ZERO; n]),
-//                 _ => {}
-//             }
-//         }
-
-//         rt.execute(&cx.dyn_map);
-//         let out = rt.get_f32(logits);
-//         assert_eq!(out.len(), seq_len * VOCAB_SIZE);
-//     }
-
-//     // #[test]
-//     // fn forward_seq_1() {
-//     //     run_forward(1);
-//     // }
-
-//     #[test]
-//     fn forward_seq_4() {
-//         run_forward(4);
-//     }
-
-//     // #[test]
-//     // fn forward_seq_8() {
-//     //     run_forward(8);
-//     // }
-// }

--- a/examples/bert/src/model.rs
+++ b/examples/bert/src/model.rs
@@ -210,6 +210,7 @@ pub struct BertSelfAttention {
     o_weight: GraphTensor,
     o_bias: GraphTensor,
     head_dim: usize,
+    n_heads: usize,
 }
 
 impl BertSelfAttention {
@@ -225,6 +226,7 @@ impl BertSelfAttention {
             o_weight: layer_linear_weight(cx, layer, "attention.output.dense", (hidden, hidden), precision),
             o_bias: layer_linear_bias(cx, layer, "attention.output.dense", hidden),
             head_dim: config.hidden / config.n_heads,
+            n_heads: config.n_heads,
         }
     }
 
@@ -240,7 +242,7 @@ impl BertSelfAttention {
         let v = v.split_dims(1, self.head_dim).transpose(0, 1);
 
         let scores = q.matmul(k.permute((0, 2, 1))) * scale;
-        let masked = scores + mask;
+        let masked = scores + mask.expand_dim(0, self.n_heads);
         let weights = masked.softmax(2);
 
         let out = weights.matmul(v).transpose(0, 1).merge_dims(1, 2);


### PR DESCRIPTION
google-bert/bert-base-uncased (https://huggingface.co/google-bert/bert-base-uncased/tree/main) support. works both f32 and bf16 weight modes