### PR TITLE
metal: guard every dtype source, not just Input nodes

### DIFF
--- a/crates/luminal_metal/src/dyn_backend.rs
+++ b/crates/luminal_metal/src/dyn_backend.rs
@@ -33,32 +33,60 @@ impl DynBackend for MetalDynBackend {
     }
 }
 
-/// Reject dtypes the Metal kernel emitters don't support.
+/// Dtypes the Metal kernel emitters cannot lower.
 ///
 /// Metal codegen has no native 64-bit integer or 64-bit float paths.
-/// Reaching the kernel emitter with one of these dtypes used to panic deep
-/// in MSL generation with an unhelpful error; surfacing a clean message
-/// at translate-time lets the user fall back to CPU or pick a narrower
-/// dtype before any Metal compilation runs.
-fn reject_unsupported_dtype(graph: &Graph) -> Result<(), String> {
+const UNSUPPORTED_DTYPES: [DType; 2] = [DType::I64, DType::F64];
+
+/// The dtype an HLIR node introduces into the graph, with a description of the
+/// node for diagnostics, or `None` if the node only propagates its inputs'
+/// dtypes.
+///
+/// Dtypes enter an HLIR graph at a closed set of ops and propagate onwards from
+/// there, so enumerating the sources covers every node that can carry an
+/// unsupported dtype. The propagated dtype facts themselves live in the e-graph
+/// rather than on the Rust graph, so they cannot be walked directly here.
+fn introduced_dtype(graph: &Graph, node_id: NodeIndex) -> Option<(DType, String)> {
+    let op = (*graph.graph[node_id]).as_any();
+    if let Some(input) = op.downcast_ref::<luminal::hlir::Input>() {
+        return Some((input.dtype, format!("input `{}`", input.label)));
+    }
+    if let Some(cast) = op.downcast_ref::<luminal::hlir::Cast>() {
+        return Some((cast.1, format!("cast to {:?}", cast.1)));
+    }
+    if op.downcast_ref::<luminal::hlir::ConstantF64>().is_some() {
+        return Some((DType::F64, "an F64 constant".to_string()));
+    }
+    if let Some(kind) = op.downcast_ref::<luminal::hlir::CustomOpKind>() {
+        return Some((kind.dtype, format!("custom op {}", kind.id)));
+    }
+    None
+}
+
+/// Reject dtypes the Metal kernel emitters don't support.
+///
+/// Reaching the kernel emitter with one of these dtypes panics deep in MSL
+/// generation with an unhelpful error (`Metal dtype Int64 is not supported
+/// yet`), or, for F64, leaves the node unlowered and panics in the runtime;
+/// surfacing a clean message at translate-time lets the user fall back to CPU
+/// or pick a narrower dtype before any Metal compilation runs.
+///
+/// The invariant is that no node in the graph may introduce a dtype Metal
+/// codegen cannot emit — not merely that no *input* may, since ops such as
+/// `Cast` and `ConstantF64` introduce dtypes with no input node involved.
+pub(crate) fn reject_unsupported_dtype(graph: &Graph) -> Result<(), String> {
     for node_id in graph.graph.node_indices() {
-        if let Some(input) = (*graph.graph[node_id])
-            .as_any()
-            .downcast_ref::<luminal::hlir::Input>()
-        {
-            match input.dtype {
-                DType::I64 | DType::F64 => {
-                    return Err(format!(
-                        "Metal backend does not support {:?} (input `{}`). \
-                         Metal codegen has no native 64-bit kernels; either \
-                         narrow the dtype (e.g. `.to(torch.int32)` / \
-                         `.to(torch.float32)`) before the boundary or \
-                         compile with the CPU / CUDA backend.",
-                        input.dtype, input.label
-                    ));
-                }
-                _ => {}
-            }
+        let Some((dtype, source)) = introduced_dtype(graph, node_id) else {
+            continue;
+        };
+        if UNSUPPORTED_DTYPES.contains(&dtype) {
+            return Err(format!(
+                "Metal backend does not support {dtype:?} ({source}). \
+                 Metal codegen has no native 64-bit kernels; either \
+                 narrow the dtype (e.g. `.to(torch.int32)` / \
+                 `.to(torch.float32)`) before the boundary or \
+                 compile with the CPU / CUDA backend."
+            ));
         }
     }
     Ok(())

--- a/crates/luminal_metal/src/tests.rs
+++ b/crates/luminal_metal/src/tests.rs
@@ -1977,3 +1977,66 @@ fn metal_constant_negative_infinity_mask_matches_reference() {
         "expected all -inf, got {metal:?}"
     );
 }
+/// Compile `build`'s graph through the `DynBackend` factory, returning the
+/// factory's error if it rejected the graph.
+fn metal_factory_error(build: impl Fn(&mut Graph)) -> Option<String> {
+    use luminal::dyn_backend::BackendCompileArgs;
+    let mut cx = Graph::default();
+    build(&mut cx);
+    let args = BackendCompileArgs {
+        search_iters: 1,
+        weights: Vec::new(),
+        tensor_sizes: HashMap::new(),
+        device_ptrs: HashMap::new(),
+    };
+    crate::dyn_backend::metal_factory(&mut cx, args).err()
+}
+
+#[test]
+fn metal_factory_rejects_i64_introduced_by_cast() {
+    // `constant_i64` builds its value from Iota limbs cast to I64. The graph
+    // has no I64 `Input`, so the dtype comes only from the casts. Reaching
+    // codegen panics with "Metal dtype Int64 is not supported yet".
+    let err = metal_factory_error(|cx| {
+        let c = cx.constant_i64(1_234_567_890_123);
+        c.cast(DType::F32).output();
+    })
+    .expect("expected the factory to reject an I64 graph");
+    assert!(
+        err.contains(&format!("{:?}", DType::I64)),
+        "error should name the offending dtype, got: {err}"
+    );
+}
+
+#[test]
+fn metal_factory_rejects_f64_constant() {
+    // `ConstantF64` introduces F64 with no input node and has no Metal
+    // rewrite, so it otherwise survives to the runtime as an unlowered node.
+    let err = metal_factory_error(|cx| {
+        let c = cx.constant_float64(1.5);
+        c.cast(DType::F32).output();
+    })
+    .expect("expected the factory to reject an F64 graph");
+    assert!(
+        err.contains(&format!("{:?}", DType::F64)),
+        "error should name the offending dtype, got: {err}"
+    );
+}
+
+#[test]
+fn metal_dtype_guard_accepts_supported_dtypes() {
+    // The guard must not reject dtypes Metal does emit. This calls the guard
+    // directly, not the factory, because the factory would go on to compile
+    // and execute the graph, which needs input data this test does not supply.
+    let mut cx = Graph::default();
+    let a = cx.named_tensor("a", 4);
+    let b = cx.named_tensor("b", 4).cast(DType::F16).cast(DType::F32);
+    let c = cx.constant(3);
+    (a + b + c.cast(DType::F32).expand_dim(0, 4)).output();
+
+    assert_eq!(
+        crate::dyn_backend::reject_unsupported_dtype(&cx),
+        Ok(()),
+        "guard rejected a graph using only Metal-supported dtypes"
+    );
+}


### PR DESCRIPTION
## Problem

`reject_unsupported_dtype` only checks `Input` nodes. Dtypes also enter a graph through `Cast`, `ConstantF64`, and `CustomOpKind`, so those graphs slip past the guard and panic in codegen.

```rust
cx.constant_i64(1_234_567_890_123)
```

```
panicked at crates/luminal_metal/src/kernel/ops.rs:103:14:
Metal dtype Int64 is not supported yet
```

`constant_i64` builds its value from `Iota` limbs cast to I64, so the graph has no I64 `Input` at all. The dtype comes only from the casts, which the guard never looked at.

`cx.constant_float64(1.5)` fails the same way at `runtime.rs:692` with "cannot execute unlowered LLIR node".

## Fix

Check every op that introduces a dtype. Dtypes enter HLIR at four ops and propagate from there, so covering the sources covers the whole graph:

| op | dtype |
|---|---|
| `Input` | `.dtype` |
| `Cast` | target dtype |
| `ConstantF64` | F64 |
| `CustomOpKind` | `.dtype` |

The invariant is that no node may introduce a dtype Metal cannot emit, rather than that no input may. The propagated dtype facts live in the e-graph, not the Rust graph, so they cannot be walked here directly.

## Tests

| test | asserts |
|---|---|
| `metal_factory_rejects_i64_introduced_by_cast` | clean `Err` naming the dtype |
| `metal_factory_rejects_f64_constant` | clean `Err` naming the dtype |
| `metal_dtype_guard_accepts_supported_dtypes` | an F32/F16/Int graph is still accepted |

Both rejection tests panic on `main` and pass here. The third guards against the wider walk over-rejecting.

## Verified locally

M1 Pro, macOS 15:

```
cargo test --release -p luminal_metal -- --test-threads=1   58 passed, 0 failed
cargo clippy -p luminal_metal --all-targets                 clean
cargo fmt --all --check                                     clean
```

## Scope

This covers the `DynBackend` path, where the guard runs. `cx.compile::<MetalRuntime>(..)` called directly still panics, since adding a check there would change the core compile signature. Happy to follow up if you want that too.
