### PR TITLE
metal: add BF16 kernel and runtime support

### DIFF
--- a/crates/luminal_metal/src/kernel/ops.rs
+++ b/crates/luminal_metal/src/kernel/ops.rs
@@ -57,7 +57,7 @@ pub type MetalOps = (
 
 fn compile_shader(device: &Device, source: &str, function_name: &str) -> ComputePipelineState {
     let options = metal::CompileOptions::new();
-    options.set_language_version(MTLLanguageVersion::V2_4);
+    options.set_language_version(MTLLanguageVersion::V3_1);
     let library = device
         .new_library_with_source(source, &options)
         .unwrap_or_else(|err| {
@@ -99,6 +99,7 @@ fn metal_buffer_type(dtype: DType) -> &'static str {
     match dtype {
         DType::F32 => "float",
         DType::F16 => "half",
+        DType::Bf16 => "bfloat",
         DType::Int => "int",
         _ => panic!("Metal dtype {dtype:?} is not supported yet"),
     }
@@ -108,6 +109,7 @@ fn metal_numeric_read(dtype: DType, buffer: &str, index: &str) -> String {
     match dtype {
         DType::F32 => format!("{buffer}[{index}]"),
         DType::F16 => format!("float({buffer}[{index}])"),
+        DType::Bf16 => format!("float({buffer}[{index}])"),
         DType::Int => format!("float({buffer}[{index}])"),
         _ => panic!("Metal dtype {dtype:?} is not supported yet"),
     }
@@ -117,6 +119,7 @@ fn metal_numeric_write(dtype: DType, expr: &str) -> String {
     match dtype {
         DType::F32 => expr.to_string(),
         DType::F16 => format!("half({expr})"),
+        DType::Bf16 => format!("bfloat({expr})"),
         DType::Int => format!("int({expr})"),
         _ => panic!("Metal dtype {dtype:?} is not supported yet"),
     }
@@ -124,7 +127,9 @@ fn metal_numeric_write(dtype: DType, expr: &str) -> String {
 
 fn metal_copy_value(dtype: DType, buffer: &str, index: &str) -> String {
     match dtype {
-        DType::F32 | DType::F16 | DType::Int => format!("{buffer}[{index}]"),
+        DType::F32 | DType::F16 | DType::Bf16 | DType::Int => {
+            format!("{buffer}[{index}]")
+        }
         _ => panic!("Metal dtype {dtype:?} is not supported yet"),
     }
 }
@@ -1717,11 +1722,12 @@ impl EgglogOp for MPSMatmul {
                 .fold(nil(), |tail, head| cons(head, tail))
         };
 
-        let matmul_rule = |name: &'static str,
+        let matmul_rule = |name: &str,
                            lhs_layout: MPSMatrixLayout,
                            rhs_layout: MPSMatrixLayout,
                            transpose_lhs: i64,
-                           transpose_rhs: i64| {
+                           transpose_rhs: i64,
+                           supported_dtype: &SortDef| {
             let m = v("?m");
             let n = v("?n");
             let k = v("?k");
@@ -1786,51 +1792,89 @@ impl EgglogOp for MPSMatmul {
                 ("m", m),
                 ("n", n),
                 ("k", k),
-                ("lhs", lhs),
+                ("lhs", lhs.clone()),
                 ("lhs_row_stride", lhs_row_stride),
-                ("rhs", rhs),
+                ("rhs", rhs.clone()),
                 ("rhs_row_stride", rhs_row_stride),
                 ("out_row_stride", out_row_stride),
                 ("transpose_lhs", lit_i64(transpose_lhs)),
                 ("transpose_rhs", lit_i64(transpose_rhs)),
             ]);
-            let dt = v(format!("?{}_dt", name.replace('-', "_")));
+            let supported_dtype = app(supported_dtype, vec![]);
 
             rule(union(sum_op.clone(), mps_op.clone()))
-                .set(dtype(mps_op), dt.clone())
-                .fact(eq(dt, dtype(sum_op)))
+                .set(dtype(mps_op), supported_dtype.clone())
+                .fact(eq(supported_dtype.clone(), dtype(sum_op)))
+                .fact(eq(supported_dtype.clone(), dtype(lhs)))
+                .fact(eq(supported_dtype, dtype(rhs)))
                 .ruleset("kernel_lower")
                 .name(name)
         };
 
         vec![
             matmul_rule(
-                "mps-matmul-row-row",
+                "mps-matmul-row-row-f32",
                 MPSMatrixLayout::RowMajor,
                 MPSMatrixLayout::RowMajor,
                 0,
                 0,
+                &SORTS.f32_dt,
             ),
             matmul_rule(
-                "mps-matmul-row-transposed-rhs",
+                "mps-matmul-row-row-f16",
+                MPSMatrixLayout::RowMajor,
+                MPSMatrixLayout::RowMajor,
+                0,
+                0,
+                &SORTS.f16_dt,
+            ),
+            matmul_rule(
+                "mps-matmul-row-transposed-rhs-f32",
                 MPSMatrixLayout::RowMajor,
                 MPSMatrixLayout::TransposedRowMajor,
                 0,
                 1,
+                &SORTS.f32_dt,
             ),
             matmul_rule(
-                "mps-matmul-transposed-lhs-row",
+                "mps-matmul-row-transposed-rhs-f16",
+                MPSMatrixLayout::RowMajor,
+                MPSMatrixLayout::TransposedRowMajor,
+                0,
+                1,
+                &SORTS.f16_dt,
+            ),
+            matmul_rule(
+                "mps-matmul-transposed-lhs-row-f32",
                 MPSMatrixLayout::TransposedRowMajor,
                 MPSMatrixLayout::RowMajor,
                 1,
                 0,
+                &SORTS.f32_dt,
             ),
             matmul_rule(
-                "mps-matmul-transposed-lhs-transposed-rhs",
+                "mps-matmul-transposed-lhs-row-f16",
+                MPSMatrixLayout::TransposedRowMajor,
+                MPSMatrixLayout::RowMajor,
+                1,
+                0,
+                &SORTS.f16_dt,
+            ),
+            matmul_rule(
+                "mps-matmul-transposed-lhs-transposed-rhs-f32",
                 MPSMatrixLayout::TransposedRowMajor,
                 MPSMatrixLayout::TransposedRowMajor,
                 1,
                 1,
+                &SORTS.f32_dt,
+            ),
+            matmul_rule(
+                "mps-matmul-transposed-lhs-transposed-rhs-f16",
+                MPSMatrixLayout::TransposedRowMajor,
+                MPSMatrixLayout::TransposedRowMajor,
+                1,
+                1,
+                &SORTS.f16_dt,
             ),
             Rule::raw(
                 "(rule
@@ -2094,10 +2138,11 @@ impl EgglogOp for MPSBatchedMatmul {
                 .fold(nil(), |tail, head| cons(head, tail))
         };
 
-        let batched_rule = |name: &'static str,
+        let batched_rule = |name: &str,
                             rhs_layout: MPSMatrixLayout,
                             lhs_inner_stride: EggTerm,
-                            transpose_rhs: i64| {
+                            transpose_rhs: i64,
+                            supported_dtype: &SortDef| {
             let batch = v("?batch");
             let m = v("?m");
             let n = v("?n");
@@ -2192,10 +2237,10 @@ impl EgglogOp for MPSBatchedMatmul {
                 ("m", m),
                 ("n", n),
                 ("k", k),
-                ("lhs", lhs),
+                ("lhs", lhs.clone()),
                 ("lhs_batch_stride", lhs_batch_stride),
                 ("lhs_row_stride", lhs_row_stride),
-                ("rhs", rhs),
+                ("rhs", rhs.clone()),
                 ("rhs_batch_stride", rhs_batch_stride),
                 ("rhs_row_stride", rhs_row_stride),
                 ("out_batch_stride", out_batch_stride),
@@ -2203,11 +2248,13 @@ impl EgglogOp for MPSBatchedMatmul {
                 ("transpose_lhs", lit_i64(0)),
                 ("transpose_rhs", lit_i64(transpose_rhs)),
             ]);
-            let dt = v(format!("?{}_dt", name.replace('-', "_")));
+            let supported_dtype = app(supported_dtype, vec![]);
 
             rule(union(sum_op.clone(), mps_op.clone()))
-                .set(dtype(mps_op), dt.clone())
-                .fact(eq(dt, dtype(sum_op)))
+                .set(dtype(mps_op), supported_dtype.clone())
+                .fact(eq(supported_dtype.clone(), dtype(sum_op)))
+                .fact(eq(supported_dtype.clone(), dtype(lhs)))
+                .fact(eq(supported_dtype, dtype(rhs)))
                 .when(mps_matrix_row_byte_guards)
                 .ruleset("kernel_lower")
                 .name(name)
@@ -2215,34 +2262,72 @@ impl EgglogOp for MPSBatchedMatmul {
 
         vec![
             batched_rule(
-                "mps-batched-matmul-row-row",
+                "mps-batched-matmul-row-row-f32",
                 MPSMatrixLayout::RowMajor,
                 z.clone(),
                 0,
+                &SORTS.f32_dt,
             ),
             batched_rule(
-                "mps-batched-matmul-row-transposed-rhs",
+                "mps-batched-matmul-row-row-f16",
+                MPSMatrixLayout::RowMajor,
+                z.clone(),
+                0,
+                &SORTS.f16_dt,
+            ),
+            batched_rule(
+                "mps-batched-matmul-row-transposed-rhs-f32",
                 MPSMatrixLayout::TransposedRowMajor,
                 z.clone(),
                 1,
+                &SORTS.f32_dt,
             ),
             batched_rule(
-                "mps-batched-matmul-row-row-wrapped-inner",
+                "mps-batched-matmul-row-transposed-rhs-f16",
+                MPSMatrixLayout::TransposedRowMajor,
+                z.clone(),
+                1,
+                &SORTS.f16_dt,
+            ),
+            batched_rule(
+                "mps-batched-matmul-row-row-wrapped-inner-f32",
                 MPSMatrixLayout::RowMajor,
                 add(
                     mul(mul(div(z.clone(), v("?k")), v("?k")), v("?m")),
                     modd(z.clone(), v("?k")),
                 ),
                 0,
+                &SORTS.f32_dt,
             ),
             batched_rule(
-                "mps-batched-matmul-row-transposed-rhs-wrapped-inner",
+                "mps-batched-matmul-row-row-wrapped-inner-f16",
+                MPSMatrixLayout::RowMajor,
+                add(
+                    mul(mul(div(z.clone(), v("?k")), v("?k")), v("?m")),
+                    modd(z.clone(), v("?k")),
+                ),
+                0,
+                &SORTS.f16_dt,
+            ),
+            batched_rule(
+                "mps-batched-matmul-row-transposed-rhs-wrapped-inner-f32",
                 MPSMatrixLayout::TransposedRowMajor,
                 add(
                     mul(mul(div(z.clone(), v("?k")), v("?k")), v("?m")),
                     modd(z.clone(), v("?k")),
                 ),
                 1,
+                &SORTS.f32_dt,
+            ),
+            batched_rule(
+                "mps-batched-matmul-row-transposed-rhs-wrapped-inner-f16",
+                MPSMatrixLayout::TransposedRowMajor,
+                add(
+                    mul(mul(div(z.clone(), v("?k")), v("?k")), v("?m")),
+                    modd(z.clone(), v("?k")),
+                ),
+                1,
+                &SORTS.f16_dt,
             ),
             Rule::raw(
                 "(rule
@@ -3760,19 +3845,15 @@ impl MetalKernelOp for MetalCast {
         let input_dtype = input_dtypes.first().copied().unwrap_or(DType::F32);
         let input_ty = metal_buffer_type(input_dtype);
         let output_ty = metal_buffer_type(output_dtype);
-        let cast_expr = match (input_dtype, output_dtype) {
-            (DType::F32, DType::F32)
-            | (DType::F16, DType::F16)
-            | (DType::Int, DType::Int)
-            | (DType::F32, DType::F16)
-            | (DType::F16, DType::F32)
-            | (DType::F32, DType::Int)
-            | (DType::Int, DType::F32)
-            | (DType::F16, DType::Int)
-            | (DType::Int, DType::F16) => format!("({output_ty})(inp[idx])"),
-            _ => panic!(
+        let supports_runtime_cast =
+            |dtype| matches!(dtype, DType::F32 | DType::F16 | DType::Bf16 | DType::Int);
+        let cast_expr = if supports_runtime_cast(input_dtype) && supports_runtime_cast(output_dtype)
+        {
+            format!("({output_ty})(inp[idx])")
+        } else {
+            panic!(
                 "MetalCast does not support runtime cast from {input_dtype:?} to {output_dtype:?}"
-            ),
+            )
         };
         let source = format!(
             r#"

--- a/crates/luminal_metal/src/runtime.rs
+++ b/crates/luminal_metal/src/runtime.rs
@@ -133,7 +133,7 @@ impl MetalRuntime {
         dtype: DType,
     ) -> Buffer {
         match (tensor.dtype(), dtype) {
-            (Dtype::F32, DType::F32) | (Dtype::F16, DType::F16) => {
+            (Dtype::F32, DType::F32) | (Dtype::F16, DType::F16) | (Dtype::BF16, DType::Bf16) => {
                 let data = tensor.data();
                 self.device.new_buffer_with_data(
                     data.as_ptr() as *const _,
@@ -166,6 +166,20 @@ impl MetalRuntime {
                 let values: Vec<f16> = bytemuck::cast_slice::<u8, bf16>(tensor.data())
                     .iter()
                     .map(|v| f16::from_f32(v.to_f32()))
+                    .collect();
+                self.buffer_from_slice(&values)
+            }
+            (Dtype::F32, DType::Bf16) => {
+                let values: Vec<bf16> = bytemuck::cast_slice::<u8, f32>(tensor.data())
+                    .iter()
+                    .map(|v| bf16::from_f32(*v))
+                    .collect();
+                self.buffer_from_slice(&values)
+            }
+            (Dtype::F16, DType::Bf16) => {
+                let values: Vec<bf16> = bytemuck::cast_slice::<u8, f16>(tensor.data())
+                    .iter()
+                    .map(|v| bf16::from_f32(v.to_f32()))
                     .collect();
                 self.buffer_from_slice(&values)
             }
@@ -298,6 +312,14 @@ impl MetalRuntime {
                 DType::F16 => {
                     let ptr = buffer.contents() as *const f16;
                     let len = logical_bytes as usize / std::mem::size_of::<f16>();
+                    std::slice::from_raw_parts(ptr, len)
+                        .iter()
+                        .map(|v| v.to_f32())
+                        .collect()
+                }
+                DType::Bf16 => {
+                    let ptr = buffer.contents() as *const bf16;
+                    let len = logical_bytes as usize / std::mem::size_of::<bf16>();
                     std::slice::from_raw_parts(ptr, len)
                         .iter()
                         .map(|v| v.to_f32())
@@ -546,6 +568,14 @@ impl MetalRuntime {
             }
             DType::F16 => {
                 let values = data.to_f16_vec();
+                self.device.new_buffer_with_data(
+                    values.as_ptr() as *const _,
+                    std::mem::size_of_val(values.as_slice()) as u64,
+                    MTLResourceOptions::StorageModeShared,
+                )
+            }
+            DType::Bf16 => {
+                let values = data.to_bf16_vec();
                 self.device.new_buffer_with_data(
                     values.as_ptr() as *const _,
                     std::mem::size_of_val(values.as_slice()) as u64,

--- a/crates/luminal_metal/src/tests.rs
+++ b/crates/luminal_metal/src/tests.rs
@@ -939,6 +939,147 @@ fn metal_f16_intermediate_add_roundtrip() {
 }
 
 #[test]
+fn metal_bf16_constant_arithmetic_rounds_to_bf16() {
+    let mut cx = Graph::default();
+    let input = cx.tensor(8).as_dtype(DType::Bf16);
+    let output = (input * 2.5_f32).output();
+    let input_data = [
+        bf16::from_f32(-0.3125),
+        bf16::from_f32(-0.1015625),
+        bf16::from_f32(0.0078125),
+        bf16::from_f32(0.125),
+        bf16::from_f32(0.203125),
+        bf16::from_f32(0.296875),
+        bf16::from_f32(0.3984375),
+        bf16::from_f32(0.5),
+    ];
+    let expected = input_data.map(|value| bf16::from_f32(value.to_f32() * 2.5).to_f32());
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    let mut rt = MetalRuntime::initialize(());
+    rt.set_data(input, &input_data);
+    rt = search_candidates(&mut cx, rt, 5);
+    rt.allocate_intermediate_buffers(&cx.dyn_map);
+    rt.execute(&cx.dyn_map);
+
+    assert_eq!(rt.get_f32(output), expected);
+}
+
+#[test]
+fn metal_bf16_embedding_gather_is_bit_exact() {
+    const VOCAB_SIZE: usize = 7;
+    const EMBED_DIM: usize = 5;
+    const SEQ_LEN: usize = 4;
+
+    let mut cx = Graph::default();
+    let token_ids = cx.tensor(SEQ_LEN).as_dtype(DType::Int);
+    let table = cx.tensor((VOCAB_SIZE, EMBED_DIM)).as_dtype(DType::Bf16);
+    let output = table
+        .gather(
+            (token_ids * EMBED_DIM).expand_dim(1, EMBED_DIM)
+                + cx.arange(EMBED_DIM).expand_dim(0, SEQ_LEN),
+        )
+        .output();
+    let token_data = [6, 1, 4, 0];
+    let table_data = (0..VOCAB_SIZE * EMBED_DIM)
+        .map(|index| bf16::from_f32(index as f32 / 16.0 - 1.0))
+        .collect::<Vec<_>>();
+    let expected = token_data
+        .iter()
+        .flat_map(|&token| {
+            table_data[token as usize * EMBED_DIM..(token as usize + 1) * EMBED_DIM]
+                .iter()
+                .map(|value| value.to_f32())
+        })
+        .collect::<Vec<_>>();
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    let mut rt = MetalRuntime::initialize(());
+    rt.set_data(token_ids, &token_data);
+    rt.set_data(table, &table_data);
+    rt = search_candidates(&mut cx, rt, 5);
+    rt.allocate_intermediate_buffers(&cx.dyn_map);
+    rt.execute(&cx.dyn_map);
+
+    assert_eq!(rt.get_f32(output), expected);
+}
+
+#[test]
+fn metal_bf16_cast_sum_cast_uses_f32_accumulation() {
+    const ROWS: usize = 4;
+    const COLS: usize = 64;
+
+    let mut cx = Graph::default();
+    let input = cx.tensor((ROWS, COLS)).as_dtype(DType::Bf16);
+    let output = input.cast(DType::F32).sum(1).cast(DType::Bf16).output();
+    let input_data = seeded_data(ROWS * COLS, 1.0, -0.5)
+        .into_iter()
+        .map(bf16::from_f32)
+        .collect::<Vec<_>>();
+    let expected = input_data
+        .chunks_exact(COLS)
+        .map(|row| bf16::from_f32(row.iter().map(|value| value.to_f32()).sum::<f32>()).to_f32())
+        .collect::<Vec<_>>();
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    let mut rt = MetalRuntime::initialize(());
+    rt.set_data(input, &input_data);
+    rt = search_candidates(&mut cx, rt, 5);
+    rt.allocate_intermediate_buffers(&cx.dyn_map);
+    rt.execute(&cx.dyn_map);
+
+    assert_close(&rt.get_f32(output), &expected, 1e-5);
+}
+
+#[test]
+fn metal_bf16_elementwise_roundtrip_matches_per_op_rounding() {
+    let mut cx = Graph::default();
+    let input = cx.tensor(8);
+    let output = ((input.cast(DType::Bf16) * 2.0_f32) + 1.0_f32)
+        .cast(DType::F32)
+        .output();
+    let input_data = [-0.91, -0.63, -0.37, -0.11, 0.13, 0.39, 0.67, 0.93];
+    let expected = input_data.map(|value| {
+        let input_bf16 = bf16::from_f32(value);
+        let product = bf16::from_f32(input_bf16.to_f32() * 2.0);
+        bf16::from_f32(product.to_f32() + 1.0).to_f32()
+    });
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    let mut rt = MetalRuntime::initialize(());
+    rt.set_data(input, &input_data);
+    rt = search_candidates(&mut cx, rt, 5);
+    rt.allocate_intermediate_buffers(&cx.dyn_map);
+    rt.execute(&cx.dyn_map);
+
+    assert_eq!(rt.get_f32(output), expected);
+}
+
+#[test]
+fn metal_bf16_reciprocal_roundtrip_matches_per_op_rounding() {
+    let mut cx = Graph::default();
+    let input = cx.tensor(8);
+    let output = ((input.cast(DType::Bf16).reciprocal()) * 1.0_f32)
+        .cast(DType::F32)
+        .output();
+    let input_data = [1.0, 1.25, 1.5, 1.75, 2.25, 2.5, 3.25, 4.0];
+    let expected = input_data.map(|value| {
+        let input_bf16 = bf16::from_f32(value);
+        let reciprocal = bf16::from_f32(1.0 / input_bf16.to_f32());
+        bf16::from_f32(reciprocal.to_f32() * 1.0).to_f32()
+    });
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    let mut rt = MetalRuntime::initialize(());
+    rt.set_data(input, &input_data);
+    rt = search_candidates(&mut cx, rt, 5);
+    rt.allocate_intermediate_buffers(&cx.dyn_map);
+    rt.execute(&cx.dyn_map);
+
+    assert_eq!(rt.get_f32(output), expected);
+}
+
+#[test]
 fn metal_specialized_matmul() {
     let mut cx = Graph::default();
     let a = cx.tensor((TRANSFORMER_SEQ, TRANSFORMER_HIDDEN));
@@ -1008,6 +1149,78 @@ fn metal_regular_tiled_matmul_path() {
     let expected: Vec<f32> = expected.flatten_all().unwrap().to_vec1().unwrap();
 
     assert_close(&result, &expected, 2e-3);
+}
+
+#[test]
+fn metal_bf16_matmul_uses_generic_f32_accumulator() {
+    const M: usize = 2;
+    const K: usize = 4;
+    const N: usize = 3;
+
+    let mut cx = Graph::default();
+    let a = cx.tensor((M, K)).as_dtype(DType::Bf16);
+    let b = cx.tensor((K, N)).as_dtype(DType::Bf16);
+    let output = a.matmul(b).cast(DType::F32).output();
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    assert!(
+        !egraph_has_op(&cx, "MPSMatmul"),
+        "MPSMatrix must not be selectable for unsupported BF16 storage"
+    );
+    assert!(
+        egraph_has_op(&cx, "GenericMatmul"),
+        "BF16 matmul must retain the generic Metal fallback"
+    );
+
+    let a_values = [1.0, -2.0, 0.5, 4.0, -1.0, 3.0, 2.0, -0.5];
+    let b_values = [
+        0.5, 2.0, -1.0, 3.0, -0.5, 1.0, 2.0, 1.5, 0.25, -1.0, 4.0, 2.0,
+    ];
+    let a_data = a_values.map(bf16::from_f32);
+    let b_data = b_values.map(bf16::from_f32);
+    let mut expected = vec![0.0; M * N];
+    for row in 0..M {
+        for col in 0..N {
+            let sum = (0..K)
+                .map(|inner| a_data[row * K + inner].to_f32() * b_data[inner * N + col].to_f32())
+                .sum::<f32>();
+            expected[row * N + col] = bf16::from_f32(sum).to_f32();
+        }
+    }
+
+    let mut rt = MetalRuntime::initialize(());
+    rt.set_data(a, &a_data);
+    rt.set_data(b, &b_data);
+    rt = search_candidates(&mut cx, rt, 8);
+    assert!(
+        rt.debug_kernel_ops()
+            .iter()
+            .any(|op| op.contains("GenericMatmul")),
+        "BF16 matmul must lower to GenericMatmul, selected ops: {:?}",
+        rt.debug_kernel_ops()
+    );
+    rt.allocate_intermediate_buffers(&cx.dyn_map);
+    rt.execute(&cx.dyn_map);
+
+    assert_close(&rt.get_f32(output), &expected, 0.001);
+}
+
+#[test]
+fn metal_bf16_batched_matmul_rejects_mps() {
+    let mut cx = Graph::default();
+    let a = cx.tensor((2, 3, 4)).as_dtype(DType::Bf16);
+    let b = cx.tensor((2, 4, 5)).as_dtype(DType::Bf16);
+    a.matmul(b).output();
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    assert!(
+        !egraph_has_op(&cx, "MPSBatchedMatmul"),
+        "MPSMatrix must not be selectable for unsupported BF16 storage"
+    );
+    assert!(
+        egraph_has_op(&cx, "GenericMatmul"),
+        "BF16 batched matmul must retain the generic Metal fallback"
+    );
 }
 
 #[test]
@@ -1651,18 +1864,27 @@ fn test_load_safetensors_converts_supported_float_dtypes() {
     let f16_to_f16 = cx.named_tensor("f16_to_f16", 2).as_dtype(DType::F16);
     let f32_to_f16 = cx.named_tensor("f32_to_f16", 2).as_dtype(DType::F16);
     let bf16_to_f16 = cx.named_tensor("bf16_to_f16", 2).as_dtype(DType::F16);
+    let bf16_to_bf16 = cx.named_tensor("bf16_to_bf16", 2).as_dtype(DType::Bf16);
+    let f32_to_bf16 = cx.named_tensor("f32_to_bf16", 2).as_dtype(DType::Bf16);
+    let f16_to_bf16 = cx.named_tensor("f16_to_bf16", 2).as_dtype(DType::Bf16);
 
     let f16_to_f32_out = (f16_to_f32 + 0.0).output();
     let bf16_to_f32_out = (bf16_to_f32 + 0.0).output();
     let f16_to_f16_out = f16_to_f16.cast(DType::F32).output();
     let f32_to_f16_out = f32_to_f16.cast(DType::F32).output();
     let bf16_to_f16_out = bf16_to_f16.cast(DType::F32).output();
+    let bf16_to_bf16_out = bf16_to_bf16.cast(DType::F32).output();
+    let f32_to_bf16_out = f32_to_bf16.cast(DType::F32).output();
+    let f16_to_bf16_out = f16_to_bf16.cast(DType::F32).output();
 
     let f16_to_f32_values = [f16::from_f32(1.5), f16::from_f32(-2.25)];
     let bf16_to_f32_values = [bf16::from_f32(3.5), bf16::from_f32(-4.25)];
     let f16_to_f16_values = [f16::from_f32(5.5), f16::from_f32(-6.25)];
     let f32_to_f16_values = [7.5f32, -8.25];
     let bf16_to_f16_values = [bf16::from_f32(9.5), bf16::from_f32(-10.25)];
+    let bf16_to_bf16_values = [bf16::from_f32(11.5), bf16::from_f32(-12.25)];
+    let f32_to_bf16_values = [13.5f32, -14.25];
+    let f16_to_bf16_values = [f16::from_f32(15.5), f16::from_f32(-16.25)];
     let tensors = [
         (
             "f16_to_f32",
@@ -1694,6 +1916,24 @@ fn test_load_safetensors_converts_supported_float_dtypes() {
             vec![2],
             bytes_of(&bf16_to_f16_values),
         ),
+        (
+            "bf16_to_bf16",
+            Dtype::BF16,
+            vec![2],
+            bytes_of(&bf16_to_bf16_values),
+        ),
+        (
+            "f32_to_bf16",
+            Dtype::F32,
+            vec![2],
+            bytes_of(&f32_to_bf16_values),
+        ),
+        (
+            "f16_to_bf16",
+            Dtype::F16,
+            vec![2],
+            bytes_of(&f16_to_bf16_values),
+        ),
     ];
     let path = write_test_safetensors(&tensors);
 
@@ -1709,6 +1949,9 @@ fn test_load_safetensors_converts_supported_float_dtypes() {
     assert_close(&rt.get_f32(f16_to_f16_out), &[5.5, -6.25], 0.001);
     assert_close(&rt.get_f32(f32_to_f16_out), &[7.5, -8.25], 0.001);
     assert_close(&rt.get_f32(bf16_to_f16_out), &[9.5, -10.25], 0.001);
+    assert_close(&rt.get_f32(bf16_to_bf16_out), &[11.5, -12.25], 0.001);
+    assert_close(&rt.get_f32(f32_to_bf16_out), &[13.5, -14.25], 0.001);
+    assert_close(&rt.get_f32(f16_to_bf16_out), &[15.5, -16.25], 0.001);
     std::fs::remove_file(path).ok();
 }
 


### PR DESCRIPTION
MPSMatmul currently supports only F32 and F16 storage, so restrict its rewrites to those dtypes and use the generic Metal matmul path for BF16.