### PR TITLE
Add native int8, uint8, and int16 HLIR support

### DIFF
--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -588,6 +588,39 @@ impl CompiledGraph {
         Ok(self.runtime.get_output_i64(*node_id))
     }
 
+    /// Read an output as i8 without widening.
+    fn get_output_i8(&self, name: &str) -> PyResult<Vec<i8>> {
+        let node_id = self.tensor_ids.get(name).ok_or_else(|| {
+            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
+                "Unknown output tensor: {}",
+                name
+            ))
+        })?;
+        Ok(self.runtime.get_output_i8(*node_id))
+    }
+
+    /// Read an output as u8 without widening.
+    fn get_output_u8(&self, name: &str) -> PyResult<Vec<u8>> {
+        let node_id = self.tensor_ids.get(name).ok_or_else(|| {
+            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
+                "Unknown output tensor: {}",
+                name
+            ))
+        })?;
+        Ok(self.runtime.get_output_u8(*node_id))
+    }
+
+    /// Read an output as i16 without widening.
+    fn get_output_i16(&self, name: &str) -> PyResult<Vec<i16>> {
+        let node_id = self.tensor_ids.get(name).ok_or_else(|| {
+            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
+                "Unknown output tensor: {}",
+                name
+            ))
+        })?;
+        Ok(self.runtime.get_output_i16(*node_id))
+    }
+
     /// Read an output as f64. Strict: the producer node must already
     /// be `DType::F64`; no widening at the read boundary.
     fn get_output_f64(&self, name: &str) -> PyResult<Vec<f64>> {

--- a/crates/luminal_python/rust/src/pt2_util.rs
+++ b/crates/luminal_python/rust/src/pt2_util.rs
@@ -209,28 +209,16 @@ pub fn resolve_neg1_dim_exprs(
 }
 
 /// Map a PT2 dtype code to luminal `DType`. Panics for variants the IR
-/// doesn't model as first-class types (narrow ints `Byte` / `Char` /
-/// `Short`, the complex family, the float8 family) and for unknown
-/// codes — better to fail loudly at the translator boundary than to
-/// silently widen and lie about the user's dtype.
+/// doesn't model as first-class types (the complex family, unsupported
+/// float8 variants, and uint16) and for unknown codes. The common narrow
+/// integers map to native-width HLIR dtypes without widening.
 pub fn torch_dtype_int_to_luminal(dtype: u32) -> DType {
     let t = crate::torch_dtype::TorchDType::from_code(dtype)
         .unwrap_or_else(|c| panic!("torch_dtype_int_to_luminal: unknown PT2 dtype code {c}"));
-    match t {
-        crate::torch_dtype::TorchDType::Byte
-        | crate::torch_dtype::TorchDType::Char
-        | crate::torch_dtype::TorchDType::Short => panic!(
-            "torch_dtype_int_to_luminal: PT2 dtype {} (code {}) isn't a first-class \
-             IR type yet — cast to torch.int32 at the call site, or wait for the \
-             narrower-int IR follow-up.",
-            t.name(),
-            t.code(),
-        ),
-        other => DType::try_from(other).unwrap_or_else(|t| {
-            panic!(
-                "torch_dtype_int_to_luminal: {} isn't a first-class luminal IR type",
-                t.name()
-            )
-        }),
-    }
+    DType::try_from(t).unwrap_or_else(|t| {
+        panic!(
+            "torch_dtype_int_to_luminal: {} isn't a first-class luminal IR type",
+            t.name()
+        )
+    })
 }

--- a/crates/luminal_python/rust/src/torch_dtype.rs
+++ b/crates/luminal_python/rust/src/torch_dtype.rs
@@ -113,17 +113,18 @@ impl TorchDType {
 }
 
 /// PyTorch dtype → luminal `DType`. `Err(self)` for variants luminal's IR
-/// doesn't model as first-class types — the narrow ints (`Byte` / `Char` /
-/// `Short`), the complex family, and the float8 NUZ variants. `DType::U8`,
-/// `DType::I8`, `DType::I16` exist on the luminal side but the IR has no
-/// kernels / codegen for them, so we refuse the conversion here rather
-/// than silently producing a buffer the kernels can't actually run.
+/// doesn't model as first-class types — uint16, the complex family, and the
+/// float8 NUZ variants. PyTorch's three common narrow integer storage dtypes
+/// map one-to-one to native luminal IR dtypes.
 /// Boundary code panics with the variant name on `Err`; cf.
 /// `typed_data::from_pytorch_bytes`, `pt2_util::torch_dtype_int_to_luminal`.
 impl TryFrom<TorchDType> for DType {
     type Error = TorchDType;
     fn try_from(t: TorchDType) -> Result<Self, Self::Error> {
         Ok(match t {
+            TorchDType::Byte => DType::U8,
+            TorchDType::Char => DType::I8,
+            TorchDType::Short => DType::I16,
             TorchDType::Int => DType::Int,
             TorchDType::Long => DType::I64,
             TorchDType::Half => DType::F16,
@@ -133,10 +134,7 @@ impl TryFrom<TorchDType> for DType {
             TorchDType::BFloat16 => DType::Bf16,
             TorchDType::Float8E4m3Fn => DType::F8E4M3,
             TorchDType::Float8E5m2 => DType::F8E5M2,
-            TorchDType::Byte
-            | TorchDType::Char
-            | TorchDType::Short
-            | TorchDType::Uint16
+            TorchDType::Uint16
             | TorchDType::Unknown
             | TorchDType::ComplexHalf
             | TorchDType::ComplexFloat
@@ -148,8 +146,8 @@ impl TryFrom<TorchDType> for DType {
 }
 
 /// luminal `DType` → PyTorch dtype. `Err(dtype)` for luminal-specific
-/// variants without a first-class PyTorch counterpart — the narrow ints
-/// (`U8` / `I8` / `I16` / `U16`), the sub-byte / exotic widths (`I4`,
+/// variants without a first-class PyTorch counterpart — `U16`, the sub-byte
+/// / exotic widths (`I4`,
 /// `U4`, `F6E2M3`, ...), and `TF32`.
 ///
 /// `TF32` is a compute-mode hint inside luminal, not a storage dtype on
@@ -167,6 +165,9 @@ impl TryFrom<DType> for TorchDType {
             DType::Bf16 => TorchDType::BFloat16,
             DType::Int => TorchDType::Int,
             DType::I64 => TorchDType::Long,
+            DType::I8 => TorchDType::Char,
+            DType::U8 => TorchDType::Byte,
+            DType::I16 => TorchDType::Short,
             DType::Bool => TorchDType::Bool,
             DType::F8E4M3 => TorchDType::Float8E4m3Fn,
             DType::F8E5M2 => TorchDType::Float8E5m2,
@@ -189,8 +190,8 @@ mod tests {
     #[test]
     fn supported_dtypes_roundtrip() {
         // Only the variants luminal's IR models as first-class can
-        // roundtrip cleanly. Narrow ints (`U8` / `I8` / `I16` / `U16`)
-        // are intentionally excluded — see the `TryFrom` impls.
+        // roundtrip cleanly. U16 remains intentionally excluded because its
+        // reference/runtime path is not native yet.
         for d in [
             DType::F32,
             DType::F64,
@@ -198,6 +199,9 @@ mod tests {
             DType::Bf16,
             DType::Int,
             DType::I64,
+            DType::I8,
+            DType::U8,
+            DType::I16,
             DType::Bool,
         ] {
             let t = TorchDType::try_from(d).expect("known DType");
@@ -207,17 +211,9 @@ mod tests {
     }
 
     #[test]
-    fn narrow_ints_refuse_conversion() {
-        // Forward (PyTorch → luminal) and reverse (luminal → PyTorch)
-        // both refuse the narrow-int variants; downstream sites translate
-        // the `Err` into a typed panic with the variant name.
-        for t in [TorchDType::Byte, TorchDType::Char, TorchDType::Short] {
-            assert!(DType::try_from(t).is_err(), "expected Err for {t:?}");
-        }
+    fn unsupported_storage_dtypes_refuse_conversion() {
+        assert!(DType::try_from(TorchDType::Uint16).is_err());
         for d in [
-            DType::U8,
-            DType::I8,
-            DType::I16,
             DType::U16,
             // TF32 is a luminal-internal compute-mode hint, not a PyTorch
             // storage dtype — refuse to silently alias it as `Float`.

--- a/crates/luminal_python/rust/src/translator/unary.rs
+++ b/crates/luminal_python/rust/src/translator/unary.rs
@@ -66,7 +66,9 @@ impl<'a> Translator<'a> {
     pub(crate) fn translate_acos(&mut self, node: &Node) -> Result<GraphTensor> {
         let input = self.get_input_tensor(node, 0)?;
         let input = match input.dtype {
-            DType::Bool | DType::Int | DType::I64 => input.cast(DType::F32),
+            DType::Bool | DType::Int | DType::I64 | DType::I8 | DType::U8 | DType::I16 => {
+                input.cast(DType::F32)
+            }
             _ => input,
         };
         let x = input.abs();
@@ -106,7 +108,9 @@ impl<'a> Translator<'a> {
     pub(crate) fn translate_acosh(&mut self, node: &Node) -> Result<GraphTensor> {
         let input = self.get_input_tensor(node, 0)?;
         let input = match input.dtype {
-            DType::Bool | DType::Int | DType::I64 => input.cast(DType::F32),
+            DType::Bool | DType::Int | DType::I64 | DType::I8 | DType::U8 | DType::I16 => {
+                input.cast(DType::F32)
+            }
             _ => input,
         };
         let reciprocal_squared = input.reciprocal().square();

--- a/crates/luminal_python/rust/src/typed_data.rs
+++ b/crates/luminal_python/rust/src/typed_data.rs
@@ -150,12 +150,8 @@ impl TypedData {
 
     /// Convert raw bytes from a PyTorch tensor (identified by PT2 dtype
     /// code) to `TypedData`. Supported dtypes preserve their raw bytes —
-    /// no width changes at the FFI boundary. Narrow integer widths
-    /// (`Byte` / `Char` / `Short`) panic: luminal's `ReferenceData` has no
-    /// narrower-integer variants yet, so the only way they could pass
-    /// through is via implicit widening to `i32`, which the no-implicit-
-    /// cast directive forbids. Cast at the call site
-    /// (`x.to(torch.int32)`) or wait for the narrower-int IR follow-up.
+    /// no width changes at the FFI boundary, including Byte/U8, Char/I8,
+    /// and Short/I16.
     pub fn from_pytorch_bytes(bytes: Vec<u8>, dtype_code: u32) -> Self {
         let t = crate::torch_dtype::TorchDType::from_code(dtype_code)
             .unwrap_or_else(|c| panic!("from_pytorch_bytes: unknown PT2 dtype code {c}"));
@@ -167,15 +163,9 @@ impl TypedData {
             crate::torch_dtype::TorchDType::Bool => Self::from_raw(bytes, DType::Bool),
             crate::torch_dtype::TorchDType::Long => Self::from_raw(bytes, DType::I64),
             crate::torch_dtype::TorchDType::Double => Self::from_raw(bytes, DType::F64),
-            crate::torch_dtype::TorchDType::Byte
-            | crate::torch_dtype::TorchDType::Char
-            | crate::torch_dtype::TorchDType::Short => panic!(
-                "from_pytorch_bytes: PT2 dtype {} (code {}) isn't a first-class \
-                 IR type yet — cast to torch.int32 at the call site, or wait \
-                 for the narrower-int IR follow-up.",
-                t.name(),
-                t.code(),
-            ),
+            crate::torch_dtype::TorchDType::Byte => Self::from_raw(bytes, DType::U8),
+            crate::torch_dtype::TorchDType::Char => Self::from_raw(bytes, DType::I8),
+            crate::torch_dtype::TorchDType::Short => Self::from_raw(bytes, DType::I16),
             other => panic!(
                 "from_pytorch_bytes: PT2 dtype {} (code {}) isn't a first-class \
                  IR type — no luminal mapping.",
@@ -282,22 +272,18 @@ impl From<TypedData> for ReferenceData {
                 let data: Vec<bool> = td.bytes.iter().map(|&b| b != 0).collect();
                 ReferenceData::Bool(data)
             }
-            // Integer types that map to ReferenceData::Int
             DType::I8 => {
-                let data: Vec<i32> = td.bytes.iter().map(|&b| b as i8 as i32).collect();
-                ReferenceData::Int(data)
+                let data: Vec<i8> = td.bytes.into_iter().map(|b| b as i8).collect();
+                ReferenceData::I8(data)
             }
-            DType::U8 => {
-                let data: Vec<i32> = td.bytes.iter().map(|&b| b as i32).collect();
-                ReferenceData::Int(data)
-            }
+            DType::U8 => ReferenceData::U8(td.bytes),
             DType::I16 => {
-                let data: Vec<i32> = td
+                let data: Vec<i16> = td
                     .bytes
                     .chunks_exact(2)
-                    .map(|b| i16::from_le_bytes([b[0], b[1]]) as i32)
+                    .map(|b| i16::from_le_bytes([b[0], b[1]]))
                     .collect();
-                ReferenceData::Int(data)
+                ReferenceData::I16(data)
             }
             DType::U16 => {
                 let data: Vec<i32> = td

--- a/crates/luminal_python/src/luminal/compiled_model.py
+++ b/crates/luminal_python/src/luminal/compiled_model.py
@@ -193,11 +193,6 @@ class CompiledModel:
         # `torch.frombuffer`. That's a reinterpret, not a numeric
         # cast — no precision change.
         #
-        # Narrow ints (`int8` / `int16` / `uint8`) are intentionally
-        # absent — luminal's IR refuses them at the FFI boundary (cf.
-        # `pt2_util::torch_dtype_int_to_luminal`,
-        # `typed_data::from_pytorch_bytes`), so a graph can never
-        # declare a narrow-int output that reaches this dispatch.
         _zero_copy_native_floats = (torch.float32, torch.float16, torch.bfloat16)
         _output_readers = {
             torch.float32: ("get_output", torch.float32),
@@ -206,6 +201,9 @@ class CompiledModel:
             torch.bfloat16: ("get_output_bf16", torch.bfloat16),
             torch.int64: ("get_output_i64", torch.int64),
             torch.int32: ("get_output_i32", torch.int32),
+            torch.int16: ("get_output_i16", torch.int16),
+            torch.int8: ("get_output_i8", torch.int8),
+            torch.uint8: ("get_output_u8", torch.uint8),
             torch.bool: ("get_output_bool", torch.bool),
         }
 
@@ -238,7 +236,7 @@ class CompiledModel:
                 if all(d != 0 for d in shape):
                     return None
                 return torch.empty(tuple(shape), dtype=out_dtype, device=input_device)
-            if out_dtype in (torch.float16, torch.bfloat16):
+            if out_dtype in (torch.float16, torch.bfloat16, torch.uint8):
                 # Getter returned an immutable `bytes` from Rust; wrap in
                 # `bytearray` to make the storage writable (suppresses
                 # the "non-writable buffer" warning), then bit-cast via

--- a/crates/luminal_python/tests/test_dtype_boundary.py
+++ b/crates/luminal_python/tests/test_dtype_boundary.py
@@ -15,6 +15,11 @@ class BoundaryNoopModel(torch.nn.Module):
         return x + torch.zeros((), dtype=x.dtype, device=x.device)
 
 
+class AbsModel(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.abs(x)
+
+
 class EmptyWeightModel(torch.nn.Module):
     def __init__(self) -> None:
         super().__init__()
@@ -190,14 +195,14 @@ def boundary_device(request) -> torch.device:
     return torch.device(device_name)
 
 
-# Dtypes that round-trip the BoundaryNoopModel without an explicit
-# `x.to(model.input_dtypes[0])` cast at the call site. Anything not in this
-# set is a narrow integer (uint8 / int8 / int16) that luminal collapses to
-# `DType::Int` internally — the hard-reject contract makes the boundary
-# refuse the mismatched dtype, and the test for those lives in
-# `test_input_dtype_mismatch_rejects` instead.
+# Dtypes that round-trip the BoundaryNoopModel without an explicit cast at the
+# call site. Each retains both its declared dtype and exact values across input
+# upload, reference execution, and output readback.
 _FIRST_CLASS_NOOP_DTYPES = {
     "bool",
+    "uint8",
+    "int8",
+    "int16",
     "int32",
     "int64_i32_range",
     "int64_outside_i32_range",
@@ -240,9 +245,32 @@ def test_boundary_noop_preserves_dtype_and_values(
 
 
 @pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(case, id=case.name)
+        for case in DTYPE_CASES
+        if case.name in {"uint8", "int8", "int16"}
+    ],
+)
+def test_narrow_integer_abs_preserves_wrapping_semantics(case: DTypeCase) -> None:
+    model = AbsModel()
+    compiled = torch.compile(model, backend=luminal_backend, fullgraph=True)
+    x = case.values()
+
+    expected = model(x)
+    actual = compiled(x)
+
+    assert actual.dtype == expected.dtype
+    assert torch.equal(actual, expected)
+
+
+@pytest.mark.parametrize(
     "dtype",
     [
         pytest.param(torch.bool, id="bool"),
+        pytest.param(torch.uint8, id="uint8"),
+        pytest.param(torch.int8, id="int8"),
+        pytest.param(torch.int16, id="int16"),
         pytest.param(torch.int32, id="int32"),
         pytest.param(torch.int64, id="int64"),
         pytest.param(torch.float16, id="float16"),
@@ -369,6 +397,9 @@ def test_item_returns_exact_python_scalar(
         pytest.param(False, True, True, torch.bfloat16, False, id="bool-scalars"),
         pytest.param(0, 3.1, 1, torch.float16, True, id="keyword-end"),
         pytest.param(1, 5, 2, torch.int64, False, id="int64-output"),
+        pytest.param(0, 6, 2, torch.uint8, False, id="uint8-output"),
+        pytest.param(-3, 4, 3, torch.int8, False, id="int8-output"),
+        pytest.param(-300, 301, 300, torch.int16, False, id="int16-output"),
         pytest.param(1.1, 1.1, -1.0, torch.float32, False, id="empty"),
     ],
 )
@@ -431,42 +462,12 @@ def test_nonempty_cpu_input_rejects_null_pointer() -> None:
     [
         pytest.param(case, id=case.name)
         for case in DTYPE_CASES
-        # Narrow integer widths (uint8 / int8 / int16) aren't first-class in
-        # luminal's IR — the translator refuses them outright. int64 /
-        # float64 are first-class and round-trip without rejection.
-        if case.name in {"uint8", "int8", "int16"}
-    ],
-)
-def test_input_dtype_mismatch_rejects(
-    boundary_device: torch.device,
-    case: DTypeCase,
-) -> None:
-    """Hard-reject contract: a graph whose declared input dtype is one of
-    the narrow ints (uint8 / int8 / int16) fails at compile time with a
-    clear panic from `torch_dtype_int_to_luminal`. Previously the
-    translator silently widened narrow ints to `Int` (i32), which left
-    the user's actual dtype invisible past the FFI boundary; today the
-    failure points at the missing IR support directly.
-    """
-    model = BoundaryNoopModel().to(boundary_device)
-    compiled = torch.compile(model, backend=luminal_backend)
-    x = case.values().to(boundary_device)
-
-    # `pyo3_runtime.PanicException` inherits from `BaseException` (not
-    # `Exception`), so `pytest.raises(Exception, ...)` would miss it.
-    # Match on the panic message text — stable across torch versions.
-    with pytest.raises(BaseException, match="isn't a first-class IR type yet"):
-        compiled(x)
-
-
-@pytest.mark.parametrize(
-    "case",
-    [
-        pytest.param(case, id=case.name)
-        for case in DTYPE_CASES
         if case.name
         in {
             "bool",
+            "uint8",
+            "int8",
+            "int16",
             "int32",
             "float16",
             "bfloat16",

--- a/src/dyn_backend.rs
+++ b/src/dyn_backend.rs
@@ -50,6 +50,15 @@ pub trait DynBackend {
     fn get_output_i64(&self, _node: NodeIndex) -> Vec<i64> {
         panic!("get_output_i64 not supported by '{}'", self.name());
     }
+    fn get_output_i8(&self, _node: NodeIndex) -> Vec<i8> {
+        panic!("get_output_i8 not supported by '{}'", self.name());
+    }
+    fn get_output_u8(&self, _node: NodeIndex) -> Vec<u8> {
+        panic!("get_output_u8 not supported by '{}'", self.name());
+    }
+    fn get_output_i16(&self, _node: NodeIndex) -> Vec<i16> {
+        panic!("get_output_i16 not supported by '{}'", self.name());
+    }
     fn get_output_f64(&self, _node: NodeIndex) -> Vec<f64> {
         panic!("get_output_f64 not supported by '{}'", self.name());
     }
@@ -249,10 +258,12 @@ pub fn bytes_to_reference_data(bytes: Vec<u8>, dtype: DType) -> ReferenceData {
             DType::F64 => ReferenceData::F64(Vec::new()),
             DType::F16 => ReferenceData::F16(Vec::new()),
             DType::Bf16 => ReferenceData::Bf16(Vec::new()),
-            DType::Int | DType::I8 | DType::U8 | DType::I16 | DType::U16 => {
-                ReferenceData::Int(Vec::new())
-            }
+            DType::Int => ReferenceData::Int(Vec::new()),
             DType::I64 => ReferenceData::I64(Vec::new()),
+            DType::I8 => ReferenceData::I8(Vec::new()),
+            DType::U8 => ReferenceData::U8(Vec::new()),
+            DType::I16 => ReferenceData::I16(Vec::new()),
+            DType::U16 => ReferenceData::Int(Vec::new()),
             DType::Bool => ReferenceData::Bool(Vec::new()),
             _ => ReferenceData::F32(Vec::new()),
         };
@@ -273,12 +284,9 @@ pub fn bytes_to_reference_data(bytes: Vec<u8>, dtype: DType) -> ReferenceData {
         DType::Int => ReferenceData::Int(unsafe { from_bytes(bytes) }),
         DType::I64 => ReferenceData::I64(unsafe { from_bytes(bytes) }),
         DType::Bool => ReferenceData::Bool(bytes.into_iter().map(|b| b != 0).collect()),
-        DType::I8 => ReferenceData::Int(bytes.iter().map(|&b| b as i8 as i32).collect()),
-        DType::U8 => ReferenceData::Int(bytes.iter().map(|&b| b as i32).collect()),
-        DType::I16 => {
-            let i16s: Vec<i16> = unsafe { from_bytes(bytes) };
-            ReferenceData::Int(i16s.into_iter().map(|v| v as i32).collect())
-        }
+        DType::I8 => ReferenceData::I8(bytes.into_iter().map(|b| b as i8).collect()),
+        DType::U8 => ReferenceData::U8(bytes),
+        DType::I16 => ReferenceData::I16(unsafe { from_bytes(bytes) }),
         DType::U16 => {
             let u16s: Vec<u16> = unsafe { from_bytes(bytes) };
             ReferenceData::Int(u16s.into_iter().map(|v| v as i32).collect())
@@ -360,6 +368,39 @@ impl DynBackend for ReferenceDynBackend {
             other => panic!(
                 "get_output_i64: buffer dtype is {:?}, expected I64. \
                  Add a `Cast(DType::I64)` before the Output.",
+                std::mem::discriminant(other)
+            ),
+        }
+    }
+
+    fn get_output_i8(&self, node: NodeIndex) -> Vec<i8> {
+        match self.output_buffer(node) {
+            ReferenceData::I8(v) => v.clone(),
+            other => panic!(
+                "get_output_i8: buffer dtype is {:?}, expected I8. \
+                 Add a `Cast(DType::I8)` before the Output.",
+                std::mem::discriminant(other)
+            ),
+        }
+    }
+
+    fn get_output_u8(&self, node: NodeIndex) -> Vec<u8> {
+        match self.output_buffer(node) {
+            ReferenceData::U8(v) => v.clone(),
+            other => panic!(
+                "get_output_u8: buffer dtype is {:?}, expected U8. \
+                 Add a `Cast(DType::U8)` before the Output.",
+                std::mem::discriminant(other)
+            ),
+        }
+    }
+
+    fn get_output_i16(&self, node: NodeIndex) -> Vec<i16> {
+        match self.output_buffer(node) {
+            ReferenceData::I16(v) => v.clone(),
+            other => panic!(
+                "get_output_i16: buffer dtype is {:?}, expected I16. \
+                 Add a `Cast(DType::I16)` before the Output.",
                 std::mem::discriminant(other)
             ),
         }
@@ -465,8 +506,36 @@ mod tests {
             ReferenceData::I64(values) if values.is_empty()
         ));
         assert!(matches!(
+            bytes_to_reference_data(Vec::new(), DType::I8),
+            ReferenceData::I8(values) if values.is_empty()
+        ));
+        assert!(matches!(
+            bytes_to_reference_data(Vec::new(), DType::U8),
+            ReferenceData::U8(values) if values.is_empty()
+        ));
+        assert!(matches!(
+            bytes_to_reference_data(Vec::new(), DType::I16),
+            ReferenceData::I16(values) if values.is_empty()
+        ));
+        assert!(matches!(
             bytes_to_reference_data(Vec::new(), DType::Bool),
             ReferenceData::Bool(values) if values.is_empty()
+        ));
+    }
+
+    #[test]
+    fn narrow_integer_bytes_preserve_width_and_signedness() {
+        assert!(matches!(
+            bytes_to_reference_data(vec![0x80, 0xff, 0x7f], DType::I8),
+            ReferenceData::I8(values) if values == [-128, -1, 127]
+        ));
+        assert!(matches!(
+            bytes_to_reference_data(vec![0, 128, 255], DType::U8),
+            ReferenceData::U8(values) if values == [0, 128, 255]
+        ));
+        assert!(matches!(
+            bytes_to_reference_data(vec![0x00, 0x80, 0xff, 0x7f], DType::I16),
+            ReferenceData::I16(values) if values == [-32_768, 32_767]
         ));
     }
 }

--- a/src/frontend/unary.rs
+++ b/src/frontend/unary.rs
@@ -264,7 +264,19 @@ impl GraphTensor {
 
     /// Take the absolute value
     pub fn abs(self) -> GraphTensor {
-        self.relu() + (-self).relu()
+        match self.dtype {
+            DType::U4 | DType::U8 | DType::U16 => self,
+            DType::I4 | DType::I8 | DType::I16 | DType::Int | DType::I64 => {
+                let zero = self
+                    .graph()
+                    .constant_float(0.0)
+                    .cast(self.dtype)
+                    .expand_rhs(self.shape);
+                let negative = self.lt(zero).cast(self.dtype);
+                self * (1.0 - negative * 2.0)
+            }
+            _ => self.relu() + (-self).relu(),
+        }
     }
 
     /// Get the sign of each element, '1' for positive and '-1' for negative

--- a/src/hlir.rs
+++ b/src/hlir.rs
@@ -1299,80 +1299,16 @@ impl EgglogOp for Cast {
 impl ReferenceOp for Cast {
     fn execute(&self, input: Vec<&ReferenceData>, _: &FxHashMap<char, usize>) -> ReferenceData {
         match self.1 {
-            DType::F32 => ReferenceData::F32(match &input[0] {
-                ReferenceData::F32(f) => f.clone(),
-                ReferenceData::F16(f) => f.iter().map(|f| f.to_f32()).collect(),
-                ReferenceData::Bf16(f) => f.iter().map(|f| f.to_f32()).collect(),
-                ReferenceData::Int(i) => i.iter().map(|i| *i as f32).collect(),
-                ReferenceData::I64(i) => i.iter().map(|i| *i as f32).collect(),
-                ReferenceData::F64(f) => f.iter().map(|f| *f as f32).collect(),
-                ReferenceData::Bool(b) => b.iter().map(|b| if *b { 1.0 } else { 0.0 }).collect(),
-            }),
-            DType::F64 => ReferenceData::F64(match &input[0] {
-                ReferenceData::F64(f) => f.clone(),
-                ReferenceData::F32(f) => f.iter().map(|f| *f as f64).collect(),
-                ReferenceData::F16(f) => f.iter().map(|f| f.to_f32() as f64).collect(),
-                ReferenceData::Bf16(f) => f.iter().map(|f| f.to_f32() as f64).collect(),
-                ReferenceData::Int(i) => i.iter().map(|i| *i as f64).collect(),
-                ReferenceData::I64(i) => i.iter().map(|i| *i as f64).collect(),
-                ReferenceData::Bool(b) => b.iter().map(|b| if *b { 1.0 } else { 0.0 }).collect(),
-            }),
-            DType::Int => ReferenceData::Int(match &input[0] {
-                ReferenceData::F32(f) => f.iter().map(|f| *f as i32).collect(),
-                ReferenceData::F16(f) => f.iter().map(|f| f.to_f32() as i32).collect(),
-                ReferenceData::Bf16(f) => f.iter().map(|f| f.to_f32() as i32).collect(),
-                ReferenceData::Int(i) => i.clone(),
-                // Saturating `Cast(I64 -> Int)`. This is the explicit
-                // graph node — `Cast` IS the user/translator-emitted
-                // operation, not an implicit bridge. Values outside the
-                // i32 range wrap via Rust's `as i32`, matching
-                // `tensor.to(torch.int32)` semantics on overflow.
-                ReferenceData::I64(i) => i.iter().map(|i| *i as i32).collect(),
-                ReferenceData::F64(f) => f.iter().map(|f| *f as i32).collect(),
-                ReferenceData::Bool(b) => b.iter().map(|b| if *b { 1 } else { 0 }).collect(),
-            }),
-            DType::I64 => ReferenceData::I64(match &input[0] {
-                ReferenceData::I64(i) => i.clone(),
-                ReferenceData::Int(i) => i.iter().map(|i| *i as i64).collect(),
-                ReferenceData::F32(f) => f.iter().map(|f| *f as i64).collect(),
-                ReferenceData::F64(f) => f.iter().map(|f| *f as i64).collect(),
-                ReferenceData::F16(f) => f.iter().map(|f| f.to_f32() as i64).collect(),
-                ReferenceData::Bf16(f) => f.iter().map(|f| f.to_f32() as i64).collect(),
-                ReferenceData::Bool(b) => b.iter().map(|b| if *b { 1 } else { 0 }).collect(),
-            }),
-            DType::F16 => ReferenceData::F16(match &input[0] {
-                ReferenceData::F32(f) => f.iter().copied().map(f16::from_f32).collect(),
-                ReferenceData::F16(f) => f.clone(),
-                ReferenceData::Bf16(f) => f.iter().map(|f| f16::from_f32(f.to_f32())).collect(),
-                ReferenceData::Int(i) => i.iter().map(|i| f16::from_f32(*i as f32)).collect(),
-                ReferenceData::I64(i) => i.iter().map(|i| f16::from_f32(*i as f32)).collect(),
-                ReferenceData::F64(f) => f.iter().map(|f| f16::from_f64(*f)).collect(),
-                ReferenceData::Bool(b) => b
-                    .iter()
-                    .map(|b| f16::from_f32(if *b { 1.0 } else { 0.0 }))
-                    .collect(),
-            }),
-            DType::Bf16 => ReferenceData::Bf16(match &input[0] {
-                ReferenceData::F32(f) => f.iter().copied().map(bf16::from_f32).collect(),
-                ReferenceData::F16(f) => f.iter().map(|f| bf16::from_f32(f.to_f32())).collect(),
-                ReferenceData::Bf16(f) => f.clone(),
-                ReferenceData::Int(i) => i.iter().map(|i| bf16::from_f32(*i as f32)).collect(),
-                ReferenceData::I64(i) => i.iter().map(|i| bf16::from_f32(*i as f32)).collect(),
-                ReferenceData::F64(f) => f.iter().map(|f| bf16::from_f64(*f)).collect(),
-                ReferenceData::Bool(b) => b
-                    .iter()
-                    .map(|b| bf16::from_f32(if *b { 1.0 } else { 0.0 }))
-                    .collect(),
-            }),
-            DType::Bool => ReferenceData::Bool(match &input[0] {
-                ReferenceData::F32(f) => f.iter().map(|f| *f != 0.0).collect(),
-                ReferenceData::F16(f) => f.iter().map(|f| f.to_f32() != 0.0).collect(),
-                ReferenceData::Bf16(f) => f.iter().map(|f| f.to_f32() != 0.0).collect(),
-                ReferenceData::Int(i) => i.iter().map(|i| *i != 0).collect(),
-                ReferenceData::I64(i) => i.iter().map(|i| *i != 0).collect(),
-                ReferenceData::F64(f) => f.iter().map(|f| *f != 0.0).collect(),
-                ReferenceData::Bool(b) => b.clone(),
-            }),
+            DType::F32 => ReferenceData::F32(input[0].to_f32_vec()),
+            DType::F64 => ReferenceData::F64(input[0].to_f64_vec()),
+            DType::F16 => ReferenceData::F16(input[0].to_f16_vec()),
+            DType::Bf16 => ReferenceData::Bf16(input[0].to_bf16_vec()),
+            DType::Int => ReferenceData::Int(input[0].to_i32_vec()),
+            DType::I64 => ReferenceData::I64(input[0].to_i64_vec()),
+            DType::I8 => ReferenceData::I8(input[0].to_i8_vec()),
+            DType::U8 => ReferenceData::U8(input[0].to_u8_vec()),
+            DType::I16 => ReferenceData::I16(input[0].to_i16_vec()),
+            DType::Bool => ReferenceData::Bool(input[0].to_bool_vec()),
             other => {
                 unimplemented!("Cast to {other} is not yet supported in reference interpreter")
             }
@@ -1406,6 +1342,9 @@ fn unary_impl(
         ReferenceData::F64(f) => ReferenceData::F64(ind.map(|i| (kernels.f64_fn)(f[i])).collect()),
         ReferenceData::Int(_) => panic!("unary_impl: no Int kernel — cast to F32 at the call site"),
         ReferenceData::I64(_) => panic!("unary_impl: no I64 kernel — cast to F32 at the call site"),
+        ReferenceData::I8(_) => panic!("unary_impl: no I8 kernel — cast to F32 at the call site"),
+        ReferenceData::U8(_) => panic!("unary_impl: no U8 kernel — cast to F32 at the call site"),
+        ReferenceData::I16(_) => panic!("unary_impl: no I16 kernel — cast to F32 at the call site"),
         ReferenceData::Bool(_) => {
             panic!("unary_impl: no Bool kernel — cast to F32 at the call site")
         }
@@ -1939,6 +1878,15 @@ impl ReferenceOp for Add {
             (ReferenceData::I64(a), ReferenceData::I64(b)) => {
                 ReferenceData::I64(bin_fn(a_ind, a, b_ind, b, |x, y| x + y))
             }
+            (ReferenceData::I8(a), ReferenceData::I8(b)) => {
+                ReferenceData::I8(bin_fn(a_ind, a, b_ind, b, i8::wrapping_add))
+            }
+            (ReferenceData::U8(a), ReferenceData::U8(b)) => {
+                ReferenceData::U8(bin_fn(a_ind, a, b_ind, b, u8::wrapping_add))
+            }
+            (ReferenceData::I16(a), ReferenceData::I16(b)) => {
+                ReferenceData::I16(bin_fn(a_ind, a, b_ind, b, i16::wrapping_add))
+            }
             (ReferenceData::F64(a), ReferenceData::F64(b)) => {
                 ReferenceData::F64(bin_fn(a_ind, a, b_ind, b, |x, y| x + y))
             }
@@ -2038,6 +1986,15 @@ impl ReferenceOp for Mul {
             }
             (ReferenceData::I64(a), ReferenceData::I64(b)) => {
                 ReferenceData::I64(bin_fn(a_ind, a, b_ind, b, |x, y| x * y))
+            }
+            (ReferenceData::I8(a), ReferenceData::I8(b)) => {
+                ReferenceData::I8(bin_fn(a_ind, a, b_ind, b, i8::wrapping_mul))
+            }
+            (ReferenceData::U8(a), ReferenceData::U8(b)) => {
+                ReferenceData::U8(bin_fn(a_ind, a, b_ind, b, u8::wrapping_mul))
+            }
+            (ReferenceData::I16(a), ReferenceData::I16(b)) => {
+                ReferenceData::I16(bin_fn(a_ind, a, b_ind, b, i16::wrapping_mul))
             }
             (ReferenceData::F64(a), ReferenceData::F64(b)) => {
                 ReferenceData::F64(bin_fn(a_ind, a, b_ind, b, |x, y| x * y))
@@ -2139,6 +2096,15 @@ impl ReferenceOp for Mod {
             (ReferenceData::I64(a), ReferenceData::I64(b)) => {
                 ReferenceData::I64(bin_fn(a_ind, a, b_ind, b, |x, y| x % y))
             }
+            (ReferenceData::I8(a), ReferenceData::I8(b)) => {
+                ReferenceData::I8(bin_fn(a_ind, a, b_ind, b, i8::wrapping_rem))
+            }
+            (ReferenceData::U8(a), ReferenceData::U8(b)) => {
+                ReferenceData::U8(bin_fn(a_ind, a, b_ind, b, |x, y| x % y))
+            }
+            (ReferenceData::I16(a), ReferenceData::I16(b)) => {
+                ReferenceData::I16(bin_fn(a_ind, a, b_ind, b, i16::wrapping_rem))
+            }
             (ReferenceData::F64(a), ReferenceData::F64(b)) => {
                 ReferenceData::F64(bin_fn(a_ind, a, b_ind, b, |x, y| x % y))
             }
@@ -2236,6 +2202,15 @@ impl ReferenceOp for LessThan {
                 ReferenceData::Bool(bin_cmp_fn(a_ind, a, b_ind, b, |x, y| x < y))
             }
             (ReferenceData::I64(a), ReferenceData::I64(b)) => {
+                ReferenceData::Bool(bin_cmp_fn(a_ind, a, b_ind, b, |x, y| x < y))
+            }
+            (ReferenceData::I8(a), ReferenceData::I8(b)) => {
+                ReferenceData::Bool(bin_cmp_fn(a_ind, a, b_ind, b, |x, y| x < y))
+            }
+            (ReferenceData::U8(a), ReferenceData::U8(b)) => {
+                ReferenceData::Bool(bin_cmp_fn(a_ind, a, b_ind, b, |x, y| x < y))
+            }
+            (ReferenceData::I16(a), ReferenceData::I16(b)) => {
                 ReferenceData::Bool(bin_cmp_fn(a_ind, a, b_ind, b, |x, y| x < y))
             }
             (ReferenceData::F64(a), ReferenceData::F64(b)) => {
@@ -2391,6 +2366,21 @@ impl ReferenceOp for Gather {
                     .collect(),
             ),
             ReferenceData::I64(a) => ReferenceData::I64(
+                indexes_ind
+                    .map(|i| a[data_ind[indexes[i] as usize]])
+                    .collect(),
+            ),
+            ReferenceData::I8(a) => ReferenceData::I8(
+                indexes_ind
+                    .map(|i| a[data_ind[indexes[i] as usize]])
+                    .collect(),
+            ),
+            ReferenceData::U8(a) => ReferenceData::U8(
+                indexes_ind
+                    .map(|i| a[data_ind[indexes[i] as usize]])
+                    .collect(),
+            ),
+            ReferenceData::I16(a) => ReferenceData::I16(
                 indexes_ind
                     .map(|i| a[data_ind[indexes[i] as usize]])
                     .collect(),
@@ -2555,6 +2545,9 @@ impl ReferenceOp for Scatter {
             (ReferenceData::Bf16(d), ReferenceData::Bf16(s)) => scatter_impl!(Bf16, d, s),
             (ReferenceData::Int(d), ReferenceData::Int(s)) => scatter_impl!(Int, d, s),
             (ReferenceData::I64(d), ReferenceData::I64(s)) => scatter_impl!(I64, d, s),
+            (ReferenceData::I8(d), ReferenceData::I8(s)) => scatter_impl!(I8, d, s),
+            (ReferenceData::U8(d), ReferenceData::U8(s)) => scatter_impl!(U8, d, s),
+            (ReferenceData::I16(d), ReferenceData::I16(s)) => scatter_impl!(I16, d, s),
             (ReferenceData::Bool(d), ReferenceData::Bool(s)) => scatter_impl!(Bool, d, s),
             _ => panic!("dest and src must have the same dtype!"),
         }
@@ -2696,6 +2689,30 @@ impl ReferenceOp for SumReduce {
                     (0..iters)
                         .map(|i| a[start + resolved_stride.exec_single_var(i)])
                         .sum::<i64>()
+                })
+                .collect(),
+            ),
+            ReferenceData::I8(a) => ReferenceData::I8(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .fold(0i8, i8::wrapping_add)
+                })
+                .collect(),
+            ),
+            ReferenceData::U8(a) => ReferenceData::U8(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .fold(0u8, u8::wrapping_add)
+                })
+                .collect(),
+            ),
+            ReferenceData::I16(a) => ReferenceData::I16(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .fold(0i16, i16::wrapping_add)
                 })
                 .collect(),
             ),
@@ -2841,6 +2858,33 @@ impl ReferenceOp for MaxReduce {
                 })
                 .collect(),
             ),
+            ReferenceData::I8(a) => ReferenceData::I8(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .max()
+                        .unwrap_or_default()
+                })
+                .collect(),
+            ),
+            ReferenceData::U8(a) => ReferenceData::U8(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .max()
+                        .unwrap_or_default()
+                })
+                .collect(),
+            ),
+            ReferenceData::I16(a) => ReferenceData::I16(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .max()
+                        .unwrap_or_default()
+                })
+                .collect(),
+            ),
             ReferenceData::F64(a) => ReferenceData::F64(
                 ind.map(|start| {
                     (0..iters)
@@ -2870,6 +2914,9 @@ pub enum ReferenceData {
     Bf16(Vec<bf16>),
     Int(Vec<i32>),
     I64(Vec<i64>),
+    I8(Vec<i8>),
+    U8(Vec<u8>),
+    I16(Vec<i16>),
     F64(Vec<f64>),
     Bool(Vec<bool>),
 }
@@ -2885,6 +2932,9 @@ impl ReferenceData {
             ReferenceData::Bf16(v) => v.len(),
             ReferenceData::Int(v) => v.len(),
             ReferenceData::I64(v) => v.len(),
+            ReferenceData::I8(v) => v.len(),
+            ReferenceData::U8(v) => v.len(),
+            ReferenceData::I16(v) => v.len(),
             ReferenceData::F64(v) => v.len(),
             ReferenceData::Bool(v) => v.len(),
         }
@@ -2896,7 +2946,25 @@ impl ReferenceData {
             ReferenceData::Bf16(v) => v.iter().map(|v| v.to_f32()).collect(),
             ReferenceData::Int(v) => v.iter().map(|v| *v as f32).collect(),
             ReferenceData::I64(v) => v.iter().map(|v| *v as f32).collect(),
+            ReferenceData::I8(v) => v.iter().map(|v| *v as f32).collect(),
+            ReferenceData::U8(v) => v.iter().map(|v| *v as f32).collect(),
+            ReferenceData::I16(v) => v.iter().map(|v| *v as f32).collect(),
             ReferenceData::F64(v) => v.iter().map(|v| *v as f32).collect(),
+            ReferenceData::Bool(v) => v.iter().map(|v| if *v { 1.0 } else { 0.0 }).collect(),
+        }
+    }
+
+    pub fn to_f64_vec(&self) -> Vec<f64> {
+        match self {
+            ReferenceData::F32(v) => v.iter().map(|v| *v as f64).collect(),
+            ReferenceData::F16(v) => v.iter().map(|v| v.to_f32() as f64).collect(),
+            ReferenceData::Bf16(v) => v.iter().map(|v| v.to_f32() as f64).collect(),
+            ReferenceData::Int(v) => v.iter().map(|v| *v as f64).collect(),
+            ReferenceData::I64(v) => v.iter().map(|v| *v as f64).collect(),
+            ReferenceData::I8(v) => v.iter().map(|v| *v as f64).collect(),
+            ReferenceData::U8(v) => v.iter().map(|v| *v as f64).collect(),
+            ReferenceData::I16(v) => v.iter().map(|v| *v as f64).collect(),
+            ReferenceData::F64(v) => v.clone(),
             ReferenceData::Bool(v) => v.iter().map(|v| if *v { 1.0 } else { 0.0 }).collect(),
         }
     }
@@ -2908,10 +2976,31 @@ impl ReferenceData {
             ReferenceData::Bf16(v) => v.iter().map(|v| f16::from_f32(v.to_f32())).collect(),
             ReferenceData::Int(v) => v.iter().map(|v| f16::from_f32(*v as f32)).collect(),
             ReferenceData::I64(v) => v.iter().map(|v| f16::from_f32(*v as f32)).collect(),
+            ReferenceData::I8(v) => v.iter().map(|v| f16::from_f32(*v as f32)).collect(),
+            ReferenceData::U8(v) => v.iter().map(|v| f16::from_f32(*v as f32)).collect(),
+            ReferenceData::I16(v) => v.iter().map(|v| f16::from_f32(*v as f32)).collect(),
             ReferenceData::F64(v) => v.iter().map(|v| f16::from_f64(*v)).collect(),
             ReferenceData::Bool(v) => v
                 .iter()
                 .map(|v| f16::from_f32(if *v { 1.0 } else { 0.0 }))
+                .collect(),
+        }
+    }
+
+    pub fn to_bf16_vec(&self) -> Vec<bf16> {
+        match self {
+            ReferenceData::F32(v) => v.iter().copied().map(bf16::from_f32).collect(),
+            ReferenceData::F16(v) => v.iter().map(|v| bf16::from_f32(v.to_f32())).collect(),
+            ReferenceData::Bf16(v) => v.clone(),
+            ReferenceData::Int(v) => v.iter().map(|v| bf16::from_f32(*v as f32)).collect(),
+            ReferenceData::I64(v) => v.iter().map(|v| bf16::from_f32(*v as f32)).collect(),
+            ReferenceData::I8(v) => v.iter().map(|v| bf16::from_f32(*v as f32)).collect(),
+            ReferenceData::U8(v) => v.iter().map(|v| bf16::from_f32(*v as f32)).collect(),
+            ReferenceData::I16(v) => v.iter().map(|v| bf16::from_f32(*v as f32)).collect(),
+            ReferenceData::F64(v) => v.iter().map(|v| bf16::from_f64(*v)).collect(),
+            ReferenceData::Bool(v) => v
+                .iter()
+                .map(|v| bf16::from_f32(if *v { 1.0 } else { 0.0 }))
                 .collect(),
         }
     }
@@ -2923,9 +3012,39 @@ impl ReferenceData {
             ReferenceData::Bf16(v) => v.iter().map(|v| v.to_f32() as i32).collect(),
             ReferenceData::Int(v) => v.clone(),
             ReferenceData::I64(v) => v.iter().map(|v| *v as i32).collect(),
+            ReferenceData::I8(v) => v.iter().map(|v| *v as i32).collect(),
+            ReferenceData::U8(v) => v.iter().map(|v| *v as i32).collect(),
+            ReferenceData::I16(v) => v.iter().map(|v| *v as i32).collect(),
             ReferenceData::F64(v) => v.iter().map(|v| *v as i32).collect(),
             ReferenceData::Bool(v) => v.iter().map(|v| if *v { 1 } else { 0 }).collect(),
         }
+    }
+
+    pub fn to_i64_vec(&self) -> Vec<i64> {
+        match self {
+            ReferenceData::F32(v) => v.iter().map(|v| *v as i64).collect(),
+            ReferenceData::F16(v) => v.iter().map(|v| v.to_f32() as i64).collect(),
+            ReferenceData::Bf16(v) => v.iter().map(|v| v.to_f32() as i64).collect(),
+            ReferenceData::Int(v) => v.iter().map(|v| *v as i64).collect(),
+            ReferenceData::I64(v) => v.clone(),
+            ReferenceData::I8(v) => v.iter().map(|v| *v as i64).collect(),
+            ReferenceData::U8(v) => v.iter().map(|v| *v as i64).collect(),
+            ReferenceData::I16(v) => v.iter().map(|v| *v as i64).collect(),
+            ReferenceData::F64(v) => v.iter().map(|v| *v as i64).collect(),
+            ReferenceData::Bool(v) => v.iter().map(|v| if *v { 1 } else { 0 }).collect(),
+        }
+    }
+
+    pub fn to_i8_vec(&self) -> Vec<i8> {
+        self.to_i64_vec().into_iter().map(|v| v as i8).collect()
+    }
+
+    pub fn to_u8_vec(&self) -> Vec<u8> {
+        self.to_i64_vec().into_iter().map(|v| v as u8).collect()
+    }
+
+    pub fn to_i16_vec(&self) -> Vec<i16> {
+        self.to_i64_vec().into_iter().map(|v| v as i16).collect()
     }
 
     pub fn to_bool_vec(&self) -> Vec<bool> {
@@ -2935,6 +3054,9 @@ impl ReferenceData {
             ReferenceData::Bf16(v) => v.iter().map(|v| v.to_f32() != 0.0).collect(),
             ReferenceData::Int(v) => v.iter().map(|v| *v != 0).collect(),
             ReferenceData::I64(v) => v.iter().map(|v| *v != 0).collect(),
+            ReferenceData::I8(v) => v.iter().map(|v| *v != 0).collect(),
+            ReferenceData::U8(v) => v.iter().map(|v| *v != 0).collect(),
+            ReferenceData::I16(v) => v.iter().map(|v| *v != 0).collect(),
             ReferenceData::F64(v) => v.iter().map(|v| *v != 0.0).collect(),
             ReferenceData::Bool(v) => v.clone(),
         }
@@ -2964,6 +3086,21 @@ impl From<Vec<i32>> for ReferenceData {
 impl From<Vec<i64>> for ReferenceData {
     fn from(value: Vec<i64>) -> Self {
         ReferenceData::I64(value)
+    }
+}
+impl From<Vec<i8>> for ReferenceData {
+    fn from(value: Vec<i8>) -> Self {
+        ReferenceData::I8(value)
+    }
+}
+impl From<Vec<u8>> for ReferenceData {
+    fn from(value: Vec<u8>) -> Self {
+        ReferenceData::U8(value)
+    }
+}
+impl From<Vec<i16>> for ReferenceData {
+    fn from(value: Vec<i16>) -> Self {
+        ReferenceData::I16(value)
     }
 }
 // No `From<Vec<f64>> for ReferenceData` impl. Adding it makes plain
@@ -3007,12 +3144,18 @@ impl_reference_data_from_ref!(f32, F32);
 impl_reference_data_from_ref!(f16, F16);
 impl_reference_data_from_ref!(bf16, Bf16);
 impl_reference_data_from_ref!(i32, Int);
+impl_reference_data_from_ref!(i8, I8);
+impl_reference_data_from_ref!(u8, U8);
+impl_reference_data_from_ref!(i16, I16);
 impl_reference_data_from_ref!(bool, Bool);
 
 impl_reference_data_from_array_ref!(f32, F32);
 impl_reference_data_from_array_ref!(f16, F16);
 impl_reference_data_from_array_ref!(bf16, Bf16);
 impl_reference_data_from_array_ref!(i32, Int);
+impl_reference_data_from_array_ref!(i8, I8);
+impl_reference_data_from_array_ref!(u8, U8);
+impl_reference_data_from_array_ref!(i16, I16);
 impl_reference_data_from_array_ref!(bool, Bool);
 
 #[derive(Default)]
@@ -3275,6 +3418,65 @@ mod tests {
             &input,
             f64::sqrt,
         );
+    }
+
+    #[test]
+    fn reference_narrow_integer_casts_preserve_native_widths() {
+        let source = ReferenceData::Int(vec![-32_769, -129, -128, -1, 0, 127, 128, 255, 256]);
+        let dyn_map = FxHashMap::default();
+
+        let i8_data = Cast(9.into(), DType::I8).execute(vec![&source], &dyn_map);
+        assert!(matches!(
+            i8_data,
+            ReferenceData::I8(ref values)
+                if values == &[-1, 127, -128, -1, 0, 127, -128, -1, 0]
+        ));
+
+        let u8_data = Cast(9.into(), DType::U8).execute(vec![&source], &dyn_map);
+        assert!(matches!(
+            u8_data,
+            ReferenceData::U8(ref values)
+                if values == &[255, 127, 128, 255, 0, 127, 128, 255, 0]
+        ));
+
+        let i16_data = Cast(9.into(), DType::I16).execute(vec![&source], &dyn_map);
+        assert!(matches!(
+            i16_data,
+            ReferenceData::I16(ref values)
+                if values == &[32767, -129, -128, -1, 0, 127, 128, 255, 256]
+        ));
+    }
+
+    #[test]
+    fn reference_narrow_integer_add_wraps_in_declared_dtype() {
+        let op = Add {
+            shape: vec![2.into()],
+            a_strides: vec!['z'.into()],
+            b_strides: vec!['z'.into()],
+            ..Default::default()
+        };
+        let dyn_map = FxHashMap::default();
+
+        let i8_lhs = ReferenceData::I8(vec![127, -128]);
+        let i8_rhs = ReferenceData::I8(vec![1, -1]);
+        assert!(matches!(
+            op.execute(vec![&i8_lhs, &i8_rhs], &dyn_map),
+            ReferenceData::I8(values) if values == [-128, 127]
+        ));
+
+        let u8_lhs = ReferenceData::U8(vec![255, 0]);
+        let u8_rhs = ReferenceData::U8(vec![1, 255]);
+        assert!(matches!(
+            op.execute(vec![&u8_lhs, &u8_rhs], &dyn_map),
+            ReferenceData::U8(values) if values == [0, 255]
+        ));
+
+        let i16_lhs = ReferenceData::I16(vec![32_767, -32_768]);
+        let i16_rhs = ReferenceData::I16(vec![1, -1]);
+        assert!(matches!(
+            op.execute(vec![&i16_lhs, &i16_rhs], &dyn_map),
+            ReferenceData::I16(values) if values == [-32_768, 32_767]
+        ));
     }
 
     fn round_tripped(v: f32) -> f32 {


### PR DESCRIPTION
## Summary

- represent `int8`, `uint8`, and `int16` as native-width reference/HLIR values instead of rejecting or widening them
- add native casts, wrapping arithmetic, comparisons, reductions, gather/scatter handling, and strict typed output readers
- map the three dtypes through the PyTorch export boundary and preserve exact input/output widths
- cover zero-length tensors, arange outputs, signed-minimum `abs`, overflow wrapping, and dtype round trips

## Root cause

Luminal already exposed `DType::I8`, `DType::U8`, and `DType::I16`, but the reference semantic value type collapsed them to `i32`, casts did not support them, and the PyTorch bridge intentionally rejected them. Consequently, OpInfo cases failed at dtype translation before reaching operator behavior.

## Impact

The first 100 OpInfo slice improves from 39 to 57 passing parent cases and from 384 to 559 passing generated samples. Eighteen deterministic narrow-integer parents now pass with zero regressions. The three narrow `geometric` cases now reach the existing missing RNG lowering rather than failing dtype translation.

## Validation

- `cargo test -p luminal` — 155 unit tests and 5 doctests passed
- `cargo test --manifest-path crates/luminal_python/rust/Cargo.toml` — 13 passed
- `pytest tests/test_dtype_boundary.py` — 61 passed, 24 CUDA cases skipped
- first 100 OpInfo parents — 57 passed, 43 failed; 559 generated samples passed
- `cargo clippy -p luminal --all-targets -- -D warnings`
- `cargo clippy --manifest-path crates/luminal_python/rust/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
