### PR TITLE
metal: add fused RMSNorm and simd-group reductions

### DIFF
--- a/crates/luminal_metal/src/kernel/ops.rs
+++ b/crates/luminal_metal/src/kernel/ops.rs
@@ -40,6 +40,7 @@ pub type MetalOps = (
     // Reduce ops
     MetalSumReduce,
     MetalMaxReduce,
+    MetalRMSNorm,
     // Matrix ops
     MPSMatmul,
     MPSBatchedMatmul,
@@ -391,6 +392,359 @@ metal_unary_op!(MetalLog2, "MetalLog2", |x: &str| format!("log2({x})"));
 metal_unary_op!(MetalSin, "MetalSin", |x: &str| format!("sin({x})"));
 metal_unary_op!(MetalSqrt, "MetalSqrt", |x: &str| format!("sqrt({x})"));
 metal_unary_op!(MetalRecip, "MetalRecip", |x: &str| format!("1.0f / ({x})"));
+
+#[derive(Debug, Clone)]
+pub struct MetalRMSNorm {
+    rows: Expression,
+    cols: usize,
+    eps: f32,
+}
+
+impl Default for MetalRMSNorm {
+    fn default() -> Self {
+        Self {
+            rows: Expression::from(0),
+            cols: 0,
+            eps: 0.0,
+        }
+    }
+}
+
+impl EgglogOp for MetalRMSNorm {
+    fn sort(&self) -> SortDef {
+        sort(
+            OP_KIND,
+            "MetalRMSNorm",
+            &[("out_shape", ELIST), ("eps", F64)],
+        )
+    }
+
+    fn n_inputs(&self) -> usize {
+        2
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![Rule::raw(
+            "(relation metal_rms_rinv (IR IR f64 Expression Expression))
+            (rule
+                (
+                    (= (F32) (dtype ?x))
+                    (= ?sq (Op (MetalMul ?sq_shape ?sq_a ?sq_b ?sq_o)
+                        (ICons ?x (ICons ?x2 (INil)))))
+                    (= ?x ?x2)
+                    (= ?sq_shape (ECons ?rows (ECons ?cols (ENil))))
+                    (= ?cols (MNum ?cols_n))
+                    (= ?sq_a
+                        (ECons (MMul (MIter) ?cols) (ECons (MIter) (ENil))))
+                    (= ?sq_b
+                        (ECons (MMul (MIter) ?cols) (ECons (MIter) (ENil))))
+                    (= ?sq_o
+                        (ECons (MMul (MIter) ?cols) (ECons (MIter) (ENil))))
+                    (= ?sum (Op (MetalSum ?sum_shape ?cols ?sum_in (MIter) ?sum_out)
+                        (ICons ?sq (INil))))
+                    (= ?sum_shape (ECons ?rows (ENil)))
+                    (= ?sum_in (ECons (MMul (MIter) ?cols) (ENil)))
+                    (= ?sum_out (ECons (MIter) (ENil)))
+
+                    (= ?mean (Op (MetalMul ?mn_shape ?mn_a ?mn_b ?mn_o)
+                        (ICons ?sum (ICons ?rcpn (INil)))))
+                    (= ?mn_shape (ECons ?rows (ENil)))
+                    (= ?mn_a (ECons (MIter) (ENil)))
+                    (= ?mn_b (ECons (MIter) (ENil)))
+                    (= ?mn_o (ECons (MIter) (ENil)))
+                    (= ?rcpn (Op (MetalRecip ?rn_shape ?rn_in ?rn_out)
+                        (ICons ?ncast (INil))))
+                    (= ?rn_shape (ECons ?rows (ENil)))
+                    (= ?rn_in (ECons (MNum 0) (ENil)))
+                    (= ?rn_out (ECons (MIter) (ENil)))
+                    (= ?ncast (MetalCast ?ncst ?nc_size (F32)))
+                    (= ?ncst (MetalIota ?cols2 ?nc_range))
+                    (= ?nc_size (MNum 1))
+                    (= ?nc_range (MNum 1))
+                    (= ?cols ?cols2)
+
+                    (= ?plus_eps (Op (MetalAdd ?pe_shape ?pe_a ?pe_b ?pe_o)
+                        (ICons ?mean (ICons ?eps_const (INil)))))
+                    (= ?pe_shape (ECons ?rows (ENil)))
+                    (= ?pe_a (ECons (MIter) (ENil)))
+                    (= ?pe_b (ECons (MNum 0) (ENil)))
+                    (= ?pe_o (ECons (MIter) (ENil)))
+                    (= ?eps_const (MetalConstant ?eps))
+                    (= ?sqrt (Op (MetalSqrt ?sqrt_shape ?sqrt_in ?sqrt_out)
+                        (ICons ?plus_eps (INil))))
+                    (= ?sqrt_shape (ECons ?rows (ENil)))
+                    (= ?sqrt_in (ECons (MIter) (ENil)))
+                    (= ?sqrt_out (ECons (MIter) (ENil)))
+                    (= ?rinv (Op (MetalRecip ?ri_shape ?ri_in ?ri_out)
+                        (ICons ?sqrt (INil))))
+                    (= ?ri_shape (ECons ?rows (ENil)))
+                    (= ?ri_in (ECons (MIter) (ENil)))
+                    (= ?ri_out (ECons (MIter) (ENil)))
+                )
+                ((metal_rms_rinv ?rinv ?x ?eps ?rows ?cols))
+                :ruleset kernel_fuse_late_pre
+                :name \"metal rms inverse root mean square\"
+            )
+            (rule
+                (
+                    (metal_rms_rinv ?rinv ?x ?eps ?rows ?cols)
+
+                    (= ?norm (Op (MetalMul ?norm_shape ?norm_a ?norm_b ?norm_o)
+                        (ICons ?rinv (ICons ?x3 (INil)))))
+                    (= ?x ?x3)
+                    (= ?norm_shape (ECons ?rows (ECons ?cols (ENil))))
+                    (= ?norm_a (ECons (MIter) (ECons (MNum 0) (ENil))))
+                    (= ?norm_b
+                        (ECons (MMul (MIter) ?cols) (ECons (MIter) (ENil))))
+                    (= ?norm_o
+                        (ECons (MMul (MIter) ?cols) (ECons (MIter) (ENil))))
+
+                    (= ?weighted (Op (MetalMul ?out_shape ?weighted_a ?weighted_b ?weighted_o)
+                        (ICons ?norm (ICons ?weight (INil)))))
+                    (= (F32) (dtype ?weight))
+                    (= ?out_shape (ECons ?rows (ECons ?cols (ENil))))
+                    (= ?weighted_a
+                        (ECons (MMul (MIter) ?cols) (ECons (MIter) (ENil))))
+                    (= ?weighted_b (ECons (MNum 0) (ECons (MIter) (ENil))))
+                    (= ?weighted_o
+                        (ECons (MMul (MIter) ?cols) (ECons (MIter) (ENil))))
+                )
+                (
+                    (let ?rms (Op (MetalRMSNorm ?out_shape ?eps)
+                        (ICons ?x (ICons ?weight (INil)))))
+                    (union ?weighted ?rms)
+                    (set (dtype ?rms) (F32))
+                )
+                :ruleset kernel_fuse_late
+                :name \"metal fused rms norm f32 2d\"
+            )",
+        )]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        let out_shape = luminal::egglog_utils::extract_expr_list(
+            egraph,
+            kind_children[0],
+            list_cache,
+            expr_cache,
+        )
+        .unwrap();
+        assert_eq!(out_shape.len(), 2, "Metal RMSNorm output must be 2-D");
+        let eps: f64 = egraph.enodes[kind_children[1]]
+            .0
+            .replace('"', "")
+            .parse()
+            .unwrap();
+        let rows = out_shape[0];
+        let cols = out_shape[1]
+            .to_usize()
+            .expect("Metal RMSNorm's last dimension must be static");
+        (
+            LLIROp::new::<dyn MetalKernelOp>(Box::new(Self {
+                rows,
+                cols,
+                eps: eps as f32,
+            })),
+            input_enodes,
+        )
+    }
+}
+
+impl MetalKernelOp for MetalRMSNorm {
+    fn compile(
+        &self,
+        device: &Device,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) -> Option<ComputePipelineState> {
+        let input_dtype = input_dtypes.first().copied().unwrap_or(DType::F32);
+        let weight_dtype = input_dtypes.get(1).copied().unwrap_or(DType::F32);
+        let input_ty = metal_buffer_type(input_dtype);
+        let weight_ty = metal_buffer_type(weight_dtype);
+        let output_ty = metal_buffer_type(output_dtype);
+        let x_val = metal_numeric_read(input_dtype, "x", "base + col");
+        let weight_val = metal_numeric_read(weight_dtype, "weight", "col");
+        let output_val = metal_numeric_write(
+            output_dtype,
+            &format!("({x_val}) * inv_rms * ({weight_val})"),
+        );
+        let cols = self.cols;
+        let eps_bits = self.eps.to_bits();
+        let eps_literal = format!("as_type<float>(0x{eps_bits:08x}u)");
+
+        let vectors_per_thread = cols / (256 * 4);
+        let source = if input_dtype == DType::F32
+            && weight_dtype == DType::F32
+            && output_dtype == DType::F32
+            && cols.is_multiple_of(256 * 4)
+            && vectors_per_thread > 0
+            && vectors_per_thread <= 4
+        {
+            format!(
+                r#"
+                #include <metal_stdlib>
+                using namespace metal;
+
+                #define THREADS_PER_GROUP 256
+                #define VECTORS_PER_THREAD {vectors_per_thread}
+
+                kernel void rms_norm(
+                    const device float4 *x [[buffer(0)]],
+                    const device float4 *weight [[buffer(1)]],
+                    device float4 *out [[buffer(2)]],
+                    uint row [[threadgroup_position_in_grid]],
+                    uint tid [[thread_index_in_threadgroup]],
+                    uint lane [[thread_index_in_simdgroup]],
+                    uint simd_group [[simdgroup_index_in_threadgroup]],
+                    uint simd_width [[threads_per_simdgroup]]
+                ) {{
+                    threadgroup float partials[256];
+                    const uint base = row * ({cols} / 4);
+                    float4 values[VECTORS_PER_THREAD];
+                    float sum = 0.0f;
+
+                    for (uint item = 0; item < VECTORS_PER_THREAD; ++item) {{
+                        const uint col = tid + item * THREADS_PER_GROUP;
+                        const float4 value = x[base + col];
+                        values[item] = value;
+                        sum += dot(value, value);
+                    }}
+
+                    const float simd_total = simd_sum(sum);
+                    if (lane == 0) partials[simd_group] = simd_total;
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+                    if (simd_group == 0) {{
+                        const uint simd_groups =
+                            (THREADS_PER_GROUP + simd_width - 1) / simd_width;
+                        float total = 0.0f;
+                        for (uint group = lane; group < simd_groups; group += simd_width) {{
+                            total += partials[group];
+                        }}
+                        total = simd_sum(total);
+                        if (lane == 0) {{
+                            partials[0] = rsqrt(total / float({cols}) + {eps_literal});
+                        }}
+                    }}
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+                    const float inv_rms = partials[0];
+                    for (uint item = 0; item < VECTORS_PER_THREAD; ++item) {{
+                        const uint col = tid + item * THREADS_PER_GROUP;
+                        out[base + col] = values[item] * inv_rms * weight[col];
+                    }}
+                }}
+                "#,
+            )
+        } else {
+            format!(
+                r#"
+            #include <metal_stdlib>
+            using namespace metal;
+
+            #define THREADS_PER_GROUP 256
+
+            kernel void rms_norm(
+                const device {input_ty} *x [[buffer(0)]],
+                const device {weight_ty} *weight [[buffer(1)]],
+                device {output_ty} *out [[buffer(2)]],
+                uint row [[threadgroup_position_in_grid]],
+                uint tid [[thread_index_in_threadgroup]],
+                uint lane [[thread_index_in_simdgroup]],
+                uint simd_group [[simdgroup_index_in_threadgroup]],
+                uint simd_width [[threads_per_simdgroup]]
+            ) {{
+                threadgroup float partials[256];
+                const uint base = row * {cols};
+                float sum = 0.0f;
+                for (uint col = tid; col < {cols}; col += THREADS_PER_GROUP) {{
+                    float value = {x_val};
+                    sum += value * value;
+                }}
+
+                const float simd_total = simd_sum(sum);
+                if (lane == 0) partials[simd_group] = simd_total;
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+
+                if (simd_group == 0) {{
+                    const uint simd_groups =
+                        (THREADS_PER_GROUP + simd_width - 1) / simd_width;
+                    float total = 0.0f;
+                    for (uint group = lane; group < simd_groups; group += simd_width) {{
+                        total += partials[group];
+                    }}
+                    total = simd_sum(total);
+                    if (lane == 0) {{
+                        partials[0] = rsqrt(total / float({cols}) + {eps_literal});
+                    }}
+                }}
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+                const float inv_rms = partials[0];
+
+                for (uint col = tid; col < {cols}; col += THREADS_PER_GROUP) {{
+                    out[base + col] = {output_val};
+                }}
+            }}
+            "#,
+            )
+        };
+        Some(compile_shader(device, &source, "rms_norm"))
+    }
+
+    fn output_size(&self) -> Expression {
+        self.rows * self.cols
+    }
+
+    fn encode_compute(
+        &self,
+        encoder: &ComputeCommandEncoderRef,
+        pipeline: &ComputePipelineState,
+        inputs: &[&Buffer],
+        output: &Buffer,
+        dyn_map: &DynMap,
+    ) {
+        assert_eq!(inputs.len(), 2, "MetalRMSNorm expects x and weight");
+        let rows = self.rows.exec(dyn_map).unwrap() as u64;
+        encoder.set_compute_pipeline_state(pipeline);
+        encoder.set_buffer(0, Some(inputs[0]), 0);
+        encoder.set_buffer(1, Some(inputs[1]), 0);
+        encoder.set_buffer(2, Some(output), 0);
+        encoder.dispatch_thread_groups(MTLSize::new(rows, 1, 1), MTLSize::new(256, 1, 1));
+    }
+
+    fn bytes_loaded(&self, dyn_map: &DynMap) -> usize {
+        let elements = self.output_size().exec(dyn_map).unwrap_or(0);
+        let vectors_per_thread = self.cols / (256 * 4);
+        let inputs_per_element = if self.cols.is_multiple_of(256 * 4)
+            && vectors_per_thread > 0
+            && vectors_per_thread <= 4
+        {
+            2
+        } else {
+            3
+        };
+        elements * inputs_per_element * std::mem::size_of::<f32>()
+    }
+
+    fn bytes_stored(&self, dyn_map: &DynMap) -> usize {
+        self.output_size().exec(dyn_map).unwrap_or(0) * std::mem::size_of::<f32>()
+    }
+
+    fn flops(&self, dyn_map: &DynMap) -> usize {
+        self.output_size().exec(dyn_map).unwrap_or(0) * 4
+    }
+}
 
 #[derive(Debug, Default, Clone)]
 pub struct MetalAdd {

--- a/crates/luminal_metal/src/kernel/ops.rs
+++ b/crates/luminal_metal/src/kernel/ops.rs
@@ -72,6 +72,22 @@ fn compile_shader(device: &Device, source: &str, function_name: &str) -> Compute
         })
 }
 
+fn reduction_thread_count(pipeline: &ComputePipelineState, reduction_len: usize) -> usize {
+    let simd_width = usize::try_from(pipeline.thread_execution_width())
+        .expect("Metal SIMD width does not fit usize")
+        .max(1);
+    let pipeline_limit = usize::try_from(pipeline.max_total_threads_per_threadgroup())
+        .expect("Metal threadgroup limit does not fit usize");
+    let preferred_limit = 256usize.max(simd_width).min(pipeline_limit);
+    let aligned_limit = (preferred_limit / simd_width) * simd_width;
+    assert!(
+        aligned_limit > 0,
+        "Metal reduction pipeline cannot launch one SIMD group"
+    );
+
+    reduction_len.max(1).min(aligned_limit).div_ceil(simd_width) * simd_width
+}
+
 pub(crate) fn lower_expression_for_metal(expr: &Expression, index_var: &str) -> String {
     expr.to_kernel_with(index_var, &|symbol| {
         format!("dyn[{}]", super::dyn_slot(symbol))
@@ -1027,41 +1043,44 @@ impl MetalKernelOp for MetalSumReduce {
             #include <metal_stdlib>
             using namespace metal;
 
-            #define THREADS_PER_GROUP 256
-
             kernel void mkernel(
                 const device {input_ty} *in [[buffer(0)]],
                 device {output_ty} *out [[buffer(1)]],
                 constant int *dyn [[buffer({dyn_buffer_index})]],
                 constant uint &n_outputs [[buffer({n_outputs_index})]],
+                constant uint &thread_count [[buffer({thread_count_index})]],
                 uint gid [[threadgroup_position_in_grid]],
-                uint tid [[thread_index_in_threadgroup]]
+                uint tid [[thread_index_in_threadgroup]],
+                uint lane [[thread_index_in_simdgroup]],
+                uint simd_group [[simdgroup_index_in_threadgroup]],
+                uint simd_width [[threads_per_simdgroup]]
             ) {{
                 if (gid >= n_outputs) return;
 
-                threadgroup float partials[THREADS_PER_GROUP];
+                threadgroup float partials[256];
 
                 int in_start = {in_idx};
                 int iters = {iters};
                 (void)dyn;
 
                 float sum = 0.0f;
-                for (int i = tid; i < iters; i += THREADS_PER_GROUP) {{
+                for (int i = tid; i < iters; i += thread_count) {{
                     sum += {in_val};
                 }}
 
-                partials[tid] = sum;
+                const float simd_total = simd_sum(sum);
+                if (lane == 0) partials[simd_group] = simd_total;
                 threadgroup_barrier(mem_flags::mem_threadgroup);
-                for (uint stride = THREADS_PER_GROUP / 2; stride > 0; stride >>= 1) {{
-                    if (tid < stride) {{
-                        partials[tid] += partials[tid + stride];
-                    }}
-                    threadgroup_barrier(mem_flags::mem_threadgroup);
-                }}
 
-                if (tid == 0) {{
-                    float block_sum = partials[0];
-                    out[{out_idx}] = {out_val};
+                if (simd_group == 0) {{
+                    const uint simd_groups =
+                        (thread_count + simd_width - 1) / simd_width;
+                    float block_sum = 0.0f;
+                    for (uint group = lane; group < simd_groups; group += simd_width) {{
+                        block_sum += partials[group];
+                    }}
+                    block_sum = simd_sum(block_sum);
+                    if (lane == 0) out[{out_idx}] = {out_val};
                 }}
             }}
             "#,
@@ -1071,6 +1090,7 @@ impl MetalKernelOp for MetalSumReduce {
             out_val = out_val,
             dyn_buffer_index = 2u64,
             n_outputs_index = 3u64,
+            thread_count_index = 4u64,
         );
         Some(compile_shader(device, &source, "mkernel"))
     }
@@ -1102,8 +1122,14 @@ impl MetalKernelOp for MetalSumReduce {
             &n_outputs as *const u32 as *const _,
         );
 
-        // One threadgroup per output element
-        let thread_group_size = MTLSize::new(256, 1, 1);
+        let reduction_len = self.iters.exec(dyn_map).unwrap_or(256);
+        let threads = reduction_thread_count(pipeline, reduction_len) as u32;
+        encoder.set_bytes(
+            4,
+            std::mem::size_of::<u32>() as u64,
+            &threads as *const u32 as *const _,
+        );
+        let thread_group_size = MTLSize::new(threads as u64, 1, 1);
         let thread_groups = MTLSize::new(n_outputs as u64, 1, 1);
         encoder.dispatch_thread_groups(thread_groups, thread_group_size);
     }
@@ -1198,7 +1224,6 @@ impl MetalKernelOp for MetalMaxReduce {
             #include <metal_stdlib>
             using namespace metal;
 
-            #define THREADS_PER_GROUP 256
             #define NEG_INF_F (-INFINITY)
 
             kernel void mkernel(
@@ -1206,34 +1231,39 @@ impl MetalKernelOp for MetalMaxReduce {
                 device {output_ty} *out [[buffer(1)]],
                 constant int *dyn [[buffer({dyn_buffer_index})]],
                 constant uint &n_outputs [[buffer({n_outputs_index})]],
+                constant uint &thread_count [[buffer({thread_count_index})]],
                 uint gid [[threadgroup_position_in_grid]],
-                uint tid [[thread_index_in_threadgroup]]
+                uint tid [[thread_index_in_threadgroup]],
+                uint lane [[thread_index_in_simdgroup]],
+                uint simd_group [[simdgroup_index_in_threadgroup]],
+                uint simd_width [[threads_per_simdgroup]]
             ) {{
                 if (gid >= n_outputs) return;
 
-                threadgroup float partials[THREADS_PER_GROUP];
+                threadgroup float partials[256];
 
                 int in_start = {in_idx};
                 int iters = {iters};
                 (void)dyn;
 
                 float max_val = NEG_INF_F;
-                for (int i = tid; i < iters; i += THREADS_PER_GROUP) {{
+                for (int i = tid; i < iters; i += thread_count) {{
                     max_val = fmax(max_val, {in_val});
                 }}
 
-                partials[tid] = max_val;
+                const float simd_maximum = simd_max(max_val);
+                if (lane == 0) partials[simd_group] = simd_maximum;
                 threadgroup_barrier(mem_flags::mem_threadgroup);
-                for (uint stride = THREADS_PER_GROUP / 2; stride > 0; stride >>= 1) {{
-                    if (tid < stride) {{
-                        partials[tid] = fmax(partials[tid], partials[tid + stride]);
-                    }}
-                    threadgroup_barrier(mem_flags::mem_threadgroup);
-                }}
 
-                if (tid == 0) {{
-                    float block_max = partials[0];
-                    out[{out_idx}] = {out_val};
+                if (simd_group == 0) {{
+                    const uint simd_groups =
+                        (thread_count + simd_width - 1) / simd_width;
+                    float block_max = NEG_INF_F;
+                    for (uint group = lane; group < simd_groups; group += simd_width) {{
+                        block_max = fmax(block_max, partials[group]);
+                    }}
+                    block_max = simd_max(block_max);
+                    if (lane == 0) out[{out_idx}] = {out_val};
                 }}
             }}
             "#,
@@ -1243,6 +1273,7 @@ impl MetalKernelOp for MetalMaxReduce {
             out_val = out_val,
             dyn_buffer_index = 2u64,
             n_outputs_index = 3u64,
+            thread_count_index = 4u64,
         );
         Some(compile_shader(device, &source, "mkernel"))
     }
@@ -1274,7 +1305,14 @@ impl MetalKernelOp for MetalMaxReduce {
             &n_outputs as *const u32 as *const _,
         );
 
-        let thread_group_size = MTLSize::new(256, 1, 1);
+        let reduction_len = self.iters.exec(dyn_map).unwrap_or(256);
+        let threads = reduction_thread_count(pipeline, reduction_len) as u32;
+        encoder.set_bytes(
+            4,
+            std::mem::size_of::<u32>() as u64,
+            &threads as *const u32 as *const _,
+        );
+        let thread_group_size = MTLSize::new(threads as u64, 1, 1);
         let thread_groups = MTLSize::new(n_outputs as u64, 1, 1);
         encoder.dispatch_thread_groups(thread_groups, thread_group_size);
     }

--- a/crates/luminal_metal/src/tests.rs
+++ b/crates/luminal_metal/src/tests.rs
@@ -35,6 +35,79 @@ fn assert_close(actual: &[f32], expected: &[f32], tolerance: f32) {
     }
 }
 
+#[test]
+fn metal_rms_norm_rewrite_matches_reference() {
+    const ROWS: usize = 3;
+    const COLS: usize = 2048;
+    const EPS: f32 = 1e-5;
+
+    let mut cx = Graph::default();
+    let input = cx.tensor(('s', COLS));
+    let weight = cx.tensor(COLS);
+    let output = rms_norm(input, weight, EPS).output();
+    cx.set_dim('s', ROWS);
+
+    let input_data = seeded_data(ROWS * COLS, 1.8, -0.9);
+    let weight_data = seeded_data(COLS, 0.8, 0.6);
+    let mut expected = vec![0.0; ROWS * COLS];
+    for row in 0..ROWS {
+        let values = &input_data[row * COLS..(row + 1) * COLS];
+        let mean_square = values.iter().map(|value| value * value).sum::<f32>() / COLS as f32;
+        let inv_rms = 1.0 / (mean_square + EPS).sqrt();
+        for col in 0..COLS {
+            expected[row * COLS + col] = values[col] * inv_rms * weight_data[col];
+        }
+    }
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    assert!(
+        egraph_has_op(&cx, "MetalRMSNorm"),
+        "expected the decomposed RMSNorm to offer a fused Metal candidate"
+    );
+    let llir = extract_llir_with_op(&cx, "MetalRMSNorm");
+    let mut runtime = MetalRuntime::initialize(());
+    runtime.load_llir(&llir);
+    runtime.set_data(input, &input_data);
+    runtime.set_data(weight, &weight_data);
+    let selected_ops = runtime.debug_kernel_ops();
+    assert!(
+        selected_ops.iter().any(|op| op.contains("MetalRMSNorm")),
+        "expected fused RMSNorm, selected ops: {selected_ops:?}"
+    );
+    runtime.allocate_intermediate_buffers(&cx.dyn_map);
+    runtime.execute(&cx.dyn_map);
+
+    assert_close(&runtime.get_f32(output), &expected, 2e-4);
+}
+
+#[test]
+fn metal_rms_norm_preserves_small_epsilon() {
+    const ROWS: usize = 2;
+    const COLS: usize = 17;
+    const EPS: f32 = 1e-12;
+
+    let mut cx = Graph::default();
+    let input = cx.tensor((ROWS, COLS));
+    let weight = cx.tensor(COLS);
+    let output = rms_norm(input, weight, EPS).output();
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    let llir = extract_llir_with_op(&cx, "MetalRMSNorm");
+    let mut runtime = MetalRuntime::initialize(());
+    runtime.load_llir(&llir);
+    runtime.set_data(input, vec![0.0f32; ROWS * COLS]);
+    runtime.set_data(weight, vec![1.0f32; COLS]);
+    runtime.allocate_intermediate_buffers(&cx.dyn_map);
+    runtime.execute(&cx.dyn_map);
+
+    let actual = runtime.get_f32(output);
+    assert!(
+        actual.iter().all(|value| value.is_finite()),
+        "small positive epsilon must prevent zero-input NaNs: {actual:?}"
+    );
+    assert_close(&actual, &[0.0; ROWS * COLS], 1e-6);
+}
+
 fn bytes_of<T: bytemuck::NoUninit>(values: &[T]) -> Vec<u8> {
     bytemuck::cast_slice(values).to_vec()
 }
@@ -54,6 +127,118 @@ fn egraph_has_op(cx: &Graph, op_name: &str) -> bool {
         .enodes
         .values()
         .any(|(label, _)| label == op_name)
+}
+
+fn extract_llir_with_op(cx: &Graph, op_name: &str) -> luminal::graph::LLIRGraph {
+    let egraph = cx.egraph().expect("search space should be built");
+    let ops = cx
+        .egglog_ops()
+        .expect("search space should have registered egglog ops");
+    let ir_nodes = egraph
+        .enodes
+        .iter()
+        .filter_map(|(node, (label, children))| {
+            if label != "Op" {
+                return None;
+            }
+            let kind_class = children.first()?;
+            egraph.eclasses[kind_class]
+                .1
+                .iter()
+                .any(|kind_node| egraph.enodes[kind_node].0 == op_name)
+                .then_some(node)
+        })
+        .collect::<Vec<_>>();
+    assert!(!ir_nodes.is_empty(), "no {op_name} IR candidate found");
+
+    let mut last_error = None;
+    for ir_node in ir_nodes {
+        for background in 0..64 {
+            let mut rng = StdRng::seed_from_u64(0x4D45_5441_4C00 + background);
+            let mut choices = luminal::egglog_utils::random_initial_choice(egraph, &mut rng);
+            choices.insert(&egraph.node_to_class[ir_node], ir_node);
+            if let Err(error) = luminal::egglog_utils::validate_choice_set(egraph, &choices, ops) {
+                last_error = Some(error);
+                continue;
+            }
+
+            let mut list_cache = FxHashMap::default();
+            let mut expr_cache = FxHashMap::default();
+            let llir = luminal::egglog_utils::egglog_to_llir(
+                egraph,
+                choices,
+                ops,
+                &cx.custom_ops,
+                &mut list_cache,
+                &mut expr_cache,
+                None,
+            );
+            if llir.node_indices().any(|node| {
+                llir[node]
+                    .to_dialect::<dyn crate::kernel::MetalKernelOp>()
+                    .is_some_and(|op| format!("{op:?}").contains(op_name))
+            }) {
+                return llir;
+            }
+            last_error = Some(format!("forced {op_name} candidate did not reach LLIR"));
+        }
+    }
+
+    panic!(
+        "failed to extract {op_name} candidate: {}",
+        last_error.as_deref().unwrap_or("no valid choice set")
+    );
+}
+
+#[test]
+fn metal_rms_norm_rewrite_rejects_noncontiguous_input() {
+    let mut cx = Graph::default();
+    let input = cx.tensor((32, 4)).permute((1, 0));
+    let weight = cx.tensor(32);
+    rms_norm(input, weight, 1e-5).output();
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    assert!(
+        !egraph_has_op(&cx, "MetalRMSNorm"),
+        "the contiguous-only fused kernel must not replace a strided RMSNorm"
+    );
+}
+
+#[test]
+fn metal_rms_norm_rewrite_rejects_dynamic_last_dimension() {
+    let mut cx = Graph::default();
+    let input = cx.tensor(('s', 'h'));
+    let weight = cx.tensor('h');
+    rms_norm(input, weight, 1e-5).output();
+    cx.set_dim('s', 2);
+    cx.set_dim('h', 32);
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    assert!(
+        !egraph_has_op(&cx, "MetalRMSNorm"),
+        "the static-column fused kernel must not be selectable for a dynamic last dimension"
+    );
+}
+
+#[test]
+fn metal_rms_norm_rewrite_rejects_mismatched_square_views() {
+    const SIZE: usize = 8;
+
+    let mut cx = Graph::default();
+    let input = cx.tensor((SIZE, SIZE));
+    let weight = cx.tensor(SIZE);
+    let axis = input.shape.last_axis();
+    let inverse_rms = ((input * input.permute((1, 0))).mean(axis) + 1e-5)
+        .sqrt()
+        .reciprocal()
+        .expand_to_shape_on_axes(input.shape, axis);
+    ((inverse_rms * input) * weight.expand_lhs([SIZE])).output();
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    assert!(
+        !egraph_has_op(&cx, "MetalRMSNorm"),
+        "the fusion must reject a lookalike whose square reads x through different layouts"
+    );
 }
 
 fn assert_matmul_options(cx: &Graph, mps_op_name: &str) {

--- a/crates/luminal_metal/src/tests.rs
+++ b/crates/luminal_metal/src/tests.rs
@@ -685,6 +685,37 @@ fn metal_simple_max_reduce() {
 }
 
 #[test]
+fn metal_reductions_cover_simd_boundaries() {
+    const ROWS: usize = 2;
+
+    for cols in [17, 33, 65, 257, 1025] {
+        let mut cx = Graph::default();
+        let input = cx.tensor((ROWS, cols));
+        let sum_output = input.sum(1).output();
+        let max_output = input.max(1).output();
+        let input_data = seeded_data(ROWS * cols, 2.0, -1.0);
+        let expected_sum = input_data
+            .chunks_exact(cols)
+            .map(|row| row.iter().sum::<f32>())
+            .collect::<Vec<_>>();
+        let expected_max = input_data
+            .chunks_exact(cols)
+            .map(|row| row.iter().copied().fold(f32::NEG_INFINITY, f32::max))
+            .collect::<Vec<_>>();
+
+        cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+        let mut rt = MetalRuntime::initialize(());
+        rt.set_data(input, &input_data);
+        rt = cx.search(rt, CompileOptions::default().search_graph_limit(5));
+        rt.allocate_intermediate_buffers(&cx.dyn_map);
+        rt.execute(&cx.dyn_map);
+
+        assert_close(&rt.get_f32(sum_output), &expected_sum, 0.001);
+        assert_close(&rt.get_f32(max_output), &expected_max, 0.001);
+    }
+}
+
+#[test]
 fn metal_f16_cast_roundtrip() {
     let mut cx = Graph::default();
     let input = cx.tensor(4);


### PR DESCRIPTION
This matches the existing CUDA warp-level reduction strategy.

llama 1b on my M3 Max:
+2.2% throughput
-2.2% tpot
-0.4% ttft