### PR TITLE
Changing symbolic dimensions from bare chars to a structure backed by a String

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,10 @@
+# `Symbol` is a `GenerationalBox` handle, so clippy sees the arena's interior
+# mutability and flags every `DynMap` as a mutable key type. The name behind the
+# handle is written once when it is interned and never mutated, so a `Symbol`'s
+# hash and ordering are stable for as long as it is a key.
+#
+# Whitelisted here rather than allowed per-crate so the lint keeps working for
+# keys that really can mutate. Must be the definition path, not the
+# `shape::Symbol` re-export. `bytes::Bytes` is clippy's default and is repeated
+# because naming a type here replaces the default list rather than adding to it.
+ignore-interior-mutability = ["bytes::Bytes", "luminal::shape::symbol::Symbol"]

--- a/crates/luminal_bench/benches/patterns.rs
+++ b/crates/luminal_bench/benches/patterns.rs
@@ -35,7 +35,7 @@ use rand::Rng;
 #[cfg(feature = "metal")]
 struct PreparedBench {
     rt: MetalRuntime,
-    dyn_map: luminal::prelude::FxHashMap<char, usize>,
+    dyn_map: luminal::prelude::DynMap,
     metrics: Option<BenchMetrics>,
 }
 

--- a/crates/luminal_cuda_lite/src/dyn_backend.rs
+++ b/crates/luminal_cuda_lite/src/dyn_backend.rs
@@ -47,7 +47,7 @@ impl DynBackend for CudaLiteDynBackend {
     fn get_output_bool(&self, node: NodeIndex) -> Vec<bool> {
         self.runtime.get_bool(node)
     }
-    fn execute(&mut self, dyn_map: &FxHashMap<char, usize>) {
+    fn execute(&mut self, dyn_map: &DynMap) {
         self.runtime.execute(dyn_map);
     }
 

--- a/crates/luminal_cuda_lite/src/host/cublaslt/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/cublaslt/mod.rs
@@ -1441,10 +1441,7 @@ impl CuBlasLt {
     /// CUDA-graph preparation, and ordinary host execution. Keeping dimension,
     /// layout, dtype, and scalar resolution here prevents those paths from
     /// silently preparing different descriptors for the same extracted op.
-    fn resolve_matmul_spec(
-        &self,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> anyhow::Result<LtMatmulSpec> {
+    fn resolve_matmul_spec(&self, dyn_map: &DynMap) -> anyhow::Result<LtMatmulSpec> {
         let resolve = |expression: &Expression, name: &str| -> anyhow::Result<usize> {
             expression
                 .substitute('z', Expression::from(1))
@@ -1560,7 +1557,7 @@ impl CuBlasLt {
         self.n_inputs()
     }
 
-    pub(crate) fn graph_spec_dyn_vars(&self) -> FxHashSet<char> {
+    pub(crate) fn graph_spec_dyn_vars(&self) -> FxHashSet<Symbol> {
         [
             &self.m,
             &self.n,
@@ -1585,7 +1582,7 @@ impl CuBlasLt {
     /// allocation preflight before any arena exists.
     pub(crate) fn prepare_key_for_resources(
         &self,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<CuBlasLtPrepareKey> {
         Ok(CuBlasLtPrepareKey {
             spec: self.resolve_matmul_spec(dyn_map)?,
@@ -1597,7 +1594,7 @@ impl CuBlasLt {
         self_node: NodeIndex,
         inputs: &[NodeIndex],
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<CuBlasLtResolvedGraphCall> {
         let spec = self.resolve_matmul_spec(dyn_map)?;
         let ptrs = resolve_cublaslt_pointers(
@@ -1704,7 +1701,7 @@ impl HostOp for CuBlasLt {
         self_node: NodeIndex,
         inputs: &[NodeIndex],
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         let spec = self.resolve_matmul_spec(dyn_map)?;
         let ptrs = resolve_cublaslt_pointers(
@@ -1760,7 +1757,7 @@ impl HostOp for CuBlasLt {
         _self_node: NodeIndex,
         _inputs: &[NodeIndex],
         _buffer_lengths: &FxHashMap<NodeIndex, usize>,
-        _dyn_map: &FxHashMap<char, usize>,
+        _dyn_map: &DynMap,
     ) -> Result<HostDeviceMemoryPlan, ResourceViolation> {
         let scale_bytes = [self.a_dtype, self.b_dtype, self.c_dtype, self.d_dtype]
             .into_iter()
@@ -1792,7 +1789,7 @@ mod tests {
             ldd: Expression::from(1),
             ..Default::default()
         };
-        let dyn_map = FxHashMap::from_iter([('m', 3)]);
+        let dyn_map = FxHashMap::from_iter([(Symbol::from('m'), 3)]);
 
         let spec = op.resolve_matmul_spec(&dyn_map).unwrap();
         let prepare_key = op.prepare_key_for_resources(&dyn_map).unwrap();

--- a/crates/luminal_cuda_lite/src/host/flashinfer/flashinfer_attention.egg
+++ b/crates/luminal_cuda_lite/src/host/flashinfer/flashinfer_attention.egg
@@ -17,7 +17,6 @@
 ; gather_idx input from the lowered flat gather index.
 ;
 ; Shape dimensions are egglog variables, not pinned constants.
-; Dynamic dims "s" (batch/seq) and "c" (context) stay pinned as MVar.
 
 (relation flashinfer_cache_pair (IR IR))
 
@@ -107,7 +106,7 @@
         ; softmax internals connect the mask chain to the second matmul —
         ; without this the two halves join as a cross-product across the
         ; distinct layer instances of rolled multi-layer bodies.
-        (= ?smax (Op (Max ?smax_shape (MVar "c") ?smax_in ?smax_iter ?smax_out)
+        (= ?smax (Op (Max ?smax_shape ?context_tokens ?smax_in ?smax_iter ?smax_out)
             (ICons ?masked (INil))))
         (= ?negmax (Op (Mul ?nm_shape ?nm_a ?nm_b ?nm_o)
             (ICons ?smax (ICons ?nm_negone (INil)))))
@@ -117,14 +116,14 @@
             (ICons ?shifted (ICons ?sc_log2e (INil)))))
         (const_like ?sc_log2e 1.442695)
         (= ?sexp (Op (Exp2 ?se_shape ?se_in ?se_out) (ICons ?sc (INil))))
-        (= ?sexpsum (Op (Sum ?ss_shape (MVar "c") ?ss_in ?ss_iter ?ss_out)
+        (= ?sexpsum (Op (Sum ?ss_shape ?context_tokens ?ss_in ?ss_iter ?ss_out)
             (ICons ?sexp (INil))))
         (= ?srecip (Op (Recip ?sr_shape ?sr_in ?sr_out) (ICons ?sexpsum (INil))))
         (= ?soft (Op (Mul ?sf_shape ?sf_a ?sf_b ?sf_o)
             (ICons ?sexp (ICons ?srecip (INil)))))
 
         (= ?mul2 (Op (Mul
-            (ECons ?nheads (ECons (MVar "s") (ECons ?hdim (ECons (MVar "c") (ENil)))))
+            (ECons ?nheads (ECons ?input_tokens (ECons ?hdim (ECons ?context_tokens (ENil)))))
             ?mul2_a_strides
             ?mul2_b_strides
             ?mul2_out_strides)
@@ -133,8 +132,8 @@
         ; ── Second matmul: Sum (reduction over c) → output ──
         ; Shape: (nheads, s, hdim) — reduces c
         (= ?output (Op (Sum
-            (ECons ?nheads2 (ECons (MVar "s") (ECons ?hdim2 (ENil))))
-            (MVar "c")
+            (ECons ?nheads2 (ECons ?input_tokens (ECons ?hdim2 (ENil))))
+            ?context_tokens
             ?out_in_strides
             (MIter)
             ?out_out_strides)
@@ -144,7 +143,7 @@
         ; Shape: (nheads, c, hdim) — 3D
         (const_like ?v_gqa_const 1.000000)
         (= ?v_gqa (Op (Mul
-            (ECons ?nheads3 (ECons (MVar "c") (ECons ?hdim3 (ENil))))
+            (ECons ?nheads3 (ECons ?context_tokens (ECons ?hdim3 (ENil))))
             ?v_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?v_gqa_out_strides)
@@ -153,7 +152,7 @@
         ; ── V Gather: rows from V_cache (2D) ──
         ; Shape: (c, kvdim), Source: (num_slots, kvdim)
         (= ?v_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim (ENil)))
             ?v_gather_strides
             (ECons ?num_slots_v (ECons ?kvdim2 (ENil)))
             ?v_src_strides)
@@ -162,7 +161,7 @@
         ; ── First matmul: Mul(Q, K_gqa) ──
         ; Shape: (nheads, s, c, hdim) — 4D
         (= ?mul1 (Op (Mul
-            (ECons ?nheads4 (ECons (MVar "s") (ECons (MVar "c") (ECons ?hdim4 (ENil)))))
+            (ECons ?nheads4 (ECons ?input_tokens (ECons ?context_tokens (ECons ?hdim4 (ENil)))))
             ?mul1_a_strides
             ?mul1_b_strides
             ?mul1_out_strides)
@@ -171,7 +170,7 @@
         ; ── First matmul: Sum (reduction over hdim) → QK scores ──
         ; Shape: (nheads, s, c) — reduces hdim
         (= ?qk (Op (Sum
-            (ECons ?nheads5 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads5 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?hdim5
             ?qk_in_strides
             (MIter)
@@ -182,7 +181,7 @@
         ; Shape: (nheads, s, c) — 3D
         ; Mask is broadcast from (s, c) via zero-stride in first dim (nheads).
         (= ?masked (Op (Add
-            (ECons ?nheads8 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads8 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?mask_add_a_strides
             (ECons (MNum 0) ?mask_rest_strides)
             ?mask_add_out_strides)
@@ -208,7 +207,7 @@
         ; Shape: (nheads, hdim, c) — 3D
         (const_like ?k_gqa_const 1.000000)
         (= ?k_gqa (Op (Mul
-            (ECons ?nheads6 (ECons ?hdim6 (ECons (MVar "c") (ENil))))
+            (ECons ?nheads6 (ECons ?hdim6 (ECons ?context_tokens (ENil))))
             ?k_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?k_gqa_out_strides)
@@ -217,7 +216,7 @@
         ; ── K Gather: rows from K_cache (2D) ──
         ; Shape: (c, kvdim), Source: (num_slots, kvdim)
         (= ?k_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim3 (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim3 (ENil)))
             ?k_gather_strides
             (ECons ?num_slots_k (ECons ?kvdim4 (ENil)))
             ?k_src_strides)
@@ -232,7 +231,7 @@
     )
     (
         (let ?fi (Op (FlashInferAttention
-            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) (MVar "s") ?dt ?sq_scale_val -1.0)
+            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) ?input_tokens ?context_tokens ?dt ?sq_scale_val -1.0)
             (ICons ?q (ICons ?k_cache (ICons ?v_cache (ICons ?k_idx (ICons ?mask (INil))))))))
         (union ?output ?fi)
         (set (dtype ?fi) ?dt)
@@ -250,15 +249,15 @@
         ; This spelling currently lowers to the fp32 batch-decode runtime path,
         ; not prefill. It is only valid when the active dynamic-dim bucket proves
         ; s == 1.
-        (= ?s_lower (lower (MVar "s")))
-        (= ?s_upper (upper (MVar "s")))
+        (= ?s_lower (lower ?input_tokens))
+        (= ?s_upper (upper ?input_tokens))
         (> ?s_lower 0)
         (< ?s_upper 2)
 
         ; softmax internals connect the mask chain to the second matmul —
         ; without this the two halves join as a cross-product across the
         ; distinct layer instances of rolled multi-layer bodies.
-        (= ?smax (Op (Max ?smax_shape (MVar "c") ?smax_in ?smax_iter ?smax_out)
+        (= ?smax (Op (Max ?smax_shape ?context_tokens ?smax_in ?smax_iter ?smax_out)
             (ICons ?masked (INil))))
         (= ?negmax (Op (Mul ?nm_shape ?nm_a ?nm_b ?nm_o)
             (ICons ?smax (ICons ?nm_negone (INil)))))
@@ -268,22 +267,22 @@
             (ICons ?shifted (ICons ?sc_log2e (INil)))))
         (const_like ?sc_log2e 1.442695)
         (= ?sexp (Op (Exp2 ?se_shape ?se_in ?se_out) (ICons ?sc (INil))))
-        (= ?sexpsum (Op (Sum ?ss_shape (MVar "c") ?ss_in ?ss_iter ?ss_out)
+        (= ?sexpsum (Op (Sum ?ss_shape ?context_tokens ?ss_in ?ss_iter ?ss_out)
             (ICons ?sexp (INil))))
         (= ?srecip (Op (Recip ?sr_shape ?sr_in ?sr_out) (ICons ?sexpsum (INil))))
         (= ?soft (Op (Mul ?sf_shape ?sf_a ?sf_b ?sf_o)
             (ICons ?sexp (ICons ?srecip (INil)))))
 
         (= ?mul2 (Op (Mul
-            (ECons ?nheads (ECons (MVar "s") (ECons ?hdim (ECons (MVar "c") (ENil)))))
+            (ECons ?nheads (ECons ?input_tokens (ECons ?hdim (ECons ?context_tokens (ENil)))))
             ?mul2_a_strides
             ?mul2_b_strides
             ?mul2_out_strides)
             (ICons ?soft (ICons ?v_gqa (INil)))))
 
         (= ?output (Op (Sum
-            (ECons ?nheads2 (ECons (MVar "s") (ECons ?hdim2 (ENil))))
-            (MVar "c")
+            (ECons ?nheads2 (ECons ?input_tokens (ECons ?hdim2 (ENil))))
+            ?context_tokens
             ?out_in_strides
             (MIter)
             ?out_out_strides)
@@ -291,28 +290,28 @@
 
         (const_like ?v_gqa_const 1.000000)
         (= ?v_gqa (Op (Mul
-            (ECons ?nheads3 (ECons (MVar "c") (ECons ?hdim3 (ENil))))
+            (ECons ?nheads3 (ECons ?context_tokens (ECons ?hdim3 (ENil))))
             ?v_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?v_gqa_out_strides)
             (ICons ?v_gathered (ICons ?v_gqa_const (INil)))))
 
         (= ?v_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim (ENil)))
             ?v_gather_strides
             (ECons ?num_slots_v (ECons ?kvdim2 (ENil)))
             ?v_src_strides)
             (ICons ?k_idx (ICons ?v_cache (INil)))))
 
         (= ?mul1 (Op (Mul
-            (ECons ?nheads4 (ECons (MVar "s") (ECons (MVar "c") (ECons ?hdim4 (ENil)))))
+            (ECons ?nheads4 (ECons ?input_tokens (ECons ?context_tokens (ECons ?hdim4 (ENil)))))
             ?mul1_a_strides
             ?mul1_b_strides
             ?mul1_out_strides)
             (ICons ?q (ICons ?k_gqa (INil)))))
 
         (= ?qk (Op (Sum
-            (ECons ?nheads5 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads5 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?hdim5
             ?qk_in_strides
             (MIter)
@@ -320,7 +319,7 @@
             (ICons ?mul1 (INil))))
 
         (= ?masked (Op (Add
-            (ECons ?nheads8 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads8 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?mask_add_a_strides
             (ECons (MNum 0) ?mask_rest_strides)
             ?mask_add_out_strides)
@@ -342,14 +341,14 @@
 
         (const_like ?k_gqa_const 1.000000)
         (= ?k_gqa (Op (Mul
-            (ECons ?nheads6 (ECons ?hdim6 (ECons (MVar "c") (ENil))))
+            (ECons ?nheads6 (ECons ?hdim6 (ECons ?context_tokens (ENil))))
             ?k_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?k_gqa_out_strides)
             (ICons ?k_gathered (ICons ?k_gqa_const (INil)))))
 
         (= ?k_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim3 (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim3 (ENil)))
             ?k_gather_strides
             (ECons ?num_slots_k (ECons ?kvdim4 (ENil)))
             ?k_src_strides)
@@ -363,7 +362,7 @@
     )
     (
         (let ?fi (Op (FlashInferAttention
-            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) (MVar "s") ?dt ?sq_scale_val -1.0)
+            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) ?input_tokens ?context_tokens ?dt ?sq_scale_val -1.0)
             (ICons ?q (ICons ?k_cache (ICons ?v_cache (ICons ?k_idx (ICons ?mask (INil))))))))
         (union ?output ?fi)
         (set (dtype ?fi) ?dt)
@@ -383,15 +382,15 @@
         ;
         ; Like the direct causal spelling, this is decode-only until the fp32
         ; prefill runtime exists. The active bucket must prove s == 1.
-        (= ?s_lower (lower (MVar "s")))
-        (= ?s_upper (upper (MVar "s")))
+        (= ?s_lower (lower ?input_tokens))
+        (= ?s_upper (upper ?input_tokens))
         (> ?s_lower 0)
         (< ?s_upper 2)
 
         ; softmax internals connect the mask chain to the second matmul —
         ; without this the two halves join as a cross-product across the
         ; distinct layer instances of rolled multi-layer bodies.
-        (= ?smax (Op (Max ?smax_shape (MVar "c") ?smax_in ?smax_iter ?smax_out)
+        (= ?smax (Op (Max ?smax_shape ?context_tokens ?smax_in ?smax_iter ?smax_out)
             (ICons ?masked (INil))))
         (= ?negmax (Op (Mul ?nm_shape ?nm_a ?nm_b ?nm_o)
             (ICons ?smax (ICons ?nm_negone (INil)))))
@@ -401,22 +400,22 @@
             (ICons ?shifted (ICons ?sc_log2e (INil)))))
         (const_like ?sc_log2e 1.442695)
         (= ?sexp (Op (Exp2 ?se_shape ?se_in ?se_out) (ICons ?sc (INil))))
-        (= ?sexpsum (Op (Sum ?ss_shape (MVar "c") ?ss_in ?ss_iter ?ss_out)
+        (= ?sexpsum (Op (Sum ?ss_shape ?context_tokens ?ss_in ?ss_iter ?ss_out)
             (ICons ?sexp (INil))))
         (= ?srecip (Op (Recip ?sr_shape ?sr_in ?sr_out) (ICons ?sexpsum (INil))))
         (= ?soft (Op (Mul ?sf_shape ?sf_a ?sf_b ?sf_o)
             (ICons ?sexp (ICons ?srecip (INil)))))
 
         (= ?mul2 (Op (Mul
-            (ECons ?nheads (ECons (MVar "s") (ECons ?hdim (ECons (MVar "c") (ENil)))))
+            (ECons ?nheads (ECons ?input_tokens (ECons ?hdim (ECons ?context_tokens (ENil)))))
             ?mul2_a_strides
             ?mul2_b_strides
             ?mul2_out_strides)
             (ICons ?soft (ICons ?v_gqa (INil)))))
 
         (= ?output (Op (Sum
-            (ECons ?nheads2 (ECons (MVar "s") (ECons ?hdim2 (ENil))))
-            (MVar "c")
+            (ECons ?nheads2 (ECons ?input_tokens (ECons ?hdim2 (ENil))))
+            ?context_tokens
             ?out_in_strides
             (MIter)
             ?out_out_strides)
@@ -424,28 +423,28 @@
 
         (const_like ?v_gqa_const 1.000000)
         (= ?v_gqa (Op (Mul
-            (ECons ?nheads3 (ECons (MVar "c") (ECons ?hdim3 (ENil))))
+            (ECons ?nheads3 (ECons ?context_tokens (ECons ?hdim3 (ENil))))
             ?v_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?v_gqa_out_strides)
             (ICons ?v_gathered (ICons ?v_gqa_const (INil)))))
 
         (= ?v_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim (ENil)))
             ?v_gather_strides
             (ECons ?num_slots_v (ECons ?kvdim2 (ENil)))
             ?v_src_strides)
             (ICons ?k_idx (ICons ?v_cache (INil)))))
 
         (= ?mul1 (Op (Mul
-            (ECons ?nheads4 (ECons (MVar "s") (ECons (MVar "c") (ECons ?hdim4 (ENil)))))
+            (ECons ?nheads4 (ECons ?input_tokens (ECons ?context_tokens (ECons ?hdim4 (ENil)))))
             ?mul1_a_strides
             ?mul1_b_strides
             ?mul1_out_strides)
             (ICons ?q (ICons ?k_gqa (INil)))))
 
         (= ?qk (Op (Sum
-            (ECons ?nheads5 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads5 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?hdim5
             ?qk_in_strides
             (MIter)
@@ -453,7 +452,7 @@
             (ICons ?mul1 (INil))))
 
         (= ?masked (Op (Add
-            (ECons ?nheads8 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads8 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?mask_add_a_strides
             (ECons (MNum 0) ?mask_rest_strides)
             ?mask_add_out_strides)
@@ -479,14 +478,14 @@
 
         (const_like ?k_gqa_const 1.000000)
         (= ?k_gqa (Op (Mul
-            (ECons ?nheads6 (ECons ?hdim6 (ECons (MVar "c") (ENil))))
+            (ECons ?nheads6 (ECons ?hdim6 (ECons ?context_tokens (ENil))))
             ?k_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?k_gqa_out_strides)
             (ICons ?k_gathered (ICons ?k_gqa_const (INil)))))
 
         (= ?k_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim3 (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim3 (ENil)))
             ?k_gather_strides
             (ECons ?num_slots_k (ECons ?kvdim4 (ENil)))
             ?k_src_strides)
@@ -500,7 +499,7 @@
     )
     (
         (let ?fi (Op (FlashInferAttention
-            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) (MVar "s") ?dt ?sq_scale_val -1.0)
+            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) ?input_tokens ?context_tokens ?dt ?sq_scale_val -1.0)
             (ICons ?q (ICons ?k_cache (ICons ?v_cache (ICons ?k_idx (ICons ?mask (INil))))))))
         (union ?output ?fi)
         (set (dtype ?fi) ?dt)
@@ -526,7 +525,7 @@
         ; softmax internals connect the mask chain to the second matmul —
         ; without this the two halves join as a cross-product across the
         ; distinct layer instances of rolled multi-layer bodies.
-        (= ?smax (Op (Max ?smax_shape (MVar "c") ?smax_in ?smax_iter ?smax_out)
+        (= ?smax (Op (Max ?smax_shape ?context_tokens ?smax_in ?smax_iter ?smax_out)
             (ICons ?masked (INil))))
         (= ?negmax (Op (Mul ?nm_shape ?nm_a ?nm_b ?nm_o)
             (ICons ?smax (ICons ?nm_negone (INil)))))
@@ -536,22 +535,22 @@
             (ICons ?shifted (ICons ?sc_log2e (INil)))))
         (const_like ?sc_log2e 1.442695)
         (= ?sexp (Op (Exp2 ?se_shape ?se_in ?se_out) (ICons ?sc (INil))))
-        (= ?sexpsum (Op (Sum ?ss_shape (MVar "c") ?ss_in ?ss_iter ?ss_out)
+        (= ?sexpsum (Op (Sum ?ss_shape ?context_tokens ?ss_in ?ss_iter ?ss_out)
             (ICons ?sexp (INil))))
         (= ?srecip (Op (Recip ?sr_shape ?sr_in ?sr_out) (ICons ?sexpsum (INil))))
         (= ?soft (Op (Mul ?sf_shape ?sf_a ?sf_b ?sf_o)
             (ICons ?sexp (ICons ?srecip (INil)))))
 
         (= ?mul2 (Op (Mul
-            (ECons ?nheads (ECons (MVar "s") (ECons ?hdim (ECons (MVar "c") (ENil)))))
+            (ECons ?nheads (ECons ?input_tokens (ECons ?hdim (ECons ?context_tokens (ENil)))))
             ?mul2_a_strides
             ?mul2_b_strides
             ?mul2_out_strides)
             (ICons ?soft (ICons ?v_gqa (INil)))))
 
         (= ?output (Op (Sum
-            (ECons ?nheads2 (ECons (MVar "s") (ECons ?hdim2 (ENil))))
-            (MVar "c")
+            (ECons ?nheads2 (ECons ?input_tokens (ECons ?hdim2 (ENil))))
+            ?context_tokens
             ?out_in_strides
             (MIter)
             ?out_out_strides)
@@ -559,28 +558,28 @@
 
         (const_like ?v_gqa_const 1.000000)
         (= ?v_gqa (Op (Mul
-            (ECons ?nheads3 (ECons (MVar "c") (ECons ?hdim3 (ENil))))
+            (ECons ?nheads3 (ECons ?context_tokens (ECons ?hdim3 (ENil))))
             ?v_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?v_gqa_out_strides)
             (ICons ?v_gathered (ICons ?v_gqa_const (INil)))))
 
         (= ?v_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim (ENil)))
             ?v_gather_strides
             (ECons ?num_slots_v (ECons ?kvdim2 (ENil)))
             ?v_src_strides)
             (ICons ?k_idx (ICons ?v_cache (INil)))))
 
         (= ?mul1 (Op (Mul
-            (ECons ?nheads4 (ECons (MVar "s") (ECons (MVar "c") (ECons ?hdim4 (ENil)))))
+            (ECons ?nheads4 (ECons ?input_tokens (ECons ?context_tokens (ECons ?hdim4 (ENil)))))
             ?mul1_a_strides
             ?mul1_b_strides
             ?mul1_out_strides)
             (ICons ?q (ICons ?k_gqa (INil)))))
 
         (= ?qk (Op (Sum
-            (ECons ?nheads5 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads5 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?hdim5
             ?qk_in_strides
             (MIter)
@@ -588,7 +587,7 @@
             (ICons ?mul1 (INil))))
 
         (= ?masked (Op (Add
-            (ECons ?nheads8 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads8 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?mask_add_a_strides
             (ECons (MNum 0) ?mask_rest_strides)
             ?mask_add_out_strides)
@@ -614,14 +613,14 @@
 
         (const_like ?k_gqa_const 1.000000)
         (= ?k_gqa (Op (Mul
-            (ECons ?nheads6 (ECons ?hdim6 (ECons (MVar "c") (ENil))))
+            (ECons ?nheads6 (ECons ?hdim6 (ECons ?context_tokens (ENil))))
             ?k_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?k_gqa_out_strides)
             (ICons ?k_gathered (ICons ?k_gqa_const (INil)))))
 
         (= ?k_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim3 (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim3 (ENil)))
             ?k_gather_strides
             (ECons ?num_slots_k (ECons ?kvdim4 (ENil)))
             ?k_src_strides)
@@ -635,7 +634,7 @@
     )
     (
         (let ?fi (Op (FlashInferAttention
-            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) (MVar "s") ?dt ?sq_scale_val -1.0)
+            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) ?input_tokens ?context_tokens ?dt ?sq_scale_val -1.0)
             (ICons ?q (ICons ?k_cache (ICons ?v_cache (ICons ?k_idx (ICons ?mask (INil))))))))
         (union ?output ?fi)
         (set (dtype ?fi) ?dt)
@@ -656,28 +655,28 @@
 (rule
     (
         (= ?cmask (Op (Gather
-            (ECons (MVar "s") (ECons (MVar "c") (ENil)))
+            (ECons ?input_tokens (ECons ?context_tokens (ENil)))
             ?mask_idx_strides
-            (ECons (MVar "c") (ECons (MVar "c") (ENil)))
+            (ECons ?context_tokens (ECons ?context_tokens (ENil)))
             ?mask_src_strides)
             (ICons ?mask_indices (ICons ?scaled_blocked (INil)))))
         (= ?mask_indices (Op (Add
-            (ECons (MVar "s") (ECons (MVar "c") (ENil)))
+            (ECons ?input_tokens (ECons ?context_tokens (ENil)))
             ?row_idx_strides
             ?col_idx_strides
             ?mask_idx_out_strides)
             (ICons ?row_offsets (ICons ?col_offsets (INil)))))
-        (= ?col_offsets (Op (Iota (MIter) (MVar "c")) (INil)))
+        (= ?col_offsets (Op (Iota (MIter) ?context_tokens) (INil)))
         (= ?row_offsets (Op (Mul
-            (ECons (MVar "s") (ENil))
+            (ECons ?input_tokens (ENil))
             ?q_pos_strides
             ?ctx_scalar_strides
             ?row_offsets_out_strides)
             (ICons ?q_pos (ICons ?ctx_scalar (INil)))))
-        (= ?ctx_scalar (Op (Iota (MVar "c") (MNum 1)) (INil)))
+        (= ?ctx_scalar (Op (Iota ?context_tokens (MNum 1)) (INil)))
 
         (= ?scaled_blocked (Op (Mul
-            (ECons (MVar "c") (ECons (MVar "c") (ENil)))
+            (ECons ?context_tokens (ECons ?context_tokens (ENil)))
             ?blocked_strides
             ?neg_scale_strides
             ?scaled_blocked_strides)
@@ -688,19 +687,19 @@
         (= ?blocked_f32 (Op (Cast ?blocked_cast_size ?blocked_cast_dt)
             (ICons ?blocked_bool (INil))))
         (= ?blocked_bool (Op (LessThan
-            (ECons (MVar "c") (ECons (MVar "c") (ENil)))
+            (ECons ?context_tokens (ECons ?context_tokens (ENil)))
             ?tri_row_strides
             ?tri_col_strides
             ?blocked_out_strides)
             (ICons ?tri_iota_f32 (ICons ?tri_iota_minus_zero (INil)))))
         (= ?tri_iota_minus_zero (Op (Add
-            (ECons (MVar "c") (ECons (MVar "c") (ENil)))
+            (ECons ?context_tokens (ECons ?context_tokens (ENil)))
             ?tri_minus_zero_a_strides
             ?tri_minus_zero_b_strides
             ?tri_minus_zero_out_strides)
             (ICons ?tri_iota_f32 (ICons ?zero_offset (INil)))))
         (= ?zero_offset (Op (Mul
-            (ECons (MVar "c") (ECons (MVar "c") (ENil)))
+            (ECons ?context_tokens (ECons ?context_tokens (ENil)))
             ?zero_offset_a_strides
             ?zero_offset_b_strides
             ?zero_offset_out_strides)
@@ -709,7 +708,7 @@
         (= ?neg_one_const (Op (Constant -1.000000) (INil)))
         (= ?tri_iota_f32 (Op (Cast ?tri_iota_cast_size (F32))
             (ICons ?tri_iota (INil))))
-        (= ?tri_iota (Op (Iota (MIter) (MVar "c")) (INil)))
+        (= ?tri_iota (Op (Iota (MIter) ?context_tokens) (INil)))
     )
     (
         (fi_triu_mask ?cmask ?q_pos)
@@ -743,7 +742,7 @@
         ;   (q_pos[:, None] < arange(c)[None, :]).cast(F32) * -1e10
         ; The "direct causal attention" island rule anchors at this fact.
         (= ?mask (Op (Mul
-            (ECons (MVar "s") (ECons (MVar "c") (ENil)))
+            (ECons ?input_tokens (ECons ?context_tokens (ENil)))
             ?blocked_strides
             ?neg_scale_strides
             ?mask_out_strides)
@@ -754,12 +753,12 @@
         (= ?blocked_f32 (Op (Cast ?blocked_cast_size ?blocked_cast_dt)
             (ICons ?blocked_bool (INil))))
         (= ?blocked_bool (Op (LessThan
-            (ECons (MVar "s") (ECons (MVar "c") (ENil)))
+            (ECons ?input_tokens (ECons ?context_tokens (ENil)))
             ?q_pos_cmp_strides
             ?col_cmp_strides
             ?blocked_out_strides)
             (ICons ?q_pos (ICons ?col_offsets (INil)))))
-        (= ?col_offsets (Op (Iota (MIter) (MVar "c")) (INil)))
+        (= ?col_offsets (Op (Iota (MIter) ?context_tokens) (INil)))
     )
     (
         (fi_direct_causal_mask ?mask ?q_pos)
@@ -773,7 +772,7 @@
         ; window term: (col < q_pos - (W-1)) cast * -1e10; the constant W-1
         ; is FlashInfer's window_left.
         (= ?wterm (Op (Mul
-            (ECons (MVar "s") (ECons (MVar "c") (ENil)))
+            (ECons ?input_tokens (ECons ?context_tokens (ENil)))
             ?wt_a_strides
             ?wt_b_strides
             ?wt_out_strides)
@@ -784,22 +783,22 @@
         (= ?w_bool_cast (Op (Cast ?w_cast_size ?w_cast_dt)
             (ICons ?w_lt (INil))))
         (= ?w_lt (Op (LessThan
-            (ECons (MVar "s") (ECons (MVar "c") (ENil)))
+            (ECons ?input_tokens (ECons ?context_tokens (ENil)))
             (ECons (MNum 0) (ECons (MIter) (ENil)))
             (ECons (MIter) (ECons (MNum 0) (ENil)))
             ?w_lt_out_strides)
             (ICons ?w_col_f (ICons ?w_lo (INil)))))
         (= ?w_col_f (Op (Cast ?w_col_cast_size (F32)) (ICons ?w_col_iota (INil))))
-        (= ?w_col_iota (Op (Iota (MIter) (MVar "c")) (INil)))
+        (= ?w_col_iota (Op (Iota (MIter) ?context_tokens) (INil)))
         (= ?w_lo (Op (Add
-            (ECons (MVar "s") (ENil))
+            (ECons ?input_tokens (ENil))
             ?w_lo_a_strides
             ?w_lo_b_strides
             ?w_lo_out_strides)
             (ICons ?w_qpos_f (ICons ?w_neg (INil)))))
         (= ?w_qpos_f (Op (Cast ?w_qpos_cast_size (F32)) (ICons ?w_qpos (INil))))
         (= ?w_neg (Op (Mul
-            (ECons (MVar "s") (ENil))
+            (ECons ?input_tokens (ENil))
             (ECons (MNum 0) (ENil))
             (ECons (MNum 0) (ENil))
             ?w_neg_out_strides)
@@ -819,8 +818,8 @@
         ; Gemma-4 full attention: scale-free, causal triu-gather mask.
         ; 16-bit only (covers head_dim 512); no s==1 guard — the tensor-core
         ; prefill runtime handles s>1.
-        (= ?s_lower (lower (MVar "s")))
-        (= ?s_upper (upper (MVar "s")))
+        (= ?s_lower (lower ?input_tokens))
+        (= ?s_upper (upper ?input_tokens))
         (> ?s_lower 0)
         (< ?s_upper 2)
 
@@ -828,12 +827,12 @@
         (fi_triu_mask ?mask ?q_pos)
         ; mask Add → softmax internals → second matmul: one connected chain.
         (= ?masked (Op (Add
-            (ECons ?nheads8 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads8 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?mask_add_a_strides
             (ECons (MNum 0) ?mask_rest_strides)
             ?mask_add_out_strides)
             (ICons ?qk (ICons ?mask (INil)))))
-        (= ?smax (Op (Max ?smax_shape (MVar "c") ?smax_in ?smax_iter ?smax_out)
+        (= ?smax (Op (Max ?smax_shape ?context_tokens ?smax_in ?smax_iter ?smax_out)
             (ICons ?masked (INil))))
         (= ?negmax (Op (Mul ?nm_shape ?nm_a ?nm_b ?nm_o)
             (ICons ?smax (ICons ?nm_negone (INil)))))
@@ -843,22 +842,22 @@
             (ICons ?shifted (ICons ?sc_log2e (INil)))))
         (const_like ?sc_log2e 1.442695)
         (= ?sexp (Op (Exp2 ?se_shape ?se_in ?se_out) (ICons ?sc (INil))))
-        (= ?sexpsum (Op (Sum ?ss_shape (MVar "c") ?ss_in ?ss_iter ?ss_out)
+        (= ?sexpsum (Op (Sum ?ss_shape ?context_tokens ?ss_in ?ss_iter ?ss_out)
             (ICons ?sexp (INil))))
         (= ?srecip (Op (Recip ?sr_shape ?sr_in ?sr_out) (ICons ?sexpsum (INil))))
         (= ?soft (Op (Mul ?sf_shape ?sf_a ?sf_b ?sf_o)
             (ICons ?sexp (ICons ?srecip (INil)))))
 
         (= ?mul2 (Op (Mul
-            (ECons ?nheads (ECons (MVar "s") (ECons ?hdim (ECons (MVar "c") (ENil)))))
+            (ECons ?nheads (ECons ?input_tokens (ECons ?hdim (ECons ?context_tokens (ENil)))))
             ?mul2_a_strides
             ?mul2_b_strides
             ?mul2_out_strides)
             (ICons ?soft (ICons ?v_gqa (INil)))))
 
         (= ?output (Op (Sum
-            (ECons ?nheads2 (ECons (MVar "s") (ECons ?hdim2 (ENil))))
-            (MVar "c")
+            (ECons ?nheads2 (ECons ?input_tokens (ECons ?hdim2 (ENil))))
+            ?context_tokens
             ?out_in_strides
             (MIter)
             ?out_out_strides)
@@ -866,14 +865,14 @@
 
         (const_like ?v_gqa_const 1.000000)
         (= ?v_gqa (Op (Mul
-            (ECons ?nheads3 (ECons (MVar "c") (ECons ?hdim3 (ENil))))
+            (ECons ?nheads3 (ECons ?context_tokens (ECons ?hdim3 (ENil))))
             ?v_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?v_gqa_out_strides)
             (ICons ?v_gathered (ICons ?v_gqa_const (INil)))))
 
         (= ?v_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim (ENil)))
             ?v_gather_strides
             (ECons ?num_slots_v (ECons ?kvdim2 (ENil)))
             ?v_src_strides)
@@ -881,28 +880,28 @@
 
         ; SCALE-FREE: ?qk (the raw QK Sum) feeds the mask Add directly.
         (= ?qk (Op (Sum
-            (ECons ?nheads5 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads5 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?hdim5
             ?qk_in_strides
             (MIter)
             ?qk_out_strides)
             (ICons ?mul1 (INil))))
         (= ?mul1 (Op (Mul
-            (ECons ?nheads4 (ECons (MVar "s") (ECons (MVar "c") (ECons ?hdim4 (ENil)))))
+            (ECons ?nheads4 (ECons ?input_tokens (ECons ?context_tokens (ECons ?hdim4 (ENil)))))
             ?mul1_a_strides
             ?mul1_b_strides
             ?mul1_out_strides)
             (ICons ?q (ICons ?k_gqa (INil)))))
         (const_like ?k_gqa_const 1.000000)
         (= ?k_gqa (Op (Mul
-            (ECons ?nheads6 (ECons ?hdim6 (ECons (MVar "c") (ENil))))
+            (ECons ?nheads6 (ECons ?hdim6 (ECons ?context_tokens (ENil))))
             ?k_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?k_gqa_out_strides)
             (ICons ?k_gathered (ICons ?k_gqa_const (INil)))))
 
         (= ?k_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim3 (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim3 (ENil)))
             ?k_gather_strides
             (ECons ?num_slots_k (ECons ?kvdim4 (ENil)))
             ?k_src_strides)
@@ -916,7 +915,7 @@
     )
     (
         (let ?fi (Op (FlashInferAttention
-            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) (MVar "s") ?dt 1.0 -1.0)
+            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) ?input_tokens ?context_tokens ?dt 1.0 -1.0)
             (ICons ?q (ICons ?k_cache (ICons ?v_cache (ICons ?k_idx (ICons ?mask (INil))))))))
         (union ?output ?fi)
         (set (dtype ?fi) ?dt)
@@ -929,14 +928,14 @@
     (
         ; Gemma-4 sliding-window attention: scale-free, causal triu-gather
         ; mask + window term; window_left carried onto the op.
-        (= ?s_lower (lower (MVar "s")))
-        (= ?s_upper (upper (MVar "s")))
+        (= ?s_lower (lower ?input_tokens))
+        (= ?s_upper (upper ?input_tokens))
         (> ?s_lower 0)
         (< ?s_upper 2)
 
         (flashinfer_prefill_dt ?dt)
         (= ?mask (Op (Add
-            (ECons (MVar "s") (ECons (MVar "c") (ENil)))
+            (ECons ?input_tokens (ECons ?context_tokens (ENil)))
             ?wm_a_strides
             ?wm_b_strides
             ?wm_out_strides)
@@ -946,12 +945,12 @@
         (= ?q_pos ?q_pos2)
         ; mask Add → softmax internals → second matmul: one connected chain.
         (= ?masked (Op (Add
-            (ECons ?nheads8 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads8 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?mask_add_a_strides
             (ECons (MNum 0) ?mask_rest_strides)
             ?mask_add_out_strides)
             (ICons ?qk (ICons ?mask (INil)))))
-        (= ?smax (Op (Max ?smax_shape (MVar "c") ?smax_in ?smax_iter ?smax_out)
+        (= ?smax (Op (Max ?smax_shape ?context_tokens ?smax_in ?smax_iter ?smax_out)
             (ICons ?masked (INil))))
         (= ?negmax (Op (Mul ?nm_shape ?nm_a ?nm_b ?nm_o)
             (ICons ?smax (ICons ?nm_negone (INil)))))
@@ -961,22 +960,22 @@
             (ICons ?shifted (ICons ?sc_log2e (INil)))))
         (const_like ?sc_log2e 1.442695)
         (= ?sexp (Op (Exp2 ?se_shape ?se_in ?se_out) (ICons ?sc (INil))))
-        (= ?sexpsum (Op (Sum ?ss_shape (MVar "c") ?ss_in ?ss_iter ?ss_out)
+        (= ?sexpsum (Op (Sum ?ss_shape ?context_tokens ?ss_in ?ss_iter ?ss_out)
             (ICons ?sexp (INil))))
         (= ?srecip (Op (Recip ?sr_shape ?sr_in ?sr_out) (ICons ?sexpsum (INil))))
         (= ?soft (Op (Mul ?sf_shape ?sf_a ?sf_b ?sf_o)
             (ICons ?sexp (ICons ?srecip (INil)))))
 
         (= ?mul2 (Op (Mul
-            (ECons ?nheads (ECons (MVar "s") (ECons ?hdim (ECons (MVar "c") (ENil)))))
+            (ECons ?nheads (ECons ?input_tokens (ECons ?hdim (ECons ?context_tokens (ENil)))))
             ?mul2_a_strides
             ?mul2_b_strides
             ?mul2_out_strides)
             (ICons ?soft (ICons ?v_gqa (INil)))))
 
         (= ?output (Op (Sum
-            (ECons ?nheads2 (ECons (MVar "s") (ECons ?hdim2 (ENil))))
-            (MVar "c")
+            (ECons ?nheads2 (ECons ?input_tokens (ECons ?hdim2 (ENil))))
+            ?context_tokens
             ?out_in_strides
             (MIter)
             ?out_out_strides)
@@ -984,14 +983,14 @@
 
         (const_like ?v_gqa_const 1.000000)
         (= ?v_gqa (Op (Mul
-            (ECons ?nheads3 (ECons (MVar "c") (ECons ?hdim3 (ENil))))
+            (ECons ?nheads3 (ECons ?context_tokens (ECons ?hdim3 (ENil))))
             ?v_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?v_gqa_out_strides)
             (ICons ?v_gathered (ICons ?v_gqa_const (INil)))))
 
         (= ?v_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim (ENil)))
             ?v_gather_strides
             (ECons ?num_slots_v (ECons ?kvdim2 (ENil)))
             ?v_src_strides)
@@ -999,28 +998,28 @@
 
         ; SCALE-FREE: ?qk (the raw QK Sum) feeds the mask Add directly.
         (= ?qk (Op (Sum
-            (ECons ?nheads5 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads5 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?hdim5
             ?qk_in_strides
             (MIter)
             ?qk_out_strides)
             (ICons ?mul1 (INil))))
         (= ?mul1 (Op (Mul
-            (ECons ?nheads4 (ECons (MVar "s") (ECons (MVar "c") (ECons ?hdim4 (ENil)))))
+            (ECons ?nheads4 (ECons ?input_tokens (ECons ?context_tokens (ECons ?hdim4 (ENil)))))
             ?mul1_a_strides
             ?mul1_b_strides
             ?mul1_out_strides)
             (ICons ?q (ICons ?k_gqa (INil)))))
         (const_like ?k_gqa_const 1.000000)
         (= ?k_gqa (Op (Mul
-            (ECons ?nheads6 (ECons ?hdim6 (ECons (MVar "c") (ENil))))
+            (ECons ?nheads6 (ECons ?hdim6 (ECons ?context_tokens (ENil))))
             ?k_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?k_gqa_out_strides)
             (ICons ?k_gathered (ICons ?k_gqa_const (INil)))))
 
         (= ?k_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim3 (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim3 (ENil)))
             ?k_gather_strides
             (ECons ?num_slots_k (ECons ?kvdim4 (ENil)))
             ?k_src_strides)
@@ -1034,7 +1033,7 @@
     )
     (
         (let ?fi (Op (FlashInferAttention
-            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) (MVar "s") ?dt 1.0 ?window_left)
+            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) ?input_tokens ?context_tokens ?dt 1.0 ?window_left)
             (ICons ?q (ICons ?k_cache (ICons ?v_cache (ICons ?k_idx (ICons ?mask (INil))))))))
         (union ?output ?fi)
         (set (dtype ?fi) ?dt)

--- a/crates/luminal_cuda_lite/src/host/flashinfer/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/flashinfer/mod.rs
@@ -44,6 +44,9 @@ pub struct FlashInferAttention {
     pub head_dim: usize,
     pub page_size: usize,
     pub batch_dim: Expression,
+    /// Total tokens attended over. Captured from the matched shape by the
+    /// rules, so it does not depend on what the graph calls this dim.
+    pub context_dim: Expression,
     pub dtype: DType,
     /// Softmax scale; 0.0 = default `1/sqrt(head_dim)`.
     pub sm_scale: f64,
@@ -197,6 +200,19 @@ fn prepared_device_bytes(
         })
 }
 
+/// Rows in a CSR index pointer, from the buffer's length.
+fn indptr_rows(
+    buffer_lengths: &FxHashMap<NodeIndex, usize>,
+    node: NodeIndex,
+) -> Result<usize, ResourceViolation> {
+    buffer_lengths
+        .get(&node)
+        .map(|bytes| bytes / std::mem::size_of::<i32>())
+        .ok_or(ResourceViolation::HostResourcePlanning {
+            name: "FlashInfer indptr length",
+        })
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct FlashInferResolvedDecode {
     spec: FlashInferDecodeSpec,
@@ -332,6 +348,7 @@ impl Default for FlashInferAttention {
             head_dim: 0,
             page_size: 0,
             batch_dim: Expression::default(),
+            context_dim: Expression::default(),
             dtype: DType::F32,
             sm_scale: 0.0,
             window_left: -1,
@@ -351,6 +368,7 @@ impl EgglogOp for FlashInferAttention {
                 ("head_dim", EXPRESSION),
                 ("page_size", EXPRESSION),
                 ("batch_dim", EXPRESSION),
+                ("context_dim", EXPRESSION),
                 ("dtype", DTYPE),
                 ("sm_scale", F64),
                 ("window_left", F64),
@@ -404,13 +422,14 @@ impl EgglogOp for FlashInferAttention {
             .exec(&FxHashMap::default())
             .unwrap();
         let batch_dim = extract_expr(egraph, kind_children[4], expr_cache).unwrap();
-        let dtype = extract_dtype(egraph, kind_children[5]);
-        let sm_scale: f64 = egraph.enodes[kind_children[6]]
+        let context_dim = extract_expr(egraph, kind_children[5], expr_cache).unwrap();
+        let dtype = extract_dtype(egraph, kind_children[6]);
+        let sm_scale: f64 = egraph.enodes[kind_children[7]]
             .0
             .replace('"', "")
             .parse()
             .unwrap();
-        let window_left = egraph.enodes[kind_children[7]]
+        let window_left = egraph.enodes[kind_children[8]]
             .0
             .replace('"', "")
             .parse::<f64>()
@@ -427,6 +446,7 @@ impl EgglogOp for FlashInferAttention {
             head_dim,
             page_size,
             batch_dim,
+            context_dim,
             dtype,
             sm_scale,
             window_left,
@@ -470,7 +490,7 @@ impl FlashInferAttention {
         &self,
         inputs: &[NodeIndex],
         buffer_lengths: &FxHashMap<NodeIndex, usize>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         enable_cuda_graph: bool,
     ) -> Result<FlashInferDeviceResourceSpec, ResourceViolation> {
         let total_q_tokens =
@@ -479,9 +499,9 @@ impl FlashInferAttention {
                 .ok_or(ResourceViolation::UnresolvedExpression {
                     resource: "FlashInfer total query tokens",
                 })?;
-        let c = dyn_map
-            .get(&'c')
-            .copied()
+        let c = self
+            .context_dim
+            .exec(dyn_map)
             .ok_or(ResourceViolation::UnresolvedExpression {
                 resource: "FlashInfer context length",
             })?;
@@ -523,13 +543,11 @@ impl FlashInferAttention {
             .unwrap_or(c);
         let explicit_indptr = inputs.len() == 6;
         let batch_size = if explicit_indptr {
-            dyn_map
-                .get(&'r')
-                .copied()
-                .ok_or(ResourceViolation::UnresolvedExpression {
-                    resource: "FlashInfer indptr rows",
-                })?
-                .saturating_sub(1)
+            // A CSR index pointer has one entry per sequence plus a terminator,
+            // so the row count is the buffer's own length. Asking dyn_map for it
+            // by name meant the caller had to declare a dim describing an input
+            // the op is already holding.
+            indptr_rows(buffer_lengths, inputs[5])?.saturating_sub(1)
         } else if total_q_tokens > 1 && dtype.supports_prefill() {
             1
         } else {
@@ -575,15 +593,16 @@ impl FlashInferAttention {
         self_node: NodeIndex,
         inputs: &[NodeIndex],
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<FlashInferResolvedDecode> {
         let total_q_tokens = self
             .batch_dim
             .exec(dyn_map)
             .ok_or_else(|| anyhow::anyhow!("FlashInferAttention batch_dim is unresolved"))?;
-        let c = *dyn_map
-            .get(&'c')
-            .ok_or_else(|| anyhow::anyhow!("FlashInferAttention requires dynamic dim 'c'"))?;
+        let c = self
+            .context_dim
+            .exec(dyn_map)
+            .ok_or_else(|| anyhow::anyhow!("FlashInferAttention context_dim is unresolved"))?;
         if inputs.len() != 4 && inputs.len() != 6 {
             anyhow::bail!(
                 "FlashInferAttention expects 4 inputs (derived causal decode) or 6 inputs (explicit indptrs), got {}",
@@ -619,11 +638,14 @@ impl FlashInferAttention {
             .unwrap_or(c);
         let (kv_indptr_host, batch_size, explicit_qo_indptr, explicit_kv_indptr) =
             if inputs.len() >= 6 {
-                let r = *dyn_map.get(&'r').ok_or_else(|| {
-                    anyhow::anyhow!("FlashInferAttention requires dynamic dim 'r'")
-                })?;
                 let qo_indptr_buf = get_buf("qo_indptr", inputs[4])?;
                 let kv_indptr_buf = get_buf("kv_indptr", inputs[5])?;
+                let r = kv_indptr_buf.len() / std::mem::size_of::<i32>();
+                anyhow::ensure!(
+                    r >= 2,
+                    "FlashInferAttention: kv_indptr holds {r} rows, need at least 2 \
+                 (one per sequence plus a terminator)"
+                );
                 // Host contents are read during prepare, where stream synchronization
                 // is allowed. The pointers are part of the capture signature.
                 (
@@ -1072,7 +1094,7 @@ impl HostOp for FlashInferAttention {
         self_node: NodeIndex,
         inputs: &[NodeIndex],
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         let resolved = self.resolve_for_graph(self_node, inputs, buffers, dyn_map)?;
         let ptrs = resolved.ptrs;
@@ -1104,7 +1126,7 @@ impl HostOp for FlashInferAttention {
         _self_node: NodeIndex,
         inputs: &[NodeIndex],
         buffer_lengths: &FxHashMap<NodeIndex, usize>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> Result<HostDeviceMemoryPlan, ResourceViolation> {
         let resource_spec = self.device_resource_spec(inputs, buffer_lengths, dyn_map, false)?;
         Ok(HostDeviceMemoryPlan {
@@ -1184,6 +1206,7 @@ mod resource_tests {
             head_dim: 64,
             page_size: 1,
             batch_dim: 1.into(),
+            context_dim: Expression::from('c'),
             dtype: DType::F16,
             sm_scale: 0.0,
             window_left: -1,
@@ -1195,7 +1218,7 @@ mod resource_tests {
             (inputs[1], 4096 * kv_row_bytes),
             (inputs[2], 4096 * kv_row_bytes),
         ]);
-        let dyn_map = FxHashMap::from_iter([('c', 100)]);
+        let dyn_map = FxHashMap::from_iter([(Symbol::from('c'), 100)]);
         let resident_before = resident_shared_device_memory_allocations();
 
         let spec = attention
@@ -1224,13 +1247,14 @@ mod resource_tests {
             head_dim: 64,
             page_size: 1,
             batch_dim: 1.into(),
+            context_dim: Expression::from('c'),
             dtype: DType::F16,
             sm_scale: 0.0,
             window_left: -1,
             plan_info: Mutex::new(Vec::new()),
         };
         let inputs = (0..4).map(NodeIndex::new).collect_vec();
-        let dyn_map = FxHashMap::from_iter([('c', 100)]);
+        let dyn_map = FxHashMap::from_iter([(Symbol::from('c'), 100)]);
         let uninstalled_lengths = FxHashMap::from_iter([(inputs[1], 0), (inputs[2], 0)]);
 
         let spec = attention
@@ -1258,6 +1282,7 @@ mod resource_tests {
             head_dim: 64,
             page_size: 1,
             batch_dim: 2.into(),
+            context_dim: Expression::from('c'),
             dtype: DType::F16,
             sm_scale: 0.0,
             window_left: -1,
@@ -1268,8 +1293,11 @@ mod resource_tests {
         let lengths = FxHashMap::from_iter([
             (inputs[1], 4096 * kv_row_bytes),
             (inputs[2], 4096 * kv_row_bytes),
+            // 3 CSR rows -> batch of 2. Supplied as the buffer's length, which
+            // is where the op reads it from.
+            (inputs[5], 3 * std::mem::size_of::<i32>()),
         ]);
-        let dyn_map = FxHashMap::from_iter([('c', 100), ('r', 3)]);
+        let dyn_map = FxHashMap::from_iter([(Symbol::from('c'), 100)]);
 
         let spec = attention
             .device_resource_spec(&inputs, &lengths, &dyn_map, true)

--- a/crates/luminal_cuda_lite/src/host/flashinfer/sink_attention.egg
+++ b/crates/luminal_cuda_lite/src/host/flashinfer/sink_attention.egg
@@ -75,7 +75,7 @@
 
 ; (out, q_bf16, k_pool, v_pool, flat_gather_idx, sinks_f32,
 ;  nheads, kvdim, hdim, scale, window_left)
-(relation sa_island (IR IR IR IR IR IR Expression Expression Expression f64 f64))
+(relation sa_island (IR IR IR IR IR IR Expression Expression Expression Expression f64 f64))
 
 (rule
     (
@@ -87,14 +87,14 @@
 
         ; ── Context gathers from both pools via ONE flat gather index ──
         (= ?k_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim (ENil)))
             ?kg_a
             (ECons ?nslots (ECons ?kvdim2 (ENil)))
             ?kg_b)
             (ICons ?flat_gidx (ICons ?k_pool (INil)))))
         (= ?k_ctx (Op (Cast ?kc_sz (F32)) (ICons ?k_gathered (INil))))
         (= ?v_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim3 (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim3 (ENil)))
             ?vg_a
             (ECons ?nslots2 (ECons ?kvdim4 (ENil)))
             ?vg_b)
@@ -107,7 +107,7 @@
 
         ; ── Q·K^T: (nheads, s, c, hd) mul + reduce over hd ──
         (= ?qk (Op (Mul
-            (ECons ?nheads (ECons (MVar "s") (ECons (MVar "c") (ECons ?hdim (ENil)))))
+            (ECons ?nheads (ECons ?input_tokens (ECons ?context_tokens (ECons ?hdim (ENil)))))
             ?qk_a ?qk_b ?qk_o)
             (ICons ?q_f (ICons ?k_ctx (INil)))))
         (= ?scores (Op (Sum ?ss_shape ?hdim ?ss_in ?ss_iter ?ss_out)
@@ -118,7 +118,7 @@
         (sa_masked ?masked ?scores ?scale_val ?window_val)
 
         ; ── Row max, then max(row_max, sink) in the lt-select spelling ──
-        (= ?rmax (Op (Max ?rm_shape (MVar "c") ?rm_in ?rm_iter ?rm_out)
+        (= ?rmax (Op (Max ?rm_shape ?context_tokens ?rm_in ?rm_iter ?rm_out)
             (ICons ?masked (INil))))
         (= ?sinks_f (Op (Cast ?sk_sz (F32)) (ICons ?sinks_w (INil))))
         (= ?lt (Op (LessThan ?lt_s ?lt_a ?lt_b ?lt_o)
@@ -149,7 +149,7 @@
             (ICons ?shifted (ICons ?log2e_a (INil)))))
         (const_like ?log2e_a 1.442695)
         (= ?num (Op (Exp2 ?ex_s ?ex_in ?ex_out) (ICons ?sc2 (INil))))
-        (= ?numsum (Op (Sum ?ns_shape (MVar "c") ?ns_in ?ns_iter ?ns_out)
+        (= ?numsum (Op (Sum ?ns_shape ?context_tokens ?ns_in ?ns_iter ?ns_out)
             (ICons ?num (INil))))
 
         ; ── The sink joins the DENOMINATOR only ──
@@ -170,15 +170,15 @@
 
         ; ── P·V: (nheads, s, hd, c) mul + reduce over c → output point ──
         (= ?pv (Op (Mul
-            (ECons ?nheads2 (ECons (MVar "s") (ECons ?hdim2 (ECons (MVar "c") (ENil)))))
+            (ECons ?nheads2 (ECons ?input_tokens (ECons ?hdim2 (ECons ?context_tokens (ENil)))))
             ?pv_a ?pv_b ?pv_o)
             (ICons ?probs (ICons ?v_ctx (INil)))))
-        (= ?out (Op (Sum ?o_shape (MVar "c") ?o_in ?o_iter ?o_out)
+        (= ?out (Op (Sum ?o_shape ?context_tokens ?o_in ?o_iter ?o_out)
             (ICons ?pv (INil))))
     )
     (
         (sa_island ?out ?q_bf ?k_pool ?v_pool ?flat_gidx ?sinks_f
-            ?nheads ?kvdim ?hdim ?scale_val ?window_val)
+            ?nheads ?kvdim ?hdim ?input_tokens ?scale_val ?window_val)
     )
     :ruleset kernel_fuse_late
     :name "SinkAttention island fact"
@@ -188,13 +188,13 @@
 
 (rule
     (
-        (sa_island ?out ?q ?kp ?vp ?g ?s ?nheads ?kvdim ?hdim ?scale_val ?window_val)
+        (sa_island ?out ?q ?kp ?vp ?g ?s ?nheads ?kvdim ?hdim ?input_tokens ?scale_val ?window_val)
         (= ?qoi (Input ?qo_idx "qo_indptr" (Int)))
         (= ?kvi (Input ?kv_idx "kv_indptr" (Int)))
     )
     (
         (let ?fi (Op (SinkAttention
-            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MVar "s") ?scale_val ?window_val)
+            ?nheads (MDiv ?kvdim ?hdim) ?hdim ?input_tokens ?scale_val ?window_val)
             (ICons ?q (ICons ?kp (ICons ?vp (ICons ?g
                 (ICons ?qoi (ICons ?kvi (ICons ?s (INil))))))))))
         (union ?out ?fi)

--- a/crates/luminal_cuda_lite/src/host/flashinfer/sink_attention.rs
+++ b/crates/luminal_cuda_lite/src/host/flashinfer/sink_attention.rs
@@ -174,7 +174,7 @@ impl HostOp for SinkAttention {
         self_node: NodeIndex,
         inputs: &[NodeIndex],
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        _dyn_map: &FxHashMap<char, usize>,
+        _dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         anyhow::ensure!(
             inputs.len() == 7,

--- a/crates/luminal_cuda_lite/src/host/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/mod.rs
@@ -144,7 +144,7 @@ pub trait HostOp: Debug + as_any::AsAny + EgglogOp {
         self_node: NodeIndex,
         inputs: &[NodeIndex],
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()>;
 
     /// Returns the output buffer size in elements.
@@ -198,7 +198,7 @@ pub trait HostOp: Debug + as_any::AsAny + EgglogOp {
         _self_node: NodeIndex,
         _inputs: &[NodeIndex],
         _buffer_lengths: &FxHashMap<NodeIndex, usize>,
-        _dyn_map: &FxHashMap<char, usize>,
+        _dyn_map: &DynMap,
     ) -> Result<HostDeviceMemoryPlan, ResourceViolation> {
         Ok(HostDeviceMemoryPlan::default())
     }

--- a/crates/luminal_cuda_lite/src/host/moe/fused.rs
+++ b/crates/luminal_cuda_lite/src/host/moe/fused.rs
@@ -147,7 +147,7 @@ impl HostOp for FusedMoE {
         self_node: NodeIndex,
         inputs: &[NodeIndex],
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         if inputs.len() < 9 {
             anyhow::bail!("FusedMoE expected 9 inputs, got {}", inputs.len());

--- a/crates/luminal_cuda_lite/src/host/moe/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/moe/mod.rs
@@ -301,7 +301,7 @@ impl HostOp for GLUMoE {
         self_node: NodeIndex,
         inputs: &[NodeIndex],
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         if inputs.len() < 6 {
             anyhow::bail!("GLUMoE expected at least 6 inputs, got {}", inputs.len());
@@ -681,7 +681,7 @@ impl HostOp for GLUMoE {
         _self_node: NodeIndex,
         _inputs: &[NodeIndex],
         _buffer_lengths: &FxHashMap<NodeIndex, usize>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> Result<HostDeviceMemoryPlan, ResourceViolation> {
         let x_bf16 = eval_resource_expression(
             Expression::from('s') * self.gu_matmul_k * 2,

--- a/crates/luminal_cuda_lite/src/kernel/argmax.rs
+++ b/crates/luminal_cuda_lite/src/kernel/argmax.rs
@@ -146,7 +146,7 @@ impl KernelOp for KernelArgmax {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .out_shape

--- a/crates/luminal_cuda_lite/src/kernel/conv2d.rs
+++ b/crates/luminal_cuda_lite/src/kernel/conv2d.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use cudarc::driver::{CudaFunction, CudaModule, CudaSlice, CudaStream};
-use luminal::prelude::FxHashMap;
+use luminal::prelude::{FxHashMap, Symbol};
 use luminal::{
     dtype::DType,
     egglog_utils::{
@@ -717,11 +717,11 @@ impl KernelOp for KernelConv2D {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         assert_eq!(self.dtype, DType::F32, "KernelConv2D currently emits F32");
 
-        let vars: FxHashSet<char> = self
+        let vars: FxHashSet<Symbol> = self
             .out_shape
             .iter()
             .chain(&self.input_shape)
@@ -779,8 +779,7 @@ impl KernelOp for KernelConv2D {
         let pad_w = self.pad_w.to_kernel();
         let out_idx = flatten_strides(&self.out_shape, &self.out_stride).to_kernel();
         let input_idx = flatten_strides(&self.input_shape, &self.input_stride)
-            .to_kernel()
-            .replace("const_z", "input_linear");
+            .to_kernel_with_index("input_linear");
         let n_outputs: Expression = self.out_shape.iter().copied().product();
 
         let kernel = format!(
@@ -867,7 +866,7 @@ extern \"C\" {{
         self.out_shape.iter().copied().product()
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.out_shape
             .iter()
             .chain(&self.input_shape)

--- a/crates/luminal_cuda_lite/src/kernel/fusion/elementwise.rs
+++ b/crates/luminal_cuda_lite/src/kernel/fusion/elementwise.rs
@@ -30,7 +30,7 @@ type CompileOut = (
     (Expression, Expression, Expression),
     (Expression, Expression, Expression),
     Expression,
-    FxHashMap<char, CudaSlice<u8>>,
+    FxHashMap<Symbol, CudaSlice<u8>>,
 );
 
 fn extract_string_label(egraph: &SerializedEGraph, node: &ENodeId) -> String {

--- a/crates/luminal_cuda_lite/src/kernel/fusion/markers.rs
+++ b/crates/luminal_cuda_lite/src/kernel/fusion/markers.rs
@@ -38,7 +38,7 @@ type CompileOut = (
     (Expression, Expression, Expression),
     (Expression, Expression, Expression),
     Expression,
-    FxHashMap<char, CudaSlice<u8>>,
+    FxHashMap<Symbol, CudaSlice<u8>>,
 );
 
 // =========================================================================

--- a/crates/luminal_cuda_lite/src/kernel/fusion/region_codegen.rs
+++ b/crates/luminal_cuda_lite/src/kernel/fusion/region_codegen.rs
@@ -170,7 +170,7 @@ struct FusionValidationCache {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 enum CanonicalSemanticExpression {
     Number(i64),
-    Variable(char),
+    Variable(Symbol),
     Binary(u8, Box<Self>, Box<Self>),
     AssociativeCommutative(u8, Vec<Self>),
 }
@@ -345,7 +345,7 @@ fn fusion_unary_dtype_supported(op: &str, dtype: DType) -> bool {
 fn expression_relation(
     lhs: Expression,
     rhs: Expression,
-    dyn_map: Option<&FxHashMap<char, usize>>,
+    dyn_map: Option<&DynMap>,
     z_witnesses: &[usize],
     exhaustive: bool,
     cache: &mut FusionValidationCache,
@@ -423,7 +423,7 @@ fn expression_relation(
         let mut different = false;
         for &z in z_witnesses {
             let mut values = concrete_map.clone();
-            values.insert('z', z);
+            values.insert(Symbol::reserved_index(), z);
             match (
                 eval_expression(lhs_simplified, &values),
                 eval_expression(rhs_simplified, &values),
@@ -462,7 +462,7 @@ fn expression_relation(
     relation
 }
 
-fn eval_expression(expression: Expression, values: &FxHashMap<char, usize>) -> Option<usize> {
+fn eval_expression(expression: Expression, values: &DynMap) -> Option<usize> {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| expression.exec(values)))
         .ok()
         .flatten()
@@ -471,7 +471,7 @@ fn eval_expression(expression: Expression, values: &FxHashMap<char, usize>) -> O
 fn layout_relation(
     lhs: FusionLayout<'_>,
     rhs: FusionLayout<'_>,
-    dyn_map: Option<&FxHashMap<char, usize>>,
+    dyn_map: Option<&DynMap>,
     cache: &mut FusionValidationCache,
 ) -> SemanticRelation {
     debug_assert_eq!(lhs.shape.len(), lhs.strides.len());
@@ -544,7 +544,7 @@ fn require_layout_compatible(
     input_slot: usize,
     produced: FusionLayout<'_>,
     expected: FusionLayout<'_>,
-    dyn_map: Option<&FxHashMap<char, usize>>,
+    dyn_map: Option<&DynMap>,
     cache: &mut FusionValidationCache,
 ) -> Result<(), FusionValidationError> {
     match layout_relation(produced, expected, dyn_map, cache) {
@@ -586,7 +586,7 @@ fn incoming_nodes(llir: &LLIRGraph, node: NodeIndex) -> Vec<NodeIndex> {
 /// rejected as an unsupported layout because codegen erases that metadata.
 pub(crate) fn validate_fusion_regions(
     llir: &LLIRGraph,
-    dyn_map: Option<&FxHashMap<char, usize>>,
+    dyn_map: Option<&DynMap>,
 ) -> Result<(), FusionValidationError> {
     let mut validation_cache = FusionValidationCache::default();
     for node in llir.node_indices() {
@@ -1429,7 +1429,7 @@ pub(crate) struct CompiledRegion {
     pub grid: (Expression, Expression, Expression),
     pub block: (Expression, Expression, Expression),
     pub shared_mem: Expression,
-    pub constants: FxHashMap<char, CudaSlice<u8>>,
+    pub constants: FxHashMap<Symbol, CudaSlice<u8>>,
 }
 
 /// Generate the fused kernel source plus launch geometry for a region.
@@ -1454,7 +1454,7 @@ pub(crate) fn region_kernel_source(
     // Aggregate all dynamic vars used anywhere in the region (FS strides,
     // FE strides and elementwise shapes.
     // own strides are likewise relevant for any future stride-affine ops).
-    let mut all_vars: FxHashSet<char> = FxHashSet::default();
+    let mut all_vars: FxHashSet<Symbol> = FxHashSet::default();
     all_vars.extend(out_shape.iter().flat_map(|e| e.dyn_vars()));
     all_vars.extend(out_strides.iter().flat_map(|e| e.dyn_vars()));
     for &fs_idx in &region.fs_nodes {
@@ -1815,7 +1815,13 @@ mod tests {
         llir.add_edge(fs, sin, ());
         llir.add_edge(sin, fe, ());
 
-        let dims = [('a', 2), ('b', 3), ('c', 4)].into_iter().collect();
+        let dims = [
+            (Symbol::from('a'), 2),
+            (Symbol::from('b'), 3),
+            (Symbol::from('c'), 4),
+        ]
+        .into_iter()
+        .collect();
         validate_fusion_regions(&llir, Some(&dims)).unwrap();
     }
 
@@ -1852,7 +1858,9 @@ mod tests {
         llir.add_edge(fs, sin, ());
         llir.add_edge(sin, fe, ());
 
-        let representative = [('a', 16), ('b', 16)].into_iter().collect();
+        let representative = [(Symbol::from('a'), 16), (Symbol::from('b'), 16)]
+            .into_iter()
+            .collect();
         let error = validate_fusion_regions(&llir, Some(&representative)).unwrap_err();
         assert!(error.reason.contains("could not be proved"));
     }

--- a/crates/luminal_cuda_lite/src/kernel/gemv.rs
+++ b/crates/luminal_cuda_lite/src/kernel/gemv.rs
@@ -168,7 +168,7 @@ impl KernelOp for KernelGemv {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .n
@@ -479,7 +479,7 @@ impl KernelOp for KernelGemvF8 {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .n

--- a/crates/luminal_cuda_lite/src/kernel/generic_matmul.rs
+++ b/crates/luminal_cuda_lite/src/kernel/generic_matmul.rs
@@ -316,7 +316,7 @@ impl KernelOp for GenericMatmul {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self.all_dyn_vars();
         let dtype = cuda_dtype(self.dtype);
@@ -330,13 +330,11 @@ impl KernelOp for GenericMatmul {
 
         let n_outputs = self.output_size();
         let sum_base_idx = flatten_strides(&self.out_shape, &self.sum_input_strides).to_kernel();
-        let iter_offset = self.sum_iter_stride.to_kernel().replace("const_z", "i");
-        let lhs_idx = flatten_strides(&self.mul_shape, &self.lhs_strides)
-            .to_kernel()
-            .replace("const_z", "mul_idx");
-        let rhs_idx = flatten_strides(&self.mul_shape, &self.rhs_strides)
-            .to_kernel()
-            .replace("const_z", "mul_idx");
+        let iter_offset = self.sum_iter_stride.to_kernel_with_index("i");
+        let lhs_idx =
+            flatten_strides(&self.mul_shape, &self.lhs_strides).to_kernel_with_index("mul_idx");
+        let rhs_idx =
+            flatten_strides(&self.mul_shape, &self.rhs_strides).to_kernel_with_index("mul_idx");
         let out_idx = flatten_strides(&self.out_shape, &self.out_strides).to_kernel();
         let k = self.k.to_kernel();
 
@@ -421,7 +419,7 @@ extern \"C\" {{
             .max(Expression::from(1))
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.out_shape
             .iter()
             .flat_map(|e| e.dyn_vars())

--- a/crates/luminal_cuda_lite/src/kernel/hlir.rs
+++ b/crates/luminal_cuda_lite/src/kernel/hlir.rs
@@ -153,7 +153,7 @@ impl KernelOp for KernelMaxReduce {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .out_shape
@@ -188,7 +188,7 @@ impl KernelOp for KernelMaxReduce {
             ", const int* dyn_dims"
         };
 
-        let iter_stride_of_i = self.iter_stride.to_kernel().replace("const_z", "i");
+        let iter_stride_of_i = self.iter_stride.to_kernel_with_index("i");
         let load_value = if low_precision_storage {
             format!("static_cast<float>(in[in_start + {iter_stride_of_i}])")
         } else {
@@ -385,7 +385,7 @@ impl KernelOp for KernelSumReduce {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .out_shape
@@ -416,7 +416,7 @@ impl KernelOp for KernelSumReduce {
             ", const int* dyn_dims"
         };
 
-        let iter_stride_of_i = self.iter_stride.to_kernel().replace("const_z", "i");
+        let iter_stride_of_i = self.iter_stride.to_kernel_with_index("i");
         let load_value = if uses_fp8_storage {
             format!("static_cast<float>(in_data[in_start + {iter_stride_of_i}])")
         } else {
@@ -643,7 +643,7 @@ impl KernelOp for KernelCastSumReduce {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .out_shape
@@ -666,7 +666,7 @@ impl KernelOp for KernelCastSumReduce {
             ", const int* dyn_dims"
         };
 
-        let iter_stride_of_i = self.iter_stride.to_kernel().replace("const_z", "i");
+        let iter_stride_of_i = self.iter_stride.to_kernel_with_index("i");
 
         let kernel = format!(
             "{includes}
@@ -903,7 +903,7 @@ impl KernelOp for KernelGather {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .out_shape
@@ -969,7 +969,7 @@ extern \"C\" {{
         self.out_shape.iter().copied().product()
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.out_shape
             .iter()
             .flat_map(|e| e.dyn_vars())
@@ -1144,9 +1144,9 @@ impl KernelOp for KernelScatter {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
-        let all_vars: FxHashSet<char> = self
+        let all_vars: FxHashSet<Symbol> = self
             .dest_shape
             .iter()
             .flat_map(|e| e.dyn_vars())
@@ -1235,7 +1235,7 @@ extern \"C\" {{
         self.dest_shape.iter().copied().product()
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.dest_shape
             .iter()
             .flat_map(|e| e.dyn_vars())
@@ -1387,7 +1387,7 @@ impl KernelOp for KernelIota {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let mut vars = self.expr.dyn_vars().into_iter().collect::<FxHashSet<_>>();
         vars.extend(self.range.dyn_vars());
@@ -1533,7 +1533,7 @@ impl KernelOp for KernelMod {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .out_shape
@@ -1711,7 +1711,7 @@ impl KernelOp for KernelLessThan {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .out_shape
@@ -1894,7 +1894,7 @@ impl KernelOp for KernelConstant {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let value_str = if self.value.is_nan() {
             "__int_as_float(0x7fc00000)".to_string()
@@ -2042,7 +2042,7 @@ impl KernelOp for KernelCast {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let out_dtype = cuda_dtype(self.out_dtype);
         let includes = dtype_includes(&[self.in_dtype, self.out_dtype]);
@@ -2147,11 +2147,11 @@ extern \"C\" {{
 /// This ensures all kernels in a CudaGraphOp use consistent indices into the shared
 /// dyn_dims buffer.
 thread_local! {
-    static GLOBAL_DYN_DIMS: std::cell::RefCell<Option<Vec<char>>> = const { std::cell::RefCell::new(None) };
+    static GLOBAL_DYN_DIMS: std::cell::RefCell<Option<Vec<Symbol>>> = const { std::cell::RefCell::new(None) };
 }
 
 /// Set the global dyn dims ordering for subsequent kernel compilations.
-pub fn set_global_dyn_dims(dims: Vec<char>) {
+pub fn set_global_dyn_dims(dims: Vec<Symbol>) {
     GLOBAL_DYN_DIMS.with(|g| *g.borrow_mut() = Some(dims));
 }
 
@@ -2161,7 +2161,7 @@ pub fn clear_global_dyn_dims() {
 }
 
 /// Get the current global dyn dims ordering.
-pub fn get_global_dyn_dims() -> Option<Vec<char>> {
+pub fn get_global_dyn_dims() -> Option<Vec<Symbol>> {
     GLOBAL_DYN_DIMS.with(|g| g.borrow().clone())
 }
 
@@ -2171,7 +2171,7 @@ pub fn get_global_dyn_dims() -> Option<Vec<char>> {
 ///
 /// When a global dyn dims ordering is set (via `set_global_dyn_dims`), indices are based
 /// on the global ordering to ensure consistency across kernels sharing a dyn_dims buffer.
-pub fn generate_dyn_dims_defines(vars: &FxHashSet<char>) -> (String, Vec<char>) {
+pub fn generate_dyn_dims_defines(vars: &FxHashSet<Symbol>) -> (String, Vec<Symbol>) {
     if vars.is_empty() {
         return (String::new(), Vec::new());
     }
@@ -2200,28 +2200,22 @@ pub fn generate_dyn_dims_defines(vars: &FxHashSet<char>) -> (String, Vec<char>) 
                     .iter()
                     .position(|d| d == dim)
                     .expect("Dim must be in global ordering after extension");
-                format!("#define const_{dim} dyn_dims[{idx}]")
+                format!("#define {} dyn_dims[{idx}]", kernel_const_name(dim))
             })
             .collect::<Vec<_>>()
             .join("\n");
         return (defines, global_order);
     }
     // Default: local ordering
-    let mut sorted_dims: Vec<char> = vars.iter().copied().collect();
+    let mut sorted_dims: Vec<Symbol> = vars.iter().copied().collect();
     sorted_dims.sort();
     let defines = sorted_dims
         .iter()
         .enumerate()
-        .map(|(idx, dim)| format!("#define const_{dim} dyn_dims[{idx}]"))
+        .map(|(idx, dim)| format!("#define {} dyn_dims[{idx}]", kernel_const_name(dim)))
         .collect::<Vec<_>>()
         .join("\n");
     (defines, sorted_dims)
-}
-
-/// Get the offset for a dynamic dimension in the shared dyn_dims buffer.
-/// Returns None if the dim is not in the set.
-pub fn get_dyn_dim_offset(dim: char, sorted_dims: &[char]) -> Option<usize> {
-    sorted_dims.iter().position(|&d| d == dim)
 }
 
 #[derive(Default, Debug, Clone)]
@@ -2486,7 +2480,7 @@ impl KernelOp for KernelEmbed {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let batch_size = self
             .batch_shape

--- a/crates/luminal_cuda_lite/src/kernel/matmul2d.rs
+++ b/crates/luminal_cuda_lite/src/kernel/matmul2d.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 use cudarc::driver::{CudaFunction, CudaModule, CudaSlice, CudaStream};
 use luminal::{
     dtype::DType, op::CustomOp, op::LLIROp, prelude::FxHashMap, prelude::GraphTensor,
-    shape::Expression,
+    prelude::Symbol, shape::Expression,
 };
 
 use crate::compile_module_image_for_current_device;
@@ -79,7 +79,7 @@ impl KernelOp for Matmul2DKernel {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let bias_param = if self.has_bias {
             ", const float* __restrict__ bias"

--- a/crates/luminal_cuda_lite/src/kernel/mod.rs
+++ b/crates/luminal_cuda_lite/src/kernel/mod.rs
@@ -211,7 +211,7 @@ pub trait KernelOp: std::fmt::Debug + as_any::AsAny {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     );
 
     /// Returns the output buffer size in elements.
@@ -220,7 +220,7 @@ pub trait KernelOp: std::fmt::Debug + as_any::AsAny {
     /// Returns all dynamic variables used by this kernel (for grid dims, strides, etc).
     /// Default: returns dyn vars from output_size(). Override if the kernel has dyn vars
     /// in expressions not captured by output_size (e.g., KernelScatter's index_shape).
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.output_size().dyn_vars().into_iter().collect()
     }
 
@@ -259,7 +259,7 @@ pub trait KernelOp: std::fmt::Debug + as_any::AsAny {
     fn allocate_internal_buffers(
         &self,
         _stream: &Arc<CudaStream>,
-        _dyn_map: &FxHashMap<char, usize>,
+        _dyn_map: &DynMap,
     ) -> Vec<CudaSlice<u8>> {
         vec![]
     }
@@ -267,7 +267,7 @@ pub trait KernelOp: std::fmt::Debug + as_any::AsAny {
     /// Returns the set of dynamic dimensions that affect internal buffer sizes.
     /// When any of these dimensions change, internal buffers should be reallocated.
     /// Default: empty set (no dimensions affect internal buffers).
-    fn internal_buffer_dyn_dims(&self) -> FxHashSet<char> {
+    fn internal_buffer_dyn_dims(&self) -> FxHashSet<Symbol> {
         FxHashSet::default()
     }
 
@@ -310,9 +310,9 @@ pub trait KernelOp: std::fmt::Debug + as_any::AsAny {
         &self,
         _stream: &Arc<CudaStream>,
         _internal_bufs: &mut [CudaSlice<u8>],
-        _constants: &mut FxHashMap<char, CudaSlice<u8>>,
+        _constants: &mut FxHashMap<Symbol, CudaSlice<u8>>,
         _all_buffer_ptrs: &FxHashMap<NodeIndex, u64>,
-        _dyn_map: &FxHashMap<char, usize>,
+        _dyn_map: &DynMap,
     ) {
     }
 

--- a/crates/luminal_cuda_lite/src/kernel/moe_gemv.rs
+++ b/crates/luminal_cuda_lite/src/kernel/moe_gemv.rs
@@ -215,12 +215,12 @@ impl KernelOp for KernelMoEGemv {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let (s, k, o, d, e, xs_s, xs_k, ts_s, ts_k) = self.dims();
         let includes = dtype_includes(&[DType::Bf16]);
 
-        let vars: FxHashSet<char> = s.dyn_vars().into_iter().collect();
+        let vars: FxHashSet<Symbol> = s.dyn_vars().into_iter().collect();
         let (dyn_defines, _sorted) = generate_dyn_dims_defines(&vars);
         let dyn_dims_param = if vars.is_empty() {
             ""
@@ -332,7 +332,7 @@ extern \"C\" {{
         DType::F32
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.out_shape[0].dyn_vars().into_iter().collect()
     }
 

--- a/crates/luminal_cuda_lite/src/kernel/other_ops.rs
+++ b/crates/luminal_cuda_lite/src/kernel/other_ops.rs
@@ -105,7 +105,7 @@ impl KernelOp for KernelMeanReduce {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .out_shape
@@ -386,9 +386,9 @@ impl KernelOp for KernelScatterNoCopy {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
-        let all_vars: FxHashSet<char> = self
+        let all_vars: FxHashSet<Symbol> = self
             .dest_shape
             .iter()
             .flat_map(|e| e.dyn_vars())
@@ -461,7 +461,7 @@ extern \"C\" {{
         self.dest_shape.iter().copied().product()
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.dest_shape
             .iter()
             .flat_map(|e| e.dyn_vars())

--- a/crates/luminal_cuda_lite/src/kernel/quant_f8.rs
+++ b/crates/luminal_cuda_lite/src/kernel/quant_f8.rs
@@ -102,7 +102,7 @@ impl KernelOp for KernelQuantF8 {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self.size.dyn_vars().into_iter().collect::<FxHashSet<_>>();
         let includes = dtype_includes(&[DType::Bf16, DType::F8E4M3]);

--- a/crates/luminal_cuda_lite/src/kernel/rms_norm.rs
+++ b/crates/luminal_cuda_lite/src/kernel/rms_norm.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use cudarc::driver::{CudaFunction, CudaModule, CudaSlice, CudaStream};
 use luminal::{
     dtype::DType, op::CustomOp, op::LLIROp, prelude::FxHashMap, prelude::GraphTensor,
-    shape::Expression,
+    prelude::Symbol, shape::Expression,
 };
 
 use crate::compile_module_image_for_current_device;
@@ -44,7 +44,7 @@ impl KernelOp for RMSNormKernel {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let cols = self.cols;
         let eps = self.eps;
@@ -248,7 +248,7 @@ impl KernelOp for RMSNormQuantKernel {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let cols = self.cols;
         let eps = self.eps;

--- a/crates/luminal_cuda_lite/src/kernel/rope.rs
+++ b/crates/luminal_cuda_lite/src/kernel/rope.rs
@@ -19,7 +19,7 @@ use luminal::{
     dtype::DType,
     egglog_utils::list_to_egglog,
     op::{CustomOp, HLIROp, LLIROp},
-    prelude::{FxHashMap, FxHashSet, GraphTensor, NodeIndex, ShapeTracker},
+    prelude::{DynMap, FxHashMap, FxHashSet, GraphTensor, NodeIndex, ShapeTracker, Symbol},
     shape::Expression,
 };
 
@@ -47,7 +47,7 @@ impl KernelOp for RoPEKernel {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let s = self.s;
         let h = self.h;
@@ -341,7 +341,7 @@ impl KernelOp for RoPEHalfKernel {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let h = self.h;
         let d = self.d;
@@ -648,7 +648,7 @@ impl KernelOp for RoPEScatterKernel {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let h = self.rope.h;
         let d = self.rope.d;
@@ -658,7 +658,7 @@ impl KernelOp for RoPEScatterKernel {
         let ty = crate::cuda_dtype(self.rope.dtype);
         let includes = crate::kernel::hlir::dtype_includes(&[self.rope.dtype]);
 
-        let vars: FxHashSet<char> = self
+        let vars: FxHashSet<Symbol> = self
             .idx_flat
             .dyn_vars()
             .into_iter()
@@ -780,7 +780,7 @@ extern "C" __global__ void rope_scatter_kernel(
         true
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.idx_flat
             .dyn_vars()
             .into_iter()
@@ -1117,7 +1117,7 @@ impl KernelOp for KernelRoPE {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let heads = self.out_shape[0].to_usize().expect("RoPE heads is static");
         let seq = self.out_shape[1];
@@ -1129,7 +1129,7 @@ impl KernelOp for KernelRoPE {
         let lnt = self.ln_theta as f32;
         let inv_hd = self.inv_hd as f32;
 
-        let vars: FxHashSet<char> = seq.dyn_vars().into_iter().collect();
+        let vars: FxHashSet<Symbol> = seq.dyn_vars().into_iter().collect();
         let (dyn_defines, _sorted) = crate::kernel::hlir::generate_dyn_dims_defines(&vars);
         let dyn_dims_param = if vars.is_empty() {
             ""
@@ -1219,7 +1219,7 @@ extern \"C\" {{
         DType::Bf16
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.out_shape[1].dyn_vars().into_iter().collect()
     }
 
@@ -1393,7 +1393,7 @@ impl KernelOp for KernelRoPEScatterFused {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let heads = self.rope.out_shape[0]
             .to_usize()
@@ -1408,7 +1408,7 @@ impl KernelOp for KernelRoPEScatterFused {
         let inv_hd = self.rope.inv_hd as f32;
         let kvd = heads * hd;
 
-        let vars: FxHashSet<char> = self.all_dyn_vars();
+        let vars: FxHashSet<Symbol> = self.all_dyn_vars();
         let (dyn_defines, _sorted) = crate::kernel::hlir::generate_dyn_dims_defines(&vars);
         let dyn_dims_param = if vars.is_empty() {
             ""
@@ -1514,7 +1514,7 @@ extern \"C\" {{
         true
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.idx_flat
             .dyn_vars()
             .into_iter()

--- a/crates/luminal_cuda_lite/src/kernel/swiglu.rs
+++ b/crates/luminal_cuda_lite/src/kernel/swiglu.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use cudarc::driver::{CudaFunction, CudaModule, CudaSlice, CudaStream};
 use luminal::{
     dtype::DType, op::CustomOp, op::LLIROp, prelude::FxHashMap, prelude::GraphTensor,
-    shape::Expression,
+    prelude::Symbol, shape::Expression,
 };
 
 use crate::compile_module_image_for_current_device;
@@ -39,7 +39,7 @@ impl KernelOp for SwigluKernel {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let i = self.intermediate;
         let ty = crate::cuda_dtype(self.dtype);
@@ -190,7 +190,7 @@ impl KernelOp for SwigluQuantKernel {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let i = self.intermediate;
         let ty = crate::cuda_dtype(self.dtype);

--- a/crates/luminal_cuda_lite/src/kernel/to_host.rs
+++ b/crates/luminal_cuda_lite/src/kernel/to_host.rs
@@ -87,11 +87,11 @@ struct CompiledKernel {
     /// Whether this compiled CUDA function has a trailing dyn_dims parameter.
     has_dyn_dims_param: bool,
     /// Dynamic dimensions that can affect launch dimensions, params, or code.
-    dyn_vars: FxHashSet<char>,
+    dyn_vars: FxHashSet<Symbol>,
     /// Internal buffers allocated for this kernel
     internal_bufs: Vec<CudaSlice<u8>>,
     /// Device constants from compile()
-    constants: FxHashMap<char, CudaSlice<u8>>,
+    constants: FxHashMap<Symbol, CudaSlice<u8>>,
     /// Graph node handle (set after graph is built)
     graph_node: Option<CUgraphNode>,
     /// Kernel name for profiling
@@ -231,7 +231,7 @@ impl RecaptureProfile {
         duration.as_secs_f64() * 1e3
     }
 
-    fn print(&self, dyn_map: &FxHashMap<char, usize>, kernels: usize, cublaslt: usize) {
+    fn print(&self, dyn_map: &DynMap, kernels: usize, cublaslt: usize) {
         if !self.enabled || (self.pending_count == 0 && self.materialize_total.is_zero()) {
             return;
         }
@@ -350,7 +350,7 @@ impl CompiledKernel {
         input_labels: Vec<String>,
         kernel_op: Arc<Box<dyn KernelOp>>,
         has_dyn_dims_param: bool,
-        constants: FxHashMap<char, CudaSlice<u8>>,
+        constants: FxHashMap<Symbol, CudaSlice<u8>>,
         kernel_name: &'static str,
         source_bytes: Option<usize>,
     ) -> Self {
@@ -441,7 +441,7 @@ struct CudaGraphOpState {
     /// Kernel params for each kernel
     kernel_params: Vec<UnifiedKernelParams>,
     /// Last dynamic dimension values (for change detection)
-    last_dyn_values: FxHashMap<char, usize>,
+    last_dyn_values: DynMap,
     /// Last buffer pointers (for change detection)
     last_buffer_ptrs: FxHashMap<NodeIndex, u64>,
     /// Timing events for profiling
@@ -492,7 +492,7 @@ pub struct CudaGraphOp {
     /// Buffer size requirements for extra nodes (node -> size in elements)
     buffer_sizes: FxHashMap<NodeIndex, Expression>,
     /// Dynamic dimensions used by this graph (sorted alphabetically)
-    dyn_dims_order: Vec<char>,
+    dyn_dims_order: Vec<Symbol>,
     /// The CUDA stream (needed for operations)
     stream: Arc<CudaStream>,
     /// Nonblocking stream used only for narrow cuBLASLt graph captures.
@@ -505,7 +505,7 @@ impl CudaGraphOp {
     fn new(
         buffer_nodes: Vec<NodeIndex>,
         buffer_sizes: FxHashMap<NodeIndex, Expression>,
-        dyn_dims_order: Vec<char>,
+        dyn_dims_order: Vec<Symbol>,
         stream: Arc<CudaStream>,
         capture_stream: Option<Arc<CudaStream>>,
         state: CudaGraphOpState,
@@ -562,7 +562,7 @@ impl CudaGraphOp {
     /// not consume search trials. It does not assign a cost to legal kernels.
     pub(crate) fn resource_plans(
         &self,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> Result<Vec<KernelResourcePlan>, ResourceViolation> {
         self.state
             .borrow()
@@ -619,14 +619,14 @@ impl CudaGraphOp {
             .collect()
     }
 
-    pub(crate) fn resource_dyn_dims(&self) -> &[char] {
+    pub(crate) fn resource_dyn_dims(&self) -> &[Symbol] {
         &self.dyn_dims_order
     }
 
     fn host_device_memory_plan(
         &self,
         buffer_lengths: &FxHashMap<NodeIndex, usize>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> Result<HostDeviceMemoryPlan, ResourceViolation> {
         let state = self.state.borrow();
         let mut persistent_bytes = self
@@ -817,7 +817,7 @@ impl HostOp for CudaGraphOp {
         _self_node: NodeIndex,
         _inputs: &[NodeIndex],
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         self.execute_internal(stream, buffers, dyn_map)
     }
@@ -837,7 +837,7 @@ impl HostOp for CudaGraphOp {
         _self_node: NodeIndex,
         _inputs: &[NodeIndex],
         buffer_lengths: &FxHashMap<NodeIndex, usize>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> Result<HostDeviceMemoryPlan, ResourceViolation> {
         self.host_device_memory_plan(buffer_lengths, dyn_map)
     }
@@ -1238,10 +1238,7 @@ impl CudaGraphOp {
         }
     }
 
-    fn kernel_requires_output_buffer(
-        kernel: &CompiledKernel,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> bool {
+    fn kernel_requires_output_buffer(kernel: &CompiledKernel, dyn_map: &DynMap) -> bool {
         kernel.kernel_op.output_size().exec(dyn_map).unwrap_or(1) != 0
             && kernel.kernel_op.output_aliases_input().is_none()
     }
@@ -1250,7 +1247,7 @@ impl CudaGraphOp {
         kernel: &CompiledKernel,
         output_ptr: u64,
         input_ptrs: &[u64],
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         if Self::kernel_requires_output_buffer(kernel, dyn_map) && output_ptr == 0 {
             anyhow::bail!(
@@ -1287,7 +1284,7 @@ impl CudaGraphOp {
     /// untouched — a dim change does not dirty it. (The process-global
     /// cuBLASLt heuristic cache is deliberately kept: purging it would fight
     /// autotune and its query is not the dominant transition cost.)
-    pub(crate) fn assume_dyn_dims_stale(&self, stale_dims: &[char]) {
+    pub(crate) fn assume_dyn_dims_stale(&self, stale_dims: &[Symbol]) {
         let mut state = self.state.borrow_mut();
         for dim in stale_dims {
             state.last_dyn_values.remove(dim);
@@ -1310,7 +1307,7 @@ impl CudaGraphOp {
         &self,
         stream: &Arc<CudaStream>,
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         let materialize_start = Instant::now();
         let mut profile = RecaptureProfile::new();
@@ -1884,7 +1881,7 @@ impl CudaGraphOp {
         &self,
         stream: &Arc<CudaStream>,
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         self.materialize(stream, buffers, dyn_map)?;
 
@@ -2316,7 +2313,7 @@ impl CudaGraphOp {
         state: &mut std::cell::RefMut<'_, CudaGraphOpState>,
         stream: &Arc<CudaStream>,
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         let ctx = stream.context().clone();
         let mut graph = CudaGraphHandle::new(ctx.clone())?;
@@ -2800,7 +2797,7 @@ pub fn kernel_to_host(
         }
 
         // Set global dyn dims ordering so compiles use consistent indices
-        let mut global_dyn_dims: Vec<char> = all_dyn_dims.iter().copied().collect();
+        let mut global_dyn_dims: Vec<Symbol> = all_dyn_dims.iter().copied().collect();
         global_dyn_dims.sort();
         set_global_dyn_dims(global_dyn_dims.clone());
 
@@ -3064,10 +3061,10 @@ pub fn kernel_to_host(
         clear_global_dyn_dims();
 
         // Use the final global ordering if it was extended during compilation
-        let mut dyn_dims_order: Vec<char> = if let Some(final_order) = final_global {
+        let mut dyn_dims_order: Vec<Symbol> = if let Some(final_order) = final_global {
             final_order
         } else {
-            let mut dims: Vec<char> = all_dyn_dims.into_iter().collect();
+            let mut dims: Vec<Symbol> = all_dyn_dims.into_iter().collect();
             dims.sort();
             dims
         };

--- a/crates/luminal_cuda_lite/src/kernel/topk.rs
+++ b/crates/luminal_cuda_lite/src/kernel/topk.rs
@@ -200,13 +200,13 @@ impl KernelOp for KernelStableSortIdx {
         (Expression, Expression, Expression),
         (Expression, Expression, Expression),
         Expression,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let rows = self.out_shape[0];
         let e = self.out_shape[1].to_usize().expect("ranks E is static");
         assert!(e <= 1024, "stable ranks kernel supports E <= 1024");
 
-        let vars: FxHashSet<char> = rows.dyn_vars().into_iter().collect();
+        let vars: FxHashSet<Symbol> = rows.dyn_vars().into_iter().collect();
         let (dyn_defines, _sorted) = generate_dyn_dims_defines(&vars);
         let dyn_dims_param = if vars.is_empty() {
             ""
@@ -285,7 +285,7 @@ extern \"C\" {{
         DType::Int
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.out_shape[0].dyn_vars().into_iter().collect()
     }
 

--- a/crates/luminal_cuda_lite/src/resource.rs
+++ b/crates/luminal_cuda_lite/src/resource.rs
@@ -23,7 +23,7 @@ use luminal::{
     graph::LLIRGraph,
     hlir::Output,
     prelude::{
-        Expression, FxHashMap, FxHashSet, NodeIndex,
+        DynMap, Expression, FxHashMap, FxHashSet, NodeIndex,
         petgraph::{
             Direction,
             algo::toposort,
@@ -521,7 +521,7 @@ where
 
 pub(crate) fn eval_resource_expression(
     expr: Expression,
-    dyn_map: &FxHashMap<char, usize>,
+    dyn_map: &DynMap,
     resource: &'static str,
 ) -> Result<usize, ResourceViolation> {
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| expr.exec(dyn_map))) {
@@ -760,7 +760,7 @@ pub(crate) fn validate_static_llir_semantics(llir: &LLIRGraph) -> Result<(), Res
 /// because non-overlapping buffers are individually large.
 pub(crate) fn plan_static_llir_resources(
     llir: &LLIRGraph,
-    dyn_map: &FxHashMap<char, usize>,
+    dyn_map: &DynMap,
 ) -> Result<CandidateResourcePlan, ResourceViolation> {
     let (topo, aliases) = validated_topology_and_aliases(llir)?;
     region_codegen::validate_fusion_regions(llir, Some(dyn_map)).map_err(|violation| {
@@ -882,6 +882,8 @@ pub(crate) fn plan_static_llir_resources(
 
 #[cfg(test)]
 mod tests {
+    use luminal::prelude::Symbol;
+
     use super::*;
 
     fn test_device(total_memory_bytes: usize) -> CudaDeviceResourceLimits {
@@ -1166,7 +1168,7 @@ mod tests {
             (Expression, Expression, Expression),
             (Expression, Expression, Expression),
             Expression,
-            FxHashMap<char, cudarc::driver::CudaSlice<u8>>,
+            FxHashMap<Symbol, cudarc::driver::CudaSlice<u8>>,
         ) {
             unreachable!("static resource planning must not compile test kernels")
         }
@@ -1211,7 +1213,7 @@ mod tests {
         llir.add_edge(input, first, ());
         llir.add_edge(first, second, ());
 
-        let dyn_map = FxHashMap::from_iter([('s', 16)]);
+        let dyn_map = FxHashMap::from_iter([(Symbol::from('s'), 16)]);
         let plan = plan_static_llir_resources(&llir, &dyn_map).unwrap();
 
         // The first output is 64 B and must coexist with the second's 128 B

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -183,8 +183,8 @@ pub(crate) struct CompiledBucket {
     arena_conflicts: FxHashSet<(NodeIndex, NodeIndex)>,
     pub(crate) cached_buffer_ptrs: FxHashMap<NodeIndex, u64>,
     pub(crate) buffer_specs: FxHashMap<NodeIndex, BufferSpec>,
-    buffer_spec_dyn_vars: FxHashMap<NodeIndex, Vec<char>>,
-    buffer_spec_nodes_by_dyn_var: FxHashMap<char, Vec<NodeIndex>>,
+    buffer_spec_dyn_vars: FxHashMap<NodeIndex, Vec<Symbol>>,
+    buffer_spec_nodes_by_dyn_var: FxHashMap<Symbol, Vec<NodeIndex>>,
     pub(crate) llir_to_hlir: FxHashMap<NodeIndex, NodeIndex>,
     pub(crate) hlir_to_llir: FxHashMap<NodeIndex, NodeIndex>,
     pub(crate) output_producers: FxHashMap<NodeIndex, NodeIndex>,
@@ -192,17 +192,17 @@ pub(crate) struct CompiledBucket {
     pub(crate) output_data_map: FxHashMap<NodeIndex, NodeIndex>,
     pub(crate) preserved_hlir_inputs: FxHashSet<NodeIndex>,
     pub(crate) kernel_names: Vec<&'static str>,
-    pub(crate) last_dyn_map: FxHashMap<char, usize>,
-    pub(crate) last_allocation_dyn_map: FxHashMap<char, usize>,
+    pub(crate) last_dyn_map: DynMap,
+    pub(crate) last_allocation_dyn_map: DynMap,
     /// Bucket-capacity dimensions used by the most recent hard-resource
     /// validation. Kept separate from allocation state so validation cannot
     /// accidentally suppress a required arena refresh.
-    last_resource_validation_dyn_map: FxHashMap<char, usize>,
+    last_resource_validation_dyn_map: DynMap,
     resource_validation_complete: bool,
-    pub(crate) intermediate_buffer_dims: FxHashSet<char>,
+    pub(crate) intermediate_buffer_dims: FxHashSet<Symbol>,
     pub(crate) cached_device_buffers: FxHashMap<NodeIndex, DeviceBuffer>,
     /// Which bucket index per dim this compilation targets
-    pub(crate) bucket_indices: FxHashMap<char, usize>,
+    pub(crate) bucket_indices: DynMap,
     /// Whether HLIR pointers have been synced into this bucket's cached_buffer_ptrs
     pub(crate) hlir_synced: bool,
     /// Test/debug mode: give every intermediate a distinct arena range so
@@ -260,7 +260,7 @@ struct ArenaReleasePlan {
 
 struct ValidatedBucketSet {
     compiled_buckets: Vec<CompiledBucket>,
-    representative_dyn_maps: Vec<FxHashMap<char, usize>>,
+    representative_dyn_maps: Vec<DynMap>,
     input_lengths_complete: bool,
 }
 
@@ -303,7 +303,7 @@ pub struct CudaRuntime {
     compiled_buckets: Vec<CompiledBucket>,
     active_bucket: usize,
     /// Bucket definitions per dimension (empty = single-bucket mode)
-    dim_buckets: FxHashMap<char, Vec<DimBucket>>,
+    dim_buckets: FxHashMap<Symbol, Vec<DimBucket>>,
 
     /// Non-owning CudaSlice wrappers for external device pointers.
     /// ManuallyDrop prevents cuMemFree — the external allocator (e.g. PyTorch) owns the memory.
@@ -1289,7 +1289,7 @@ impl CudaRuntime {
     fn allocate_intermediate_buffers(
         bucket: &mut CompiledBucket,
         stream: &Arc<CudaStream>,
-        dyn_dims: &FxHashMap<char, usize>,
+        dyn_dims: &DynMap,
     ) {
         let profile_alloc = std::env::var_os("LUMINAL_CUDA_PROFILE_RECAPTURE").is_some();
         let alloc_profile_start = std::time::Instant::now();
@@ -1445,7 +1445,7 @@ impl CudaRuntime {
         }
     }
 
-    fn buffer_plan_matches(bucket: &CompiledBucket, dyn_dims: &FxHashMap<char, usize>) -> bool {
+    fn buffer_plan_matches(bucket: &CompiledBucket, dyn_dims: &DynMap) -> bool {
         if bucket.buffer_specs.is_empty() {
             return true;
         }
@@ -1467,10 +1467,7 @@ impl CudaRuntime {
         })
     }
 
-    fn refresh_intermediate_buffer_lengths(
-        bucket: &mut CompiledBucket,
-        dyn_dims: &FxHashMap<char, usize>,
-    ) {
+    fn refresh_intermediate_buffer_lengths(bucket: &mut CompiledBucket, dyn_dims: &DynMap) {
         bucket.logical_buffer_bytes.clear();
         for (node, spec) in &bucket.buffer_specs {
             let bytes = spec.bytes.exec(dyn_dims).unwrap();
@@ -1510,7 +1507,7 @@ impl CudaRuntime {
 
     fn refresh_intermediate_buffer_lengths_for_changed_dims(
         bucket: &mut CompiledBucket,
-        dyn_dims: &FxHashMap<char, usize>,
+        dyn_dims: &DynMap,
     ) {
         if bucket.last_dyn_map.is_empty() {
             Self::refresh_intermediate_buffer_lengths(bucket, dyn_dims);
@@ -1555,10 +1552,7 @@ impl CudaRuntime {
         bucket.last_dyn_map = dyn_dims.clone();
     }
 
-    fn initialize_fixed_intermediate_buffer_plan(
-        bucket: &mut CompiledBucket,
-        dyn_dims: &FxHashMap<char, usize>,
-    ) {
+    fn initialize_fixed_intermediate_buffer_plan(bucket: &mut CompiledBucket, dyn_dims: &DynMap) {
         bucket.arena_slots.clear();
         bucket.logical_buffer_slots.clear();
 
@@ -1626,10 +1620,7 @@ impl CudaRuntime {
         }
     }
 
-    fn refresh_fixed_intermediate_buffer_plan(
-        bucket: &mut CompiledBucket,
-        dyn_dims: &FxHashMap<char, usize>,
-    ) {
+    fn refresh_fixed_intermediate_buffer_plan(bucket: &mut CompiledBucket, dyn_dims: &DynMap) {
         bucket.logical_buffer_offsets.clear();
         bucket.logical_buffer_bytes.clear();
         bucket.logical_buffer_capacity_bytes.clear();
@@ -1683,7 +1674,7 @@ impl CudaRuntime {
 
     fn planned_intermediate_buffers(
         bucket: &mut CompiledBucket,
-        dyn_dims: &FxHashMap<char, usize>,
+        dyn_dims: &DynMap,
         include_zero_sized: bool,
     ) -> Vec<PlannedBuffer> {
         bucket.intermediate_buffer_dims.clear();
@@ -1827,7 +1818,7 @@ impl CudaRuntime {
             .collect_vec()
     }
 
-    fn plan_intermediate_buffers(bucket: &mut CompiledBucket, dyn_dims: &FxHashMap<char, usize>) {
+    fn plan_intermediate_buffers(bucket: &mut CompiledBucket, dyn_dims: &DynMap) {
         let old_offsets = bucket.logical_buffer_offsets.clone();
         let old_bytes = bucket.logical_buffer_bytes.clone();
         let old_capacity_bytes = bucket.logical_buffer_capacity_bytes.clone();
@@ -2107,7 +2098,7 @@ impl CudaRuntime {
         }
     }
 
-    fn prepare_bucket_buffers(&mut self, bucket_idx: usize, dyn_map: &FxHashMap<char, usize>) {
+    fn prepare_bucket_buffers(&mut self, bucket_idx: usize, dyn_map: &DynMap) {
         debug_assert!(
             self.compiled_buckets
                 .iter()
@@ -2419,10 +2410,7 @@ impl CudaRuntime {
     /// Post-mortem aid for sticky CUDA errors during search: keep the most
     /// recent candidate's LLIR on disk so a crash identifies the genome that
     /// was executing. Gated on LUMINAL_SEARCH_DUMP_LAST_LLIR.
-    fn dump_candidate_llir_for_postmortem(
-        llir_graph: &LLIRGraph,
-        dyn_map: &FxHashMap<char, usize>,
-    ) {
+    fn dump_candidate_llir_for_postmortem(llir_graph: &LLIRGraph, dyn_map: &DynMap) {
         if std::env::var_os("LUMINAL_SEARCH_DUMP_LAST_LLIR").is_none() {
             return;
         }
@@ -2447,7 +2435,7 @@ impl CudaRuntime {
     fn materialize_bucket_cuda_graphs(
         &self,
         bucket_idx: usize,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         allow_missing_inputs: bool,
     ) -> anyhow::Result<()> {
         let bucket = &self.compiled_buckets[bucket_idx];
@@ -2466,11 +2454,7 @@ impl CudaRuntime {
         Ok(())
     }
 
-    fn bucket_capacity_dyn_map(
-        &self,
-        bucket_idx: usize,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> FxHashMap<char, usize> {
+    fn bucket_capacity_dyn_map(&self, bucket_idx: usize, dyn_map: &DynMap) -> DynMap {
         let mut capacity_dyn_map = dyn_map.clone();
         let Some(bucket) = self.compiled_buckets.get(bucket_idx) else {
             return capacity_dyn_map;
@@ -2485,10 +2469,10 @@ impl CudaRuntime {
     }
 
     fn bucket_capacity_dyn_map_from_context(
-        dyn_map: &FxHashMap<char, usize>,
-        bucket_indices: &FxHashMap<char, usize>,
-        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
-    ) -> FxHashMap<char, usize> {
+        dyn_map: &DynMap,
+        bucket_indices: &DynMap,
+        dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
+    ) -> DynMap {
         let mut capacity_dyn_map = dyn_map.clone();
         for (dim, buckets) in dim_buckets {
             let bucket_idx = bucket_indices.get(dim).copied().unwrap_or(0);
@@ -2499,10 +2483,7 @@ impl CudaRuntime {
         capacity_dyn_map
     }
 
-    fn dry_plan_intermediate_buffers(
-        bucket: &mut CompiledBucket,
-        dyn_dims: &FxHashMap<char, usize>,
-    ) {
+    fn dry_plan_intermediate_buffers(bucket: &mut CompiledBucket, dyn_dims: &DynMap) {
         let needs_new_plan =
             bucket.logical_buffer_slots.is_empty() && !bucket.buffer_specs.is_empty();
         if needs_new_plan {
@@ -2528,9 +2509,7 @@ impl CudaRuntime {
         }
     }
 
-    fn candidate_allocation_dyn_map(
-        context: luminal::op::CandidateFilterContext<'_>,
-    ) -> FxHashMap<char, usize> {
+    fn candidate_allocation_dyn_map(context: luminal::op::CandidateFilterContext<'_>) -> DynMap {
         if let Some(bucket_context) = context.bucket_context {
             Self::bucket_capacity_dyn_map_from_context(
                 context.dyn_map,
@@ -2544,7 +2523,7 @@ impl CudaRuntime {
 
     fn compiled_kernel_resource_plans(
         bucket: &CompiledBucket,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> Result<Vec<KernelResourcePlan>, ResourceViolation> {
         let mut plans = Vec::new();
         for executable in bucket.exec_graph.node_weights() {
@@ -2555,10 +2534,7 @@ impl CudaRuntime {
         Ok(plans)
     }
 
-    fn complete_resource_dyn_map(
-        bucket: &CompiledBucket,
-        mut dyn_map: FxHashMap<char, usize>,
-    ) -> FxHashMap<char, usize> {
+    fn complete_resource_dyn_map(bucket: &CompiledBucket, mut dyn_map: DynMap) -> DynMap {
         for dim in bucket
             .buffer_specs
             .values()
@@ -2691,7 +2667,7 @@ impl CudaRuntime {
 
     fn compiled_host_device_memory_plans(
         bucket: &CompiledBucket,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         buffer_lengths: &FxHashMap<NodeIndex, usize>,
     ) -> Result<Vec<HostDeviceMemoryPlan>, ResourceViolation> {
         bucket
@@ -2778,7 +2754,7 @@ impl CudaRuntime {
     /// rejected before replacing the working runtime.
     fn retained_bucket_resource_plan(
         buckets: &mut [CompiledBucket],
-        allocation_dyn_maps: &[FxHashMap<char, usize>],
+        allocation_dyn_maps: &[DynMap],
         hlir_buffer_lengths: &FxHashMap<NodeIndex, usize>,
     ) -> Result<CandidateResourcePlan, ResourceViolation> {
         assert_eq!(buckets.len(), allocation_dyn_maps.len());
@@ -2812,7 +2788,7 @@ impl CudaRuntime {
     fn validate_compiled_bucket_resources(
         &mut self,
         bucket_idx: usize,
-        allocation_dyn_map: &FxHashMap<char, usize>,
+        allocation_dyn_map: &DynMap,
     ) -> Result<(), ResourceViolation> {
         let caps = CandidateResourceCaps {
             max_intermediate_bytes: self.max_intermediate_memory_bytes,
@@ -2874,11 +2850,11 @@ impl CudaRuntime {
     /// Pre-allocate buffers and materialize CUDA graphs with the given dynamic
     /// dimension values when all required input buffers are already available.
     #[tracing::instrument(skip_all)]
-    pub fn prebuild_graphs(&mut self, dyn_map: &FxHashMap<char, usize>) {
+    pub fn prebuild_graphs(&mut self, dyn_map: &DynMap) {
         self.try_prebuild_graphs(dyn_map).unwrap();
     }
 
-    fn try_prebuild_graphs(&mut self, dyn_map: &FxHashMap<char, usize>) -> anyhow::Result<()> {
+    fn try_prebuild_graphs(&mut self, dyn_map: &DynMap) -> anyhow::Result<()> {
         let bucket_idx = self.active_bucket;
         self.prepare_bucket_buffers(bucket_idx, dyn_map);
         self.materialize_bucket_cuda_graphs(bucket_idx, dyn_map, true)
@@ -3051,7 +3027,7 @@ impl CudaRuntime {
             // trip-difference terms by a constant per body (~3x observed on
             // gemma4_moe) regardless of the candidate's true dim
             // sensitivity.
-            let stale_dims: Vec<char> = {
+            let stale_dims: Vec<Symbol> = {
                 let bucket = &self.compiled_buckets[bucket_idx];
                 bucket
                     .last_dyn_map
@@ -3092,7 +3068,7 @@ impl CudaRuntime {
     fn profile_loaded_llir(
         &mut self,
         llir_graph: &LLIRGraph,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         trials: usize,
         timeout: Option<std::time::Duration>,
         early_stop: Option<(Duration, f64)>,
@@ -3265,7 +3241,7 @@ impl CudaRuntime {
 
     fn try_load_llir_buckets(
         &mut self,
-        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
+        dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
         bucket_llirs: &[BucketLLIR],
     ) -> anyhow::Result<()> {
         let bucket_llir_refs = bucket_llirs.iter().map(BucketLLIRRef::from).collect_vec();
@@ -3321,7 +3297,7 @@ impl CudaRuntime {
     /// load time.
     fn compile_and_validate_bucket_set(
         &mut self,
-        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
+        dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
         bucket_llirs: &[BucketLLIRRef<'_>],
     ) -> anyhow::Result<ValidatedBucketSet> {
         // Validate the entire stitched candidate before mutating the currently
@@ -3458,7 +3434,7 @@ impl Runtime for CudaRuntime {
 
     fn filter_llir_bucket_set(
         &mut self,
-        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
+        dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
         bucket_llirs: &[BucketLLIRRef<'_>],
         _search_options: &CompileOptions,
     ) -> luminal::op::CandidateFilterResult {
@@ -3548,7 +3524,7 @@ impl Runtime for CudaRuntime {
             .sum()
     }
 
-    fn has_nan_outputs(&self, _llir_graph: &LLIRGraph, _dyn_map: &FxHashMap<char, usize>) -> bool {
+    fn has_nan_outputs(&self, _llir_graph: &LLIRGraph, _dyn_map: &DynMap) -> bool {
         let _ = self.cuda_stream.synchronize();
         let bucket = self.active();
         let mut checked = FxHashSet::default();
@@ -3596,7 +3572,7 @@ impl Runtime for CudaRuntime {
     fn profile(
         &mut self,
         llir_graph: &LLIRGraph,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         trials: usize,
         timeout: Option<std::time::Duration>,
         early_stop: Option<(Self::ProfileMetric, f64)>,
@@ -3618,7 +3594,7 @@ impl Runtime for CudaRuntime {
     fn profile_with_bucket_context(
         &mut self,
         llir_graph: &LLIRGraph,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         trials: usize,
         timeout: Option<std::time::Duration>,
         early_stop: Option<(Self::ProfileMetric, f64)>,
@@ -3648,7 +3624,7 @@ impl Runtime for CudaRuntime {
     }
 
     #[tracing::instrument(skip_all)]
-    fn execute(&mut self, dyn_map: &FxHashMap<char, usize>) -> Self::ExecReturn {
+    fn execute(&mut self, dyn_map: &DynMap) -> Self::ExecReturn {
         let profile_runtime = std::env::var_os("LUMINAL_CUDA_PROFILE_RECAPTURE").is_some();
         let runtime_profile_start = std::time::Instant::now();
         let mut bucket_dispatch_time = Duration::ZERO;
@@ -3882,7 +3858,7 @@ impl Runtime for CudaRuntime {
 
     fn load_llir_buckets(
         &mut self,
-        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
+        dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
         bucket_llirs: &[BucketLLIR],
     ) {
         self.try_load_llir_buckets(dim_buckets, bucket_llirs)
@@ -4172,7 +4148,7 @@ impl CudaRuntime {
     }
 
     /// Resolve which bucket matches the current dyn_map values.
-    fn resolve_bucket(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn resolve_bucket(&self, dyn_map: &DynMap) -> usize {
         self.compiled_buckets
             .iter()
             .position(|bucket| {
@@ -4801,7 +4777,7 @@ mod arena_plan_tests {
     fn bucket_memory_dry_plan_uses_bucket_capacity_dims() {
         let data = NodeIndex::new(1);
         let mut bucket = CompiledBucket::new();
-        bucket.bucket_indices.insert('s', 1);
+        bucket.bucket_indices.insert(Symbol::from('s'), 1);
         bucket.buffer_specs.insert(
             data,
             BufferSpec {
@@ -4812,10 +4788,13 @@ mod arena_plan_tests {
         bucket.output_producers.insert(NodeIndex::new(99), data);
 
         let mut dim_buckets = FxHashMap::default();
-        dim_buckets.insert('s', vec![DimBucket::new(1, 1), DimBucket::new(2, 64)]);
+        dim_buckets.insert(
+            Symbol::from('s'),
+            vec![DimBucket::new(1, 1), DimBucket::new(2, 64)],
+        );
 
         let mut representative_dyn_map = FxHashMap::default();
-        representative_dyn_map.insert('s', 16);
+        representative_dyn_map.insert(Symbol::from('s'), 16);
         let capacity_dyn_map = CudaRuntime::bucket_capacity_dyn_map_from_context(
             &representative_dyn_map,
             &bucket.bucket_indices,
@@ -4824,7 +4803,7 @@ mod arena_plan_tests {
 
         CudaRuntime::dry_plan_intermediate_buffers(&mut bucket, &capacity_dyn_map);
 
-        assert_eq!(capacity_dyn_map[&'s'], 64);
+        assert_eq!(capacity_dyn_map[&Symbol::from('s')], 64);
         assert_eq!(bucket.arena_bytes, align_up(64 * 4, ARENA_ALIGNMENT));
         assert_eq!(
             CudaRuntime::planned_allocation_bytes(&bucket),
@@ -4994,13 +4973,13 @@ mod arena_plan_tests {
         });
 
         let mut dyn_map = FxHashMap::default();
-        dyn_map.insert('s', 4);
+        dyn_map.insert(Symbol::from('s'), 4);
         CudaRuntime::refresh_fixed_intermediate_buffer_plan(&mut bucket, &dyn_map);
         let first_offset_a = bucket.logical_buffer_offsets[&a];
         let first_offset_b = bucket.logical_buffer_offsets[&b];
         let first_arena_bytes = bucket.arena_bytes;
 
-        dyn_map.insert('s', 32);
+        dyn_map.insert(Symbol::from('s'), 32);
         CudaRuntime::refresh_fixed_intermediate_buffer_plan(&mut bucket, &dyn_map);
 
         assert_eq!(bucket.logical_buffer_slots[&a], 0);

--- a/crates/luminal_cuda_lite/src/tests/cublaslt_rewrite_tests.rs
+++ b/crates/luminal_cuda_lite/src/tests/cublaslt_rewrite_tests.rs
@@ -1068,18 +1068,21 @@ fn bucket_range_and_singleton_cublaslt_buckets_are_captured() {
     let llir =
         extract_forced_cublaslt_llir_where(&mut cx, "bucketed s cuBLASLt graph capture", |_| true);
 
-    let dim_buckets = [('s', vec![DimBucket::new(1, 1), DimBucket::new(2, 4)])]
-        .into_iter()
-        .collect();
+    let dim_buckets = [(
+        Symbol::from('s'),
+        vec![DimBucket::new(1, 1), DimBucket::new(2, 4)],
+    )]
+    .into_iter()
+    .collect();
     let bucket_llirs = vec![
         (
-            [('s', 0usize)].into_iter().collect(),
-            [('s', 1usize)].into_iter().collect(),
+            [(Symbol::from('s'), 0usize)].into_iter().collect(),
+            [(Symbol::from('s'), 1usize)].into_iter().collect(),
             llir.clone(),
         ),
         (
-            [('s', 1usize)].into_iter().collect(),
-            [('s', 3usize)].into_iter().collect(),
+            [(Symbol::from('s'), 1usize)].into_iter().collect(),
+            [(Symbol::from('s'), 3usize)].into_iter().collect(),
             llir,
         ),
     ];

--- a/crates/luminal_cuda_lite/src/tests/flashinfer.rs
+++ b/crates/luminal_cuda_lite/src/tests/flashinfer.rs
@@ -152,6 +152,7 @@ fn run_flashinfer(
         head_dim: HEAD_DIM,
         page_size: 1,
         batch_dim: Expression::from('s'),
+        context_dim: Expression::from('c'),
         dtype: luminal::dtype::DType::F32,
         sm_scale: 0.0,
         window_left: -1,
@@ -183,9 +184,9 @@ fn run_flashinfer(
     let inputs = [q_n, k_n, v_n, idx_n, qo_n, kv_n];
 
     let mut dyn_map = FxHashMap::default();
-    dyn_map.insert('s', batch_size);
-    dyn_map.insert('c', kv_indices.len());
-    dyn_map.insert('r', kv_indptr.len());
+    dyn_map.insert(Symbol::from('s'), batch_size);
+    dyn_map.insert(Symbol::from('c'), kv_indices.len());
+    dyn_map.insert(Symbol::from('r'), kv_indptr.len());
 
     fi.execute(stream, out_n, &inputs, &buffers, &dyn_map)
         .expect("FlashInferAttention execute failed");
@@ -226,6 +227,7 @@ fn run_flashinfer_with_compact_decode_indices(
         head_dim: HEAD_DIM,
         page_size: 1,
         batch_dim: Expression::from('s'),
+        context_dim: Expression::from('c'),
         dtype: luminal::dtype::DType::F32,
         sm_scale: 0.0,
         window_left: -1,
@@ -250,8 +252,8 @@ fn run_flashinfer_with_compact_decode_indices(
     let inputs = [q_n, k_n, v_n, idx_n];
 
     let mut dyn_map = FxHashMap::default();
-    dyn_map.insert('s', batch_size);
-    dyn_map.insert('c', kv_indices.len());
+    dyn_map.insert(Symbol::from('s'), batch_size);
+    dyn_map.insert(Symbol::from('c'), kv_indices.len());
 
     fi.execute(stream, out_n, &inputs, &buffers, &dyn_map)
         .expect("FlashInferAttention compact-index execute failed");
@@ -281,6 +283,7 @@ fn resolve_flashinfer_decode_for_signature_test(
         head_dim: HEAD_DIM,
         page_size: 1,
         batch_dim: Expression::from('s'),
+        context_dim: Expression::from('c'),
         dtype: luminal::dtype::DType::F32,
         sm_scale: 0.0,
         window_left: -1,
@@ -296,8 +299,8 @@ fn resolve_flashinfer_decode_for_signature_test(
     buffers.insert(out_n, DeviceBuffer::new(0x6000, HIDDEN * 4));
 
     let mut dyn_map = FxHashMap::default();
-    dyn_map.insert('s', 1);
-    dyn_map.insert('c', context_len);
+    dyn_map.insert(Symbol::from('s'), 1);
+    dyn_map.insert(Symbol::from('c'), context_len);
     fi.resolve_for_graph(out_n, &[q_n, k_n, v_n, idx_n], &buffers, &dyn_map)
         .unwrap()
 }
@@ -721,25 +724,52 @@ fn build_paged_attention_graph_with_mask_and_cache_provenance(
     k_provenance: TestCacheProvenance,
     v_provenance: TestCacheProvenance,
 ) -> (Graph, PagedAttnHandles) {
+    build_paged_attention_graph_with_token_dim(
+        n_heads,
+        n_kv_heads,
+        head_dim,
+        mask_kind,
+        k_provenance,
+        v_provenance,
+        's',
+        'c',
+    )
+}
+
+/// `token_dim` and `context_dim` name the per-forward-pass token dimension and
+/// the total attended context. The rules bind both as pattern variables, so any
+/// names work; the parameters exist so a test can prove that rather than assert
+/// it.
+#[allow(clippy::too_many_arguments)] // test builder; the two dims are the point
+fn build_paged_attention_graph_with_token_dim(
+    n_heads: usize,
+    n_kv_heads: usize,
+    head_dim: usize,
+    mask_kind: TestMaskKind,
+    k_provenance: TestCacheProvenance,
+    v_provenance: TestCacheProvenance,
+    token_dim: char,
+    context_dim: char,
+) -> (Graph, PagedAttnHandles) {
     let kv_groups = n_heads / n_kv_heads;
     let kv_dim = n_kv_heads * head_dim;
     let hidden = n_heads * head_dim;
 
     let mut cx = Graph::default();
 
-    let q_rope = cx.named_tensor("q_rope", ('s', hidden));
-    let k_rope = cx.named_tensor("k_rope", ('s', kv_dim));
-    let v_new = cx.named_tensor("v_new", ('s', kv_dim));
+    let q_rope = cx.named_tensor("q_rope", (token_dim, hidden));
+    let k_rope = cx.named_tensor("k_rope", (token_dim, kv_dim));
+    let v_new = cx.named_tensor("v_new", (token_dim, kv_dim));
     let k_cache = cx.named_tensor("k_cache", (2048, kv_dim)).persist();
     let v_cache = cx.named_tensor("v_cache", (2048, kv_dim)).persist();
     let scatter_idx = cx
-        .named_tensor("scatter_idx", 's')
+        .named_tensor("scatter_idx", token_dim)
         .as_dtype(luminal::dtype::DType::Int);
     let gather_idx = cx
-        .named_tensor("gather_idx", 'c')
+        .named_tensor("gather_idx", context_dim)
         .as_dtype(luminal::dtype::DType::Int);
     let q_pos = cx
-        .named_tensor("q_pos", 's')
+        .named_tensor("q_pos", token_dim)
         .as_dtype(luminal::dtype::DType::Int);
     let qo_indptr = cx
         .named_tensor("qo_indptr", 'r')
@@ -757,7 +787,7 @@ fn build_paged_attention_graph_with_mask_and_cache_provenance(
     let k = gather_rows(k_cache_out, gather_idx, kv_dim);
     let v_ctx = gather_rows(v_cache_out, gather_idx, kv_dim);
 
-    let c: Expression = 'c'.into();
+    let c: Expression = context_dim.into();
     let attn_mask = match mask_kind {
         TestMaskKind::Indptr => test_compute_attn_mask(&mut cx, q_pos, qo_indptr, kv_indptr, c),
         TestMaskKind::TriuGather => test_compute_triu_gather_mask(&mut cx, q_pos, c),
@@ -829,7 +859,10 @@ fn saturate_and_has_flashinfer_inner(
     // whether downstream extraction would have pruned it.
     let egraph = if let Some((s_min, s_max)) = s_interval {
         let mut intervals = luminal::prelude::FxHashMap::default();
-        intervals.insert('s', luminal::shape::DimInterval::new(s_min, s_max));
+        intervals.insert(
+            Symbol::from('s'),
+            luminal::shape::DimInterval::new(s_min, s_max),
+        );
         let interval_facts = luminal::egglog_utils::base::interval_facts_egglog(&intervals, []);
         let program = format!("{interval_facts}\n{program}");
         run_egglog_with_late_passes_and_interval_analysis(&program, &root, &ops, false, &[], true)
@@ -1260,6 +1293,35 @@ fn flashinfer_rule_fires_on_non_llama_dims() {
 }
 
 #[test]
+fn flashinfer_rule_fires_regardless_of_dim_names() {
+    if !crate::tests::utilities::gpu_supports_flashinfer() {
+        return;
+    }
+    // The rules bind both dynamic dims as pattern variables rather than matching
+    // literal names, so an identical graph must be recognised under any names.
+    // Before that change this graph produced no FlashInferAttention at all -- it
+    // silently fell back to the HLIR chain, which is why PT2-imported models
+    // (dims named s77/u0) never hit this path.
+    let (cx, _) = build_paged_attention_graph_with_token_dim(
+        8,
+        8,
+        64,
+        TestMaskKind::Indptr,
+        TestCacheProvenance::Raw,
+        TestCacheProvenance::Raw,
+        'w',
+        'x',
+    );
+    let (has_flashinfer, op_kinds) = saturate_and_has_flashinfer(&cx);
+    assert!(
+        has_flashinfer,
+        "FlashInferAttention was NOT found for a graph whose dims are named \
+         'w'/'x' instead of 's'/'c'. The rules are still name-coupled. \
+         OpKinds: {op_kinds:?}"
+    );
+}
+
+#[test]
 fn flashinfer_rule_fires_on_mha() {
     if !crate::tests::utilities::gpu_supports_flashinfer() {
         return;
@@ -1438,6 +1500,7 @@ fn run_flashinfer_bf16(
         head_dim: HEAD_DIM,
         page_size: 1,
         batch_dim: Expression::from('s'),
+        context_dim: Expression::from('c'),
         dtype: luminal::dtype::DType::Bf16,
         sm_scale: 0.0,
         window_left: -1,
@@ -1473,8 +1536,8 @@ fn run_flashinfer_bf16(
     );
 
     let mut dyn_map = FxHashMap::default();
-    dyn_map.insert('s', total_q_tokens);
-    dyn_map.insert('c', kv_indices.len());
+    dyn_map.insert(Symbol::from('s'), total_q_tokens);
+    dyn_map.insert(Symbol::from('c'), kv_indices.len());
 
     let _qo_buf;
     let _kv_buf;
@@ -1491,7 +1554,7 @@ fn run_flashinfer_bf16(
             kv_n,
             DeviceBuffer::new(_kv_buf.device_ptr(stream).0, kv_indptr.len() * 4),
         );
-        dyn_map.insert('r', kv_indptr.len());
+        dyn_map.insert(Symbol::from('r'), kv_indptr.len());
         vec![q_n, k_n, v_n, idx_n, qo_n, kv_n]
     } else {
         vec![q_n, k_n, v_n, idx_n]

--- a/crates/luminal_metal/src/dyn_backend.rs
+++ b/crates/luminal_metal/src/dyn_backend.rs
@@ -28,7 +28,7 @@ impl DynBackend for MetalDynBackend {
     fn get_output_f32(&self, node: NodeIndex) -> Vec<f32> {
         self.runtime.get_f32(node)
     }
-    fn execute(&mut self, dyn_map: &FxHashMap<char, usize>) {
+    fn execute(&mut self, dyn_map: &DynMap) {
         self.runtime.execute(dyn_map);
     }
 }

--- a/crates/luminal_metal/src/kernel/mod.rs
+++ b/crates/luminal_metal/src/kernel/mod.rs
@@ -15,7 +15,40 @@ use objc::runtime::Object;
 use objc::{class, msg_send, sel, sel_impl};
 use std::cell::RefCell;
 
-pub const DYN_SLOT_COUNT: usize = 26;
+thread_local! {
+    /// Layout of the shared `dyn[]` buffer: slot `i` holds the size of
+    /// `DYN_DIMS_ORDER[i]`. Codegen bakes these indices into generated source
+    /// and the runtime uploads in the same order, so both must read one list.
+    /// Built by `dyn_slot` as compilation reaches each dim.
+    static DYN_DIMS_ORDER: RefCell<Vec<Symbol>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Drop the previous graph's layout. Must run before compiling, or slots
+/// carry over and the buffer is sized for dims this graph never reads.
+pub(crate) fn clear_dyn_dims_order() {
+    DYN_DIMS_ORDER.with(|order| order.borrow_mut().clear());
+}
+
+/// The current `dyn[]` buffer layout.
+pub(crate) fn dyn_dims_order() -> Vec<Symbol> {
+    DYN_DIMS_ORDER.with(|order| order.borrow().clone())
+}
+
+/// This dim's slot, assigning the next one if it has not been seen.
+///
+/// Appends, never inserts, so a slot already baked into emitted source keeps
+/// its meaning. The runtime re-reads the layout after compiling and sizes the
+/// buffer to match.
+pub(crate) fn dyn_slot(symbol: &Symbol) -> usize {
+    DYN_DIMS_ORDER.with(|order| {
+        if let Some(slot) = order.borrow().iter().position(|d| d == symbol) {
+            return slot;
+        }
+        let mut order = order.borrow_mut();
+        order.push(*symbol);
+        order.len() - 1
+    })
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct MpsMatrixDescriptorKey {
@@ -163,7 +196,7 @@ pub trait MetalKernelOp: EgglogOp {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     );
 
     #[allow(clippy::too_many_arguments)]
@@ -173,7 +206,7 @@ pub trait MetalKernelOp: EgglogOp {
         pipeline: Option<&ComputePipelineState>,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         _input_dtypes: &[DType],
         _output_dtype: DType,
     ) {
@@ -189,15 +222,15 @@ pub trait MetalKernelOp: EgglogOp {
     // Performance Metrics for MBU/MFU Calculation
     // ========================================================================
 
-    fn bytes_loaded(&self, _dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_loaded(&self, _dyn_map: &DynMap) -> usize {
         0
     }
 
-    fn bytes_stored(&self, _dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_stored(&self, _dyn_map: &DynMap) -> usize {
         0
     }
 
-    fn flops(&self, _dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn flops(&self, _dyn_map: &DynMap) -> usize {
         0
     }
 

--- a/crates/luminal_metal/src/kernel/ops.rs
+++ b/crates/luminal_metal/src/kernel/ops.rs
@@ -72,19 +72,10 @@ fn compile_shader(device: &Device, source: &str, function_name: &str) -> Compute
         })
 }
 
-fn lower_dynamic_consts(mut code: String) -> String {
-    for c in b'a'..=b'y' {
-        let symbol = c as char;
-        code = code.replace(
-            &format!("const_{symbol}"),
-            &format!("dyn[{}]", (c - b'a') as usize),
-        );
-    }
-    code
-}
-
 pub(crate) fn lower_expression_for_metal(expr: &Expression, index_var: &str) -> String {
-    lower_dynamic_consts(expr.to_kernel().replace("const_z", index_var))
+    expr.to_kernel_with(index_var, &|symbol| {
+        format!("dyn[{}]", super::dyn_slot(symbol))
+    })
 }
 
 fn metal_buffer_type(dtype: DType) -> &'static str {
@@ -179,17 +170,17 @@ fn binary_dtype_rewrite(hlir_sort: &SortDef, metal_sort: &SortDef) -> Rule {
 /// Generate metrics methods for unary ops: 1 input read, 1 output write, 1 flop per element
 macro_rules! impl_unary_metrics {
     ($self:ident, $dyn_map:ident) => {
-        fn bytes_loaded(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+        fn bytes_loaded(&$self, $dyn_map: &DynMap) -> usize {
             let n = $self.output_size().exec($dyn_map).unwrap_or(0);
             n * std::mem::size_of::<f32>()
         }
 
-        fn bytes_stored(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+        fn bytes_stored(&$self, $dyn_map: &DynMap) -> usize {
             let n = $self.output_size().exec($dyn_map).unwrap_or(0);
             n * std::mem::size_of::<f32>()
         }
 
-        fn flops(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+        fn flops(&$self, $dyn_map: &DynMap) -> usize {
             $self.output_size().exec($dyn_map).unwrap_or(0)
         }
     };
@@ -198,17 +189,17 @@ macro_rules! impl_unary_metrics {
 /// Generate metrics methods for binary ops: 2 inputs read, 1 output write, flops_per_elem per element
 macro_rules! impl_binary_metrics {
     ($self:ident, $dyn_map:ident, $flops_per_elem:expr) => {
-        fn bytes_loaded(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+        fn bytes_loaded(&$self, $dyn_map: &DynMap) -> usize {
             let n = $self.output_size().exec($dyn_map).unwrap_or(0);
             n * 2 * std::mem::size_of::<f32>()
         }
 
-        fn bytes_stored(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+        fn bytes_stored(&$self, $dyn_map: &DynMap) -> usize {
             let n = $self.output_size().exec($dyn_map).unwrap_or(0);
             n * std::mem::size_of::<f32>()
         }
 
-        fn flops(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+        fn flops(&$self, $dyn_map: &DynMap) -> usize {
             $self.output_size().exec($dyn_map).unwrap_or(0) * $flops_per_elem
         }
     };
@@ -217,18 +208,18 @@ macro_rules! impl_binary_metrics {
 /// Generate metrics methods for reduce ops
 macro_rules! impl_reduce_metrics {
     ($self:ident, $dyn_map:ident) => {
-        fn bytes_loaded(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+        fn bytes_loaded(&$self, $dyn_map: &DynMap) -> usize {
             let n_outputs = $self.output_size().exec($dyn_map).unwrap_or(0);
             let iters = $self.iters.exec($dyn_map).unwrap_or(0);
             n_outputs * iters * std::mem::size_of::<f32>()
         }
 
-        fn bytes_stored(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+        fn bytes_stored(&$self, $dyn_map: &DynMap) -> usize {
             let n = $self.output_size().exec($dyn_map).unwrap_or(0);
             n * std::mem::size_of::<f32>()
         }
 
-        fn flops(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+        fn flops(&$self, $dyn_map: &DynMap) -> usize {
             let n_outputs = $self.output_size().exec($dyn_map).unwrap_or(0);
             let iters = $self.iters.exec($dyn_map).unwrap_or(0);
             n_outputs * iters
@@ -355,7 +346,7 @@ macro_rules! metal_unary_op {
                 pipeline: &ComputePipelineState,
                 inputs: &[&Buffer],
                 output: &Buffer,
-                dyn_map: &FxHashMap<char, usize>,
+                dyn_map: &DynMap,
             ) {
                 let n_elements = self.output_size().exec(dyn_map).unwrap() as u32;
 
@@ -508,7 +499,7 @@ impl MetalKernelOp for MetalAdd {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_elements = self.output_size().exec(dyn_map).unwrap() as u32;
 
@@ -640,7 +631,7 @@ impl MetalKernelOp for MetalMul {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_elements = self.output_size().exec(dyn_map).unwrap() as u32;
 
@@ -787,7 +778,7 @@ impl MetalKernelOp for MetalMod {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_elements = self.output_size().exec(dyn_map).unwrap() as u32;
 
@@ -932,7 +923,7 @@ impl MetalKernelOp for MetalLessThan {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_elements = self.output_size().exec(dyn_map).unwrap() as u32;
 
@@ -1098,7 +1089,7 @@ impl MetalKernelOp for MetalSumReduce {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_outputs = self.output_size().exec(dyn_map).unwrap() as u32;
 
@@ -1270,7 +1261,7 @@ impl MetalKernelOp for MetalMaxReduce {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_outputs = self.output_size().exec(dyn_map).unwrap() as u32;
 
@@ -1501,7 +1492,7 @@ impl EgglogOp for MPSMatmul {
 }
 
 impl MPSMatmul {
-    fn row_bytes(row_stride: Expression, dtype: DType, dyn_map: &FxHashMap<char, usize>) -> u64 {
+    fn row_bytes(row_stride: Expression, dtype: DType, dyn_map: &DynMap) -> u64 {
         let elems = row_stride
             .substitute('z', Expression::from(1))
             .exec(dyn_map)
@@ -1557,7 +1548,7 @@ impl MetalKernelOp for MPSMatmul {
         _pipeline: &ComputePipelineState,
         _inputs: &[&Buffer],
         _output: &Buffer,
-        _dyn_map: &FxHashMap<char, usize>,
+        _dyn_map: &DynMap,
     ) {
         panic!("MPSMatmul encodes directly onto the command buffer")
     }
@@ -1568,7 +1559,7 @@ impl MetalKernelOp for MPSMatmul {
         _pipeline: Option<&ComputePipelineState>,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         input_dtypes: &[DType],
         output_dtype: DType,
     ) {
@@ -1636,20 +1627,20 @@ impl MetalKernelOp for MPSMatmul {
         }
     }
 
-    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_loaded(&self, dyn_map: &DynMap) -> usize {
         let m = self.m.exec(dyn_map).unwrap_or(0);
         let n = self.n.exec(dyn_map).unwrap_or(0);
         let k = self.k.exec(dyn_map).unwrap_or(0);
         2 * m * n * k * std::mem::size_of::<f32>()
     }
 
-    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_stored(&self, dyn_map: &DynMap) -> usize {
         let m = self.m.exec(dyn_map).unwrap_or(0);
         let n = self.n.exec(dyn_map).unwrap_or(0);
         m * n * std::mem::size_of::<f32>()
     }
 
-    fn flops(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn flops(&self, dyn_map: &DynMap) -> usize {
         let m = self.m.exec(dyn_map).unwrap_or(0);
         let n = self.n.exec(dyn_map).unwrap_or(0);
         let k = self.k.exec(dyn_map).unwrap_or(0);
@@ -1940,7 +1931,7 @@ impl MetalKernelOp for MPSBatchedMatmul {
         _pipeline: &ComputePipelineState,
         _inputs: &[&Buffer],
         _output: &Buffer,
-        _dyn_map: &FxHashMap<char, usize>,
+        _dyn_map: &DynMap,
     ) {
         panic!("MPSBatchedMatmul encodes directly onto the command buffer")
     }
@@ -1951,7 +1942,7 @@ impl MetalKernelOp for MPSBatchedMatmul {
         _pipeline: Option<&ComputePipelineState>,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         input_dtypes: &[DType],
         output_dtype: DType,
     ) {
@@ -2033,7 +2024,7 @@ impl MetalKernelOp for MPSBatchedMatmul {
         }
     }
 
-    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_loaded(&self, dyn_map: &DynMap) -> usize {
         let batch = self.batch.exec(dyn_map).unwrap_or(0);
         let m = self.m.exec(dyn_map).unwrap_or(0);
         let n = self.n.exec(dyn_map).unwrap_or(0);
@@ -2041,14 +2032,14 @@ impl MetalKernelOp for MPSBatchedMatmul {
         2 * batch * m * n * k * std::mem::size_of::<f32>()
     }
 
-    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_stored(&self, dyn_map: &DynMap) -> usize {
         let batch = self.batch.exec(dyn_map).unwrap_or(0);
         let m = self.m.exec(dyn_map).unwrap_or(0);
         let n = self.n.exec(dyn_map).unwrap_or(0);
         batch * m * n * std::mem::size_of::<f32>()
     }
 
-    fn flops(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn flops(&self, dyn_map: &DynMap) -> usize {
         let batch = self.batch.exec(dyn_map).unwrap_or(0);
         let m = self.m.exec(dyn_map).unwrap_or(0);
         let n = self.n.exec(dyn_map).unwrap_or(0);
@@ -2304,7 +2295,7 @@ impl MetalKernelOp for GenericMatmul {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_outputs = self.output_size().exec(dyn_map).unwrap() as u32;
 
@@ -2323,17 +2314,17 @@ impl MetalKernelOp for GenericMatmul {
         encoder.dispatch_thread_groups(thread_groups, thread_group_size);
     }
 
-    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_loaded(&self, dyn_map: &DynMap) -> usize {
         let n_outputs = self.output_size().exec(dyn_map).unwrap_or(0);
         let k = self.k.exec(dyn_map).unwrap_or(0);
         2 * n_outputs * k * std::mem::size_of::<f32>()
     }
 
-    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_stored(&self, dyn_map: &DynMap) -> usize {
         self.output_size().exec(dyn_map).unwrap_or(0) * std::mem::size_of::<f32>()
     }
 
-    fn flops(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn flops(&self, dyn_map: &DynMap) -> usize {
         let n_outputs = self.output_size().exec(dyn_map).unwrap_or(0);
         let k = self.k.exec(dyn_map).unwrap_or(0);
         2 * n_outputs * k
@@ -2444,7 +2435,7 @@ impl MetalKernelOp for MetalConstant {
         pipeline: &ComputePipelineState,
         _inputs: &[&Buffer],
         output: &Buffer,
-        _dyn_map: &FxHashMap<char, usize>,
+        _dyn_map: &DynMap,
     ) {
         encoder.set_compute_pipeline_state(pipeline);
         encoder.set_buffer(0, Some(output), 0);
@@ -2552,7 +2543,7 @@ impl MetalKernelOp for MetalIota {
         pipeline: &ComputePipelineState,
         _inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_elements = self.range.exec(dyn_map).unwrap() as u32;
 
@@ -2725,7 +2716,7 @@ impl MetalKernelOp for MetalGather {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_elements = self.output_size().exec(dyn_map).unwrap() as u32;
 
@@ -2745,19 +2736,19 @@ impl MetalKernelOp for MetalGather {
     }
 
     // Gather metrics: read indices + read gathered data + write output
-    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_loaded(&self, dyn_map: &DynMap) -> usize {
         let n = self.output_size().exec(dyn_map).unwrap_or(0);
         // Read n indices (i32 = 4 bytes) + n data elements (f32 = 4 bytes)
         n * std::mem::size_of::<i32>() + n * std::mem::size_of::<f32>()
     }
 
-    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_stored(&self, dyn_map: &DynMap) -> usize {
         let n = self.output_size().exec(dyn_map).unwrap_or(0);
         // Write n output elements (f32)
         n * std::mem::size_of::<f32>()
     }
 
-    fn flops(&self, _dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn flops(&self, _dyn_map: &DynMap) -> usize {
         // Gather is memory-bound, no significant FLOPs
         0
     }
@@ -2975,7 +2966,7 @@ impl MetalKernelOp for MetalScatter {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_dest = self
             .dest_shape
@@ -3027,7 +3018,7 @@ impl MetalKernelOp for MetalScatter {
         );
     }
 
-    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_loaded(&self, dyn_map: &DynMap) -> usize {
         let n_dest = self.output_size().exec(dyn_map).unwrap_or(0);
         let n_src = self
             .index_shape
@@ -3041,12 +3032,12 @@ impl MetalKernelOp for MetalScatter {
             + n_src * std::mem::size_of::<f32>()
     }
 
-    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_stored(&self, dyn_map: &DynMap) -> usize {
         let n = self.output_size().exec(dyn_map).unwrap_or(0);
         n * std::mem::size_of::<f32>()
     }
 
-    fn flops(&self, _dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn flops(&self, _dyn_map: &DynMap) -> usize {
         0
     }
 }
@@ -3255,7 +3246,7 @@ impl MetalKernelOp for MetalScatterNoCopy {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_src = self
             .index_shape
@@ -3281,7 +3272,7 @@ impl MetalKernelOp for MetalScatterNoCopy {
         );
     }
 
-    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_loaded(&self, dyn_map: &DynMap) -> usize {
         let n_src = self
             .index_shape
             .iter()
@@ -3292,7 +3283,7 @@ impl MetalKernelOp for MetalScatterNoCopy {
         n_src * std::mem::size_of::<i32>() + n_src * std::mem::size_of::<f32>()
     }
 
-    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_stored(&self, dyn_map: &DynMap) -> usize {
         let n_src = self
             .index_shape
             .iter()
@@ -3303,7 +3294,7 @@ impl MetalKernelOp for MetalScatterNoCopy {
         n_src * std::mem::size_of::<f32>()
     }
 
-    fn flops(&self, _dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn flops(&self, _dyn_map: &DynMap) -> usize {
         0
     }
 
@@ -3431,7 +3422,7 @@ impl MetalKernelOp for MetalCast {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_elements = self.size.exec(dyn_map).unwrap_or(0) as u32;
 
@@ -3450,19 +3441,19 @@ impl MetalKernelOp for MetalCast {
     }
 
     // Cast is memory-bound: 1 read, 1 write, minimal compute
-    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_loaded(&self, dyn_map: &DynMap) -> usize {
         let n = self.size.exec(dyn_map).unwrap_or(0);
         // TODO: input dtype is not encoded; treat as 4B for now (matches current MetalRuntime IO path).
         n * std::mem::size_of::<f32>()
     }
 
-    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_stored(&self, dyn_map: &DynMap) -> usize {
         let n = self.size.exec(dyn_map).unwrap_or(0);
         // TODO: output dtype sizing should be wired through MetalRuntime allocation.
         n * std::mem::size_of::<f32>()
     }
 
-    fn flops(&self, _dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn flops(&self, _dyn_map: &DynMap) -> usize {
         0 // Type conversion has negligible compute cost
     }
 }

--- a/crates/luminal_metal/src/memory_analysis.rs
+++ b/crates/luminal_metal/src/memory_analysis.rs
@@ -29,7 +29,7 @@ const DTYPE_BITS: &[(&str, usize)] = &[
 pub(crate) fn metal_memory_analysis_pass(
     ops: &[Arc<Box<dyn EgglogOp>>],
     max_memory_bytes: Option<usize>,
-    _dyn_map: &FxHashMap<char, usize>,
+    _dyn_map: &DynMap,
 ) -> LateEgglogPass {
     let mut sorts = ops
         .iter()
@@ -86,7 +86,7 @@ pub(crate) fn metal_memory_analysis_pass(
 pub(crate) fn estimate_graph_memory_bytes<'a>(
     egraph: &'a SerializedEGraph,
     choices: &EGraphChoiceSet<'a>,
-    dyn_map: &FxHashMap<char, usize>,
+    dyn_map: &DynMap,
 ) -> Option<usize> {
     ChoiceMemoryEstimator::new(egraph, choices, dyn_map)
         .root_state()
@@ -213,7 +213,7 @@ pub(crate) struct MemorySplitStats {
 pub(crate) fn split_egraph_by_memory_limit(
     egraph: &mut SerializedEGraph,
     limit: usize,
-    dyn_map: &FxHashMap<char, usize>,
+    dyn_map: &DynMap,
 ) -> MemorySplitStats {
     let original_enodes = egraph.enodes.len();
     let original_eclasses = egraph.eclasses.len();
@@ -236,7 +236,7 @@ struct StateSplitter<'a> {
     original: &'a SerializedEGraph,
     split: SerializedEGraph,
     limit: usize,
-    dyn_map: &'a FxHashMap<char, usize>,
+    dyn_map: &'a DynMap,
     sort_by_name: FxHashMap<String, SortDef>,
     ir_memo: FxHashMap<ClassId, Vec<(MemoryState, ClassId)>>,
     list_memo: FxHashMap<ClassId, Vec<(ListMemoryState, ClassId)>>,
@@ -253,11 +253,7 @@ struct StateSplitter<'a> {
 }
 
 impl<'a> StateSplitter<'a> {
-    fn new(
-        original: &'a SerializedEGraph,
-        limit: usize,
-        dyn_map: &'a FxHashMap<char, usize>,
-    ) -> Self {
+    fn new(original: &'a SerializedEGraph, limit: usize, dyn_map: &'a DynMap) -> Self {
         let mut split = SerializedEGraph {
             enodes: FxHashMap::default(),
             eclasses: FxHashMap::default(),
@@ -761,7 +757,7 @@ impl<'a> StateSplitter<'a> {
 struct ChoiceMemoryEstimator<'a> {
     egraph: &'a SerializedEGraph,
     choices: &'a EGraphChoiceSet<'a>,
-    dyn_map: &'a FxHashMap<char, usize>,
+    dyn_map: &'a DynMap,
     sort_by_name: FxHashMap<String, SortDef>,
     ir_cache: FxHashMap<ClassId, MemoryState>,
     list_cache: FxHashMap<ClassId, ListMemoryState>,
@@ -773,7 +769,7 @@ impl<'a> ChoiceMemoryEstimator<'a> {
     fn new(
         egraph: &'a SerializedEGraph,
         choices: &'a EGraphChoiceSet<'a>,
-        dyn_map: &'a FxHashMap<char, usize>,
+        dyn_map: &'a DynMap,
     ) -> Self {
         Self {
             egraph,
@@ -936,7 +932,7 @@ fn kind_memory_for_node(
     egraph: &SerializedEGraph,
     sort_by_name: &FxHashMap<String, SortDef>,
     node: &NodeId,
-    dyn_map: &FxHashMap<char, usize>,
+    dyn_map: &DynMap,
 ) -> Option<KindMemory> {
     let (kind_label, kind_child_classes) = egraph.enodes.get(node)?;
     if zero_local_op_kind(kind_label) {
@@ -970,9 +966,9 @@ fn first_data_node<'a>(egraph: &'a SerializedEGraph, class: &'a ClassId) -> Opti
     nodes.iter().find(|node| egraph.enodes.contains_key(*node))
 }
 
-fn eval_bytes(expr: Expression, dyn_map: &FxHashMap<char, usize>) -> Option<usize> {
+fn eval_bytes(expr: Expression, dyn_map: &DynMap) -> Option<usize> {
     let mut dyn_map = dyn_map.clone();
-    dyn_map.entry('z').or_insert(1);
+    dyn_map.entry(Symbol::reserved_index()).or_insert(1);
     expr.simplify().exec(&dyn_map)
 }
 

--- a/crates/luminal_metal/src/runtime.rs
+++ b/crates/luminal_metal/src/runtime.rs
@@ -1,4 +1,4 @@
-use crate::kernel::{DYN_SLOT_COUNT, MetalEncodeContext, MetalKernelOp, MpsKernelCache};
+use crate::kernel::{MetalEncodeContext, MetalKernelOp, MpsKernelCache, clear_dyn_dims_order};
 use half::{bf16, f16};
 use itertools::Itertools;
 use luminal::{
@@ -7,7 +7,7 @@ use luminal::{
     hlir::{Input, Output, ReferenceData},
     op::{ExecutionStats, Runtime, RuntimeStats, TimingMethod},
     prelude::{
-        FxHashMap, NodeIndex, ToId,
+        DynMap, FxHashMap, NodeIndex, Symbol, ToId,
         petgraph::{Direction, algo::toposort, prelude::StableGraph, visit::EdgeRef},
     },
 };
@@ -28,7 +28,7 @@ struct MetalExecutionStep {
 
 #[derive(Clone)]
 struct MetalCompiledBucket {
-    bucket_indices: FxHashMap<char, usize>,
+    bucket_indices: DynMap,
     llir_graph: LLIRGraph,
     llir_to_hlir: FxHashMap<NodeIndex, NodeIndex>,
     node_dtypes: FxHashMap<NodeIndex, DType>,
@@ -49,8 +49,12 @@ pub struct MetalRuntime {
     pub buffers: FxHashMap<NodeIndex, Buffer>,
     /// Logical byte length for each active LLIR buffer.
     buffer_lengths: FxHashMap<NodeIndex, u64>,
-    /// Dynamic dimensions table (a-z), shared across all kernels.
+    /// Dynamic dimension sizes, shared across all kernels. Slot `i` holds
+    /// `dyn_dims_order[i]`.
     dyn_buffer: Buffer,
+    /// Layout of `dyn_buffer`. Duplicated from the codegen thread-local so an
+    /// upload on another thread still sees this runtime's layout.
+    dyn_dims_order: Vec<Symbol>,
     /// Retained MPS descriptors/kernels reused across command encodes.
     mps_cache: RefCell<MpsKernelCache>,
     /// The current LLIR graph
@@ -68,7 +72,7 @@ pub struct MetalRuntime {
     /// Precomputed executable nodes and input metadata for the active LLIR graph.
     execution_plan: Vec<MetalExecutionStep>,
     /// Bucket definitions for dynamic dimensions.
-    dim_buckets: FxHashMap<char, Vec<DimBucket>>,
+    dim_buckets: FxHashMap<Symbol, Vec<DimBucket>>,
     /// Compiled LLIR variants, one per bucket combination.
     compiled_buckets: Vec<MetalCompiledBucket>,
     /// Currently active compiled bucket.
@@ -326,7 +330,7 @@ impl Runtime for MetalRuntime {
     fn late_egglog_passes(
         ops: &[std::sync::Arc<Box<dyn luminal::op::EgglogOp>>],
         _options: &luminal::graph::CompileOptions,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> Vec<luminal::egglog_utils::LateEgglogPass> {
         vec![crate::memory_analysis::metal_memory_analysis_pass(
             ops, None, dyn_map,
@@ -336,8 +340,9 @@ impl Runtime for MetalRuntime {
     fn initialize(_: Self::CompileArg) -> Self {
         let device = Device::system_default().expect("No Metal device found!");
         let command_queue = device.new_command_queue();
+        // Resized in finish_dyn_dims_layout once the dim set is known.
         let dyn_buffer = device.new_buffer(
-            (DYN_SLOT_COUNT * std::mem::size_of::<i32>()) as u64,
+            std::mem::size_of::<i32>() as u64,
             MTLResourceOptions::StorageModeShared,
         );
 
@@ -349,6 +354,7 @@ impl Runtime for MetalRuntime {
             buffers: FxHashMap::default(),
             buffer_lengths: FxHashMap::default(),
             dyn_buffer,
+            dyn_dims_order: Vec::new(),
             mps_cache: RefCell::new(MpsKernelCache::default()),
             llir_graph: StableGraph::default(),
             llir_to_hlir: FxHashMap::default(),
@@ -372,7 +378,9 @@ impl Runtime for MetalRuntime {
         self.buffers.clear();
         self.buffer_lengths.clear();
         self.dim_buckets.clear();
+        clear_dyn_dims_order();
         self.compiled_buckets = vec![self.compile_bucket(FxHashMap::default(), llir_graph)];
+        self.finish_dyn_dims_layout();
         self.activate_bucket(0);
     }
 
@@ -380,7 +388,7 @@ impl Runtime for MetalRuntime {
     fn profile(
         &mut self,
         llir_graph: &LLIRGraph,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         trials: usize,
         timeout: Option<std::time::Duration>,
         early_stop: Option<(Self::ProfileMetric, f64)>,
@@ -415,7 +423,7 @@ impl Runtime for MetalRuntime {
     }
 
     #[tracing::instrument(skip_all)]
-    fn execute(&mut self, dyn_map: &FxHashMap<char, usize>) -> Self::ExecReturn {
+    fn execute(&mut self, dyn_map: &DynMap) -> Self::ExecReturn {
         autoreleasepool(|| {
             self.select_bucket(dyn_map);
             self.allocate_active_intermediate_buffers(dyn_map);
@@ -478,12 +486,15 @@ impl Runtime for MetalRuntime {
 
     fn load_llir_buckets(
         &mut self,
-        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
+        dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
         bucket_llirs: &[BucketLLIR],
     ) {
         self.buffers.clear();
         self.buffer_lengths.clear();
         self.dim_buckets = dim_buckets.clone();
+        // Every bucket encodes against the same dyn_buffer, so one layout covers
+        // all of them; compiling in sequence accumulates into it.
+        clear_dyn_dims_order();
         self.compiled_buckets = bucket_llirs
             .iter()
             .map(|(bucket_indices, _, llir)| self.compile_bucket(bucket_indices.clone(), llir))
@@ -492,12 +503,13 @@ impl Runtime for MetalRuntime {
             !self.compiled_buckets.is_empty(),
             "Metal runtime received no bucketed LLIRs"
         );
+        self.finish_dyn_dims_layout();
         self.activate_bucket(0);
     }
 }
 
 impl RuntimeStats for MetalRuntime {
-    fn execute_with_stats(&mut self, dyn_map: &FxHashMap<char, usize>) -> Option<ExecutionStats> {
+    fn execute_with_stats(&mut self, dyn_map: &DynMap) -> Option<ExecutionStats> {
         let mut total_bytes_loaded = 0usize;
         let mut total_bytes_stored = 0usize;
         let mut total_flops = 0usize;
@@ -552,12 +564,12 @@ impl MetalRuntime {
         }
     }
 
-    pub fn allocate_intermediate_buffers(&mut self, dyn_map: &FxHashMap<char, usize>) {
+    pub fn allocate_intermediate_buffers(&mut self, dyn_map: &DynMap) {
         self.select_bucket(dyn_map);
         self.allocate_active_intermediate_buffers(dyn_map);
     }
 
-    fn allocate_active_intermediate_buffers(&mut self, dyn_map: &FxHashMap<char, usize>) {
+    fn allocate_active_intermediate_buffers(&mut self, dyn_map: &DynMap) {
         let mut planned = Vec::new();
         let capacity_dyn_map = self.active_capacity_dyn_map(dyn_map);
 
@@ -596,16 +608,12 @@ impl MetalRuntime {
         }
     }
 
-    fn output_bytes(
-        kernel_op: &dyn MetalKernelOp,
-        dtype: DType,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> u64 {
+    fn output_bytes(kernel_op: &dyn MetalKernelOp, dtype: DType, dyn_map: &DynMap) -> u64 {
         let size = kernel_op.output_size().exec(dyn_map).unwrap();
         (size * dtype.bits().div_ceil(8)) as u64
     }
 
-    fn active_capacity_dyn_map(&self, dyn_map: &FxHashMap<char, usize>) -> FxHashMap<char, usize> {
+    fn active_capacity_dyn_map(&self, dyn_map: &DynMap) -> DynMap {
         let mut capacity_dyn_map = dyn_map.clone();
         let Some(active_bucket) = self.compiled_buckets.get(self.active_bucket) else {
             return capacity_dyn_map;
@@ -624,7 +632,7 @@ impl MetalRuntime {
 
     fn compile_bucket(
         &self,
-        bucket_indices: FxHashMap<char, usize>,
+        bucket_indices: DynMap,
         llir_graph: &LLIRGraph,
     ) -> MetalCompiledBucket {
         let mut node_dtypes = FxHashMap::default();
@@ -742,7 +750,7 @@ impl MetalRuntime {
         }
     }
 
-    fn select_bucket(&mut self, dyn_map: &FxHashMap<char, usize>) {
+    fn select_bucket(&mut self, dyn_map: &DynMap) {
         if self.compiled_buckets.len() <= 1 {
             return;
         }
@@ -753,7 +761,7 @@ impl MetalRuntime {
         }
     }
 
-    fn resolve_bucket(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn resolve_bucket(&self, dyn_map: &DynMap) -> usize {
         self.compiled_buckets
             .iter()
             .position(|bucket| {
@@ -774,25 +782,36 @@ impl MetalRuntime {
             })
     }
 
-    fn update_dyn_buffer(&mut self, dyn_map: &FxHashMap<char, usize>) {
+    /// Adopt the layout codegen built and size the buffer to it. Runs *after*
+    /// compiling, since that is when the dims are discovered.
+    fn finish_dyn_dims_layout(&mut self) {
+        self.dyn_dims_order = crate::kernel::dyn_dims_order();
+        // Metal rejects a zero-length buffer; a graph with no dynamic dims
+        // still binds this argument but never reads it.
+        self.dyn_buffer = self.device.new_buffer(
+            (self.dyn_dims_order.len().max(1) * std::mem::size_of::<i32>()) as u64,
+            MTLResourceOptions::StorageModeShared,
+        );
+    }
+
+    fn update_dyn_buffer(&mut self, dyn_map: &DynMap) {
         let ptr = self.dyn_buffer.contents() as *mut i32;
-        unsafe {
-            for idx in 0..DYN_SLOT_COUNT {
-                *ptr.add(idx) = 0;
-            }
-            for (&symbol, &value) in dyn_map {
-                if symbol.is_ascii_lowercase() {
-                    let slot = (symbol as u8 - b'a') as usize;
-                    if slot < DYN_SLOT_COUNT {
-                        *ptr.add(slot) = value as i32;
-                    }
-                }
-            }
+        // By layout position, not by iterating dyn_map: every slot the kernels
+        // can read gets a value, and unreferenced dims are ignored.
+        for (slot, symbol) in self.dyn_dims_order.iter().enumerate() {
+            let value = dyn_map.get(symbol).copied().unwrap_or_else(|| {
+                panic!(
+                    "Metal has no value for dim {symbol}, which its kernels read \
+                     from dyn[{slot}]. Bound dims: {:?}",
+                    dyn_map.keys().collect::<Vec<_>>(),
+                )
+            });
+            unsafe { *ptr.add(slot) = value as i32 };
         }
     }
 
     /// Execute and return GPU-side execution time in microseconds.
-    fn execute_timed(&mut self, dyn_map: &FxHashMap<char, usize>) -> (f64, TimingMethod) {
+    fn execute_timed(&mut self, dyn_map: &DynMap) -> (f64, TimingMethod) {
         autoreleasepool(|| {
             self.select_bucket(dyn_map);
             self.allocate_active_intermediate_buffers(dyn_map);

--- a/crates/luminal_metal/src/tests.rs
+++ b/crates/luminal_metal/src/tests.rs
@@ -277,19 +277,61 @@ fn generate_layer_weights(layer: &MiniTransformerLayer) -> Vec<(GraphTensor, Vec
         .collect()
 }
 
-/// dynamic symbols in kernel expressions should route through dyn buffer.
-#[test]
-fn dynamic_const_codegen_uses_dyn_buffer() {
-    let expr = (Expression::from('a') * 2 + Expression::from('z')).simplify();
-    let code = lower_expression_for_metal(&expr, "idx");
+/// Which slot a dim gets, by lowering it and reading the emitted subscript.
+fn slot_of(name: &str) -> usize {
+    lower_expression_for_metal(&Expression::from(Symbol::new(name)), "idx")
+        .trim_start_matches("dyn[")
+        .trim_end_matches(']')
+        .parse::<usize>()
+        .unwrap()
+}
 
-    assert!(
-        !code.contains("*const_"),
-        "dynamic symbols should be lowered via dyn buffer, got: {code}"
+/// Slots come from the layout, not from the name. The old ABI computed one as
+/// `name_byte - b'a'`, so it could only carry a single `a`..`y` and had no
+/// representation at all for a multi-char or upper-case name.
+#[test]
+fn dyn_slots_are_assigned_by_position_not_by_letter() {
+    crate::kernel::clear_dyn_dims_order();
+
+    // None of these is a single letter, and the last would have collided with
+    // the first under the old byte arithmetic.
+    assert_eq!(slot_of("context_tokens"), 0);
+    assert_eq!(slot_of("input_tokens"), 1);
+    assert_eq!(slot_of("Cached"), 2);
+}
+
+/// A slot is assigned once and never moves. Codegen bakes it into emitted
+/// source as it goes, so a dim discovered later must append rather than
+/// displace one already written.
+#[test]
+fn a_slot_is_stable_once_assigned() {
+    crate::kernel::clear_dyn_dims_order();
+
+    assert_eq!(slot_of("input_tokens"), 0);
+    // Sorts before input_tokens, so it would displace it if the layout re-sorted.
+    assert_eq!(slot_of("cached_tokens"), 1);
+    assert_eq!(slot_of("input_tokens"), 0, "existing slot must be stable");
+    assert_eq!(
+        crate::kernel::dyn_dims_order().len(),
+        2,
+        "the runtime sizes the buffer from this, so every slot must be visible"
     );
-    assert!(
-        code.contains("dyn["),
-        "expected generated kernel expression to reference dyn buffer, got: {code}"
+}
+
+/// Each graph load starts from an empty layout, or slots carry over and the
+/// buffer is sized for dims the new graph never reads.
+#[test]
+fn clearing_the_layout_resets_slot_assignment() {
+    crate::kernel::clear_dyn_dims_order();
+    assert_eq!(slot_of("input_tokens"), 0);
+    assert_eq!(slot_of("cached_tokens"), 1);
+
+    crate::kernel::clear_dyn_dims_order();
+    assert!(crate::kernel::dyn_dims_order().is_empty());
+    assert_eq!(
+        slot_of("cached_tokens"),
+        0,
+        "a fresh graph starts at slot 0"
     );
 }
 

--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -32,8 +32,8 @@ fn copy_host_bytes(ptr: u64, n_bytes: usize, buffer_kind: &str) -> PyResult<Vec<
     Ok(unsafe { std::slice::from_raw_parts(ptr as *const u8, n_bytes).to_vec() })
 }
 
-/// Maps symbolic dimension parameter names (e.g. "seq_len") to luminal Expression variable chars.
-pub type DimParamMap = HashMap<String, char>;
+/// Maps symbolic dimension parameter names (e.g. "seq_len") to their dim symbol.
+pub type DimParamMap = HashMap<String, Symbol>;
 
 /// Recover a single-variable dim's variable value from an observed runtime size.
 ///
@@ -43,12 +43,12 @@ pub type DimParamMap = HashMap<String, char>;
 /// — multi-variable expressions, non-affine forms, slope==0, and inversions
 /// that don't divide cleanly are all rejected so we never write a wrong
 /// guess into `dyn_map`.
-fn solve_single_var_dim(expr: &Expression, dim_val: usize) -> Option<(char, usize)> {
+fn solve_single_var_dim(expr: &Expression, dim_val: usize) -> Option<(Symbol, usize)> {
     use luminal::shape::Term;
     let terms = expr.terms.read();
 
     // Identify the unique variable, if any.
-    let mut var: Option<char> = None;
+    let mut var: Option<Symbol> = None;
     for t in terms.iter() {
         if let Term::Var(c) = t {
             match var {

--- a/crates/luminal_python/rust/src/pt2_compiled_model.rs
+++ b/crates/luminal_python/rust/src/pt2_compiled_model.rs
@@ -17,7 +17,7 @@ type PreloadResult = (Vec<(String, TypedData)>, HashMap<String, usize>);
 
 fn resolve_dim_sizes(
     sizes: &[pt2_schema::DimSize],
-    sym_to_char: &HashMap<String, char>,
+    sym_to_symbol: &HashMap<String, Symbol>,
 ) -> Vec<Expression> {
     sizes
         .iter()
@@ -32,10 +32,10 @@ fn resolve_dim_sizes(
                 // the bare-Symbol fast path when that fails — the parser
                 // bails on unrecognised heads (Pow, Min, etc.) and we'd
                 // rather lose the symbolic info than misinterpret it.
-                parse_sympy_expr(s, sym_to_char)
+                parse_sympy_expr(s, sym_to_symbol)
                     .or_else(|| {
                         pt2_parser::extract_symbol_name_pub(s)
-                            .and_then(|sym| sym_to_char.get(&sym).map(|c| Expression::from(*c)))
+                            .and_then(|sym| sym_to_symbol.get(&sym).map(|c| Expression::from(*c)))
                     })
                     .or_else(|| {
                         // As a last resort, if the EP gave us a concrete `hint`
@@ -133,7 +133,7 @@ pub fn translate_pt2(
     // Set initial dynamic dim values from symbol ranges. PT2 emits
     // `min_val: null` when the constraint is unbounded; fall back to 1 in
     // that case (the smallest valid dim — used only as an initial value).
-    for (sym_name, c) in &translated.sym_map.sym_to_char {
+    for (sym_name, c) in &translated.sym_map.sym_to_symbol {
         if let Some(rc) = translated.sym_map.ranges.get(sym_name) {
             let initial = rc.min_val.unwrap_or(1).max(0) as usize;
             graph.set_dim(*c, initial);
@@ -147,7 +147,7 @@ pub fn translate_pt2(
         .map(|(name, _id)| {
             parsed
                 .tensor_meta(name)
-                .map(|meta| resolve_dim_sizes(&meta.sizes, &translated.sym_map.sym_to_char))
+                .map(|meta| resolve_dim_sizes(&meta.sizes, &translated.sym_map.sym_to_symbol))
                 .unwrap_or_default()
         })
         .collect();
@@ -180,7 +180,7 @@ pub fn translate_pt2(
         .map(|(name, _id)| {
             parsed
                 .tensor_meta(name)
-                .map(|meta| resolve_dim_sizes(&meta.sizes, &translated.sym_map.sym_to_char))
+                .map(|meta| resolve_dim_sizes(&meta.sizes, &translated.sym_map.sym_to_symbol))
                 .unwrap_or_default()
         })
         .collect();
@@ -250,7 +250,7 @@ pub fn translate_pt2(
         }
     }
 
-    let dim_param_map: DimParamMap = translated.sym_map.sym_to_char;
+    let dim_param_map: DimParamMap = translated.sym_map.sym_to_symbol;
 
     let translation = GraphTranslation {
         graph,

--- a/crates/luminal_python/rust/src/pt2_expr.rs
+++ b/crates/luminal_python/rust/src/pt2_expr.rs
@@ -41,22 +41,22 @@ struct BoundedExpr {
 /// Supports the subset of sympy heads PT2 emits for symbolic shape metadata.
 pub(crate) fn parse_sympy_expr(
     expr: &str,
-    sym_to_char: &HashMap<String, char>,
+    sym_to_symbol: &HashMap<String, Symbol>,
 ) -> Option<Expression> {
-    parse_sympy_expr_with_ranges(expr, sym_to_char, &HashMap::new())
+    parse_sympy_expr_with_ranges(expr, sym_to_symbol, &HashMap::new())
 }
 
 pub(crate) fn parse_sympy_expr_with_ranges(
     expr: &str,
-    sym_to_char: &HashMap<String, char>,
+    sym_to_symbol: &HashMap<String, Symbol>,
     ranges: &HashMap<String, RangeConstraint>,
 ) -> Option<Expression> {
-    parse_sympy_expr_inner(expr, sym_to_char, ranges).map(|parsed| parsed.expr)
+    parse_sympy_expr_inner(expr, sym_to_symbol, ranges).map(|parsed| parsed.expr)
 }
 
-pub(crate) fn sym_char_ranges(sym_map: &SymDimMap) -> FxHashMap<char, ExprBounds> {
+pub(crate) fn sym_char_ranges(sym_map: &SymDimMap) -> FxHashMap<Symbol, ExprBounds> {
     sym_map
-        .sym_to_char
+        .sym_to_symbol
         .iter()
         .map(|(sym_name, sym_char)| {
             let range = sym_map.ranges.get(sym_name);
@@ -74,7 +74,7 @@ pub(crate) fn sym_char_ranges(sym_map: &SymDimMap) -> FxHashMap<char, ExprBounds
 
 pub(crate) fn simplify_expr_with_ranges(
     expr: Expression,
-    sym_ranges: &FxHashMap<char, ExprBounds>,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
 ) -> Expression {
     simplify_bound_expr(expr, sym_ranges).expr
 }
@@ -82,7 +82,7 @@ pub(crate) fn simplify_expr_with_ranges(
 pub(crate) fn same_expr_with_ranges(
     lhs: Expression,
     rhs: Expression,
-    sym_ranges: &FxHashMap<char, ExprBounds>,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
 ) -> bool {
     let lhs = simplify_bound_expr(lhs, sym_ranges);
     let rhs = simplify_bound_expr(rhs, sym_ranges);
@@ -94,7 +94,7 @@ pub(crate) fn same_expr_with_ranges(
 pub(crate) fn canonical_equal_expr(
     lhs: Expression,
     rhs: Expression,
-    sym_ranges: &FxHashMap<char, ExprBounds>,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
 ) -> Option<Expression> {
     if !same_expr_with_ranges(lhs, rhs, sym_ranges) {
         return None;
@@ -110,7 +110,7 @@ pub(crate) fn canonical_equal_expr(
 
 fn parse_sympy_expr_inner(
     expr: &str,
-    sym_to_char: &HashMap<String, char>,
+    sym_to_symbol: &HashMap<String, Symbol>,
     ranges: &HashMap<String, RangeConstraint>,
 ) -> Option<ParsedExpr> {
     let expr = expr.trim();
@@ -127,7 +127,7 @@ fn parse_sympy_expr_inner(
         "Symbol" => {
             let name = extract_first_quoted(body)?;
             let bounds = infer_symbol_bounds(body, ranges.get(&name));
-            sym_to_char.get(&name).map(|c| ParsedExpr {
+            sym_to_symbol.get(&name).map(|c| ParsedExpr {
                 expr: Expression::from(*c),
                 bounds,
             })
@@ -145,9 +145,9 @@ fn parse_sympy_expr_inner(
                 return None;
             }
             let mut iter = parts.into_iter();
-            let mut acc = parse_sympy_expr_inner(iter.next()?, sym_to_char, ranges)?;
+            let mut acc = parse_sympy_expr_inner(iter.next()?, sym_to_symbol, ranges)?;
             for part in iter {
-                let rhs = parse_sympy_expr_inner(part, sym_to_char, ranges)?;
+                let rhs = parse_sympy_expr_inner(part, sym_to_symbol, ranges)?;
                 acc = match head {
                     "Mul" => ParsedExpr {
                         expr: normalize_mul_expr(acc.expr, rhs.expr),
@@ -166,8 +166,8 @@ fn parse_sympy_expr_inner(
         }
         "FloorDiv" => {
             let mut parts = split_top_level_args(body).into_iter();
-            let lhs = parse_sympy_expr_inner(parts.next()?, sym_to_char, ranges)?;
-            let rhs = parse_sympy_expr_inner(parts.next()?, sym_to_char, ranges)?;
+            let lhs = parse_sympy_expr_inner(parts.next()?, sym_to_symbol, ranges)?;
+            let rhs = parse_sympy_expr_inner(parts.next()?, sym_to_symbol, ranges)?;
             if parts.next().is_some() {
                 return None;
             }
@@ -178,8 +178,8 @@ fn parse_sympy_expr_inner(
         }
         "Mod" => {
             let mut parts = split_top_level_args(body).into_iter();
-            let lhs = parse_sympy_expr_inner(parts.next()?, sym_to_char, ranges)?;
-            let rhs = parse_sympy_expr_inner(parts.next()?, sym_to_char, ranges)?;
+            let lhs = parse_sympy_expr_inner(parts.next()?, sym_to_symbol, ranges)?;
+            let rhs = parse_sympy_expr_inner(parts.next()?, sym_to_symbol, ranges)?;
             if parts.next().is_some() {
                 return None;
             }
@@ -437,7 +437,7 @@ fn simplify_add(lhs: BoundedExpr, rhs: BoundedExpr) -> BoundedExpr {
 fn simplify_sub(
     lhs: BoundedExpr,
     rhs: BoundedExpr,
-    sym_ranges: &FxHashMap<char, ExprBounds>,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
 ) -> BoundedExpr {
     if same_expr_with_ranges(lhs.expr, rhs.expr, sym_ranges) {
         return exact_expr(0);
@@ -459,7 +459,7 @@ fn simplify_sub(
 fn simplify_min(
     lhs: BoundedExpr,
     rhs: BoundedExpr,
-    sym_ranges: &FxHashMap<char, ExprBounds>,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
 ) -> BoundedExpr {
     let bounds = min_bounds(lhs.bounds, rhs.bounds);
     if same_expr_with_ranges(lhs.expr, rhs.expr, sym_ranges) {
@@ -493,7 +493,7 @@ fn simplify_min(
 fn simplify_max(
     lhs: BoundedExpr,
     rhs: BoundedExpr,
-    sym_ranges: &FxHashMap<char, ExprBounds>,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
 ) -> BoundedExpr {
     let bounds = max_bounds(lhs.bounds, rhs.bounds);
     if same_expr_with_ranges(lhs.expr, rhs.expr, sym_ranges) {
@@ -524,7 +524,10 @@ fn simplify_max(
     with_bounds(normalize_expr(lhs.expr.max(rhs.expr)), bounds)
 }
 
-fn simplify_bound_expr(expr: Expression, sym_ranges: &FxHashMap<char, ExprBounds>) -> BoundedExpr {
+fn simplify_bound_expr(
+    expr: Expression,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
+) -> BoundedExpr {
     let mut stack: Vec<BoundedExpr> = Vec::new();
     let terms = expr.terms.read().clone();
     for term in terms {

--- a/crates/luminal_python/rust/src/pt2_parser.rs
+++ b/crates/luminal_python/rust/src/pt2_parser.rs
@@ -10,6 +10,9 @@ use std::io::Read;
 use anyhow::{Context, Result};
 use zip::ZipArchive;
 
+use luminal::prelude::Symbol;
+use luminal::prelude::tracing::warn;
+
 use crate::pt2_schema::*;
 
 /// Parsed PT2 file contents — everything needed for graph translation.
@@ -42,11 +45,14 @@ pub enum InputKind {
     UserInput { graph_name: String },
 }
 
-/// Symbolic dimension mapping: PT2 symbol name -> luminal char variable.
+/// Symbolic dimension mapping: PT2 symbol name -> luminal dim symbol.
+///
+/// Usually the same string — torch's `s77` stays `s77` — but a name luminal
+/// cannot use is mapped to a minted one.
 #[derive(Debug, Clone)]
 pub struct SymDimMap {
-    /// Maps PT2 symbol names (e.g., "s77") to luminal char variables ('a', 'b', ...)
-    pub sym_to_char: HashMap<String, char>,
+    /// Maps PT2 symbol names (e.g. "s77") to the dim symbol of the same name.
+    pub sym_to_symbol: HashMap<String, Symbol>,
     /// Range constraints for each symbol
     pub ranges: HashMap<String, RangeConstraint>,
 }
@@ -134,8 +140,7 @@ impl ParsedPT2 {
 
     /// Build the symbolic dimension mapping.
     pub fn build_sym_dim_map(&self) -> SymDimMap {
-        let mut sym_to_char = HashMap::new();
-        let mut next_char = b'a';
+        let mut sym_to_symbol = HashMap::new();
 
         // Collect all symbolic dimension names from tensor_values
         let mut sym_set = std::collections::HashSet::new();
@@ -152,15 +157,36 @@ impl ParsedPT2 {
         let mut sym_names: Vec<String> = sym_set.into_iter().collect();
         sym_names.sort();
 
+        // A name we cannot use is remapped, not dropped: a symbol absent from
+        // this map never gets a value, so its dim would freeze at the export
+        // hint while torch, told it was dynamic, declines to recompile.
+        //
+        // Counted rather than derived, because deriving is not injective —
+        // `a.b` and `a-b` both sanitize to `a_b`, putting two dims on one
+        // symbol. Loops because `Dim("pt2_dim_0")` is legal input.
+        let mut minted = 0usize;
         for name in &sym_names {
-            if next_char <= b'z' {
-                sym_to_char.insert(name.clone(), next_char as char);
-                next_char += 1;
-            }
+            let symbol = Symbol::try_new_dim(name).unwrap_or_else(|e| {
+                let replacement = loop {
+                    let candidate = format!("pt2_dim_{minted}");
+                    minted += 1;
+                    if !sym_names.contains(&candidate) {
+                        break candidate;
+                    }
+                };
+                warn!(
+                    "PT2 symbol {name:?} is not a usable luminal dimension name \
+                     ({e}); using {replacement:?} internally. The dim stays \
+                     dynamic and is still addressed as {name:?}."
+                );
+                Symbol::try_new_dim(&replacement)
+                    .expect("minted names are well-formed by construction")
+            });
+            sym_to_symbol.insert(name.clone(), symbol);
         }
 
         SymDimMap {
-            sym_to_char,
+            sym_to_symbol,
             ranges: self.program.range_constraints.clone(),
         }
     }
@@ -318,9 +344,92 @@ mod tests {
         }
         let parsed = parse_pt2(path).unwrap();
         let sym_map = parsed.build_sym_dim_map();
-        // Should have one symbolic dim (s77)
-        assert_eq!(sym_map.sym_to_char.len(), 1);
-        assert!(sym_map.sym_to_char.contains_key("s77"));
-        assert_eq!(sym_map.sym_to_char["s77"], 'a');
+        // Should have one symbolic dim (s77), keeping the name torch gave it.
+        // This used to assert 'a' — the first char out of the 51-name pool.
+        assert_eq!(sym_map.sym_to_symbol.len(), 1);
+        assert!(sym_map.sym_to_symbol.contains_key("s77"));
+        assert_eq!(sym_map.sym_to_symbol["s77"].to_string(), "s77");
+    }
+
+    /// Builds a program whose only tensor has one dim per given symbol name.
+    fn program_with_dim_symbols(names: &[&str]) -> ParsedPT2 {
+        let sizes = names
+            .iter()
+            .map(|n| {
+                format!(
+                    r#"{{"as_expr":{{"expr_str":"Symbol('{n}', positive=True, integer=True)"}}}}"#
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        let json = format!(
+            r#"{{"graph_module":{{"graph":{{"inputs":[],"outputs":[],"nodes":[],
+               "tensor_values":{{"x":{{"dtype":6,"sizes":[{sizes}]}}}}}},
+               "signature":{{"input_specs":[]}}}}}}"#
+        );
+        ParsedPT2 {
+            program: serde_json::from_str(&json).expect("fixture must parse"),
+            constants_config: None,
+            archive_prefix: String::new(),
+            pt2_path: String::new(),
+        }
+    }
+
+    /// torch lets a user write `Dim("_batch")` or `Dim("a__b")` — ordinary
+    /// Python names that are not usable C++ identifiers — and `z` is luminal's
+    /// reserved loop index, which is our constraint leaking into their
+    /// namespace. Every one of them still has to produce a *dynamic* dim:
+    /// dropping the symbol freezes it at the export-time hint (or 1) with
+    /// nothing to correct it later, and torch will not recompile.
+    #[test]
+    fn build_sym_dim_map_remaps_unusable_names_and_keeps_them_dynamic() {
+        let names = ["s77", "u0", "batch", "_batch", "a__b", "z"];
+        let map = program_with_dim_symbols(&names).build_sym_dim_map();
+
+        assert_eq!(map.sym_to_symbol.len(), 6, "no dim may be dropped");
+        for name in names {
+            assert!(map.sym_to_symbol.contains_key(name), "{name} addressable");
+        }
+        // Usable names keep their spelling; only the rejects are renamed.
+        for ok in ["s77", "u0", "batch"] {
+            assert_eq!(map.sym_to_symbol[ok].to_string(), ok);
+        }
+        for rejected in ["_batch", "a__b", "z"] {
+            assert_ne!(map.sym_to_symbol[rejected].to_string(), rejected);
+        }
+
+        let distinct: std::collections::HashSet<_> =
+            map.sym_to_symbol.values().map(|s| s.to_string()).collect();
+        assert_eq!(distinct.len(), 6, "two dims must never share a symbol");
+    }
+
+    /// Minting must not collide with a name the user actually wrote. Deriving
+    /// the replacement from the rejected name would also collapse `a.b` and
+    /// `a-b` onto one symbol, which is why it is counted instead.
+    #[test]
+    fn build_sym_dim_map_mints_around_a_name_the_user_already_used() {
+        let map = program_with_dim_symbols(&["pt2_dim_0", "z"]).build_sym_dim_map();
+
+        assert_eq!(map.sym_to_symbol["pt2_dim_0"].to_string(), "pt2_dim_0");
+        assert_ne!(
+            map.sym_to_symbol["z"].to_string(),
+            "pt2_dim_0",
+            "minted name must not steal the one the user declared"
+        );
+    }
+
+    /// The ceiling this branch removed. `build_sym_dim_map` used to hand each
+    /// symbol a char from an `a..y` + `A..Z` pool and panic at 52 — and symbol
+    /// #26 landed on `z`, the reserved index, so it vanished from the buffer
+    /// planner. A 32-layer llama under sdpa + DynamicCache mints more than 26.
+    #[test]
+    fn build_sym_dim_map_has_no_symbol_ceiling() {
+        let names: Vec<String> = (0..200).map(|n| format!("s{n}")).collect();
+        let refs: Vec<&str> = names.iter().map(String::as_str).collect();
+        let map = program_with_dim_symbols(&refs).build_sym_dim_map();
+        assert_eq!(map.sym_to_symbol.len(), 200);
+        let distinct: std::collections::HashSet<_> =
+            map.sym_to_symbol.values().map(|s| s.to_string()).collect();
+        assert_eq!(distinct.len(), 200, "every dim must stay distinct");
     }
 }

--- a/crates/luminal_python/rust/src/translator/binary.rs
+++ b/crates/luminal_python/rust/src/translator/binary.rs
@@ -11,7 +11,7 @@ use super::Translator;
 fn normalize_equal_dims(
     a: &mut GraphTensor,
     b: &mut GraphTensor,
-    sym_ranges: &FxHashMap<char, ExprBounds>,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
 ) {
     for i in 0..a.shape.len() {
         let lhs = a.shape.dims[i];
@@ -26,7 +26,7 @@ fn normalize_equal_dims(
 fn same_dims(
     lhs: &[Expression],
     rhs: &[Expression],
-    sym_ranges: &FxHashMap<char, ExprBounds>,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
 ) -> bool {
     lhs.len() == rhs.len()
         && lhs
@@ -185,7 +185,7 @@ mod tests {
         let lhs = (a.min(1) + a).min(a + 1) - 1;
         let rhs = (a.min(1) + a).min(a);
         let sym_ranges = [(
-            'a',
+            Symbol::from('a'),
             ExprBounds {
                 min: Some(2),
                 max: None,

--- a/crates/luminal_python/rust/src/translator/mod.rs
+++ b/crates/luminal_python/rust/src/translator/mod.rs
@@ -386,10 +386,10 @@ impl<'a> Translator<'a> {
     }
 
     pub(crate) fn resolve_expr_str(&self, expr_str: &str) -> Option<Expression> {
-        parse_sympy_expr_with_ranges(expr_str, &self.sym_map.sym_to_char, &self.sym_map.ranges)
+        parse_sympy_expr_with_ranges(expr_str, &self.sym_map.sym_to_symbol, &self.sym_map.ranges)
             .or_else(|| {
                 crate::pt2_parser::extract_symbol_name_pub(expr_str)
-                    .and_then(|sym| self.sym_map.sym_to_char.get(&sym).copied())
+                    .and_then(|sym| self.sym_map.sym_to_symbol.get(&sym).copied())
                     .map(Expression::from)
             })
     }

--- a/crates/luminal_python/rust/src/translator/movement.rs
+++ b/crates/luminal_python/rust/src/translator/movement.rs
@@ -17,7 +17,7 @@ fn normalize_concat_dims(
     lhs: &mut GraphTensor,
     rhs: &mut GraphTensor,
     skip_dim: Option<usize>,
-    sym_ranges: &FxHashMap<char, ExprBounds>,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
 ) {
     for i in 0..lhs.shape.len() {
         if Some(i) == skip_dim {

--- a/crates/luminal_training/src/reference.rs
+++ b/crates/luminal_training/src/reference.rs
@@ -111,7 +111,7 @@ impl OptimizerStep {
 /// calling `new`.
 pub struct Trainer<O> {
     pub rt: ReferenceRuntime,
-    dyn_map: FxHashMap<char, usize>,
+    dyn_map: DynMap,
     step: OptimizerStep,
     params: Vec<GraphTensor>,
     resident: Vec<GraphTensor>,

--- a/crates/luminal_training/src/view.rs
+++ b/crates/luminal_training/src/view.rs
@@ -168,7 +168,7 @@ pub(crate) fn static_scatter_add(
     m: usize,
     l: usize,
 ) -> Option<GraphTensor> {
-    if m > MAX_STATIC_MAP || !f.dyn_vars().iter().all(|c| *c == 'z') {
+    if m > MAX_STATIC_MAP || !f.dyn_vars().iter().all(|c| c.is_reserved()) {
         return None;
     }
     let mut vals = Vec::with_capacity(m);

--- a/crates/luminal_training/tests/optimizers.rs
+++ b/crates/luminal_training/tests/optimizers.rs
@@ -19,7 +19,7 @@ fn seq(n: usize, lo: f32, hi: f32) -> Vec<f32> {
 /// step scalars; reads updated params and state back after each execute.
 struct OptTrainer {
     rt: ReferenceRuntime,
-    dyn_map: FxHashMap<char, usize>,
+    dyn_map: DynMap,
     loss_out: GraphTensor,
     step: OptimizerStep,
     param_ids: Vec<NodeIndex>,

--- a/crates/luminal_training/tests/training.rs
+++ b/crates/luminal_training/tests/training.rs
@@ -21,7 +21,7 @@ fn seq(n: usize, lo: f32, hi: f32) -> Vec<f32> {
 /// a real training loop would rebind weight buffers.
 struct Trainer {
     rt: ReferenceRuntime,
-    dyn_map: FxHashMap<char, usize>,
+    dyn_map: DynMap,
     loss_out: GraphTensor,
     grad_outs: Vec<GraphTensor>,
     param_ids: Vec<NodeIndex>,

--- a/examples/qwen/src/lib.rs
+++ b/examples/qwen/src/lib.rs
@@ -59,7 +59,7 @@ pub trait QwenRuntime: Runtime<ExecReturn = ()> {
     fn set_buffer(&mut self, id: NodeIndex, buffer: Self::Buffer);
     fn get_f32(&self, id: NodeIndex) -> Vec<f32>;
 
-    fn prepare_execute(&mut self, _dyn_map: &FxHashMap<char, usize>) {}
+    fn prepare_execute(&mut self, _dyn_map: &DynMap) {}
 }
 
 #[cfg(feature = "cuda")]

--- a/src/dyn_backend.rs
+++ b/src/dyn_backend.rs
@@ -10,12 +10,12 @@ use std::collections::HashMap;
 
 use half::{bf16, f16};
 use petgraph::stable_graph::NodeIndex;
-use rustc_hash::FxHashMap;
 
 use crate::dtype::DType;
 use crate::graph::{CompileOptions, Graph};
 use crate::hlir::{Output, ReferenceData, ReferenceRuntime};
 use crate::op::Runtime;
+use crate::shape::DynMap;
 
 // ---------------------------------------------------------------------------
 // DynBackend trait
@@ -56,7 +56,7 @@ pub trait DynBackend {
     fn get_output_bool(&self, _node: NodeIndex) -> Vec<bool> {
         panic!("get_output_bool not supported by '{}'", self.name());
     }
-    fn execute(&mut self, dyn_map: &FxHashMap<char, usize>);
+    fn execute(&mut self, dyn_map: &DynMap);
 
     // --- Optional device pointer support (GPU backends) --------------------
 
@@ -387,7 +387,7 @@ impl DynBackend for ReferenceDynBackend {
         }
     }
 
-    fn execute(&mut self, dyn_map: &FxHashMap<char, usize>) {
+    fn execute(&mut self, dyn_map: &DynMap) {
         self.runtime.execute(dyn_map);
     }
 }

--- a/src/egglog_utils/base.rs
+++ b/src/egglog_utils/base.rs
@@ -168,7 +168,7 @@ pub fn expr_to_term(expr: &shape::Expression) -> Term {
     for term in expr.terms.read().iter() {
         let t = match term {
             shape::Term::Num(n) => num(i64(*n)),
-            shape::Term::Var(c) => mvar(str(&c.to_string())),
+            shape::Term::Var(c) => mvar(str(&shape::egglog_var_name(c))),
             op => {
                 let a = stack.pop().unwrap();
                 let b = stack.pop().unwrap();
@@ -430,7 +430,7 @@ pub fn dtype(e: Term) -> Term {
 
 pub fn interval_facts_egglog(
     intervals: &shape::DynDimIntervals,
-    vars: impl IntoIterator<Item = char>,
+    vars: impl IntoIterator<Item = shape::Symbol>,
 ) -> String {
     let mut all_vars = FxHashSet::default();
     all_vars.extend(intervals.keys().copied());
@@ -445,7 +445,7 @@ pub fn interval_facts_egglog(
             .get(&var)
             .copied()
             .unwrap_or_else(shape::DimInterval::unbounded);
-        let var_expr = mvar(str(&var.to_string()));
+        let var_expr = mvar(str(&shape::egglog_var_name(&var)));
         out.push_str(&format!(
             "(set {} {})\n",
             term_to_egglog(&interval_lower(var_expr.clone())),
@@ -459,7 +459,7 @@ pub fn interval_facts_egglog(
         if interval.min == interval.max {
             out.push_str(&format!(
                 "(union {} {})\n",
-                term_to_egglog(&mvar(str(&var.to_string()))),
+                term_to_egglog(&mvar(str(&shape::egglog_var_name(&var)))),
                 term_to_egglog(&num(i64(interval.min)))
             ));
         }

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -1705,6 +1705,20 @@ pub fn extract_dtype<'a>(egraph: &'a SerializedEGraph, node: &'a NodeId) -> DTyp
     }
 }
 
+/// Decode the op label of an egglog String-primitive e-node into its name.
+///
+/// egglog spells these either `Boxed("name")` or as a bare quoted `"name"`
+/// depending on the sort. Stripped anchored, so a name whose content contains
+/// `")` or `Boxed("` survives intact.
+fn decode_string_literal_op(op: &str) -> Option<String> {
+    let body = op
+        .strip_prefix("Boxed(")
+        .and_then(|s| s.strip_suffix(')'))
+        .unwrap_or(op);
+    let inner = body.strip_prefix('"')?.strip_suffix('"')?;
+    Some(inner.to_string())
+}
+
 pub fn extract_expr<'a>(
     egraph: &'a SerializedEGraph,
     node: &'a NodeId,
@@ -1805,16 +1819,19 @@ pub fn extract_expr<'a>(
                 *current += 1;
                 build_expression(egraph, trajectory, current)
             }
-            "MIter" => Expression::from('z'),
-            op if op.starts_with("Boxed(\"") => {
-                let name = op.replace("Boxed(\"", "").replace("\")", "");
-                Expression::from(name.chars().next().unwrap())
+            "MIter" => Expression::from(crate::shape::Symbol::reserved_index()),
+            op => {
+                if let Some(name) = decode_string_literal_op(op) {
+                    Expression::from(crate::shape::symbol_from_egglog_name(&name))
+                } else if let Ok(n) = op.parse::<i64>() {
+                    Expression::from(n)
+                } else {
+                    panic!(
+                        "unsupported expression op '{op}': expected an integer, or a dim \
+                         name quoted as \"name\" / Boxed(\"name\")"
+                    )
+                }
             }
-            op => op
-                .parse::<i64>()
-                .map(Expression::from)
-                .or_else(|_| op.replace('"', "").parse::<char>().map(Expression::from))
-                .unwrap_or_else(|_| panic!("unsupported expression op '{op}'")),
         }
     }
     let e = build_expression(egraph, &traj, &mut 0);
@@ -3006,5 +3023,65 @@ mod tests {
             root_labels.contains(&"Input"),
             "late union should add Input to root eclass, got {root_labels:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod string_literal_op_tests {
+    use super::decode_string_literal_op;
+    use crate::shape::symbol_from_egglog_name;
+
+    #[test]
+    fn decodes_both_spellings_whole() {
+        assert_eq!(
+            decode_string_literal_op(r#"Boxed("s")"#).as_deref(),
+            Some("s")
+        );
+        assert_eq!(decode_string_literal_op(r#""s""#).as_deref(), Some("s"));
+        // Whole name, not a prefix.
+        assert_eq!(
+            decode_string_literal_op(r#"Boxed("s77")"#).as_deref(),
+            Some("s77")
+        );
+        assert_eq!(decode_string_literal_op(r#""s77""#).as_deref(), Some("s77"));
+    }
+
+    #[test]
+    fn stripping_is_anchored_not_substring() {
+        // A name whose content embeds the delimiters must survive.
+        assert_eq!(
+            decode_string_literal_op(r#"Boxed("a")b")"#).as_deref(),
+            Some(r#"a")b"#)
+        );
+    }
+
+    #[test]
+    fn non_string_ops_decode_to_none() {
+        assert_eq!(decode_string_literal_op("5"), None);
+        assert_eq!(decode_string_literal_op("MAdd"), None);
+    }
+
+    /// The reserved index round-trips: it appears in serialized strides.
+    #[test]
+    fn reserved_index_survives_the_boundary() {
+        assert_eq!(symbol_from_egglog_name("z").to_string(), "z");
+    }
+
+    /// The bug this whole change exists to remove. Extraction used to take
+    /// `name.chars().next()`, so a dim named `s77` came back as `s` — a
+    /// *different, possibly live* variable, silently. The bad name then missed
+    /// in `dyn_map`, and cuda_lite turned that miss into a dimension of 0.
+    #[test]
+    fn multichar_dim_names_survive_extraction() {
+        assert_eq!(symbol_from_egglog_name("s77").to_string(), "s77");
+        assert_ne!(symbol_from_egglog_name("s77"), symbol_from_egglog_name("s"));
+    }
+
+    /// Names that cannot be a C identifier or an egglog literal are still
+    /// rejected loudly rather than mangled into something that collides.
+    #[test]
+    #[should_panic(expected = "bad dim name out of egglog")]
+    fn malformed_dim_name_from_egglog_is_loud() {
+        symbol_from_egglog_name("s-77");
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -78,16 +78,16 @@ struct RollingSearchReport {
 
 #[derive(Debug, Clone, Default)]
 struct SearchSpaceContext {
-    bucket_indices: FxHashMap<char, usize>,
-    representative_dyn_map: FxHashMap<char, usize>,
+    bucket_indices: DynMap,
+    representative_dyn_map: DynMap,
     intervals: DynDimIntervals,
 }
 
 #[derive(Debug, Clone)]
 struct SearchProfileBucketContext {
-    dim_buckets: FxHashMap<char, Vec<DimBucket>>,
-    bucket_indices: FxHashMap<char, usize>,
-    representative_dyn_map: FxHashMap<char, usize>,
+    dim_buckets: FxHashMap<Symbol, Vec<DimBucket>>,
+    bucket_indices: DynMap,
+    representative_dyn_map: DynMap,
 }
 
 struct Finalist<M> {
@@ -125,14 +125,14 @@ struct BucketFinalistSearch<'a, M> {
 }
 
 /// A compiled bucket: (bucket_indices, representative_dyn_map, stitched_llir).
-pub type BucketLLIR = (FxHashMap<char, usize>, FxHashMap<char, usize>, LLIRGraph);
+pub type BucketLLIR = (DynMap, DynMap, LLIRGraph);
 
 /// Borrowed view of a compiled bucket used for non-committing aggregate
 /// candidate filtering.
 #[derive(Clone, Copy)]
 pub struct BucketLLIRRef<'a> {
-    pub bucket_indices: &'a FxHashMap<char, usize>,
-    pub representative_dyn_map: &'a FxHashMap<char, usize>,
+    pub bucket_indices: &'a DynMap,
+    pub representative_dyn_map: &'a DynMap,
     pub llir: &'a LLIRGraph,
 }
 
@@ -240,12 +240,12 @@ pub struct CompileOptions {
     /// the base representative values for unbucketed dimensions. Per-bucket
     /// representatives override them during bucketed search, and
     /// [`CompileOptions::profile_dims`] override them only while profiling.
-    pub search_dims: FxHashMap<char, usize>,
+    pub search_dims: DynMap,
     /// Optional profiling dimension overrides.
-    pub profile_dims: FxHashMap<char, usize>,
+    pub profile_dims: DynMap,
     /// Bucket definitions per dynamic dimension. Dimensions without buckets use
     /// a single implicit bucket.
-    pub dim_buckets: FxHashMap<char, Vec<DimBucket>>,
+    pub dim_buckets: FxHashMap<Symbol, Vec<DimBucket>>,
     /// Enable egglog progress logging. Quiet by default; overridden by
     /// `EGGLOG_LOG=1` or `LUMINAL_LOG=1`.
     pub egglog_log: bool,
@@ -255,6 +255,22 @@ pub struct CompileOptions {
     /// Enable search progress logging. Enabled by default; overridden by
     /// `SEARCH_LOG=0`/`1` or `LUMINAL_LOG=1`.
     pub search_log: bool,
+}
+
+/// Resolve a caller-supplied dimension name, rejecting the reserved loop index.
+///
+/// Covers the methods that give a dimension a value, not every way in:
+/// `Graph::dyn_map` and `CompileOptions::{search_dims, profile_dims,
+/// dim_buckets}` are public fields, and a serialized `ShapeTracker`
+/// deserializes without passing through here.
+fn checked_dim(dimension: impl Into<Symbol>) -> Symbol {
+    let dimension = dimension.into();
+    assert!(
+        !dimension.is_reserved(),
+        "{}",
+        crate::shape::InvalidSymbolName::Reserved
+    );
+    dimension
 }
 
 impl CompileOptions {
@@ -326,13 +342,15 @@ impl CompileOptions {
     /// search. This is equivalent to calling [`Graph::set_dim`] between
     /// [`Graph::build_search_space`] and [`Graph::search`], while still using
     /// the unified [`Graph::compile`] API.
-    pub fn search_dim(mut self, dim: char, value: usize) -> Self {
+    pub fn search_dim(mut self, dim: impl Into<Symbol>, value: usize) -> Self {
+        let dim = checked_dim(dim);
         self.search_dims.insert(dim, value);
         self
     }
 
     /// Override a dynamic dimension value used during search profiling.
-    pub fn profile_dim(mut self, dim: char, value: usize) -> Self {
+    pub fn profile_dim(mut self, dim: impl Into<Symbol>, value: usize) -> Self {
+        let dim = checked_dim(dim);
         self.profile_dims.insert(dim, value);
         self
     }
@@ -342,7 +360,8 @@ impl CompileOptions {
     /// Bucketed compilation builds a separate search space and selected LLIR for
     /// each bucket combination. Buckets must not overlap and must cover all
     /// values that will be used at runtime.
-    pub fn dim_buckets(mut self, dimension: char, buckets: &[DimBucket]) -> Self {
+    pub fn dim_buckets(mut self, dimension: impl Into<Symbol>, buckets: &[DimBucket]) -> Self {
+        let dimension = checked_dim(dimension);
         validate_dim_buckets(dimension, buckets);
         self.dim_buckets.insert(dimension, buckets.to_vec());
         self
@@ -405,7 +424,7 @@ impl Default for CompileOptions {
     }
 }
 
-fn validate_dim_buckets(dimension: char, buckets: &[DimBucket]) {
+fn validate_dim_buckets(dimension: Symbol, buckets: &[DimBucket]) {
     assert!(
         !buckets.is_empty(),
         "Buckets for dim '{dimension}' must not be empty"
@@ -425,7 +444,7 @@ fn validate_dim_buckets(dimension: char, buckets: &[DimBucket]) {
     }
 }
 
-fn maybe_dump_selected_llir(label: &str, dyn_map: &FxHashMap<char, usize>, llir: &LLIRGraph) {
+fn maybe_dump_selected_llir(label: &str, dyn_map: &DynMap, llir: &LLIRGraph) {
     let Ok(dir) = std::env::var("LLIR_DUMP_DIR") else {
         return;
     };
@@ -529,7 +548,7 @@ fn panic_initial_filter_limit(filter_fails: usize, last_rejection: Option<&str>)
 #[derive(Debug, Default)]
 pub struct Graph {
     /// A map of dynamic dimensions to concrete dimension sizes
-    pub dyn_map: FxHashMap<char, usize>,
+    pub dyn_map: DynMap,
     /// Edge weights: (Input index, Output index, Input shape)
     pub graph: HLIRGraph,
     /// E-Graph search spaces. Bucketed compilation stores one egraph per
@@ -541,7 +560,7 @@ pub struct Graph {
     /// Custom ops
     pub custom_ops: Vec<Box<dyn CustomOp>>,
     /// Bucket definitions used by the currently built search space.
-    search_space_dim_buckets: FxHashMap<char, Vec<DimBucket>>,
+    search_space_dim_buckets: FxHashMap<Symbol, Vec<DimBucket>>,
     /// Optional graph-wide interval assumptions for dynamic dimensions.
     pub dim_intervals: DynDimIntervals,
     /// Metadata for Input nodes: NodeIndex -> (label, dtype).
@@ -1008,11 +1027,13 @@ impl Graph {
     }
 
     /// Set a runtime dimension
-    pub fn set_dim(&mut self, dimension: char, val: usize) {
+    pub fn set_dim(&mut self, dimension: impl Into<Symbol>, val: usize) {
+        let dimension = checked_dim(dimension);
         self.dyn_map.insert(dimension, val);
     }
 
-    pub fn set_dim_interval(&mut self, dimension: char, min: i64, max: i64) {
+    pub fn set_dim_interval(&mut self, dimension: impl Into<Symbol>, min: i64, max: i64) {
+        let dimension = checked_dim(dimension);
         self.dim_intervals
             .insert(dimension, DimInterval::new(min, max));
     }
@@ -1639,7 +1660,7 @@ impl Graph {
 
     fn search_space_contexts(
         &self,
-        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
+        dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
     ) -> Vec<SearchSpaceContext> {
         if dim_buckets.is_empty() {
             return vec![SearchSpaceContext {
@@ -2094,14 +2115,13 @@ impl Graph {
     /// Returns Vec of (bucket_indices, representative_dyn_map).
     fn bucket_combinations(
         &self,
-        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
-    ) -> Vec<(FxHashMap<char, usize>, FxHashMap<char, usize>)> {
-        let mut dims: Vec<(char, &Vec<DimBucket>)> =
+        dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
+    ) -> Vec<(DynMap, DynMap)> {
+        let mut dims: Vec<(Symbol, &Vec<DimBucket>)> =
             dim_buckets.iter().map(|(c, b)| (*c, b)).collect();
         dims.sort_by_key(|(c, _)| *c);
 
-        let mut combos: Vec<(FxHashMap<char, usize>, FxHashMap<char, usize>)> =
-            vec![(FxHashMap::default(), self.dyn_map.clone())];
+        let mut combos: Vec<(DynMap, DynMap)> = vec![(FxHashMap::default(), self.dyn_map.clone())];
 
         for (dim, buckets) in &dims {
             let mut new_combos = Vec::new();
@@ -2120,10 +2140,7 @@ impl Graph {
         combos
     }
 
-    fn late_pass_dyn_map(
-        &self,
-        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
-    ) -> FxHashMap<char, usize> {
+    fn late_pass_dyn_map(&self, dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>) -> DynMap {
         let mut dyn_map = self.dyn_map.clone();
         for (&dim, buckets) in dim_buckets {
             if let Some(max) = buckets.iter().map(|bucket| bucket.max).max() {
@@ -2136,8 +2153,8 @@ impl Graph {
     /// Format a human-readable label for a bucket combination.
     fn format_bucket_label(
         &self,
-        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
-        bucket_indices: &FxHashMap<char, usize>,
+        dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
+        bucket_indices: &DynMap,
     ) -> String {
         let mut parts: Vec<String> = Vec::new();
         let mut dims: Vec<_> = bucket_indices.iter().collect();
@@ -2170,7 +2187,7 @@ impl Graph {
         runtime: &mut R,
         options: &CompileOptions,
         rng: &mut G,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         bucket_progress: Option<(usize, usize)>,
         bucket_profile_context: Option<SearchProfileBucketContext>,
         egraph_index: usize,
@@ -2742,7 +2759,7 @@ impl Graph {
         candidates: &mut LazyFinalists<'a, R::ProfileMetric>,
         target: usize,
         options: &CompileOptions,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         bucket_profile_context: Option<&SearchProfileBucketContext>,
         egraph_index: usize,
         search_started_at: std::time::Instant,
@@ -2909,7 +2926,7 @@ impl Graph {
 
     fn dump_selected_finalist<M>(
         finalist: &Finalist<M>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         bucket_progress: Option<(usize, usize)>,
     ) {
         if let Some(pre_unroll) = &finalist.pre_unroll {
@@ -2932,7 +2949,7 @@ impl Graph {
         &self,
         runtime: &mut R,
         llir_graph: &LLIRGraph,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         search_options: &CompileOptions,
         bucket_profile_context: Option<&SearchProfileBucketContext>,
     ) -> CandidateFilterResult {
@@ -4311,8 +4328,8 @@ mod tests {
 
     #[derive(Default)]
     struct SearchDimRecordingRuntime {
-        profile_dyn_maps: Vec<FxHashMap<char, usize>>,
-        bucket_representative_dyn_maps: Vec<FxHashMap<char, usize>>,
+        profile_dyn_maps: Vec<DynMap>,
+        bucket_representative_dyn_maps: Vec<DynMap>,
     }
 
     impl Runtime for SearchDimRecordingRuntime {
@@ -4324,10 +4341,10 @@ mod tests {
         fn late_egglog_passes(
             _: &[Arc<Box<dyn EgglogOp>>],
             _: &CompileOptions,
-            dyn_map: &FxHashMap<char, usize>,
+            dyn_map: &DynMap,
         ) -> Vec<crate::egglog_utils::LateEgglogPass> {
             SEARCH_DIM_LATE_PASS_CALLED.store(true, Ordering::SeqCst);
-            SEARCH_DIM_LATE_PASS_SAW_C.store(dyn_map.contains_key(&'c'), Ordering::SeqCst);
+            SEARCH_DIM_LATE_PASS_SAW_C.store(dyn_map.contains_key(&sym("c")), Ordering::SeqCst);
             vec![]
         }
 
@@ -4339,7 +4356,7 @@ mod tests {
 
         fn load_llir_buckets(
             &mut self,
-            _: &FxHashMap<char, Vec<DimBucket>>,
+            _: &FxHashMap<Symbol, Vec<DimBucket>>,
             bucket_llirs: &[BucketLLIR],
         ) {
             self.bucket_representative_dyn_maps = bucket_llirs
@@ -4348,12 +4365,12 @@ mod tests {
                 .collect();
         }
 
-        fn execute(&mut self, _: &FxHashMap<char, usize>) -> Self::ExecReturn {}
+        fn execute(&mut self, _: &DynMap) -> Self::ExecReturn {}
 
         fn profile(
             &mut self,
             _: &LLIRGraph,
-            dyn_map: &FxHashMap<char, usize>,
+            dyn_map: &DynMap,
             _: usize,
             _: Option<std::time::Duration>,
             _: Option<(Self::ProfileMetric, f64)>,
@@ -4380,12 +4397,12 @@ mod tests {
 
         fn load_llir(&mut self, _: &LLIRGraph) {}
 
-        fn execute(&mut self, _: &FxHashMap<char, usize>) -> Self::ExecReturn {}
+        fn execute(&mut self, _: &DynMap) -> Self::ExecReturn {}
 
         fn profile(
             &mut self,
             _: &LLIRGraph,
-            _: &FxHashMap<char, usize>,
+            _: &DynMap,
             _: usize,
             _: Option<std::time::Duration>,
             _: Option<(Self::ProfileMetric, f64)>,
@@ -4425,12 +4442,12 @@ mod tests {
 
         fn load_llir(&mut self, _: &LLIRGraph) {}
 
-        fn execute(&mut self, _: &FxHashMap<char, usize>) -> Self::ExecReturn {}
+        fn execute(&mut self, _: &DynMap) -> Self::ExecReturn {}
 
         fn profile(
             &mut self,
             _: &LLIRGraph,
-            _: &FxHashMap<char, usize>,
+            _: &DynMap,
             _: usize,
             _: Option<std::time::Duration>,
             _: Option<(Self::ProfileMetric, f64)>,
@@ -4505,11 +4522,7 @@ mod tests {
             }
 
             impl ReferenceOp for $name {
-                fn execute(
-                    &self,
-                    inputs: Vec<&ReferenceData>,
-                    _: &FxHashMap<char, usize>,
-                ) -> ReferenceData {
+                fn execute(&self, inputs: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
                     let ReferenceData::F32(input) = inputs[0] else {
                         panic!("final-filter test Sin candidates only support F32")
                     };
@@ -4566,12 +4579,12 @@ mod tests {
             self.loaded_signatures.push(signature);
         }
 
-        fn execute(&mut self, _: &FxHashMap<char, usize>) -> Self::ExecReturn {}
+        fn execute(&mut self, _: &DynMap) -> Self::ExecReturn {}
 
         fn profile(
             &mut self,
             llir: &LLIRGraph,
-            _: &FxHashMap<char, usize>,
+            _: &DynMap,
             _: usize,
             _: Option<std::time::Duration>,
             _: Option<(Self::ProfileMetric, f64)>,
@@ -4638,12 +4651,12 @@ mod tests {
             self.loaded_signatures.push(signature);
         }
 
-        fn execute(&mut self, _: &FxHashMap<char, usize>) -> Self::ExecReturn {}
+        fn execute(&mut self, _: &DynMap) -> Self::ExecReturn {}
 
         fn profile(
             &mut self,
             llir: &LLIRGraph,
-            dyn_map: &FxHashMap<char, usize>,
+            dyn_map: &DynMap,
             _: usize,
             _: Option<std::time::Duration>,
             _: Option<(Self::ProfileMetric, f64)>,
@@ -4654,7 +4667,7 @@ mod tests {
                 3,
                 "profiling should see the fully unrolled candidate"
             );
-            self.last_profile_dim = dyn_map.get(&'s').copied();
+            self.last_profile_dim = dyn_map.get(&Symbol::from('s')).copied();
             if fast == 1 {
                 (0, "fast".to_string())
             } else {
@@ -4669,7 +4682,11 @@ mod tests {
         ) -> CandidateFilterResult {
             let (fast, safe, _) = FinalFilterRuntime::signature(llir);
             let is_unrolled = fast + safe > 1;
-            let filter_dim = context.dyn_map.get(&'s').copied().unwrap_or(1);
+            let filter_dim = context
+                .dyn_map
+                .get(&Symbol::from('s'))
+                .copied()
+                .unwrap_or(1);
             if is_unrolled && fast > 0 && filter_dim > 1 {
                 self.rejected_unrolled_fast += 1;
                 CandidateFilterResult::reject_with_display(format!(
@@ -4705,7 +4722,7 @@ mod tests {
 
         fn load_llir_buckets(
             &mut self,
-            _: &FxHashMap<char, Vec<DimBucket>>,
+            _: &FxHashMap<Symbol, Vec<DimBucket>>,
             bucket_llirs: &[BucketLLIR],
         ) {
             let signatures = bucket_llirs
@@ -4725,12 +4742,12 @@ mod tests {
             self.loaded_sets.push(signatures);
         }
 
-        fn execute(&mut self, _: &FxHashMap<char, usize>) -> Self::ExecReturn {}
+        fn execute(&mut self, _: &DynMap) -> Self::ExecReturn {}
 
         fn profile(
             &mut self,
             llir: &LLIRGraph,
-            _: &FxHashMap<char, usize>,
+            _: &DynMap,
             _: usize,
             _: Option<std::time::Duration>,
             _: Option<(Self::ProfileMetric, f64)>,
@@ -4761,7 +4778,7 @@ mod tests {
 
         fn filter_llir_bucket_set(
             &mut self,
-            _: &FxHashMap<char, Vec<DimBucket>>,
+            _: &FxHashMap<Symbol, Vec<DimBucket>>,
             bucket_llirs: &[BucketLLIRRef<'_>],
             _: &CompileOptions,
         ) -> CandidateFilterResult {
@@ -4810,12 +4827,12 @@ mod tests {
             panic!("a runtime with no viable final candidate must not be loaded")
         }
 
-        fn execute(&mut self, _: &FxHashMap<char, usize>) -> Self::ExecReturn {}
+        fn execute(&mut self, _: &DynMap) -> Self::ExecReturn {}
 
         fn profile(
             &mut self,
             llir: &LLIRGraph,
-            _: &FxHashMap<char, usize>,
+            _: &DynMap,
             _: usize,
             _: Option<std::time::Duration>,
             _: Option<(Self::ProfileMetric, f64)>,
@@ -4876,12 +4893,12 @@ mod tests {
             panic!("a timed-out final candidate must not be loaded")
         }
 
-        fn execute(&mut self, _: &FxHashMap<char, usize>) -> Self::ExecReturn {}
+        fn execute(&mut self, _: &DynMap) -> Self::ExecReturn {}
 
         fn profile(
             &mut self,
             llir: &LLIRGraph,
-            _: &FxHashMap<char, usize>,
+            _: &DynMap,
             _: usize,
             _: Option<std::time::Duration>,
             _: Option<(Self::ProfileMetric, f64)>,
@@ -4928,7 +4945,7 @@ mod tests {
             .search_log(false);
         assert_eq!(opts.limit, 7);
         assert_eq!(opts.search_time_limit, time_limit);
-        assert_eq!(opts.search_dims[&'c'], 16);
+        assert_eq!(opts.search_dims[&sym("c")], 16);
         assert!(opts.egglog_log);
         assert!(opts.rolling_log);
         assert!(!opts.search_log);
@@ -4958,13 +4975,13 @@ mod tests {
             "search-only dimensions must not leak into build-time late passes"
         );
         assert_eq!(runtime.profile_dyn_maps.len(), 1);
-        assert_eq!(runtime.profile_dyn_maps[0][&'s'], 2);
-        assert_eq!(runtime.profile_dyn_maps[0][&'c'], 7);
+        assert_eq!(runtime.profile_dyn_maps[0][&sym("s")], 2);
+        assert_eq!(runtime.profile_dyn_maps[0][&sym("c")], 7);
         assert_eq!(runtime.bucket_representative_dyn_maps.len(), 1);
-        assert_eq!(runtime.bucket_representative_dyn_maps[0][&'s'], 3);
-        assert_eq!(runtime.bucket_representative_dyn_maps[0][&'c'], 16);
-        assert_eq!(cx.dyn_map[&'s'], 4);
-        assert_eq!(cx.dyn_map[&'c'], 16);
+        assert_eq!(runtime.bucket_representative_dyn_maps[0][&sym("s")], 3);
+        assert_eq!(runtime.bucket_representative_dyn_maps[0][&sym("c")], 16);
+        assert_eq!(cx.dyn_map[&sym("s")], 4);
+        assert_eq!(cx.dyn_map[&sym("c")], 16);
     }
 
     #[test]
@@ -5085,12 +5102,12 @@ mod tests {
 
         fn load_llir(&mut self, _: &LLIRGraph) {}
 
-        fn execute(&mut self, _: &FxHashMap<char, usize>) -> Self::ExecReturn {}
+        fn execute(&mut self, _: &DynMap) -> Self::ExecReturn {}
 
         fn profile(
             &mut self,
             _: &LLIRGraph,
-            _: &FxHashMap<char, usize>,
+            _: &DynMap,
             _: usize,
             _: Option<std::time::Duration>,
             early_stop: Option<(Self::ProfileMetric, f64)>,
@@ -5307,11 +5324,11 @@ mod tests {
         assert_eq!(cx.egraphs.len(), 2);
         assert_eq!(cx.egraph_contexts.len(), 2);
         assert_eq!(
-            cx.egraph_contexts[0].intervals[&'s'],
+            cx.egraph_contexts[0].intervals[&sym("s")],
             DimInterval::new(1, 1)
         );
         assert_eq!(
-            cx.egraph_contexts[1].intervals[&'s'],
+            cx.egraph_contexts[1].intervals[&sym("s")],
             DimInterval::new(2, 4)
         );
     }

--- a/src/hlir.rs
+++ b/src/hlir.rs
@@ -319,7 +319,7 @@ impl HLIROp for Input {
 }
 
 impl ReferenceOp for Input {
-    fn execute(&self, _: Vec<&ReferenceData>, _: &FxHashMap<char, usize>) -> ReferenceData {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
         unimplemented!()
     }
 }
@@ -390,7 +390,7 @@ impl HLIROp for Output {
 }
 
 impl ReferenceOp for Output {
-    fn execute(&self, _: Vec<&ReferenceData>, _: &FxHashMap<char, usize>) -> ReferenceData {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
         unimplemented!()
     }
 }
@@ -433,7 +433,7 @@ impl HLIROp for CustomOpKind {
 }
 
 impl ReferenceOp for CustomOpKind {
-    fn execute(&self, _: Vec<&ReferenceData>, _: &FxHashMap<char, usize>) -> ReferenceData {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
         unimplemented!()
     }
 }
@@ -549,7 +549,7 @@ impl HLIROp for LoopStart {
 }
 
 impl ReferenceOp for LoopStart {
-    fn execute(&self, _: Vec<&ReferenceData>, _: &FxHashMap<char, usize>) -> ReferenceData {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
         unimplemented!("LoopStart is driven by the runtime loop compiler")
     }
 }
@@ -638,7 +638,7 @@ impl HLIROp for LoopEnd {
 }
 
 impl ReferenceOp for LoopEnd {
-    fn execute(&self, _: Vec<&ReferenceData>, _: &FxHashMap<char, usize>) -> ReferenceData {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
         unimplemented!("LoopEnd is driven by the runtime loop compiler")
     }
 }
@@ -770,7 +770,7 @@ impl HLIROp for LoopInput {
 }
 
 impl ReferenceOp for LoopInput {
-    fn execute(&self, _: Vec<&ReferenceData>, _: &FxHashMap<char, usize>) -> ReferenceData {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
         unimplemented!("LoopInput is driven by the runtime loop compiler")
     }
 }
@@ -863,7 +863,7 @@ impl HLIROp for LoopInputStatic {
 }
 
 impl ReferenceOp for LoopInputStatic {
-    fn execute(&self, _: Vec<&ReferenceData>, _: &FxHashMap<char, usize>) -> ReferenceData {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
         unimplemented!("LoopInputStatic is driven by the runtime loop compiler")
     }
 }
@@ -953,7 +953,7 @@ impl HLIROp for LoopOutput {
 }
 
 impl ReferenceOp for LoopOutput {
-    fn execute(&self, _: Vec<&ReferenceData>, _: &FxHashMap<char, usize>) -> ReferenceData {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
         unimplemented!("LoopOutput is driven by the runtime loop compiler")
     }
 }
@@ -1057,7 +1057,7 @@ impl HLIROp for LoopOutputSelect {
 }
 
 impl ReferenceOp for LoopOutputSelect {
-    fn execute(&self, _: Vec<&ReferenceData>, _: &FxHashMap<char, usize>) -> ReferenceData {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
         unimplemented!("LoopOutputSelect is driven by the runtime loop compiler")
     }
 }
@@ -1116,7 +1116,7 @@ impl EgglogOp for Constant {
 }
 
 impl ReferenceOp for Constant {
-    fn execute(&self, _: Vec<&ReferenceData>, _: &FxHashMap<char, usize>) -> ReferenceData {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
         ReferenceData::F32(vec![self.0])
     }
 }
@@ -1180,7 +1180,7 @@ impl EgglogOp for ConstantF64 {
 }
 
 impl ReferenceOp for ConstantF64 {
-    fn execute(&self, _: Vec<&ReferenceData>, _: &FxHashMap<char, usize>) -> ReferenceData {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
         ReferenceData::F64(vec![self.0])
     }
 }
@@ -1235,7 +1235,7 @@ impl EgglogOp for Iota {
     }
 }
 impl ReferenceOp for Iota {
-    fn execute(&self, _: Vec<&ReferenceData>, dyn_map: &FxHashMap<char, usize>) -> ReferenceData {
+    fn execute(&self, _: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
         let length = self.1.exec(dyn_map).unwrap();
         let expr = self.0.resolve_vars(dyn_map);
         ReferenceData::Int(
@@ -1297,7 +1297,7 @@ impl EgglogOp for Cast {
     }
 }
 impl ReferenceOp for Cast {
-    fn execute(&self, input: Vec<&ReferenceData>, _: &FxHashMap<char, usize>) -> ReferenceData {
+    fn execute(&self, input: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
         match self.1 {
             DType::F32 => ReferenceData::F32(match &input[0] {
                 ReferenceData::F32(f) => f.clone(),
@@ -1393,7 +1393,7 @@ fn unary_impl(
     inp: &ReferenceData,
     shape: &[Expression],
     strides: &[Expression],
-    dyn_map: &FxHashMap<char, usize>,
+    dyn_map: &DynMap,
     kernels: UnaryKernels,
 ) -> ReferenceData {
     let ind = StridedIterator::new(shape, strides, dyn_map);
@@ -1467,11 +1467,7 @@ impl EgglogOp for Log2 {
     }
 }
 impl ReferenceOp for Log2 {
-    fn execute(
-        &self,
-        inputs: Vec<&ReferenceData>,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> ReferenceData {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
         unary_impl(
             inputs[0],
             &self.shape,
@@ -1542,11 +1538,7 @@ impl EgglogOp for Exp2 {
     }
 }
 impl ReferenceOp for Exp2 {
-    fn execute(
-        &self,
-        inputs: Vec<&ReferenceData>,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> ReferenceData {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
         unary_impl(
             inputs[0],
             &self.shape,
@@ -1618,11 +1610,7 @@ impl EgglogOp for Sin {
     }
 }
 impl ReferenceOp for Sin {
-    fn execute(
-        &self,
-        inputs: Vec<&ReferenceData>,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> ReferenceData {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
         unary_impl(
             inputs[0],
             &self.shape,
@@ -1694,11 +1682,7 @@ impl EgglogOp for Recip {
     }
 }
 impl ReferenceOp for Recip {
-    fn execute(
-        &self,
-        inputs: Vec<&ReferenceData>,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> ReferenceData {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
         unary_impl(
             inputs[0],
             &self.shape,
@@ -1770,11 +1754,7 @@ impl EgglogOp for Sqrt {
     }
 }
 impl ReferenceOp for Sqrt {
-    fn execute(
-        &self,
-        inputs: Vec<&ReferenceData>,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> ReferenceData {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
         unary_impl(
             inputs[0],
             &self.shape,
@@ -1913,11 +1893,7 @@ impl EgglogOp for Add {
 }
 
 impl ReferenceOp for Add {
-    fn execute(
-        &self,
-        inputs: Vec<&ReferenceData>,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> ReferenceData {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
         let (a, b) = (inputs[0], inputs[1]);
         let (a_ind, b_ind) = (
             StridedIterator::new(&self.shape, &self.a_strides, dyn_map),
@@ -2013,11 +1989,7 @@ impl EgglogOp for Mul {
 }
 
 impl ReferenceOp for Mul {
-    fn execute(
-        &self,
-        inputs: Vec<&ReferenceData>,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> ReferenceData {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
         let (a, b) = (inputs[0], inputs[1]);
         let (a_ind, b_ind) = (
             StridedIterator::new(&self.shape, &self.a_strides, dyn_map),
@@ -2113,11 +2085,7 @@ impl EgglogOp for Mod {
 }
 
 impl ReferenceOp for Mod {
-    fn execute(
-        &self,
-        inputs: Vec<&ReferenceData>,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> ReferenceData {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
         let (a, b) = (inputs[0], inputs[1]);
         let (a_ind, b_ind) = (
             StridedIterator::new(&self.shape, &self.a_strides, dyn_map),
@@ -2212,11 +2180,7 @@ impl EgglogOp for LessThan {
 }
 
 impl ReferenceOp for LessThan {
-    fn execute(
-        &self,
-        inputs: Vec<&ReferenceData>,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> ReferenceData {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
         let (a, b) = (inputs[0], inputs[1]);
         let (a_ind, b_ind) = (
             StridedIterator::new(&self.shape, &self.a_strides, dyn_map),
@@ -2357,11 +2321,7 @@ impl EgglogOp for Gather {
     }
 }
 impl ReferenceOp for Gather {
-    fn execute(
-        &self,
-        inputs: Vec<&ReferenceData>,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> ReferenceData {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
         let (indexes, data) = (inputs[0], inputs[1]);
         let indexes_ind = StridedIterator::new(&self.index_shape, &self.index_strides, dyn_map);
         let data_ind =
@@ -2522,11 +2482,7 @@ impl EgglogOp for Scatter {
     }
 }
 impl ReferenceOp for Scatter {
-    fn execute(
-        &self,
-        inputs: Vec<&ReferenceData>,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> ReferenceData {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
         let (dest, indexes, src) = (inputs[0], inputs[1], inputs[2]);
         let dest_ind =
             StridedIterator::new(&self.dest_shape, &self.dest_strides, dyn_map).collect_vec();
@@ -2646,11 +2602,7 @@ impl EgglogOp for SumReduce {
 }
 
 impl ReferenceOp for SumReduce {
-    fn execute(
-        &self,
-        inputs: Vec<&ReferenceData>,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> ReferenceData {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
         let ind = StridedIterator::new(&self.shape, &self.strides, dyn_map);
         // Resolve dyn vars in iter_stride, then evaluate z-stride at each iteration
         let mut resolved_stride = self.iter_stride;
@@ -2783,11 +2735,7 @@ impl EgglogOp for MaxReduce {
 }
 
 impl ReferenceOp for MaxReduce {
-    fn execute(
-        &self,
-        inputs: Vec<&ReferenceData>,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> ReferenceData {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
         let ind = StridedIterator::new(&self.shape, &self.strides, dyn_map);
         // Resolve dyn vars in iter_stride, then evaluate z-stride at each iteration
         let mut resolved_stride = self.iter_stride;
@@ -2856,11 +2804,7 @@ impl ReferenceOp for MaxReduce {
 }
 
 pub trait ReferenceOp: Debug + AsAny + Send + Sync {
-    fn execute(
-        &self,
-        inputs: Vec<&ReferenceData>,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> ReferenceData;
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData;
 }
 
 #[derive(Debug, Clone)]
@@ -3055,7 +2999,7 @@ impl Runtime for ReferenceRuntime {
     fn profile(
         &mut self,
         _: &LLIRGraph,
-        _: &FxHashMap<char, usize>,
+        _: &DynMap,
         _: usize,
         _: Option<std::time::Duration>,
         _: Option<(Self::ProfileMetric, f64)>,
@@ -3088,7 +3032,7 @@ impl Runtime for ReferenceRuntime {
         self.graph = graph;
     }
 
-    fn execute(&mut self, dyn_map: &FxHashMap<char, usize>) -> Self::ExecReturn {
+    fn execute(&mut self, dyn_map: &DynMap) -> Self::ExecReturn {
         for node in toposort(&self.graph, None).unwrap() {
             if (**self.graph[node]).as_any().is::<Input>() {
                 continue;
@@ -3161,7 +3105,7 @@ struct StridedIterator {
 }
 
 impl StridedIterator {
-    fn new(shape: &[Expression], strides: &[Expression], dyn_map: &FxHashMap<char, usize>) -> Self {
+    fn new(shape: &[Expression], strides: &[Expression], dyn_map: &DynMap) -> Self {
         let shape: Vec<usize> = shape.iter().map(|e| e.exec(dyn_map).unwrap()).collect();
         // Resolve dynamic vars in strides but keep 'z' as a variable
         let strides: Vec<Expression> = strides

--- a/src/op.rs
+++ b/src/op.rs
@@ -9,15 +9,15 @@ use rustc_hash::FxHashMap;
 
 #[derive(Clone, Copy)]
 pub struct ProfileBucketContext<'a> {
-    pub dim_buckets: &'a FxHashMap<char, Vec<DimBucket>>,
-    pub bucket_indices: &'a FxHashMap<char, usize>,
-    pub representative_dyn_map: &'a FxHashMap<char, usize>,
+    pub dim_buckets: &'a FxHashMap<Symbol, Vec<DimBucket>>,
+    pub bucket_indices: &'a DynMap,
+    pub representative_dyn_map: &'a DynMap,
 }
 
 #[derive(Clone, Copy)]
 pub struct CandidateFilterContext<'a> {
     pub search_options: &'a crate::graph::CompileOptions,
-    pub dyn_map: &'a FxHashMap<char, usize>,
+    pub dyn_map: &'a DynMap,
     pub bucket_context: Option<ProfileBucketContext<'a>>,
 }
 
@@ -69,7 +69,7 @@ pub trait Runtime {
     fn late_egglog_passes(
         _ops: &[Arc<Box<dyn EgglogOp>>],
         _options: &crate::graph::CompileOptions,
-        _dyn_map: &FxHashMap<char, usize>,
+        _dyn_map: &DynMap,
     ) -> Vec<crate::egglog_utils::LateEgglogPass>
     where
         Self: Sized,
@@ -88,7 +88,7 @@ pub trait Runtime {
     }
     fn initialize(arg: Self::CompileArg) -> Self;
     fn load_llir(&mut self, llir_graph: &LLIRGraph);
-    fn execute(&mut self, dyn_map: &FxHashMap<char, usize>) -> Self::ExecReturn;
+    fn execute(&mut self, dyn_map: &DynMap) -> Self::ExecReturn;
     /// `early_stop` is `Some((best_metric, factor))` when the search already
     /// holds a best candidate: once this candidate's running mean exceeds
     /// `best * factor`, the runtime may stop remaining trials and return the
@@ -99,7 +99,7 @@ pub trait Runtime {
     fn profile(
         &mut self,
         llir_graph: &LLIRGraph,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         trials: usize,
         timeout: Option<std::time::Duration>,
         early_stop: Option<(Self::ProfileMetric, f64)>,
@@ -111,7 +111,7 @@ pub trait Runtime {
     fn profile_with_bucket_context(
         &mut self,
         llir_graph: &LLIRGraph,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         trials: usize,
         timeout: Option<std::time::Duration>,
         early_stop: Option<(Self::ProfileMetric, f64)>,
@@ -145,7 +145,7 @@ pub trait Runtime {
     }
     /// Check if the most recent execution produced NaN in any output buffer.
     /// Used by the search to reject NaN-producing graph variants.
-    fn has_nan_outputs(&self, _llir_graph: &LLIRGraph, _dyn_map: &FxHashMap<char, usize>) -> bool {
+    fn has_nan_outputs(&self, _llir_graph: &LLIRGraph, _dyn_map: &DynMap) -> bool {
         false
     }
     /// Runtime-specific pre-profile candidate filter. Backends can reject an
@@ -166,7 +166,7 @@ pub trait Runtime {
     /// same dry planning used by [`Runtime::load_llir_buckets`].
     fn filter_llir_bucket_set(
         &mut self,
-        _dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
+        _dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
         _bucket_llirs: &[BucketLLIRRef<'_>],
         _search_options: &crate::graph::CompileOptions,
     ) -> CandidateFilterResult {
@@ -177,7 +177,7 @@ pub trait Runtime {
     /// The runtime dispatches between them in execute() based on dyn_map values.
     fn load_llir_buckets(
         &mut self,
-        _dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
+        _dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
         bucket_llirs: &[BucketLLIR],
     ) {
         if bucket_llirs.len() == 1 {
@@ -190,7 +190,7 @@ pub trait Runtime {
 
 /// Optional runtime instrumentation for collecting execution statistics.
 pub trait RuntimeStats: Runtime {
-    fn execute_with_stats(&mut self, dyn_map: &FxHashMap<char, usize>) -> Option<ExecutionStats>;
+    fn execute_with_stats(&mut self, dyn_map: &DynMap) -> Option<ExecutionStats>;
 }
 
 /// Shared early-stop predicate for duration-metric runtimes: true once a

--- a/src/shape/expression.rs
+++ b/src/shape/expression.rs
@@ -14,6 +14,7 @@ use std::{
 };
 
 use crate::egglog_utils::{self, SerializedEGraph, extract_expr};
+use crate::shape::symbol::{DynMap, Symbol, egglog_var_name, kernel_const_name};
 use egglog::{ast::Span, prelude::RustSpan, var};
 
 type ExprBox = GenerationalBox<Vec<Term>, SyncStorage>;
@@ -50,15 +51,15 @@ impl DimInterval {
     }
 }
 
-pub type DynDimIntervals = FxHashMap<char, DimInterval>;
+pub type DynDimIntervals = FxHashMap<Symbol, DimInterval>;
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 struct IntervalSimplifyKey {
     expr: Expression,
-    intervals: Vec<(char, DimInterval)>,
+    intervals: Vec<(Symbol, DimInterval)>,
 }
 
-fn canonical_intervals(intervals: &DynDimIntervals) -> Vec<(char, DimInterval)> {
+fn canonical_intervals(intervals: &DynDimIntervals) -> Vec<(Symbol, DimInterval)> {
     let mut intervals = intervals.iter().map(|(&c, &i)| (c, i)).collect::<Vec<_>>();
     intervals.sort_by_key(|(c, _)| *c);
     intervals
@@ -146,20 +147,36 @@ impl Expression {
     pub fn is_dynamic(&self) -> bool {
         self.terms.read().iter().any(|i| {
             if let Term::Var(v) = i {
-                *v != 'z'
+                !v.is_reserved()
             } else {
                 false
             }
         })
     }
 
-    pub fn dyn_vars(&self) -> Vec<char> {
+    /// Whether this expression mentions the reserved loop index.
+    ///
+    /// Distinct from [`dyn_vars`](Self::dyn_vars), which *excludes* the
+    /// reserved index — this is how a caller asks "is the index in here at
+    /// all", which strides legitimately are and dimension sizes must not be.
+    pub fn uses_reserved_index(&self) -> bool {
+        self.terms
+            .read()
+            .iter()
+            .any(|t| matches!(t, Term::Var(v) if v.is_reserved()))
+    }
+
+    /// The dimension variables this expression depends on.
+    ///
+    /// Excludes the reserved loop index — it is an index, not a dimension, so
+    /// nothing downstream should plan buffers or emit `dyn_dims` slots for it.
+    pub fn dyn_vars(&self) -> Vec<Symbol> {
         self.terms
             .read()
             .iter()
             .filter_map(|i| {
                 if let Term::Var(v) = i {
-                    if *v != 'z' { Some(*v) } else { None }
+                    (!v.is_reserved()).then_some(*v)
                 } else {
                     None
                 }
@@ -184,7 +201,7 @@ impl Default for Expression {
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Term {
     Num(i64),
-    Var(char),
+    Var(Symbol),
     Add,
     Sub,
     Mul,
@@ -338,7 +355,7 @@ impl Expression {
         for term in self.terms.read().iter() {
             let new_symbol = match term {
                 Term::Num(n) => format!("(MNum {n})"),
-                Term::Var(c) => format!("(MVar \"{c}\")"),
+                Term::Var(c) => format!("(MVar \"{}\")", egglog_var_name(c)),
                 Term::Max => format!(
                     "(MMax {} {})",
                     symbols.pop().unwrap(),
@@ -361,12 +378,25 @@ impl Expression {
         symbols.pop().unwrap_or_default()
     }
 
-    pub fn to_kernel(&self) -> String {
+    /// Emit C for this expression, spelling the reserved loop index as
+    /// `index_var` instead of its default `const_z`.
+    ///
+    /// Substitutes on the term, so no dim name can be a prefix of another and
+    /// get rewritten mid-name.
+    pub fn to_kernel_with_index(&self, index_var: &str) -> String {
+        self.to_kernel_with(index_var, &kernel_const_name)
+    }
+
+    /// As [`to_kernel_with_index`](Self::to_kernel_with_index), but also chooses
+    /// how each dynamic dim is spelled — Metal names them by buffer slot rather
+    /// than by `const_<name>`.
+    pub fn to_kernel_with(&self, index_var: &str, dim: &dyn Fn(&Symbol) -> String) -> String {
         let mut symbols = vec![];
         for term in self.terms.read().iter() {
             let new_symbol = match term {
                 Term::Num(n) => n.to_string(),
-                Term::Var(c) => format!("const_{c}"),
+                Term::Var(c) if c.is_reserved() => index_var.to_string(),
+                Term::Var(c) => dim(c),
                 Term::Max => format!(
                     "max((int){}, (int){})",
                     symbols.pop().unwrap(),
@@ -403,6 +433,13 @@ impl Expression {
         }
         symbols.pop().unwrap_or_default()
     }
+
+    /// Emit C for this expression, with the reserved loop index spelled
+    /// `const_z` — the name generated kernels give their thread index.
+    pub fn to_kernel(&self) -> String {
+        self.to_kernel_with_index(&kernel_const_name(&Symbol::reserved_index()))
+    }
+
     /// Simplify the expression to its minimal terms
     #[tracing::instrument(skip_all)]
     pub fn simplify(self) -> Self {
@@ -557,7 +594,8 @@ impl Expression {
         Expression::new(terms)
     }
     /// Substitute an expression for a variable
-    pub fn substitute(self, var: char, expr: impl Into<Expression>) -> Self {
+    pub fn substitute(self, var: impl Into<Symbol>, expr: impl Into<Expression>) -> Self {
+        let var = var.into();
         let mut new_terms = vec![];
         let t = expr.into().terms.read();
         for term in self.terms.read().iter() {
@@ -615,15 +653,11 @@ impl Expression {
         stack.pop().unwrap() as usize
     }
     /// Evaluate the expression given variables.
-    pub fn exec(&self, variables: &FxHashMap<char, usize>) -> Option<usize> {
+    pub fn exec(&self, variables: &DynMap) -> Option<usize> {
         self.exec_stack(variables, &mut Vec::new())
     }
     /// Evaluate the expression given variables. This function requires a stack to be given for use as storage
-    pub fn exec_stack(
-        &self,
-        variables: &FxHashMap<char, usize>,
-        stack: &mut Vec<i64>,
-    ) -> Option<usize> {
+    pub fn exec_stack(&self, variables: &DynMap, stack: &mut Vec<i64>) -> Option<usize> {
         for term in self.terms.read().iter() {
             match term {
                 Term::Num(n) => stack.push(*n),
@@ -638,7 +672,7 @@ impl Expression {
         stack.pop().map(|i| i as usize)
     }
     /// Retrieve all symbols in the expression.
-    pub fn to_symbols(&self) -> Vec<char> {
+    pub fn to_symbols(&self) -> Vec<Symbol> {
         self.terms
             .read()
             .iter()
@@ -649,7 +683,7 @@ impl Expression {
             .collect()
     }
     /// Resolve all known variables from dyn map into real values
-    pub fn resolve_vars(&self, dyn_map: &FxHashMap<char, usize>) -> Expression {
+    pub fn resolve_vars(&self, dyn_map: &DynMap) -> Expression {
         let new_terms: Vec<Term> = self
             .terms
             .read()
@@ -739,15 +773,23 @@ impl From<Term> for Expression {
     }
 }
 
+impl From<Symbol> for Expression {
+    fn from(value: Symbol) -> Self {
+        Expression::new(vec![Term::Var(value)])
+    }
+}
+
+/// Names the same dim as `sym("s")`; a literal just reads better in
+/// hand-written models.
 impl From<char> for Expression {
     fn from(value: char) -> Self {
-        Expression::new(vec![Term::Var(value)])
+        Expression::from(Symbol::from(value))
     }
 }
 
 impl From<&char> for Expression {
     fn from(value: &char) -> Self {
-        Expression::new(vec![Term::Var(*value)])
+        Expression::from(Symbol::from(*value))
     }
 }
 
@@ -1271,6 +1313,7 @@ fn egglog_simplify_with_intervals(e: Expression, intervals: &DynDimIntervals) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::shape::sym;
     use proptest::prelude::*;
 
     #[test]
@@ -1302,7 +1345,10 @@ mod tests {
         assert_eq!(((a * 1) + 0) / 1 + (1 - 1), a);
         // Evaluation after simplification
         let n = (x + (256 - (x % 256))).simplify();
-        assert_eq!(n.exec(&[('x', 767)].into_iter().collect()).unwrap(), 768);
+        assert_eq!(
+            n.exec(&[(sym("x"), 767)].into_iter().collect()).unwrap(),
+            768
+        );
     }
 
     #[test]
@@ -1327,7 +1373,7 @@ mod tests {
     #[test]
     fn test_interval_simplifications() {
         let s = expr('s');
-        let intervals = [('s', DimInterval::new(0, 127))].into_iter().collect();
+        let intervals = [(sym("s"), DimInterval::new(0, 127))].into_iter().collect();
 
         assert_eq!((s % 128).simplify_with_intervals(&intervals), s);
         assert_eq!((s / 128).simplify_with_intervals(&intervals), expr(0));
@@ -1354,7 +1400,7 @@ mod tests {
     #[test]
     fn test_singleton_interval_substitutes_dynamic_var() {
         let s = expr('s');
-        let intervals = [('s', DimInterval::new(1, 1))].into_iter().collect();
+        let intervals = [(sym("s"), DimInterval::new(1, 1))].into_iter().collect();
 
         assert_eq!((s + 127).simplify_with_intervals(&intervals), expr(128));
         assert_eq!((s.lt(2)).simplify_with_intervals(&intervals), expr(1));
@@ -1363,7 +1409,7 @@ mod tests {
     #[test]
     fn test_interval_simplification_requires_proof() {
         let s = expr('s');
-        let intervals = [('s', DimInterval::new(0, 256))].into_iter().collect();
+        let intervals = [(sym("s"), DimInterval::new(0, 256))].into_iter().collect();
 
         assert_ne!((s % 128).simplify_with_intervals(&intervals), s);
         assert_ne!(s.lt(128).simplify_with_intervals(&intervals), expr(1));
@@ -1445,12 +1491,12 @@ mod tests {
             let (x, y, z) = (expr('x'), expr('y'), expr('z'));
             // Simplification preserves evaluation
             let expr = ((x + 3) * 2) - (x * 2) + (y % 5);
-            let env = [('x', x_val), ('y', y_val)].into_iter().collect();
+            let env = [(sym("x"), x_val), (sym("y"), y_val)].into_iter().collect();
             assert_eq!(expr.exec(&env).unwrap(), expr.simplify().exec(&env).unwrap());
             // Substitution + simplification preserves evaluation
             let expr = (x + y) * (y - x);
             let substituted = expr.substitute('x', z + 1).substitute('y', z - 1);
-            let env = [('z', z_val)].into_iter().collect();
+            let env = [(sym("z"), z_val)].into_iter().collect();
             assert_eq!(substituted.exec(&env).unwrap(), substituted.simplify().exec(&env).unwrap());
         }
     }
@@ -1458,8 +1504,10 @@ mod tests {
     #[test]
     fn test_hash_consing() {
         // Creating identical expressions should return the same underlying storage
-        // Use unique variable names to avoid interference from other tests
-        let unique_var = '\u{E000}'; // Private use area character unlikely to conflict
+        // Use a unique variable name to avoid interference from other tests.
+        // This used to need a private-use-area char, because a dim was a char
+        // and every readable one was potentially in use by another test.
+        let unique_var = sym("hashConsingProbe");
 
         // Create expression with unique var + 42
         let x1 = expr(unique_var) + 42;
@@ -1479,7 +1527,7 @@ mod tests {
         );
 
         // Different expression should create new entry
-        let unique_var2 = '\u{E001}';
+        let unique_var2 = sym("hashConsingProbe2");
         let y = expr(unique_var2) + 43;
         assert_ne!(
             x1.terms.id(),

--- a/src/shape/mod.rs
+++ b/src/shape/mod.rs
@@ -1,7 +1,9 @@
 mod expression;
+mod symbol;
 mod tracker;
 
 pub use expression::*;
+pub use symbol::*;
 pub use tracker::*;
 
 use std::ops::{Bound, Range, RangeBounds, RangeFrom, RangeFull, RangeTo, RangeToInclusive};

--- a/src/shape/symbol.rs
+++ b/src/shape/symbol.rs
@@ -1,0 +1,544 @@
+//! Symbolic dimension variables.
+//!
+//! A [`Symbol`] names one dynamic dimension — the `s` in a `[s, 128]` shape.
+//! Everything that means "a dim variable" says `Symbol`, and every
+//! symbol-to-concrete-size mapping says [`DynMap`].
+//!
+//! A `Symbol` is a `Copy` handle into a generational arena, the same shape as
+//! [`Expression`](crate::shape::Expression) and its `Vec<Term>`: the name lives
+//! in the arena, and the handle is a pointer plus a generation. That is what
+//! keeps [`Term`](crate::shape::Term) `Copy` while a dim name is an owned,
+//! arbitrary-length string.
+//!
+//! `GenerationalBox` supplies only `Copy`, `Clone` and `Debug`, so equality,
+//! ordering and hashing are written by hand here and read *through* the handle,
+//! comparing names rather than arena slots. `Expression` does the same for its
+//! `Hash` and `PartialEq`.
+//!
+//! `Ord` compares names, not handles, because CUDA assigns each dim a
+//! `dyn_dims[]` slot by sorting the dim set and the host uploads values in that
+//! same order. Sorting by name keeps that a function of the graph alone; handle
+//! order is allocation order.
+//!
+//! One name is reserved. `"z"` is the runtime loop index, not a dimension:
+//! [`Expression::dyn_vars`](crate::shape::Expression::dyn_vars) filters it out
+//! and generated kernels declare their own `long long const_z`, so a dimension
+//! named `z` would vanish from the buffer planner and collide with that local.
+//! See [`RESERVED_INDEX_NAME`] and [`Symbol::try_new_dim`].
+
+use std::fmt;
+use std::sync::{OnceLock, RwLock};
+
+use generational_box::{AnyStorage, GenerationalBox, Owner, SyncStorage};
+use rustc_hash::FxHashMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// A `Copy` handle to a name in the arena, as `ExprBox` is to a `Vec<Term>`.
+type NameBox = GenerationalBox<String, SyncStorage>;
+
+/// Names one symbolic dimension.
+///
+/// `Copy`, and compares/hashes/orders by name.
+///
+/// Most code never names a constructor: the dim-taking methods on `Graph` and
+/// `CompileOptions` are generic over `impl Into<Symbol>`, so `set_dim("seq", 8)`
+/// and `set_dim('s', 8)` both work. Reach for [`sym`] when you need a value
+/// directly, or [`Symbol::try_new_dim`] for a name from a frontend.
+#[derive(Clone, Copy)]
+pub struct Symbol(NameBox);
+
+/// Concrete sizes for the symbolic dimensions of a graph, resolved at runtime.
+pub type DynMap = FxHashMap<Symbol, usize>;
+
+/// The runtime loop index. Reserved — never hand this out as a dimension.
+///
+/// A `&str` rather than a `Symbol` because a `Symbol` is an arena handle and so
+/// cannot be a `const`. Use [`Symbol::reserved_index`] for the value.
+const RESERVED_INDEX_NAME: &str = "z";
+
+/// A name that cannot be a dimension.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InvalidSymbolName {
+    /// Not `[A-Za-z][A-Za-z0-9_]*`.
+    ///
+    /// The alphabet makes `const_<name>` a usable identifier and `"<name>"` a
+    /// valid egglog literal by construction, so no codegen site re-checks. The
+    /// `__` rule is C++'s, not C's: C++ reserves every identifier containing a
+    /// doubled underscore, not just leading ones.
+    ///
+    /// Rejected rather than sanitized — sanitizing is not injective, so `a.b`
+    /// and `a-b` would land on one `#define` and one `MVar`.
+    Malformed(String),
+    /// The reserved loop index — see [`RESERVED_INDEX_NAME`].
+    Reserved,
+}
+
+impl fmt::Display for InvalidSymbolName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Malformed(name) => write!(
+                f,
+                "dim name {name:?} must match [A-Za-z][A-Za-z0-9_]* with no \
+                 doubled underscore, so that const_<name> is never an identifier \
+                 C++ reserves to the implementation, and <name> is a valid \
+                 egglog literal"
+            ),
+            Self::Reserved => write!(
+                f,
+                "{RESERVED_INDEX_NAME:?} is the reserved runtime loop index, not a \
+                 dimension: kernels declare their own const_{RESERVED_INDEX_NAME} \
+                 local and dyn_vars() filters it out, so a dim with this name would \
+                 be dropped from the buffer planner"
+            ),
+        }
+    }
+}
+
+static NAME_OWNER: OnceLock<Owner<SyncStorage>> = OnceLock::new();
+static NAME_INTERNER: OnceLock<RwLock<FxHashMap<String, NameBox>>> = OnceLock::new();
+
+/// One arena slot per distinct name.
+///
+/// Not needed for correctness — equality reads through the handle and compares
+/// names — but without it every `Symbol::new` would claim a fresh slot that is
+/// never reclaimed. Mirrors `EXPRESSION_INTERNER`.
+fn intern(name: &str) -> NameBox {
+    let interner = NAME_INTERNER.get_or_init(|| RwLock::new(FxHashMap::default()));
+    if let Some(existing) = interner.read().unwrap().get(name) {
+        return *existing;
+    }
+    let mut guard = interner.write().unwrap();
+    if let Some(existing) = guard.get(name) {
+        return *existing;
+    }
+    let boxed = NAME_OWNER
+        .get_or_init(SyncStorage::owner)
+        .insert(name.to_string());
+    guard.insert(name.to_string(), boxed);
+    boxed
+}
+
+fn is_well_formed(name: &str) -> bool {
+    // No is_empty check: starts_with already rejects "".
+    name.starts_with(|c: char| c.is_ascii_alphabetic())
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        && !name.contains("__")
+}
+
+impl Symbol {
+    /// The reserved runtime loop index.
+    pub fn reserved_index() -> Symbol {
+        Symbol(intern(RESERVED_INDEX_NAME))
+    }
+
+    /// Build a symbol, allowing the reserved index.
+    ///
+    /// Panics if the name is malformed. Prefer [`Symbol::try_new_dim`] for
+    /// names arriving from a frontend: it also rejects the reserved index, and
+    /// reports rather than unwinding.
+    pub fn new(name: &str) -> Symbol {
+        Self::try_new(name).unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Build a symbol, allowing the reserved index.
+    fn try_new(name: &str) -> Result<Symbol, InvalidSymbolName> {
+        if !is_well_formed(name) {
+            return Err(InvalidSymbolName::Malformed(name.to_string()));
+        }
+        Ok(Symbol(intern(name)))
+    }
+
+    /// Build a symbol for a *dimension*, rejecting the reserved loop index.
+    ///
+    /// This is the guard a frontend should use on a name it did not choose.
+    pub fn try_new_dim(name: &str) -> Result<Symbol, InvalidSymbolName> {
+        let sym = Self::try_new(name)?;
+        if sym.is_reserved() {
+            return Err(InvalidSymbolName::Reserved);
+        }
+        Ok(sym)
+    }
+
+    /// Whether this is the reserved loop index rather than a real dimension.
+    pub fn is_reserved(&self) -> bool {
+        *self.0.read() == RESERVED_INDEX_NAME
+    }
+}
+
+/// Build a dim symbol. Shorthand for [`Symbol::new`].
+pub fn sym(name: &str) -> Symbol {
+    Symbol::new(name)
+}
+
+// GenerationalBox supplies only Copy/Clone/Debug, and a derived PartialEq would
+// compare arena slot and generation — so two symbols named `s` would differ.
+// These read through the handle and compare names.
+
+impl PartialEq for Symbol {
+    fn eq(&self, other: &Self) -> bool {
+        *self.0.read() == *other.0.read()
+    }
+}
+
+impl Eq for Symbol {}
+
+impl PartialOrd for Symbol {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Symbol {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.read().cmp(&other.0.read())
+    }
+}
+
+impl std::hash::Hash for Symbol {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // Hash the name, not the handle: two symbols named `s` must agree.
+        (**self.0.read()).hash(state);
+    }
+}
+
+// No `Borrow<str>`: probing a DynMap with a bare `&str` would need one borrowed
+// from the Symbol, but the name lives behind a read guard that outlives nothing.
+// Callers build a Symbol to look up.
+
+impl fmt::Display for Symbol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0.read())
+    }
+}
+
+/// Prints the bare name, matching how `Term` and `Expression` render dims.
+impl fmt::Debug for Symbol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0.read())
+    }
+}
+
+/// `expr('s')` reads better than `expr(sym("s"))` in hand-written models.
+/// Validated like any other name, so `'%'` panics rather than minting `const_%`.
+impl From<char> for Symbol {
+    fn from(c: char) -> Self {
+        let mut buf = [0u8; 4];
+        Symbol::new(c.encode_utf8(&mut buf))
+    }
+}
+
+/// Serializes as the name, so the encoding is unchanged from when a dim was a
+/// `char`: `Term::Var('s')` was `{"Var":"s"}` and still is, and artifacts
+/// written before this change still load.
+impl Serialize for Symbol {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.0.read())
+    }
+}
+
+impl<'de> Deserialize<'de> for Symbol {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let name = String::deserialize(deserializer)?;
+        // try_new, not try_new_dim: the reserved index appears in serialized
+        // strides and has to round-trip.
+        Symbol::try_new(&name).map_err(serde::de::Error::custom)
+    }
+}
+
+/// The C identifier a symbol takes in generated kernel source.
+///
+/// Kernels also declare a *local* `const_z` for the thread index, so this
+/// namespace is shared with generated code — see [`RESERVED_INDEX_NAME`].
+pub fn kernel_const_name(sym: &Symbol) -> String {
+    format!("const_{sym}")
+}
+
+/// The name a symbol carries inside egglog, as the payload of `(MVar "…")`.
+///
+/// Kept separate from [`kernel_const_name`] even though both are the bare
+/// spelling: the `.egg` rewrite rules match these literally, so this one is a
+/// wire format that rules depend on, not a display detail.
+pub fn egglog_var_name(sym: &Symbol) -> String {
+    sym.to_string()
+}
+
+/// Inverse of [`egglog_var_name`], for names read back out of the e-graph.
+///
+/// Validates rather than trusting. A name that does not survive the round trip
+/// means the boundary mangled it, and a mangled name misses in `dyn_map`, where
+/// a miss silently becomes a dimension of 0.
+pub fn symbol_from_egglog_name(name: &str) -> Symbol {
+    Symbol::try_new(name).unwrap_or_else(|e| panic!("bad dim name out of egglog: {e}"))
+}
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+
+    /// The whole reason `to_kernel_with_index` exists. Callers used to string-
+    /// replace `const_z` in generated source, which is prefix-unsafe once dim
+    /// names can exceed one char: `const_z` is a prefix of `const_zip`, so a
+    /// dim named `zip` would be rewritten mid-name to `iip`.
+    ///
+    /// Substituting on the term means only the reserved index moves and every
+    /// dim is emitted untouched. `zip` is not spellable while `Symbol` is a
+    /// char, so the prefix case itself gets pinned when the newtype lands.
+    #[test]
+    fn index_substitution_only_touches_the_reserved_index() {
+        let e = expr('z') + expr('a');
+        assert_eq!(e.to_kernel_with_index("i"), "(i+const_a)");
+        assert!(!e.to_kernel_with_index("i").contains("const_z"));
+    }
+
+    #[test]
+    fn to_kernel_defaults_to_const_z_for_the_index() {
+        assert_eq!((expr('z') + expr('a')).to_kernel(), "(const_z+const_a)");
+    }
+
+    /// Generated kernels declare a local `long long const_z` for the thread
+    /// index, so a dim may never be named `z` — it would `#define` over that
+    /// local.
+    #[test]
+    fn reserved_index_is_z_and_is_not_a_dyn_var() {
+        assert_eq!(Symbol::reserved_index().to_string(), "z");
+        assert_eq!(kernel_const_name(&Symbol::reserved_index()), "const_z");
+        assert!(expr('z').dyn_vars().is_empty());
+        assert_eq!(expr('a').dyn_vars(), vec![sym("a")]);
+    }
+
+    #[cfg(test)]
+    mod no_const_prefix_surgery {
+        use std::path::Path;
+
+        fn scan(dir: &Path, needle: &str, hits: &mut Vec<String>) {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                if path.is_dir() {
+                    if name != "target" && name != ".git" {
+                        scan(&path, needle, hits);
+                    }
+                } else if name.ends_with(".rs")
+                    && let Ok(src) = std::fs::read_to_string(&path)
+                    && src.contains(needle)
+                {
+                    hits.push(path.display().to_string());
+                }
+            }
+        }
+
+        /// Rewriting generated kernel source by string-replacing a `const_`-prefixed
+        /// name is prefix-unsafe: `const_z` sits inside `const_zip`, so the surgery
+        /// lands in the middle of an unrelated dim's name and silently miscompiles.
+        ///
+        /// `Expression::to_kernel_with_index` / `to_kernel_with` substitute on the
+        /// term instead, before any string exists. Nothing stops someone reaching
+        /// for the old pattern again, so fail the build if they do.
+        #[test]
+        fn no_source_file_string_replaces_a_const_prefix() {
+            // Assembled so this file does not match its own needles.
+            //
+            // Two forms, because the original bug had the second one: Metal built
+            // the name with `format!("const_{symbol}")` and then replaced *that*,
+            // so a needle matching only a string literal would have missed it.
+            let literal = format!("{}(\"const_", "replace");
+            let built = format!("{}!(\"const_", "format");
+            let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+
+            let mut hits = Vec::new();
+            for sub in ["src", "crates", "examples"] {
+                let dir = root.join(sub);
+                assert!(dir.is_dir(), "expected to scan {}", dir.display());
+                scan(&dir, &literal, &mut hits);
+                // Building the name is only a problem when it feeds a rewrite, so
+                // require a rewrite call in the same file rather than flagging
+                // every construction site — kernel_const_name is a legitimate one.
+                // Needles are assembled rather than written literally, or this
+                // file matches itself.
+                let mut built_hits = Vec::new();
+                scan(&dir, &built, &mut built_hits);
+                // Assembled, or this file matches its own filter: it contains
+                // kernel_const_name's legitimate `format!("const_…")`.
+                let rewrite = format!(".{}(", "replace");
+                let rewrite_n = format!(".{}(", "replacen");
+                hits.extend(built_hits.into_iter().filter(|f| {
+                    std::fs::read_to_string(f)
+                        .map(|src| src.contains(&rewrite) || src.contains(&rewrite_n))
+                        .unwrap_or(false)
+                }));
+            }
+            hits.sort();
+            hits.dedup();
+
+            // A lint that cannot tell "clean" from "never looked" is worse than no
+            // lint: scan() swallows read_dir errors and the needles are assembled
+            // at runtime, so prove the scanner finds something it should.
+            let mut control = Vec::new();
+            scan(&root.join("src"), "fn is_well_formed", &mut control);
+            assert!(
+                !control.is_empty(),
+                "scanner found nothing at all — the lint is not actually looking"
+            );
+
+            assert!(
+                hits.is_empty(),
+                "these files rewrite generated source with {literal}…) or {built}…), which is \
+             prefix-unsafe — a dim named `zip` emits `const_zip` and the replace \
+             lands mid-name. Use Expression::to_kernel_with_index / to_kernel_with \
+             instead, which substitute on the term:\n  {}",
+                hits.join("\n  ")
+            );
+        }
+    }
+
+    /// Symbol #26 used to land on 'z', the reserved loop index, which
+    /// `dyn_vars()` filters out — so the dim vanished from the buffer planner
+    /// and every search candidate died evaluating its size.
+    #[test]
+    fn reserved_index_cannot_be_minted_as_a_dim() {
+        assert_eq!(Symbol::try_new_dim("z"), Err(InvalidSymbolName::Reserved));
+        assert!(Symbol::try_new("z").is_ok(), "still nameable as the index");
+    }
+
+    #[test]
+    #[should_panic(expected = "reserved runtime loop index")]
+    fn set_dim_rejects_the_reserved_index() {
+        let mut cx = Graph::new();
+        cx.set_dim('z', 4);
+    }
+
+    /// `set_dim` is not the only way a dim gets named — a shape can name one
+    /// directly, and that path had no guard. `cx.tensor(('z', 4))` built fine,
+    /// reported no dyn_vars (so the buffer planner never saw the dim), and
+    /// emitted `const_z`, which in generated CUDA is the thread index.
+    #[test]
+    #[should_panic(expected = "reserved runtime loop index")]
+    fn a_shape_cannot_be_sized_by_the_loop_index() {
+        let mut cx = Graph::default();
+        let _ = cx.tensor(('z', 4));
+    }
+
+    /// ...but a *stride* legitimately uses it, which is what makes the guard
+    /// specific to dimension sizes rather than to expressions generally.
+    #[test]
+    fn strides_may_use_the_loop_index() {
+        let cx_shape = ShapeTracker::new((4, 8));
+        assert!(
+            cx_shape.strides.iter().any(|s| s.uses_reserved_index()),
+            "strides are indexed by the loop var"
+        );
+        assert!(!cx_shape.dims.iter().any(|d| d.uses_reserved_index()));
+    }
+
+    /// Equality is by name, so a char literal and a string name a single dim.
+    /// The `.egg` rewrite rules match `(MVar "s")` literally, so this is what
+    /// keeps hand-written models hitting them.
+    #[test]
+    fn char_and_str_spellings_name_the_same_dim() {
+        assert_eq!(Symbol::from('s'), sym("s"));
+        assert_eq!(expr('s'), expr(sym("s")));
+        assert_eq!(expr('s').to_egglog(), "(MVar \"s\")");
+    }
+
+    /// Ordering drives `dyn_dims[]` slot assignment, and the host uploads in
+    /// that same order. Sorting by name keeps it a function of the graph — for
+    /// single-char names, byte-identical to the char ordering this replaced.
+    #[test]
+    fn ordering_is_by_name_and_matches_the_old_char_order() {
+        let mut got: Vec<Symbol> = ['s', 'a', 'Z', 'A', 'c'].map(Symbol::from).to_vec();
+        got.sort();
+        let mut want = ['s', 'a', 'Z', 'A', 'c'];
+        want.sort();
+        assert_eq!(
+            got,
+            want.iter().copied().map(Symbol::from).collect::<Vec<_>>()
+        );
+
+        // Independent of the order the names were first interned in.
+        let _ = sym("zz9");
+        let _ = sym("aa9");
+        let mut a = [sym("zz9"), sym("aa9")];
+        a.sort();
+        assert_eq!(a, [sym("aa9"), sym("zz9")]);
+    }
+
+    /// `From<char>` used to hand back any ASCII byte straight from the name
+    /// static ASCII table this branch later deleted, skipping validation
+    /// entirely — so `expr('%')` produced
+    /// `const_%`, not a C identifier, and `Symbol::from('"')` produced
+    /// `(MVar """)`, not an egglog literal. The module claims the alphabet
+    /// holds *by construction* so codegen need not re-check; this is what
+    /// makes that true.
+    #[test]
+    fn char_conversion_is_validated_too() {
+        for c in ['a', 'z', 'A', 'Z'] {
+            assert_eq!(Symbol::from(c).to_string(), c.to_string());
+        }
+        for c in ['%', '"', '-', '7', ' ', '\\', '_'] {
+            assert!(
+                std::panic::catch_unwind(|| Symbol::from(c)).is_err(),
+                "Symbol::from({c:?}) must not mint an unusable name"
+            );
+        }
+    }
+
+    /// The seam this whole change exists to fix, joined end to end.
+    ///
+    /// `simplify()` round-trips through egglog: `to_egglog` encodes the dim as
+    /// `(MVar "s77")`, egglog runs, and extraction decodes it back. Extraction
+    /// used to take `name.chars().next()`, so `s77` came back as `s` — a
+    /// *different, possibly live* dim — and the wrong name then missed in
+    /// `dyn_map`, where cuda_lite turns a miss into a dimension of 0. Wrong
+    /// numerics, no diagnostic.
+    ///
+    /// The decoder is unit-tested in egglog_utils, but nothing ran a
+    /// multi-char name through the real encode/egglog/decode path until this.
+    #[test]
+    fn multichar_dim_survives_a_simplify_round_trip() {
+        let s = expr(sym("s77"));
+
+        // More than one term, so this takes the egglog path rather than
+        // Expression::simplify's single-term shortcut.
+        let simplified = ((s * 2) / 2).simplify();
+
+        assert_eq!(
+            simplified.dyn_vars(),
+            vec![sym("s77")],
+            "name must survive egglog; truncation would yield s"
+        );
+
+        let mut env = DynMap::default();
+        env.insert(sym("s77"), 12);
+        assert_eq!(
+            simplified.exec(&env),
+            Some(12),
+            "a truncated name misses in dyn_map and resolves to nothing"
+        );
+    }
+
+    /// A dim is emitted as `const_<name>`, so the alphabet has to keep that a
+    /// valid C identifier. Rejected, never sanitized: a sanitizer maps `a.b`
+    /// and `a-b` both to `a_b`, silently collapsing two dims onto one #define.
+    #[test]
+    fn malformed_names_are_rejected_not_mangled() {
+        for bad in ["s-77", "_x", "a__b", "7s", "a b", "a\"b", ""] {
+            assert!(
+                Symbol::try_new(bad).is_err(),
+                "{bad:?} should not be a dim name"
+            );
+        }
+        assert_eq!(kernel_const_name(&sym("s77")), "const_s77");
+    }
+
+    /// The prefix hazard that `to_kernel_with_index` exists to prevent, now
+    /// that a dim named `zip` is actually spellable.
+    #[test]
+    fn index_substitution_does_not_clobber_a_z_prefixed_dim() {
+        let e = expr('z') + expr(sym("zip"));
+        let out = e.to_kernel_with_index("i");
+        assert_eq!(out, "(i+const_zip)");
+    }
+}

--- a/src/shape/tracker.rs
+++ b/src/shape/tracker.rs
@@ -1,7 +1,6 @@
 use std::fmt::Display;
 
 use itertools::Itertools;
-use rustc_hash::FxHashMap;
 use tinyvec::ArrayVec;
 
 use crate::prelude::*;
@@ -38,6 +37,13 @@ impl ShapeTracker {
         };
         let mut stride = expr('z');
         for d in dims.to_shape().into_iter().rev() {
+            // A size may not depend on the runtime loop index, though a
+            // stride must.
+            assert!(
+                !d.uses_reserved_index(),
+                "dimension size {d:?} uses the reserved runtime loop index; \
+                 it is an index, not a dimension"
+            );
             s.dims.insert(0, d);
             s.strides.insert(0, stride);
             stride *= d;
@@ -325,7 +331,7 @@ impl ShapeTracker {
     }
 
     /// Given a dyn dim map, resolve global dyn dims into known dims
-    pub fn resolve_dyn_dims(&mut self, dyn_dim_map: &FxHashMap<char, usize>) {
+    pub fn resolve_dyn_dims(&mut self, dyn_dim_map: &DynMap) {
         for d in self.dims.iter_mut().chain(&mut self.strides) {
             *d = d.resolve_vars(dyn_dim_map);
         }
@@ -502,7 +508,7 @@ fn eval_stride_at(stride: Expression, z: usize) -> Option<i64> {
     for term in stride.terms.read().iter() {
         match *term {
             Term::Num(n) => stack.push(n),
-            Term::Var('z') => stack.push(z as i64),
+            Term::Var(v) if v.is_reserved() => stack.push(z as i64),
             Term::Var(_) => return None,
             _ => {
                 let a = stack.pop()?;
@@ -514,16 +520,18 @@ fn eval_stride_at(stride: Expression, z: usize) -> Option<i64> {
     stack.pop()
 }
 
-fn fresh_split_var(expressions: &[Expression], excluded: &[char]) -> char {
-    let candidates = ('a'..='y').chain('A'..='Y');
-    candidates
-        .filter(|&candidate| candidate != 'z' && !excluded.contains(&candidate))
-        .find(|&candidate| {
-            expressions
-                .iter()
-                .all(|expr| !expr.to_symbols().contains(&candidate))
+/// A scratch dimension for the split_dims proof, distinct from `excluded` and
+/// from anything `expressions` already mentions.
+fn fresh_split_var(expressions: &[Expression], excluded: &[Symbol]) -> Symbol {
+    (0..)
+        .map(|n| Symbol::new(&format!("split{n}")))
+        .find(|candidate| {
+            !excluded.contains(candidate)
+                && expressions
+                    .iter()
+                    .all(|expr| !expr.to_symbols().contains(candidate))
         })
-        .expect("ran out of temporary symbols for split_dims proof")
+        .expect("usize is not exhaustible")
 }
 
 #[cfg(test)]
@@ -543,7 +551,7 @@ mod tests {
         // few concrete sizes: span and n_elements must agree (regression for the
         // Add fold bug that over-counted the constant as 533 instead of 383).
         for s in 1usize..=4 {
-            let map: crate::prelude::FxHashMap<char, usize> = [('s', s)].into_iter().collect();
+            let map: crate::prelude::DynMap = [(sym("s"), s)].into_iter().collect();
             assert_eq!(
                 span.exec(&map),
                 n_elem.exec(&map),


### PR DESCRIPTION
We used to have a char back the symbolic dimensions. This left us with only those values we could fit into chat as names, it also meant we had a limited set of them, a->z, A->Z. With lowercase z actually reserved for the index dimension. On graphs like Qwen 3.5, where it has Gated Delta Attention, this function torch_recurrent_gated_delta_rule would produce more symbolic dimensions than we could support. 

https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen3_5/modeling_qwen3_5.py

So we are upgrading from being backed by a char to being backed by a string so we can have more symbolic names and those names can be more descriptive as well over time. 