### PR TITLE
metal: lower leading-axis-reduction matmuls to MPSMatmul (autograd weight grads)

### DIFF
--- a/crates/luminal_metal/src/kernel/ops.rs
+++ b/crates/luminal_metal/src/kernel/ops.rs
@@ -1803,6 +1803,120 @@ impl EgglogOp for MPSMatmul {
                 .name(name)
         };
 
+        // Leading-axis-reduction variant. luminal_training autograd rebuilds a
+        // GEMM from Mul + SumReduce VJPs without going through the frontend
+        // `matmul` builder, so the contracted axis lands as the LEADING axis of
+        // the broadcast-multiply: `SumReduce(dim=0, Mul([k, m, n]))` with the
+        // reduced axis carrying stride `m*n*z` instead of the innermost `z` the
+        // `matmul_rule` template above expects. Semantically identical (the
+        // reduction is order-independent), so we match that shape directly and
+        // union it with the same MPSMatmul op. See issue #382.
+        let matmul_rule_leading = |name: &'static str,
+                                   lhs_layout: MPSMatrixLayout,
+                                   rhs_layout: MPSMatrixLayout,
+                                   transpose_lhs: i64,
+                                   transpose_rhs: i64| {
+            let m = v("?m");
+            let n = v("?n");
+            let k = v("?k");
+            let lhs = v("?lhs");
+            let rhs = v("?rhs");
+            let lhs_row_stride = match lhs_layout {
+                MPSMatrixLayout::RowMajor => mul(k.clone(), z.clone()),
+                MPSMatrixLayout::TransposedRowMajor => mul(m.clone(), z.clone()),
+            };
+            let rhs_row_stride = match rhs_layout {
+                MPSMatrixLayout::RowMajor => mul(n.clone(), z.clone()),
+                MPSMatrixLayout::TransposedRowMajor => mul(k.clone(), z.clone()),
+            };
+            // Operand strides in [k, m, n] axis order (contraction leading).
+            let lhs_strides = match lhs_layout {
+                MPSMatrixLayout::RowMajor => {
+                    vec![z.clone(), lhs_row_stride.clone(), zero.clone()]
+                }
+                MPSMatrixLayout::TransposedRowMajor => {
+                    vec![lhs_row_stride.clone(), z.clone(), zero.clone()]
+                }
+            };
+            let rhs_strides = match rhs_layout {
+                MPSMatrixLayout::RowMajor => {
+                    vec![rhs_row_stride.clone(), zero.clone(), z.clone()]
+                }
+                MPSMatrixLayout::TransposedRowMajor => {
+                    vec![z.clone(), zero.clone(), rhs_row_stride.clone()]
+                }
+            };
+            let out_row_stride = mul(n.clone(), z.clone());
+            // Reduced (leading) axis stride in the contiguous [k, m, n] product:
+            // product of the trailing (m, n) dims times the element stride z.
+            let reduced_stride = mul(mul(z.clone(), n.clone()), m.clone());
+            // The surviving axes [m, n] must be read contiguously from the
+            // [k, m, n] product (m-stride n*z, n-stride z). Pinning these
+            // instead of leaving them free is a correctness requirement: a
+            // movement-only view that permutes the surviving axes before the
+            // reduction (e.g. a square `prod.permute((0, 2, 1)).sum(0)`)
+            // preserves the shape and reduced-axis stride but transposes the
+            // result, and must NOT be unioned with this untransposed MPSMatmul.
+            let surviving_strides = cons(out_row_stride.clone(), cons(z.clone(), nil()));
+            // The product itself is emitted contiguously as [k, m, n].
+            let mul_output_strides = cons(
+                reduced_stride.clone(),
+                cons(out_row_stride.clone(), cons(z.clone(), nil())),
+            );
+
+            let mul_op = op_term(
+                MetalMul {
+                    shape: vec![],
+                    a_strides: vec![],
+                    b_strides: vec![],
+                    output_strides: vec![],
+                }
+                .sort()
+                .call([
+                    (
+                        "shape",
+                        cons(k.clone(), cons(m.clone(), cons(n.clone(), nil()))),
+                    ),
+                    ("a_strides", expr_list(lhs_strides)),
+                    ("b_strides", expr_list(rhs_strides)),
+                    ("out_strides", mul_output_strides),
+                ]),
+                ilist(vec![lhs.clone(), rhs.clone()]),
+            );
+            let sum_op = op_term(
+                MetalSumReduce::default().sort().call([
+                    ("shape", cons(m.clone(), cons(n.clone(), nil()))),
+                    ("iters", k.clone()),
+                    ("strides", surviving_strides),
+                    ("iter_stride", reduced_stride),
+                    (
+                        "out_strides",
+                        cons(out_row_stride.clone(), cons(z.clone(), nil())),
+                    ),
+                ]),
+                ilist(vec![mul_op.clone()]),
+            );
+            let mps_op = MPSMatmul::default().sort().call([
+                ("m", m),
+                ("n", n),
+                ("k", k),
+                ("lhs", lhs),
+                ("lhs_row_stride", lhs_row_stride),
+                ("rhs", rhs),
+                ("rhs_row_stride", rhs_row_stride),
+                ("out_row_stride", out_row_stride),
+                ("transpose_lhs", lit_i64(transpose_lhs)),
+                ("transpose_rhs", lit_i64(transpose_rhs)),
+            ]);
+            let dt = v(format!("?{}_dt", name.replace('-', "_")));
+
+            rule(union(sum_op.clone(), mps_op.clone()))
+                .set(dtype(mps_op), dt.clone())
+                .fact(eq(dt, dtype(sum_op)))
+                .ruleset("kernel_lower")
+                .name(name)
+        };
+
         vec![
             matmul_rule(
                 "mps-matmul-row-row",
@@ -1827,6 +1941,34 @@ impl EgglogOp for MPSMatmul {
             ),
             matmul_rule(
                 "mps-matmul-transposed-lhs-transposed-rhs",
+                MPSMatrixLayout::TransposedRowMajor,
+                MPSMatrixLayout::TransposedRowMajor,
+                1,
+                1,
+            ),
+            matmul_rule_leading(
+                "mps-matmul-leading-row-row",
+                MPSMatrixLayout::RowMajor,
+                MPSMatrixLayout::RowMajor,
+                0,
+                0,
+            ),
+            matmul_rule_leading(
+                "mps-matmul-leading-row-transposed-rhs",
+                MPSMatrixLayout::RowMajor,
+                MPSMatrixLayout::TransposedRowMajor,
+                0,
+                1,
+            ),
+            matmul_rule_leading(
+                "mps-matmul-leading-transposed-lhs-row",
+                MPSMatrixLayout::TransposedRowMajor,
+                MPSMatrixLayout::RowMajor,
+                1,
+                0,
+            ),
+            matmul_rule_leading(
+                "mps-matmul-leading-transposed-lhs-transposed-rhs",
                 MPSMatrixLayout::TransposedRowMajor,
                 MPSMatrixLayout::TransposedRowMajor,
                 1,

--- a/crates/luminal_metal/src/tests.rs
+++ b/crates/luminal_metal/src/tests.rs
@@ -138,6 +138,11 @@ fn extract_llir_with_op(cx: &Graph, op_name: &str) -> luminal::graph::LLIRGraph 
         .enodes
         .iter()
         .filter_map(|(node, (label, children))| {
+            // Bare first-class IR nodes (e.g. MPSMatmul, unioned into the
+            // Mul+Sum eclass rather than wrapped in an `Op`).
+            if label == op_name {
+                return Some(node);
+            }
             if label != "Op" {
                 return None;
             }
@@ -1008,6 +1013,93 @@ fn metal_regular_tiled_matmul_path() {
     let expected: Vec<f32> = expected.flatten_all().unwrap().to_vec1().unwrap();
 
     assert_close(&result, &expected, 2e-3);
+}
+
+#[test]
+fn metal_mps_matmul_leading_axis_contraction() {
+    // Regression for issue #382: a matmul whose contraction lands on the
+    // LEADING axis of the broadcast-multiply (as produced by luminal_training
+    // autograd weight gradients, `dW = Σ_k g[k,·]·x[k,·]`) must still lower to
+    // MPSMatmul. Reproduces the exact leading-reduction `SumReduce(dim=0, Mul)`
+    // shape without pulling in luminal_training. (Here the product axes are
+    // [k, n, m], i.e. the rule binds its output dims as m'=n, n'=m.) Before
+    // this rule the shape only offered GenericMatmul (~10-20 GFLOP/s vs ~800).
+    let mut cx = Graph::default();
+    let k = 6;
+    let n = 4;
+    let m = 8;
+    let g = cx.tensor((k, n));
+    let x = cx.tensor((k, m));
+    // [k,n,m] product contracting the leading k axis.
+    let prod = g.expand_dim(2, m) * x.expand_dim(1, n);
+    let output = prod.sum(0).output();
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    // The leading-axis contraction must now offer an MPSMatmul candidate, at
+    // parity with the equivalent forward matmul.
+    assert_matmul_options(&cx, "MPSMatmul");
+
+    // And the compiled result must be correct: out[i, j] = Σ_k g[k, i] · x[k, j],
+    // shape [n, m]. Guards against the union asserting a wrong equivalence.
+    let g_data = seeded_data(k * n, 0.31, -0.14);
+    let x_data = seeded_data(k * m, 0.23, -0.11);
+    let mut expected = vec![0.0f32; n * m];
+    for i in 0..n {
+        for j in 0..m {
+            let mut sum = 0.0;
+            for kk in 0..k {
+                sum += g_data[kk * n + i] * x_data[kk * m + j];
+            }
+            expected[i * m + j] = sum;
+        }
+    }
+
+    // Force the MPS candidate (search prefers GenericMatmul at these sizes, for
+    // this and the equivalent forward matmul alike) and execute it, so the
+    // operand-stride -> transpose-flag mapping of the leading rule is validated
+    // numerically, not just by option presence.
+    let llir = extract_llir_with_op(&cx, "MPSMatmul");
+    let mut rt = MetalRuntime::initialize(());
+    rt.load_llir(&llir);
+    rt.set_data(g, &g_data);
+    rt.set_data(x, &x_data);
+    let selected = rt.debug_kernel_ops();
+    assert!(
+        selected.iter().any(|op| op.contains("MPSMatmul")),
+        "forced LLIR must run the leading-axis MPSMatmul, got: {selected:?}"
+    );
+    rt.allocate_intermediate_buffers(&cx.dyn_map);
+    rt.execute(&cx.dyn_map);
+    assert_close(&rt.get_f32(output), &expected, 1e-3);
+}
+
+#[test]
+fn metal_leading_axis_contraction_rejects_permuted_surviving_axes() {
+    // The leading-axis MPS rule must match ONLY the canonical contiguous read of
+    // the surviving axes. For a SQUARE [k, m, m] product, a movement-only
+    // `permute((0, 2, 1))` before the reduction keeps the [m, m] shape and the
+    // leading m*m*z reduction stride but transposes the result. It must NOT be
+    // unioned with the (untransposed) MPSMatmul — otherwise selecting MPS would
+    // return the transpose. The e-graph must offer GenericMatmul (correct) and
+    // must not offer an MPSMatmul candidate for this view.
+    let mut cx = Graph::default();
+    let k = 6;
+    let mm = 5;
+    let g = cx.tensor((k, mm));
+    let x = cx.tensor((k, mm));
+    let prod = g.expand_dim(2, mm) * x.expand_dim(1, mm); // [k, mm, mm]
+    let output = prod.permute((0, 2, 1)).sum(0).output();
+    let _ = output;
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    assert!(
+        egraph_has_op(&cx, "GenericMatmul"),
+        "expected GenericMatmul rewrite option in e-graph"
+    );
+    assert!(
+        !egraph_has_op(&cx, "MPSMatmul"),
+        "a permuted-surviving-axes (transposed) reduction must not be unioned with an untransposed MPSMatmul"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Autograd weight-gradient matmuls contract over the **leading** axis of the broadcast-multiply, so they never matched the `MPSMatmul` rewrite and fell back to `GenericMatmul`. This adds the leading-axis layouts to the MPS rule.

On the tested Mac (Apple Silicon), the `dW` contraction from #382 (`N=M=2048, K=256`), forced kernel vs. kernel, timed as synchronized `execute()` + output readback over 30 post-warmup reps:

| kernel | time | throughput |
|---|---|---|
| `GenericMatmul` (before) | 109.9 ms | 19.5 GFLOP/s |
| `MPSMatmul` (after) | 1.24 ms | ~1727 GFLOP/s |

~88× on the gradient GEMM in that run, and default `cx.compile()` search selected `MPSMatmul { transpose_lhs: true, transpose_rhs: false }`. (End-to-end execute+readback, one machine; search selection is per-shape/device, not guaranteed.)

Fixes #382.

## Why

`luminal_training` autograd has no matmul op — it rebuilds a GEMM from `Mul` + `SumReduce` VJPs. The frontend `matmul` builder always emits the product as `[m, n, k]` with the contraction **innermost**, but a weight gradient `dW = Σ_k g[k,n]·x[k,m]` contracts over the **leading** axis (`SumReduce(dim=0, Mul([k, m, n]))`), so its reduced axis carries stride `m*n*z` instead of the innermost `z` the existing rule requires. Forward 2D matmuls already expose an MPS candidate via the trailing-axis rewrite; these rules give the canonical autograd weight-gradient contraction equivalent MPS eligibility (runtime search still chooses among MPS and GenericMatmul per shape/device).

## How

Adds four `mps-matmul-leading-*` rewrite alternatives in `MPSMatmul::rewrites()`, mirroring the existing `matmul_rule` template with the contracted axis first (product `[k, m, n]`, `iter_stride = (z*n)*m`), unioned with the **same** `MPSMatmul` op. The `dW` witness (lhs `g` = `(m*z, z, 0)`, rhs `x` = `(n*z, 0, z)`) selects transposed-lhs × row-rhs. No Rust-side LLIR rewrite or post-extraction selection pass is introduced.

## Correctness

The rule matches only when the surviving axes are read **contiguously** (sum input `[n*z, z]`, product output `[m*n*z, n*z, z]`). This is required, not cosmetic: for a square `[k, m, m]` product a movement-only `permute((0,2,1))` before the reduction keeps the shape and reduced-axis stride but transposes the result — pinning the strides prevents unioning it with the untransposed `MPSMatmul`. A negative test covers this (verified to fail if the strides are left free). Higher-rank / batched products don't match the exact 3-element product list and keep their existing paths (`GenericMatmul` / `MPSBatchedMatmul`).

## Tests

New positive test forces the leading `MPSMatmul` LLIR, asserts it's selected, executes it, and checks against a reference sum; new negative test asserts the permuted-square view is *not* offered MPS. Full `luminal_metal` suite passes (release); `fmt` and `clippy -D warnings` clean.

## Follow-ups (out of scope)

- The pre-existing trailing-axis rule leaves `?sum_in_strides` unconstrained — the same latent transpose hole for forward matmuls; worth hardening to the same complete-layout invariant.
- CUDA/cuBLASLt has the analogous leading-axis fast-path gap; a core-level canonicalization could fix both backends.
