### PR TITLE
Fix main: retype the dim maps #394 added while #396 was open

### DIFF
--- a/crates/luminal_cuda_lite/src/kernel/to_host.rs
+++ b/crates/luminal_cuda_lite/src/kernel/to_host.rs
@@ -493,7 +493,7 @@ pub struct CudaGraphOp {
     /// Reverse dependency indices built once at graph construction. These let
     /// pointer/dimension changes identify affected kernel nodes directly.
     kernel_users_by_buffer: FxHashMap<NodeIndex, Vec<usize>>,
-    kernel_users_by_dyn_dim: FxHashMap<char, Vec<usize>>,
+    kernel_users_by_dyn_dim: FxHashMap<Symbol, Vec<usize>>,
     output_aliases: Vec<(NodeIndex, NodeIndex)>,
     library_buffer_nodes: FxHashSet<NodeIndex>,
     /// Buffer size requirements for extra nodes (node -> size in elements)
@@ -518,7 +518,7 @@ impl CudaGraphOp {
         state: CudaGraphOpState,
     ) -> Self {
         let mut kernel_users_by_buffer: FxHashMap<NodeIndex, Vec<usize>> = FxHashMap::default();
-        let mut kernel_users_by_dyn_dim: FxHashMap<char, Vec<usize>> = FxHashMap::default();
+        let mut kernel_users_by_dyn_dim: FxHashMap<Symbol, Vec<usize>> = FxHashMap::default();
         let mut output_aliases = Vec::new();
         let mut library_buffer_nodes = FxHashSet::default();
         // Build reverse dependency indexes once so materialization can update only the kernels
@@ -1367,7 +1367,7 @@ impl CudaGraphOp {
         &self,
         stream: &Arc<CudaStream>,
         changed_buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<bool> {
         let mut state = self.state.borrow_mut();
         if state.cuda_graph.is_none() || state.cuda_graph_exec.is_none() {

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -61,7 +61,7 @@ struct ResourceInputFootprint {
 /// must not rebuild the same aggregate resource plan.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct ResourceValidationSignature {
-    allocation_dyn_maps: Vec<Vec<(char, usize)>>,
+    allocation_dyn_maps: Vec<Vec<(Symbol, usize)>>,
     input_footprints: Vec<(usize, ResourceInputFootprint)>,
 }
 
@@ -2941,8 +2941,8 @@ impl CudaRuntime {
     fn retained_bucket_allocation_dyn_maps(
         &self,
         bucket_idx: usize,
-        allocation_dyn_map: &FxHashMap<char, usize>,
-    ) -> Vec<FxHashMap<char, usize>> {
+        allocation_dyn_map: &DynMap,
+    ) -> Vec<DynMap> {
         self.compiled_buckets
             .iter()
             .enumerate()
@@ -2961,7 +2961,7 @@ impl CudaRuntime {
     fn resource_validation_signature(
         &self,
         bucket_idx: usize,
-        allocation_dyn_map: &FxHashMap<char, usize>,
+        allocation_dyn_map: &DynMap,
     ) -> ResourceValidationSignature {
         let allocation_dyn_maps = self
             .retained_bucket_allocation_dyn_maps(bucket_idx, allocation_dyn_map)
@@ -5202,7 +5202,7 @@ mod arena_plan_tests {
     #[test]
     fn resource_validation_cache_reuses_nonconsecutive_exact_signatures() {
         let signature = |a, bytes| ResourceValidationSignature {
-            allocation_dyn_maps: vec![vec![('a', a)]],
+            allocation_dyn_maps: vec![vec![(Symbol::from('a'), a)]],
             input_footprints: vec![(7, ResourceInputFootprint::external(bytes))],
         };
         let a17 = signature(17, 64);


### PR DESCRIPTION
main does not build. `cargo check -p luminal_cuda_lite` gives 27 type errors, every one a `FxHashMap<char, usize>` meeting a `Symbol`-typed caller.

## What happened

Neither PR is wrong on its own.

```
09:41  #398 lands
       ↓  #396 merges main here — converts the 37 char-keyed maps that exist
12:35  #394 lands — rewrites runtime.rs (+774/-215), adds NEW char-keyed signatures
15:03  #396 squash-merged on top — never saw #394
```

`resource_validation_signature`, one of the four broken functions, **did not exist** when #396 last merged main. #394 created it typed `&FxHashMap<char, usize>`, correct against the main it was written on. When #396 squash-merged, its diff could not touch lines absent from its base — so those signatures survived as `char` while every caller became `Symbol`.

No textual conflict, because a conflict needs both sides to edit the same lines and only one side had them. Both PRs were green: neither CI run ever compiled the combination.

## The fix

Eight sites, all types, no behaviour change:

| file | |
|---|---|
| `runtime.rs` | `resource_validation_signature` / `build_allocation_dyn_maps` args → `DynMap` |
| `runtime.rs` | `allocation_dyn_maps: Vec<Vec<(char, usize)>>` → `(Symbol, usize)` |
| `to_host.rs` | `kernel_users_by_dyn_dim: FxHashMap<char, Vec<usize>>` → `Symbol` |
| `to_host.rs` | `upload_dyn_dims` `dyn_map` arg → `DynMap` |

No char-keyed dim map remains anywhere in the tree.

## Verified

- core **175/175**
- `cargo check --all-targets` clean on `luminal` and `luminal_cuda_lite`
- `cargo fmt --all --check` clean
- `cargo clippy -D warnings` clean
- full `luminal_cuda_lite` suite running locally; will report

## Process note

This class is invisible to per-PR CI by construction — two changes each correct against their own base, broken together, with no lines in common. Requiring branches to be up to date before merge, or rebasing instead of squash-merging a stale branch, is what forces the combination to be compiled at least once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)