### PR TITLE
Allow vLLM FX region compilation

### DIFF
--- a/crates/luminal_cuda_lite/src/tests/consumed_buffer_tests.rs
+++ b/crates/luminal_cuda_lite/src/tests/consumed_buffer_tests.rs
@@ -192,6 +192,56 @@ fn test_scatter_nocopy_candidate_rejected_when_dest_has_unordered_read() {
         .expect("the copying scatter remains a legal candidate");
 }
 
+/// Search must be able to select copying scatters when several results read
+/// the same logical destination and therefore cannot mutate it in place.
+#[test]
+fn test_scatter_search_handles_shared_destination_branches() {
+    let ctx = CudaContext::new(0).unwrap();
+    ctx.bind_to_thread().unwrap();
+    let stream = ctx.default_stream();
+
+    let mut cx = Graph::default();
+    let dest = cx.tensor(8).persist();
+    let indexes = cx.tensor(8).as_dtype(DType::Int).persist();
+    let zero = cx.tensor(8).persist();
+    let shared = zero.scatter(indexes, dest);
+    let sources: Vec<_> = (0..4).map(|_| cx.tensor(8).persist()).collect();
+    for source in &sources {
+        source.scatter(indexes, shared).output();
+    }
+
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let mut runtime = CudaRuntime::initialize(stream);
+    runtime.set_data(dest, vec![0.0f32; 8]);
+    runtime.set_data(indexes, (0..8).collect::<Vec<i32>>());
+    runtime.set_data(zero, vec![0.0f32; 8]);
+    for (value, source) in sources.into_iter().enumerate() {
+        runtime.set_data(source, vec![value as f32; 8]);
+    }
+
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(0x5CA7_5A4E);
+    runtime = cx.search_with_rng(
+        runtime,
+        CompileOptions::default().search_graph_limit(1),
+        &mut rng,
+    );
+    let scatter_names: Vec<_> = runtime
+        .kernel_names()
+        .iter()
+        .copied()
+        .filter(|name| name.contains("Scatter"))
+        .collect();
+    assert_eq!(scatter_names.len(), 5);
+    assert!(
+        scatter_names
+            .iter()
+            .filter(|&&name| name == "ScatterNoCopy")
+            .count()
+            <= 1,
+        "shared destination branches must use copying scatter: {scatter_names:?}",
+    );
+}
+
 /// Candidate-local validation follows every edge, including reads where the
 /// destination is not the first input (Gather takes indexes before data).
 #[test]

--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -393,14 +393,13 @@ impl CompiledGraph {
         let mut inferred = HashMap::new();
         for (shape_exprs, shape) in self.input_shape_exprs.iter().zip(input_shapes.iter()) {
             for (dim_expr, &dim_val) in shape_exprs.iter().zip(shape.iter()) {
-                if let Some((var, value)) = solve_single_var_dim(dim_expr, dim_val) {
-                    if let Some(previous) = inferred.insert(var, value)
-                        && previous != value
-                    {
-                        return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                            "a dynamic dimension was inferred as both {previous} and {value}"
-                        )));
-                    }
+                if let Some((var, value)) = solve_single_var_dim(dim_expr, dim_val)
+                    && let Some(previous) = inferred.insert(var, value)
+                    && previous != value
+                {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "a dynamic dimension was inferred as both {previous} and {value}"
+                    )));
                 }
             }
         }

--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -35,6 +35,29 @@ fn copy_host_bytes(ptr: u64, n_bytes: usize, buffer_kind: &str) -> PyResult<Vec<
 /// Maps symbolic dimension parameter names (e.g. "seq_len") to their dim symbol.
 pub type DimParamMap = HashMap<String, Symbol>;
 
+/// Inclusive runtime bounds for symbolic dimensions.
+pub type DimBoundsMap = HashMap<Symbol, (Option<usize>, Option<usize>)>;
+
+fn check_dim_bounds(
+    name: &str,
+    value: usize,
+    bounds: Option<&(Option<usize>, Option<usize>)>,
+) -> PyResult<()> {
+    let Some((minimum, maximum)) = bounds else {
+        return Ok(());
+    };
+    if minimum.is_some_and(|minimum| value < minimum)
+        || maximum.is_some_and(|maximum| value > maximum)
+    {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "dynamic dimension '{name}' expected value in [{}, {}], got {value}",
+            minimum.map_or_else(|| "-inf".to_string(), |value| value.to_string()),
+            maximum.map_or_else(|| "inf".to_string(), |value| value.to_string()),
+        )));
+    }
+    Ok(())
+}
+
 /// Recover a single-variable dim's variable value from an observed runtime size.
 ///
 /// Returns `Some((var, value))` when the expression contains exactly one
@@ -118,6 +141,7 @@ pub struct GraphTranslation {
     pub output_dtypes: Vec<u32>,
     pub input_shape_exprs: Vec<Vec<Expression>>,
     pub dim_param_map: DimParamMap,
+    pub dim_bounds: DimBoundsMap,
     /// (output position, user-input name) for outputs that write back into a
     /// user input's buffer (in-place state updates like HF StaticCache k/v).
     pub writeback_outputs: Vec<(usize, String)>,
@@ -151,6 +175,7 @@ pub struct CompiledGraph {
     pub output_dtypes: Vec<u32>,
     pub input_shape_exprs: Vec<Vec<Expression>>,
     pub dim_param_map: DimParamMap,
+    pub dim_bounds: DimBoundsMap,
     /// See [`GraphTranslation::writeback_outputs`].
     pub writeback_outputs: Vec<(usize, String)>,
 }
@@ -178,6 +203,7 @@ impl CompiledGraph {
             output_dtypes,
             input_shape_exprs,
             dim_param_map,
+            dim_bounds,
             writeback_outputs,
         } = translation;
         let WeightData {
@@ -201,10 +227,16 @@ impl CompiledGraph {
         let rt =
             luminal::dyn_backend::compile_backend_from_factory(factory, &mut graph, compile_args)?;
 
-        // Resolve concrete output shapes from expressions
+        // Dynamic dimensions were initialized before backend compilation, so
+        // these are the representative output shapes used for this artifact.
         let output_shapes: Vec<Vec<usize>> = output_shape_exprs
             .iter()
-            .map(|exprs| exprs.iter().map(|e| e.to_usize().unwrap_or(1)).collect())
+            .map(|exprs| {
+                exprs
+                    .iter()
+                    .map(|e| e.exec(&graph.dyn_map).or_else(|| e.to_usize()).unwrap_or(1))
+                    .collect()
+            })
             .collect();
 
         let label_map = luminal::dyn_backend::build_label_map(&graph);
@@ -223,6 +255,7 @@ impl CompiledGraph {
             output_dtypes,
             input_shape_exprs,
             dim_param_map,
+            dim_bounds,
             writeback_outputs,
         })
     }
@@ -334,6 +367,7 @@ impl CompiledGraph {
                 self.dim_param_map.keys().collect::<Vec<_>>()
             ))
         })?;
+        check_dim_bounds(param_name, value, self.dim_bounds.get(ch))?;
         self.graph.set_dim(*ch, value);
         Ok(())
     }
@@ -355,14 +389,32 @@ impl CompiledGraph {
     ///
     /// Multi-variable dims are skipped here; another input's shape — or an
     /// explicit `set_dim` call — is expected to bind those.
-    fn auto_set_dims_from_input_shapes(&mut self, input_shapes: Vec<Vec<usize>>) {
+    fn auto_set_dims_from_input_shapes(&mut self, input_shapes: Vec<Vec<usize>>) -> PyResult<()> {
+        let mut inferred = HashMap::new();
         for (shape_exprs, shape) in self.input_shape_exprs.iter().zip(input_shapes.iter()) {
             for (dim_expr, &dim_val) in shape_exprs.iter().zip(shape.iter()) {
                 if let Some((var, value)) = solve_single_var_dim(dim_expr, dim_val) {
-                    self.graph.set_dim(var, value);
+                    if let Some(previous) = inferred.insert(var, value)
+                        && previous != value
+                    {
+                        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                            "a dynamic dimension was inferred as both {previous} and {value}"
+                        )));
+                    }
                 }
             }
         }
+
+        for (symbol, value) in inferred {
+            let name = self
+                .dim_param_map
+                .iter()
+                .find_map(|(name, candidate)| (*candidate == symbol).then_some(name.as_str()))
+                .unwrap_or("<unknown>");
+            check_dim_bounds(name, value, self.dim_bounds.get(&symbol))?;
+            self.graph.set_dim(symbol, value);
+        }
+        Ok(())
     }
 
     /// Resolve output shapes using current dynamic dimension values.

--- a/crates/luminal_python/rust/src/pt2_compiled_model.rs
+++ b/crates/luminal_python/rust/src/pt2_compiled_model.rs
@@ -5,7 +5,9 @@ use pyo3::prelude::*;
 use pyo3::types::{PyCapsule, PyCapsuleMethods};
 use std::collections::HashMap;
 
-use crate::compiled_graph::{CompiledGraph, DimParamMap, GraphTranslation, WeightData};
+use crate::compiled_graph::{
+    CompiledGraph, DimBoundsMap, DimParamMap, GraphTranslation, WeightData,
+};
 use crate::pt2_expr::parse_sympy_expr;
 use crate::pt2_parser;
 use crate::pt2_schema;
@@ -200,12 +202,11 @@ pub fn translate_pt2(
     let translated = translator::translate(&parsed)?;
     let mut graph = translated.graph;
 
-    // Set initial dynamic dim values from symbol ranges. PT2 emits
-    // `min_val: null` when the constraint is unbounded; fall back to 1 in
-    // that case (the smallest valid dim — used only as an initial value).
+    // Compile bounded graphs at their largest supported shape. Unbounded
+    // dimensions fall back to their minimum, then to 1.
     for (sym_name, c) in &translated.sym_map.sym_to_symbol {
         if let Some(rc) = translated.sym_map.ranges.get(sym_name) {
-            let initial = rc.min_val.unwrap_or(1).max(0) as usize;
+            let initial = rc.max_val.or(rc.min_val).unwrap_or(1).max(0) as usize;
             graph.set_dim(*c, initial);
         }
     }
@@ -320,10 +321,15 @@ pub fn translate_pt2(
         if !tensor_sizes.contains_key(name)
             && let Some(meta) = parsed.tensor_meta(name)
         {
-            let n: usize = meta
-                .sizes
+            let shape = resolve_dim_sizes(&meta.sizes, &translated.sym_map.sym_to_symbol);
+            let n: usize = shape
                 .iter()
-                .map(|s| s.hint().unwrap_or(1) as usize)
+                .zip(&meta.sizes)
+                .map(|(dim, meta_dim)| {
+                    dim.exec(&graph.dyn_map)
+                        .or_else(|| meta_dim.hint().map(|hint| hint as usize))
+                        .unwrap_or(1)
+                })
                 .product::<usize>()
                 * TorchDType::from_code(meta.dtype)
                     .map(TorchDType::storage_factor)
@@ -332,6 +338,32 @@ pub fn translate_pt2(
         }
     }
 
+    let mut dim_bounds = DimBoundsMap::new();
+    for (name, symbol) in &translated.sym_map.sym_to_symbol {
+        let Some(range) = translated.sym_map.ranges.get(name) else {
+            continue;
+        };
+        let minimum = range
+            .min_val
+            .map(|value| {
+                usize::try_from(value)
+                    .map_err(|_| anyhow::anyhow!("negative minimum for dynamic dimension {name}"))
+            })
+            .transpose()?;
+        let maximum = range
+            .max_val
+            .map(|value| {
+                usize::try_from(value)
+                    .map_err(|_| anyhow::anyhow!("negative maximum for dynamic dimension {name}"))
+            })
+            .transpose()?;
+        if let (Some(minimum), Some(maximum)) = (minimum, maximum)
+            && maximum < minimum
+        {
+            anyhow::bail!("invalid range for dynamic dimension {name}: [{minimum}, {maximum}]");
+        }
+        dim_bounds.insert(*symbol, (minimum, maximum));
+    }
     let dim_param_map: DimParamMap = translated.sym_map.sym_to_symbol;
 
     let translation = GraphTranslation {
@@ -345,6 +377,7 @@ pub fn translate_pt2(
         output_shape_exprs,
         input_shape_exprs,
         dim_param_map,
+        dim_bounds,
         writeback_outputs: parsed.writeback_outputs(),
     };
 

--- a/crates/luminal_python/rust/src/pt2_schema.rs
+++ b/crates/luminal_python/rust/src/pt2_schema.rs
@@ -19,11 +19,8 @@ pub struct RangeConstraint {
     /// constraint is unbounded (no min set), so this must accept None.
     #[serde(default)]
     pub min_val: Option<i64>,
-    /// Upper bound on a symbolic dimension. Also nullable in PT2. Currently
-    /// unused on the luminal side, but accepted to avoid deserialization
-    /// errors when PT2 emits it.
+    /// Upper bound on a symbolic dimension. Also nullable in PT2.
     #[serde(default)]
-    #[allow(dead_code)]
     pub max_val: Option<i64>,
 }
 

--- a/crates/luminal_python/src/luminal/__init__.py
+++ b/crates/luminal_python/src/luminal/__init__.py
@@ -8,6 +8,7 @@ from .compiled_model import CompiledModel
 # Import Rust extension components (built by maturin)
 from .luminal import CompiledGraph, process_pt2
 from .main import luminal_backend, register_backend
+from .region_compile import compile_region
 
 _register_cache_serialization()
 
@@ -17,5 +18,6 @@ __all__ = [
     "luminal_backend",
     "register_backend",
     "CompiledGraph",
+    "compile_region",
     "process_pt2",
 ]

--- a/crates/luminal_python/src/luminal/pt2.py
+++ b/crates/luminal_python/src/luminal/pt2.py
@@ -460,7 +460,7 @@ def _strip_symint_placeholders(gm, example_inputs):
     return new_inputs, kept_indices, True
 
 
-def _build_dynamic_shapes_from_gm(gm):
+def _build_dynamic_shapes_from_gm(gm, dynamic_range=None):
     """Construct a torch.export.export `dynamic_shapes` spec from FX metadata.
 
     Walks each tensor placeholder's `meta['example_value']` FakeTensor and
@@ -478,6 +478,13 @@ def _build_dynamic_shapes_from_gm(gm):
     from torch.export import Dim
 
     placeholders = [n for n in gm.graph.nodes if n.op == "placeholder"]
+
+    if dynamic_range is not None:
+        minimum, maximum = dynamic_range
+        if minimum < 0 or maximum < minimum:
+            raise ValueError(f"invalid dynamic range [{minimum}, {maximum}]")
+        if minimum == maximum:
+            return None
 
     per_input_spec = []
     saw_dynamic = False

--- a/crates/luminal_python/src/luminal/pt2.py
+++ b/crates/luminal_python/src/luminal/pt2.py
@@ -309,6 +309,11 @@ def _save_and_compile(
     try:
         if owns_tmpdir:
             pt2_path = os.path.join(tmpdir, "model.pt2")
+            # `_example_inputs` is an optional copy of the arguments used to create an
+            # ExportedProgram and is not part of the executable graph's semantics. vLLM
+            # invokes compiler backends during torch.compile tracing, so these inputs may
+            # be FakeTensors, which Luminal does not currently serialize or consume.
+            ep_or_path._example_inputs = None
             _lower_sym_sum(ep_or_path)  # serde gap workaround; see docstring
             torch.export.save(ep_or_path, pt2_path)
             weight_source = ep_or_path.state_dict
@@ -817,10 +822,6 @@ def _eager_pt2_compile(
     # alive during compile would double weight memory on GPU.
     tmpdir = tempfile.mkdtemp(prefix="luminal_")
     pt2_path = os.path.join(tmpdir, "model.pt2")
-    # torch.export.save pickles ep.example_inputs (real tensor data) into the
-    # archive; with weights flowing as inputs that is the entire parameter
-    # set per compile. Nothing reads them back — drop before saving.
-    ep._example_inputs = None
     _lower_sym_sum(ep)  # serde gap workaround; see docstring
     torch.export.save(ep, pt2_path)
 

--- a/crates/luminal_python/src/luminal/pt2.py
+++ b/crates/luminal_python/src/luminal/pt2.py
@@ -469,10 +469,8 @@ def _build_dynamic_shapes_from_gm(gm, dynamic_range=None):
     """Construct a torch.export.export `dynamic_shapes` spec from FX metadata.
 
     Walks each tensor placeholder's `meta['example_value']` FakeTensor and
-    marks every SymInt dim as `Dim.AUTO`. Sharing/equality relationships
-    between symbolic dims are already encoded in the FakeTensor shapes —
-    torch.export's symbolic-shape engine recovers them during the trace, so
-    we don't need to allocate named `Dim` objects ourselves.
+    marks every SymInt dimension as dynamic. Bounded exports reuse the same
+    `Dim` object wherever the same original FakeTensor symbol appears.
 
     The returned spec is wrapped under `{"args": (...)}` because Dynamo's
     `GraphModule.forward(*args, **kwargs)` signature treats positional inputs
@@ -491,8 +489,19 @@ def _build_dynamic_shapes_from_gm(gm, dynamic_range=None):
         if minimum == maximum:
             return None
 
+        # torch.export specializes dimensions of size 0 and 1 instead of
+        # representing them with a backed symbolic Dim. Ranged artifacts must
+        # therefore start at 2 or higher; exact 0/1 artifacts take the static
+        # path above.
+        effective_minimum = max(2, minimum)
+        if maximum < effective_minimum:
+            raise ValueError(
+                f"dynamic range [{minimum}, {maximum}] has no symbolic values"
+            )
+
     per_input_spec = []
     saw_dynamic = False
+    bounded_dims = {}
     for node in placeholders:
         ev = node.meta.get("example_value")
         if not torch.is_tensor(ev):
@@ -501,7 +510,20 @@ def _build_dynamic_shapes_from_gm(gm, dynamic_range=None):
         spec = {}
         for d, s in enumerate(ev.shape):
             if isinstance(s, torch.SymInt):
-                spec[d] = Dim.AUTO
+                if dynamic_range is None:
+                    spec[d] = Dim.AUTO
+                else:
+                    # The fresh export inputs deliberately carry independent
+                    # symbols. Reusing this Dim is the one place that restores
+                    # equality between occurrences of the original symbol.
+                    key = str(s.node.expr)
+                    if key not in bounded_dims:
+                        bounded_dims[key] = Dim(
+                            f"luminal_dim_{len(bounded_dims)}",
+                            min=effective_minimum,
+                            max=dynamic_range[1],
+                        )
+                    spec[d] = bounded_dims[key]
                 saw_dynamic = True
         per_input_spec.append(spec if spec else None)
 

--- a/crates/luminal_python/src/luminal/region_abi.py
+++ b/crates/luminal_python/src/luminal/region_abi.py
@@ -1,0 +1,190 @@
+"""Storage-free metadata for a compiled graph region boundary.
+
+The types in this module describe what a region requires without retaining
+PyTorch tensors or inspecting their storage.  Compilation may construct these
+specifications from FakeTensors; real storage addresses belong to a later
+runtime binding phase.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TypeAlias
+
+import torch
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolSpec:
+    """A symbolic scalar expression carried by captured graph metadata."""
+
+    expression: str
+
+    def __post_init__(self) -> None:
+        if not self.expression.strip():
+            raise ValueError("symbol expression must not be empty")
+
+
+Dimension: TypeAlias = int | SymbolSpec
+ScalarValue: TypeAlias = bool | int | float | SymbolSpec
+
+
+def _dimension(value: int | torch.SymInt) -> Dimension:
+    if isinstance(value, torch.SymInt):
+        return SymbolSpec(str(value))
+    return int(value)
+
+
+@dataclass(frozen=True, slots=True)
+class TensorSpec:
+    """Tensor metadata that is safe to collect from a FakeTensor."""
+
+    dtype: str
+    device_type: str
+    device_index: int | None
+    layout: str
+    shape: tuple[Dimension, ...]
+    stride: tuple[Dimension, ...]
+    storage_offset: Dimension
+    requires_grad: bool
+
+    def __post_init__(self) -> None:
+        if not self.dtype:
+            raise ValueError("tensor dtype must not be empty")
+        if not self.device_type:
+            raise ValueError("tensor device type must not be empty")
+        if not self.layout:
+            raise ValueError("tensor layout must not be empty")
+        if len(self.shape) != len(self.stride):
+            raise ValueError("tensor shape and stride must have the same rank")
+        if any(isinstance(dim, int) and dim < 0 for dim in self.shape):
+            raise ValueError("concrete tensor dimensions must be non-negative")
+        if isinstance(self.storage_offset, int) and self.storage_offset < 0:
+            raise ValueError("tensor storage offset must be non-negative")
+
+    @classmethod
+    def from_tensor(cls, tensor: torch.Tensor) -> TensorSpec:
+        """Read metadata only; never materialize or inspect tensor storage."""
+
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(f"expected a torch.Tensor, got {type(tensor).__name__}")
+        return cls(
+            dtype=str(tensor.dtype),
+            device_type=tensor.device.type,
+            device_index=tensor.device.index,
+            layout=str(tensor.layout),
+            shape=tuple(_dimension(dim) for dim in tensor.shape),
+            stride=tuple(_dimension(dim) for dim in tensor.stride()),
+            storage_offset=_dimension(tensor.storage_offset()),
+            requires_grad=tensor.requires_grad,
+        )
+
+
+class InputKind(str, Enum):
+    """How a real value will be supplied after compilation."""
+
+    RUNTIME = "runtime"
+    WEIGHT = "weight"
+
+
+ValueSpec: TypeAlias = TensorSpec | ScalarValue
+
+
+@dataclass(frozen=True, slots=True)
+class InputSpec:
+    name: str
+    value: ValueSpec
+    kind: InputKind
+    mutable: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("input name must not be empty")
+        if self.mutable and not isinstance(self.value, TensorSpec):
+            raise ValueError("only tensor inputs can be mutable")
+
+
+@dataclass(frozen=True, slots=True)
+class OutputSpec:
+    name: str
+    value: ValueSpec
+    aliases_input: str | None = None
+    consumer_writable: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("output name must not be empty")
+        if self.consumer_writable and not isinstance(self.value, TensorSpec):
+            raise ValueError("only tensor outputs can be consumer-writable")
+
+
+@dataclass(frozen=True, slots=True)
+class MutationSpec:
+    """A caller-visible input mutation required by region semantics."""
+
+    input_name: str
+
+    def __post_init__(self) -> None:
+        if not self.input_name:
+            raise ValueError("mutation input name must not be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class DynamicRange:
+    """Inclusive bounds for one symbolic runtime value."""
+
+    symbol: str
+    minimum: int
+    maximum: int
+
+    def __post_init__(self) -> None:
+        if not self.symbol:
+            raise ValueError("dynamic range symbol must not be empty")
+        if self.minimum < 0:
+            raise ValueError("dynamic range minimum must be non-negative")
+        if self.maximum < self.minimum:
+            raise ValueError("dynamic range maximum must be at least its minimum")
+
+    @property
+    def is_exact(self) -> bool:
+        return self.minimum == self.maximum
+
+
+@dataclass(frozen=True, slots=True)
+class RegionSpec:
+    """Semantic boundary contract for one compiler-owned graph region."""
+
+    inputs: tuple[InputSpec, ...]
+    outputs: tuple[OutputSpec, ...]
+    mutations: tuple[MutationSpec, ...] = ()
+    dynamic_ranges: tuple[DynamicRange, ...] = ()
+
+    def __post_init__(self) -> None:
+        inputs = {item.name: item for item in self.inputs}
+        if len(inputs) != len(self.inputs):
+            raise ValueError("region input names must be unique")
+
+        output_names = {item.name for item in self.outputs}
+        if len(output_names) != len(self.outputs):
+            raise ValueError("region output names must be unique")
+
+        range_symbols = {item.symbol for item in self.dynamic_ranges}
+        if len(range_symbols) != len(self.dynamic_ranges):
+            raise ValueError("dynamic range symbols must be unique")
+
+        mutated_names = {item.input_name for item in self.mutations}
+        if len(mutated_names) != len(self.mutations):
+            raise ValueError("mutation input names must be unique")
+        for name in mutated_names:
+            if name not in inputs:
+                raise ValueError(f"mutation refers to unknown input {name!r}")
+            if not inputs[name].mutable:
+                raise ValueError(f"mutation input {name!r} is not declared mutable")
+
+        for output in self.outputs:
+            if output.aliases_input is not None and output.aliases_input not in inputs:
+                raise ValueError(
+                    f"output {output.name!r} aliases unknown input "
+                    f"{output.aliases_input!r}"
+                )

--- a/crates/luminal_python/src/luminal/region_compile.py
+++ b/crates/luminal_python/src/luminal/region_compile.py
@@ -1,0 +1,39 @@
+"""Compile a normalized vLLM-style region from exported tensor metadata."""
+
+from __future__ import annotations
+
+from .compiled_model import CompiledModel
+from .pt2 import _save_and_compile
+from .region_export import RegionExport
+
+
+def compile_region(
+    region: RegionExport,
+    *,
+    device_type: str = "cuda",
+    search_iterations: int = 1,
+) -> CompiledModel:
+    """Compile a region without borrowing storage from its example inputs.
+
+    The PT2 program contains the shape and dtype metadata needed to allocate
+    Luminal's search inputs. Real tensor addresses are bound by CompiledModel
+    only when the returned callable is invoked.
+    """
+
+    if device_type != "cuda":
+        raise ValueError(f"unsupported region device type: {device_type!r}")
+
+    try:
+        from .luminal import _cuda_lite_factory_capsule
+    except (ImportError, AttributeError) as error:
+        raise RuntimeError(
+            "region compilation requires luminal_python built with CUDA support"
+        ) from error
+
+    return _save_and_compile(
+        region.program,
+        _cuda_lite_factory_capsule(),
+        search_iterations,
+        user_indices=region.input_indices,
+        input_device_ptrs=None,
+    )

--- a/crates/luminal_python/src/luminal/region_export.py
+++ b/crates/luminal_python/src/luminal/region_export.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import inspect
+from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -19,11 +20,17 @@ from .pt2 import (
 )
 
 
+@dataclass(frozen=True, slots=True)
+class RegionExport:
+    program: torch.export.ExportedProgram
+    input_indices: tuple[int, ...]
+
+
 def export_region(
     graph: fx.GraphModule,
     example_inputs: list[Any],
     dynamic_range: tuple[int, int] | None = None,
-) -> torch.export.ExportedProgram:
+) -> RegionExport:
     """Normalize an FX region without storage access or static fallback.
 
     Dynamo may expose a symbolic tensor dimension as a separate ``SymInt``
@@ -34,7 +41,9 @@ def export_region(
 
     graph = copy.deepcopy(graph).eval()
     _strip_data_attr(graph)
-    inputs, _, strip_ok = _strip_symint_placeholders(graph, list(example_inputs))
+    inputs, input_indices, strip_ok = _strip_symint_placeholders(
+        graph, list(example_inputs)
+    )
     if not strip_ok:
         raise RuntimeError(
             "cannot export region: a SymInt input could not be derived from "
@@ -58,8 +67,9 @@ def export_region(
         _drop_input_guards(exported)
         _drop_dead_data_dependent_ops(exported.graph_module)
         exported = exported.run_decompositions(_decomp_table())
+        _drop_input_guards(exported)
         _set_range_constraints(exported, dynamic_range)
-        return exported
+        return RegionExport(exported, tuple(input_indices))
     except Exception as error:
         raise RuntimeError(
             "torch.export failed for compiler-owned FX region: "

--- a/crates/luminal_python/src/luminal/region_export.py
+++ b/crates/luminal_python/src/luminal/region_export.py
@@ -1,0 +1,121 @@
+"""Strict ``torch.export`` normalization for compiler-owned FX regions."""
+
+from __future__ import annotations
+
+import copy
+import inspect
+from typing import Any
+
+import torch
+from torch import fx
+
+from .pt2 import (
+    _build_dynamic_shapes_from_gm,
+    _decomp_table,
+    _drop_dead_data_dependent_ops,
+    _drop_input_guards,
+    _export_kwargs,
+    _strip_symint_placeholders,
+)
+
+
+def export_region(
+    graph: fx.GraphModule,
+    example_inputs: list[Any],
+    dynamic_range: tuple[int, int] | None = None,
+) -> torch.export.ExportedProgram:
+    """Normalize an FX region without storage access or static fallback.
+
+    Dynamo may expose a symbolic tensor dimension as a separate ``SymInt``
+    argument.  Replace that argument with a tensor-size operation before
+    re-exporting so the exported program has a tensor-only runtime signature.
+    The caller's graph is never modified.
+    """
+
+    graph = copy.deepcopy(graph).eval()
+    _strip_data_attr(graph)
+    inputs, _, strip_ok = _strip_symint_placeholders(graph, list(example_inputs))
+    if not strip_ok:
+        raise RuntimeError(
+            "cannot export region: a SymInt input could not be derived from "
+            "a tensor dimension"
+        )
+
+    dynamic_shapes = _build_dynamic_shapes_from_gm(graph, dynamic_range)
+    has_varargs = any(
+        parameter.kind is inspect.Parameter.VAR_POSITIONAL
+        for parameter in inspect.signature(graph.forward).parameters.values()
+    )
+    if dynamic_shapes is not None and not has_varargs:
+        dynamic_shapes = dynamic_shapes["args"]
+    try:
+        exported = torch.export.export(
+            graph,
+            tuple(inputs),
+            dynamic_shapes=dynamic_shapes,
+            **_export_kwargs(),
+        )
+        _drop_input_guards(exported)
+        _drop_dead_data_dependent_ops(exported.graph_module)
+        exported = exported.run_decompositions(_decomp_table())
+        _set_range_constraints(exported, dynamic_range)
+        return exported
+    except Exception as error:
+        raise RuntimeError(
+            "torch.export failed for compiler-owned FX region: "
+            f"{type(error).__name__}: {error}"
+        ) from error
+
+
+def _strip_data_attr(graph: fx.GraphModule) -> None:
+    """Treat ``Tensor.data`` as identity inside an inference-only region.
+
+    Dynamo represents ``tensor.data`` with the private ``_get_data_attr`` op.
+    If that op reaches ``torch.export``, export may lift the aliased tensor as a
+    constant instead of preserving the original region input. Luminal regions
+    run without autograd, so the detached alias has the same observable value
+    and storage semantics as its source tensor.
+    """
+
+    target = getattr(torch._C._autograd, "_get_data_attr", None)
+    if target is None:
+        return
+
+    changed = False
+    for node in list(graph.graph.nodes):
+        if node.op != "call_function" or node.target is not target:
+            continue
+        if len(node.args) != 1 or node.kwargs:
+            raise RuntimeError("unexpected _get_data_attr invocation")
+        node.replace_all_uses_with(node.args[0])
+        graph.graph.erase_node(node)
+        changed = True
+
+    if changed:
+        graph.graph.lint()
+        graph.recompile()
+
+
+def _set_range_constraints(
+    exported: torch.export.ExportedProgram,
+    dynamic_range: tuple[int, int] | None,
+) -> None:
+    from torch.utils._sympy.value_ranges import ValueRanges
+
+    used_symbols = set()
+    for node in exported.graph_module.graph.nodes:
+        for value in torch.utils._pytree.tree_leaves(node.meta.get("val")):
+            values = (
+                (*value.shape, *value.stride())
+                if isinstance(value, torch.Tensor)
+                else (value,)
+            )
+            for item in values:
+                if isinstance(item, (torch.SymInt, torch.SymFloat, torch.SymBool)):
+                    used_symbols.update(item.node.expr.free_symbols)
+    for symbol in list(exported.range_constraints):
+        if symbol not in used_symbols:
+            del exported.range_constraints[symbol]
+        elif dynamic_range is not None and dynamic_range[0] != dynamic_range[1]:
+            bounds = ValueRanges(max(2, dynamic_range[0]), dynamic_range[1])
+            exported.range_constraints[symbol] &= bounds

--- a/crates/luminal_python/src/luminal/region_export.py
+++ b/crates/luminal_python/src/luminal/region_export.py
@@ -18,12 +18,14 @@ from .pt2 import (
     _export_kwargs,
     _strip_symint_placeholders,
 )
+from .region_abi import DynamicRange
 
 
 @dataclass(frozen=True, slots=True)
 class RegionExport:
     program: torch.export.ExportedProgram
     input_indices: tuple[int, ...]
+    dynamic_ranges: tuple[DynamicRange, ...]
 
 
 def export_region(
@@ -51,6 +53,7 @@ def export_region(
         )
 
     dynamic_shapes = _build_dynamic_shapes_from_gm(graph, dynamic_range)
+    export_inputs = _fresh_export_inputs(inputs)
     has_varargs = any(
         parameter.kind is inspect.Parameter.VAR_POSITIONAL
         for parameter in inspect.signature(graph.forward).parameters.values()
@@ -58,23 +61,79 @@ def export_region(
     if dynamic_shapes is not None and not has_varargs:
         dynamic_shapes = dynamic_shapes["args"]
     try:
-        exported = torch.export.export(
-            graph,
-            tuple(inputs),
-            dynamic_shapes=dynamic_shapes,
-            **_export_kwargs(),
-        )
+        # This backend runs inside Dynamo's tracing context. The normalized
+        # region is a separate export, so it must build its own shape guards
+        # instead of adding them to vLLM's outer ShapeEnv.
+        with torch._guards.tracing(None):
+            exported = torch.export.export(
+                graph,
+                tuple(export_inputs),
+                dynamic_shapes=dynamic_shapes,
+                **_export_kwargs(),
+            )
         _drop_input_guards(exported)
         _drop_dead_data_dependent_ops(exported.graph_module)
         exported = exported.run_decompositions(_decomp_table())
         _drop_input_guards(exported)
-        _set_range_constraints(exported, dynamic_range)
-        return RegionExport(exported, tuple(input_indices))
+        ranges = _set_range_constraints(exported, dynamic_range)
+        return RegionExport(exported, tuple(input_indices), ranges)
     except Exception as error:
         raise RuntimeError(
             "torch.export failed for compiler-owned FX region: "
             f"{type(error).__name__}: {error}"
         ) from error
+
+
+def _fresh_export_inputs(inputs: list[Any]) -> list[Any]:
+    """Detach a second export from Dynamo's original symbolic ShapeEnv.
+
+    Dynamo FakeTensors still refer to symbols and guards from the outer vLLM
+    trace. Recreate only their metadata so our dynamic_shapes specification,
+    rather than those stale outer-trace guards, defines the exported symbols.
+    """
+
+    from torch._dynamo.source import LocalSource
+    from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+    from torch.fx.experimental.symbolic_shapes import DimDynamic, ShapeEnv
+
+    if not any(isinstance(value, FakeTensor) for value in inputs):
+        return inputs
+
+    shape_env = ShapeEnv()
+    fake_mode = FakeTensorMode(shape_env=shape_env)
+    symbol_index = 0
+
+    def fresh_dim(dim: Any) -> int | torch.SymInt:
+        nonlocal symbol_index
+        if not isinstance(dim, torch.SymInt):
+            return int(dim)
+        hint = dim.node.hint
+        if hint is None:
+            raise RuntimeError(
+                f"symbolic dimension {dim.node.expr} has no concrete hint"
+            )
+        name = f"luminal_export_dim_{symbol_index}"
+        symbol_index += 1
+        return shape_env.create_symintnode(
+            shape_env.create_symbol(
+                int(hint), LocalSource(name), dynamic_dim=DimDynamic.DYNAMIC
+            ),
+            hint=int(hint),
+        )
+
+    with fake_mode:
+        return [
+            torch.empty_strided(
+                tuple(fresh_dim(dim) for dim in value.shape),
+                tuple(int(dim) for dim in value.stride()),
+                dtype=value.dtype,
+                device=value.device,
+                requires_grad=value.requires_grad,
+            )
+            if torch.is_tensor(value)
+            else value
+            for value in inputs
+        ]
 
 
 def _strip_data_attr(graph: fx.GraphModule) -> None:
@@ -109,7 +168,7 @@ def _strip_data_attr(graph: fx.GraphModule) -> None:
 def _set_range_constraints(
     exported: torch.export.ExportedProgram,
     dynamic_range: tuple[int, int] | None,
-) -> None:
+) -> tuple[DynamicRange, ...]:
     from torch.utils._sympy.value_ranges import ValueRanges
 
     used_symbols = set()
@@ -126,6 +185,31 @@ def _set_range_constraints(
     for symbol in list(exported.range_constraints):
         if symbol not in used_symbols:
             del exported.range_constraints[symbol]
-        elif dynamic_range is not None and dynamic_range[0] != dynamic_range[1]:
-            bounds = ValueRanges(max(2, dynamic_range[0]), dynamic_range[1])
-            exported.range_constraints[symbol] &= bounds
+
+    if dynamic_range is None or dynamic_range[0] == dynamic_range[1]:
+        return ()
+    if len(exported.range_constraints) != 1:
+        raise RuntimeError(
+            "ranged region export requires exactly one dynamic dimension, "
+            f"found {len(exported.range_constraints)}"
+        )
+
+    minimum, maximum = dynamic_range
+    effective_minimum = max(2, minimum)
+    if maximum < effective_minimum:
+        raise RuntimeError(
+            f"dynamic range [{minimum}, {maximum}] has no values supported "
+            "by torch.export; sizes 0 and 1 require exact artifacts"
+        )
+
+    symbol, constraint = next(iter(exported.range_constraints.items()))
+    constraint &= ValueRanges(effective_minimum, maximum)
+    exported.range_constraints[symbol] = constraint
+    try:
+        lower = int(constraint.lower)
+        upper = int(constraint.upper)
+    except (TypeError, ValueError, OverflowError) as error:
+        raise RuntimeError(
+            f"dynamic dimension {symbol} does not have finite bounds"
+        ) from error
+    return (DynamicRange(str(symbol), lower, upper),)

--- a/crates/luminal_python/tests/test_region_abi.py
+++ b/crates/luminal_python/tests/test_region_abi.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from luminal.region_abi import (
+    DynamicRange,
+    InputKind,
+    InputSpec,
+    MutationSpec,
+    OutputSpec,
+    RegionSpec,
+    SymbolSpec,
+    TensorSpec,
+)
+
+
+def _tensor_spec(**overrides) -> TensorSpec:
+    values = {
+        "dtype": "torch.float16",
+        "device_type": "cuda",
+        "device_index": 0,
+        "layout": "torch.strided",
+        "shape": (4, 8),
+        "stride": (8, 1),
+        "storage_offset": 0,
+        "requires_grad": False,
+    }
+    values.update(overrides)
+    return TensorSpec(**values)
+
+
+def test_tensor_spec_collects_noncontiguous_metadata() -> None:
+    tensor = torch.arange(20, dtype=torch.float32).reshape(4, 5).t()
+
+    spec = TensorSpec.from_tensor(tensor)
+
+    assert spec == TensorSpec(
+        dtype="torch.float32",
+        device_type="cpu",
+        device_index=None,
+        layout="torch.strided",
+        shape=(5, 4),
+        stride=(1, 5),
+        storage_offset=0,
+        requires_grad=False,
+    )
+    assert all(
+        not isinstance(getattr(spec, name), torch.Tensor) for name in spec.__slots__
+    )
+
+
+def test_tensor_spec_reads_fake_cuda_metadata_without_cuda() -> None:
+    from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+
+    with FakeTensorMode():
+        tensor = torch.empty_strided(
+            (4, 4, 64),
+            (768, 64, 1),
+            device="cuda:0",
+            dtype=torch.float16,
+        )
+        assert isinstance(tensor, FakeTensor)
+        spec = TensorSpec.from_tensor(tensor)
+
+    assert spec.dtype == "torch.float16"
+    assert spec.device_type == "cuda"
+    assert spec.device_index == 0
+    assert spec.shape == (4, 4, 64)
+    assert spec.stride == (768, 64, 1)
+
+
+def test_tensor_spec_preserves_symbolic_fake_tensor_dimension() -> None:
+    from torch._dynamo.source import LocalSource
+    from torch._subclasses.fake_tensor import FakeTensorMode
+    from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+    shape_env = ShapeEnv()
+    symbol = shape_env.create_symintnode(
+        shape_env.create_symbol(4, LocalSource("num_tokens")), hint=4
+    )
+    with FakeTensorMode(shape_env=shape_env):
+        tensor = torch.empty_strided(
+            (symbol, 8), (8, 1), device="cuda:0", dtype=torch.float16
+        )
+        spec = TensorSpec.from_tensor(tensor)
+
+    assert isinstance(spec.shape[0], SymbolSpec)
+    assert spec.shape[0].expression
+    assert spec.shape[1] == 8
+    assert spec.stride == (8, 1)
+
+
+def test_tensor_spec_preserves_v_projection_layout_and_offset() -> None:
+    storage = torch.empty(4096, dtype=torch.float16)
+    value = storage.as_strided((4, 4, 64), (768, 64, 1), storage_offset=512)
+
+    spec = TensorSpec.from_tensor(value)
+
+    assert spec.shape == (4, 4, 64)
+    assert spec.stride == (768, 64, 1)
+    assert spec.storage_offset == 512
+
+
+def test_dynamic_range_distinguishes_ranged_and_exact_artifacts() -> None:
+    assert not DynamicRange("num_tokens", 1, 128).is_exact
+    assert DynamicRange("num_tokens", 4, 4).is_exact
+
+    with pytest.raises(ValueError, match="non-negative"):
+        DynamicRange("num_tokens", -1, 4)
+    with pytest.raises(ValueError, match="at least"):
+        DynamicRange("num_tokens", 8, 4)
+
+
+def test_region_spec_represents_residual_mutation() -> None:
+    tensor = _tensor_spec()
+    spec = RegionSpec(
+        inputs=(
+            InputSpec("activation", tensor, InputKind.RUNTIME),
+            InputSpec("residual", tensor, InputKind.RUNTIME, mutable=True),
+            InputSpec("weight", tensor, InputKind.WEIGHT),
+        ),
+        outputs=(OutputSpec("normalized", tensor),),
+        mutations=(MutationSpec("residual"),),
+        dynamic_ranges=(DynamicRange("num_tokens", 1, 128),),
+    )
+
+    assert spec.mutations == (MutationSpec("residual"),)
+
+    with pytest.raises(ValueError, match="not declared mutable"):
+        RegionSpec(
+            inputs=(InputSpec("residual", tensor, InputKind.RUNTIME),),
+            outputs=(),
+            mutations=(MutationSpec("residual"),),
+        )
+    with pytest.raises(ValueError, match="unknown input"):
+        RegionSpec(
+            inputs=(),
+            outputs=(),
+            mutations=(MutationSpec("residual"),),
+        )
+
+
+def test_region_spec_represents_writable_attention_output() -> None:
+    tensor = _tensor_spec(shape=(4, 4096), stride=(4096, 1))
+
+    spec = RegionSpec(
+        inputs=(InputSpec("hidden_states", tensor, InputKind.RUNTIME),),
+        outputs=(
+            OutputSpec(
+                "attention_output",
+                tensor,
+                consumer_writable=True,
+            ),
+        ),
+        dynamic_ranges=(DynamicRange("num_tokens", 4, 4),),
+    )
+
+    assert spec.outputs[0].consumer_writable
+    assert spec.dynamic_ranges[0].is_exact
+
+
+def test_region_spec_validates_names_and_aliases() -> None:
+    tensor = _tensor_spec()
+    duplicate = InputSpec("x", tensor, InputKind.RUNTIME)
+
+    with pytest.raises(ValueError, match="input names must be unique"):
+        RegionSpec(inputs=(duplicate, duplicate), outputs=())
+    with pytest.raises(ValueError, match="aliases unknown input"):
+        RegionSpec(
+            inputs=(duplicate,),
+            outputs=(OutputSpec("view", tensor, aliases_input="missing"),),
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"shape": (4, 8), "stride": (8,)},
+        {"shape": (-1, 8)},
+        {"storage_offset": -1},
+    ],
+)
+def test_tensor_spec_rejects_invalid_concrete_metadata(kwargs) -> None:
+    with pytest.raises(ValueError):
+        _tensor_spec(**kwargs)

--- a/crates/luminal_python/tests/test_region_compile.py
+++ b/crates/luminal_python/tests/test_region_compile.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import fx
+
+import luminal.region_compile as region_compile_module
+from luminal.region_compile import compile_region
+from luminal.region_export import export_region
+
+
+def _add_graph() -> fx.GraphModule:
+    graph = fx.Graph()
+    left = graph.placeholder("left")
+    right = graph.placeholder("right")
+    result = graph.call_function(torch.ops.aten.add.Tensor, (left, right))
+    graph.output((result,))
+    return fx.GraphModule(torch.nn.Module(), graph)
+
+
+def test_compile_region_preserves_runtime_input_indices(monkeypatch) -> None:
+    region = export_region(
+        _add_graph(),
+        [torch.randn(2, 4), torch.randn(2, 4)],
+    )
+    sentinel = object()
+    factory = object()
+    received = {}
+
+    monkeypatch.setattr(
+        "luminal.luminal._cuda_lite_factory_capsule", lambda: factory, raising=False
+    )
+
+    def fake_save_and_compile(program, capsule, iterations, **kwargs):
+        received.update(
+            program=program,
+            capsule=capsule,
+            iterations=iterations,
+            **kwargs,
+        )
+        return sentinel
+
+    monkeypatch.setattr(
+        region_compile_module, "_save_and_compile", fake_save_and_compile
+    )
+
+    assert compile_region(region, search_iterations=3) is sentinel
+    assert received == {
+        "program": region.program,
+        "capsule": factory,
+        "iterations": 3,
+        "user_indices": region.input_indices,
+        "input_device_ptrs": None,
+    }
+
+
+def _cuda_skip_reason() -> str | None:
+    if not torch.cuda.is_available():
+        return "CUDA is not available"
+    try:
+        from luminal.luminal import _cuda_lite_factory_capsule
+
+        _cuda_lite_factory_capsule()
+    except (ImportError, AttributeError, RuntimeError) as error:
+        return f"luminal_python was not built with CUDA support: {error}"
+    return None
+
+
+_CUDA_SKIP_REASON = _cuda_skip_reason()
+
+
+@pytest.mark.skipif(
+    _CUDA_SKIP_REASON is not None, reason=_CUDA_SKIP_REASON or "CUDA is unavailable"
+)
+def test_compile_region_from_fake_cuda_metadata() -> None:
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        fake_inputs = [
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+        ]
+        region = export_region(_add_graph(), fake_inputs)
+
+    compiled = compile_region(region, search_iterations=1)
+
+    real_inputs = [
+        torch.randn((2, 4), device="cuda", dtype=torch.float16),
+        torch.randn((2, 4), device="cuda", dtype=torch.float16),
+    ]
+    (actual,) = compiled(*real_inputs)
+    torch.testing.assert_close(actual, real_inputs[0] + real_inputs[1])

--- a/crates/luminal_python/tests/test_region_compile.py
+++ b/crates/luminal_python/tests/test_region_compile.py
@@ -106,12 +106,8 @@ def test_compile_region_enforces_dynamic_range() -> None:
     )
     fake_mode = FakeTensorMode(shape_env=shape_env)
     with fake_mode:
-        fake_left = torch.empty(
-            (tokens, 8), device="cuda", dtype=torch.float16
-        )
-        fake_right = torch.empty(
-            (tokens, 8), device="cuda", dtype=torch.float16
-        )
+        fake_left = torch.empty((tokens, 8), device="cuda", dtype=torch.float16)
+        fake_right = torch.empty((tokens, 8), device="cuda", dtype=torch.float16)
 
     graph = fx.Graph()
     left = graph.placeholder("left")

--- a/crates/luminal_python/tests/test_region_compile.py
+++ b/crates/luminal_python/tests/test_region_compile.py
@@ -90,3 +90,58 @@ def test_compile_region_from_fake_cuda_metadata() -> None:
     ]
     (actual,) = compiled(*real_inputs)
     torch.testing.assert_close(actual, real_inputs[0] + real_inputs[1])
+
+
+@pytest.mark.skipif(
+    _CUDA_SKIP_REASON is not None, reason=_CUDA_SKIP_REASON or "CUDA is unavailable"
+)
+def test_compile_region_enforces_dynamic_range() -> None:
+    from torch._dynamo.source import LocalSource
+    from torch._subclasses.fake_tensor import FakeTensorMode
+    from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+    shape_env = ShapeEnv()
+    tokens = shape_env.create_symintnode(
+        shape_env.create_symbol(4, LocalSource("num_tokens")), hint=4
+    )
+    fake_mode = FakeTensorMode(shape_env=shape_env)
+    with fake_mode:
+        fake_left = torch.empty(
+            (tokens, 8), device="cuda", dtype=torch.float16
+        )
+        fake_right = torch.empty(
+            (tokens, 8), device="cuda", dtype=torch.float16
+        )
+
+    graph = fx.Graph()
+    left = graph.placeholder("left")
+    left.meta["example_value"] = fake_left
+    right = graph.placeholder("right")
+    right.meta["example_value"] = fake_right
+    result = graph.call_function(torch.ops.aten.cat.default, ([left, right], 0))
+    graph.output((result,))
+
+    region = export_region(
+        fx.GraphModule(torch.nn.Module(), graph),
+        [fake_left, fake_right],
+        dynamic_range=(1, 8),
+    )
+    compiled = compile_region(region, search_iterations=1)
+    assert compiled._graph.output_shapes == [[16, 8]]
+
+    for size in (2, 3, 5, 8):
+        left_value = torch.randn((size, 8), device="cuda", dtype=torch.float16)
+        right_value = torch.randn((size, 8), device="cuda", dtype=torch.float16)
+        (actual,) = compiled(left_value, right_value)
+        assert actual.shape == (size * 2, 8)
+        torch.testing.assert_close(actual, torch.cat((left_value, right_value)))
+
+    for size in (1, 9):
+        value = torch.randn((size, 8), device="cuda", dtype=torch.float16)
+        with pytest.raises(ValueError, match="expected value in"):
+            compiled(value, value)
+
+    left_value = torch.randn((3, 8), device="cuda", dtype=torch.float16)
+    right_value = torch.randn((4, 8), device="cuda", dtype=torch.float16)
+    with pytest.raises(ValueError, match="inferred as both 3 and 4"):
+        compiled(left_value, right_value)

--- a/crates/luminal_python/tests/test_region_export.py
+++ b/crates/luminal_python/tests/test_region_export.py
@@ -155,9 +155,7 @@ def test_export_region_preserves_shared_dynamic_dimension() -> None:
     left.meta["example_value"] = left_value
     right = graph.placeholder("right")
     right.meta["example_value"] = right_value
-    graph.output(
-        graph.call_function(torch.ops.aten.cat.default, ([left, right], 0))
-    )
+    graph.output(graph.call_function(torch.ops.aten.cat.default, ([left, right], 0)))
 
     result = export_region(
         fx.GraphModule(torch.nn.Module(), graph),

--- a/crates/luminal_python/tests/test_region_export.py
+++ b/crates/luminal_python/tests/test_region_export.py
@@ -7,7 +7,7 @@ import torch
 import torch.nn.functional as F
 from torch import fx
 
-from luminal.region_export import export_region
+from luminal.region_export import _fresh_export_inputs, export_region
 
 
 def _linear_graph() -> fx.GraphModule:
@@ -26,7 +26,7 @@ def _symbolic_inputs():
     from torch._subclasses.fake_tensor import FakeTensorMode
     from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
-    shape_env = ShapeEnv()
+    shape_env = ShapeEnv(tracked_fakes=[])
     symbol = shape_env.create_symintnode(
         shape_env.create_symbol(4, LocalSource("num_tokens")), hint=4
     )
@@ -130,13 +130,17 @@ def test_export_region_applies_bounded_dynamic_range() -> None:
     x.meta["example_value"] = tensor
     graph.output(graph.call_method("view", (x, size, 2, 4)))
 
-    exported = export_region(
+    result = export_region(
         fx.GraphModule(torch.nn.Module(), graph),
         [symbol, tensor],
         dynamic_range=(1, 8),
-    ).program
+    )
+    exported = result.program
 
     assert exported.range_constraints
+    assert result.dynamic_ranges[0].minimum == 2
+    assert result.dynamic_ranges[0].maximum == 8
+    assert all(int(value.lower) == 2 for value in exported.range_constraints.values())
     assert all(int(value.upper) == 8 for value in exported.range_constraints.values())
 
 
@@ -151,16 +155,78 @@ def test_export_region_preserves_shared_dynamic_dimension() -> None:
     left.meta["example_value"] = left_value
     right = graph.placeholder("right")
     right.meta["example_value"] = right_value
-    graph.output(graph.call_function(torch.ops.aten.add.Tensor, (left, right)))
+    graph.output(
+        graph.call_function(torch.ops.aten.cat.default, ([left, right], 0))
+    )
 
-    exported = export_region(
+    result = export_region(
         fx.GraphModule(torch.nn.Module(), graph),
         [left_value, right_value],
         dynamic_range=(1, 8),
-    ).program
+    )
+    exported = result.program
 
     assert len(exported.range_constraints) == 1
+    assert len(result.dynamic_ranges) == 1
     assert int(next(iter(exported.range_constraints.values())).upper) == 8
+
+
+def test_export_region_uses_a_fresh_fake_mode() -> None:
+    symbol, tensor = _symbolic_inputs()
+    graph = fx.Graph()
+    x = graph.placeholder("x")
+    x.meta["example_value"] = tensor
+    graph.output(x)
+
+    result = export_region(
+        fx.GraphModule(torch.nn.Module(), graph),
+        [tensor],
+        dynamic_range=(1, 8),
+    )
+
+    example_inputs, _ = result.program.example_inputs
+    assert example_inputs[0].fake_mode is not tensor.fake_mode
+    assert example_inputs[0].fake_mode.shape_env is not None
+    assert isinstance(example_inputs[0].shape[0], torch.SymInt)
+
+
+def test_fresh_export_inputs_do_not_duck_shape_equal_dimensions() -> None:
+    symbol, left = _symbolic_inputs()
+    with left.fake_mode:
+        right = torch.empty_strided(
+            (symbol, 8), (8, 1), device="cuda:0", dtype=torch.float16
+        )
+
+    fresh_left, fresh_right = _fresh_export_inputs([left, right])
+
+    assert fresh_left.shape[0].node.expr != fresh_right.shape[0].node.expr
+
+
+def test_export_region_inside_outer_tracing_context() -> None:
+    from torch._guards import TracingContext, tracing
+
+    symbol, left = _symbolic_inputs()
+    with left.fake_mode:
+        right = torch.empty_strided(
+            (symbol, 8), (8, 1), device="cuda:0", dtype=torch.float16
+        )
+    graph = fx.Graph()
+    left_node = graph.placeholder("left")
+    left_node.meta["example_value"] = left
+    right_node = graph.placeholder("right")
+    right_node.meta["example_value"] = right
+    graph.output(
+        graph.call_function(torch.ops.aten.cat.default, ([left_node, right_node], 0))
+    )
+
+    with tracing(TracingContext(left.fake_mode)):
+        result = export_region(
+            fx.GraphModule(torch.nn.Module(), graph),
+            [left, right],
+            dynamic_range=(1, 8),
+        )
+
+    assert len(result.program.range_constraints) == 1
 
 
 def test_export_region_specializes_exact_range() -> None:
@@ -176,14 +242,29 @@ def test_export_region_specializes_exact_range() -> None:
         concrete_tensor = torch.empty_strided(
             (8, 8), (8, 1), device="cuda:0", dtype=torch.float16
         )
-    exported = export_region(
+    result = export_region(
         fx.GraphModule(torch.nn.Module(), graph),
         [8, concrete_tensor],
         dynamic_range=(8, 8),
-    ).program
+    )
+    exported = result.program
 
+    assert not result.dynamic_ranges
     assert not exported.range_constraints
     assert "Sym(" not in exported.graph_module.print_readable(print_output=False)
+
+
+def test_export_region_rejects_static_graph_for_ranged_artifact() -> None:
+    graph = fx.Graph()
+    x = graph.placeholder("x")
+    graph.output(graph.call_function(torch.ops.aten.relu.default, (x,)))
+
+    with pytest.raises(RuntimeError, match="exactly one dynamic dimension"):
+        export_region(
+            fx.GraphModule(torch.nn.Module(), graph),
+            [torch.randn(4, 8)],
+            dynamic_range=(1, 8),
+        )
 
 
 def test_export_region_rejects_unrepresentable_symbol() -> None:

--- a/crates/luminal_python/tests/test_region_export.py
+++ b/crates/luminal_python/tests/test_region_export.py
@@ -38,12 +38,15 @@ def _symbolic_inputs():
     return symbol, tensor
 
 
-def test_export_region_normalizes_to_aten_and_matches_eager() -> None:
+def test_export_region_normalizes_to_aten_and_matches_eager(tmp_path) -> None:
     graph = _linear_graph()
     inputs = [torch.randn(3, 8), torch.randn(4, 8), torch.randn(4)]
 
-    exported = export_region(graph, inputs)
+    result = export_region(graph, inputs)
+    exported = result.program
 
+    assert result.input_indices == (0, 1, 2)
+    assert not getattr(exported, "_guards_code", [])
     targets = [
         node.target
         for node in exported.graph_module.graph.nodes
@@ -52,6 +55,11 @@ def test_export_region_normalizes_to_aten_and_matches_eager() -> None:
     assert targets
     assert all(isinstance(target, torch._ops.OpOverload) for target in targets)
     torch.testing.assert_close(exported.module()(*inputs), graph(*inputs))
+
+    path = tmp_path / "region.pt2"
+    torch.export.save(exported, path)
+    loaded = torch.export.load(path)
+    torch.testing.assert_close(loaded.module()(*inputs), graph(*inputs))
 
 
 def test_export_region_does_not_modify_original_graph() -> None:
@@ -75,8 +83,10 @@ def test_export_region_treats_data_attr_as_input_alias() -> None:
     graph_module = fx.GraphModule(torch.nn.Module(), graph)
     inputs = [torch.randn(3, 8), torch.randn(3, 8)]
 
-    exported = export_region(graph_module, inputs)
+    result = export_region(graph_module, inputs)
+    exported = result.program
 
+    assert result.input_indices == (0, 1)
     assert not exported.constants
     assert all(
         node.target is not torch._C._autograd._get_data_attr
@@ -97,8 +107,10 @@ def test_export_region_preserves_symbolic_fake_tensor_dimension() -> None:
     graph.output(output)
     graph_module = fx.GraphModule(torch.nn.Module(), graph)
 
-    exported = export_region(graph_module, [symbol, tensor])
+    result = export_region(graph_module, [symbol, tensor])
+    exported = result.program
 
+    assert result.input_indices == (1,)
     placeholders = list(exported.graph_module.graph.find_nodes(op="placeholder"))
     assert len(placeholders) == 1
     assert exported.range_constraints
@@ -122,7 +134,7 @@ def test_export_region_applies_bounded_dynamic_range() -> None:
         fx.GraphModule(torch.nn.Module(), graph),
         [symbol, tensor],
         dynamic_range=(1, 8),
-    )
+    ).program
 
     assert exported.range_constraints
     assert all(int(value.upper) == 8 for value in exported.range_constraints.values())
@@ -145,7 +157,7 @@ def test_export_region_preserves_shared_dynamic_dimension() -> None:
         fx.GraphModule(torch.nn.Module(), graph),
         [left_value, right_value],
         dynamic_range=(1, 8),
-    )
+    ).program
 
     assert len(exported.range_constraints) == 1
     assert int(next(iter(exported.range_constraints.values())).upper) == 8
@@ -168,7 +180,7 @@ def test_export_region_specializes_exact_range() -> None:
         fx.GraphModule(torch.nn.Module(), graph),
         [8, concrete_tensor],
         dynamic_range=(8, 8),
-    )
+    ).program
 
     assert not exported.range_constraints
     assert "Sym(" not in exported.graph_module.print_readable(print_output=False)

--- a/crates/luminal_python/tests/test_region_export.py
+++ b/crates/luminal_python/tests/test_region_export.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import operator
+
+import pytest
+import torch
+import torch.nn.functional as F
+from torch import fx
+
+from luminal.region_export import export_region
+
+
+def _linear_graph() -> fx.GraphModule:
+    graph = fx.Graph()
+    x = graph.placeholder("x")
+    weight = graph.placeholder("weight")
+    bias = graph.placeholder("bias")
+    linear = graph.call_function(F.linear, (x, weight, bias))
+    output = graph.call_function(F.silu, (linear,))
+    graph.output(output)
+    return fx.GraphModule(torch.nn.Module(), graph)
+
+
+def _symbolic_inputs():
+    from torch._dynamo.source import LocalSource
+    from torch._subclasses.fake_tensor import FakeTensorMode
+    from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+    shape_env = ShapeEnv()
+    symbol = shape_env.create_symintnode(
+        shape_env.create_symbol(4, LocalSource("num_tokens")), hint=4
+    )
+    fake_mode = FakeTensorMode(shape_env=shape_env)
+    with fake_mode:
+        tensor = torch.empty_strided(
+            (symbol, 8), (8, 1), device="cuda:0", dtype=torch.float16
+        )
+    return symbol, tensor
+
+
+def test_export_region_normalizes_to_aten_and_matches_eager() -> None:
+    graph = _linear_graph()
+    inputs = [torch.randn(3, 8), torch.randn(4, 8), torch.randn(4)]
+
+    exported = export_region(graph, inputs)
+
+    targets = [
+        node.target
+        for node in exported.graph_module.graph.nodes
+        if node.op == "call_function"
+    ]
+    assert targets
+    assert all(isinstance(target, torch._ops.OpOverload) for target in targets)
+    torch.testing.assert_close(exported.module()(*inputs), graph(*inputs))
+
+
+def test_export_region_does_not_modify_original_graph() -> None:
+    graph = _linear_graph()
+    before = str(graph.graph)
+
+    export_region(
+        graph,
+        [torch.randn(3, 8), torch.randn(4, 8), torch.randn(4)],
+    )
+
+    assert str(graph.graph) == before
+
+
+def test_export_region_treats_data_attr_as_input_alias() -> None:
+    graph = fx.Graph()
+    x = graph.placeholder("x")
+    weight = graph.placeholder("weight")
+    data = graph.call_function(torch._C._autograd._get_data_attr, (weight,))
+    graph.output(graph.call_function(torch.ops.aten.mul.Tensor, (x, data)))
+    graph_module = fx.GraphModule(torch.nn.Module(), graph)
+    inputs = [torch.randn(3, 8), torch.randn(3, 8)]
+
+    exported = export_region(graph_module, inputs)
+
+    assert not exported.constants
+    assert all(
+        node.target is not torch._C._autograd._get_data_attr
+        for node in exported.graph_module.graph.nodes
+        if node.op == "call_function"
+    )
+    torch.testing.assert_close(exported.module()(*inputs), graph_module(*inputs))
+
+
+def test_export_region_preserves_symbolic_fake_tensor_dimension() -> None:
+    symbol, tensor = _symbolic_inputs()
+    graph = fx.Graph()
+    size = graph.placeholder("num_tokens")
+    size.meta["example_value"] = symbol
+    x = graph.placeholder("x")
+    x.meta["example_value"] = tensor
+    output = graph.call_method("view", (x, size, 2, 4))
+    graph.output(output)
+    graph_module = fx.GraphModule(torch.nn.Module(), graph)
+
+    exported = export_region(graph_module, [symbol, tensor])
+
+    placeholders = list(exported.graph_module.graph.find_nodes(op="placeholder"))
+    assert len(placeholders) == 1
+    assert exported.range_constraints
+    assert any(
+        node.target == torch.ops.aten.sym_size.int
+        for node in exported.graph_module.graph.nodes
+        if node.op == "call_function"
+    )
+
+
+def test_export_region_applies_bounded_dynamic_range() -> None:
+    symbol, tensor = _symbolic_inputs()
+    graph = fx.Graph()
+    size = graph.placeholder("num_tokens")
+    size.meta["example_value"] = symbol
+    x = graph.placeholder("x")
+    x.meta["example_value"] = tensor
+    graph.output(graph.call_method("view", (x, size, 2, 4)))
+
+    exported = export_region(
+        fx.GraphModule(torch.nn.Module(), graph),
+        [symbol, tensor],
+        dynamic_range=(1, 8),
+    )
+
+    assert exported.range_constraints
+    assert all(int(value.upper) == 8 for value in exported.range_constraints.values())
+
+
+def test_export_region_preserves_shared_dynamic_dimension() -> None:
+    symbol, left_value = _symbolic_inputs()
+    with left_value.fake_mode:
+        right_value = torch.empty_strided(
+            (symbol, 8), (8, 1), device="cuda:0", dtype=torch.float16
+        )
+    graph = fx.Graph()
+    left = graph.placeholder("left")
+    left.meta["example_value"] = left_value
+    right = graph.placeholder("right")
+    right.meta["example_value"] = right_value
+    graph.output(graph.call_function(torch.ops.aten.add.Tensor, (left, right)))
+
+    exported = export_region(
+        fx.GraphModule(torch.nn.Module(), graph),
+        [left_value, right_value],
+        dynamic_range=(1, 8),
+    )
+
+    assert len(exported.range_constraints) == 1
+    assert int(next(iter(exported.range_constraints.values())).upper) == 8
+
+
+def test_export_region_specializes_exact_range() -> None:
+    symbol, tensor = _symbolic_inputs()
+    graph = fx.Graph()
+    size = graph.placeholder("num_tokens")
+    size.meta["example_value"] = symbol
+    x = graph.placeholder("x")
+    x.meta["example_value"] = tensor
+    graph.output(graph.call_method("view", (x, size, 2, 4)))
+
+    with tensor.fake_mode:
+        concrete_tensor = torch.empty_strided(
+            (8, 8), (8, 1), device="cuda:0", dtype=torch.float16
+        )
+    exported = export_region(
+        fx.GraphModule(torch.nn.Module(), graph),
+        [8, concrete_tensor],
+        dynamic_range=(8, 8),
+    )
+
+    assert not exported.range_constraints
+    assert "Sym(" not in exported.graph_module.print_readable(print_output=False)
+
+
+def test_export_region_rejects_unrepresentable_symbol() -> None:
+    symbol, tensor = _symbolic_inputs()
+    graph = fx.Graph()
+    size = graph.placeholder("unrelated_symbol")
+    size.meta["example_value"] = symbol + 1
+    x = graph.placeholder("x")
+    x.meta["example_value"] = tensor
+    output = graph.call_function(operator.mul, (x, size))
+    graph.output(output)
+    graph_module = fx.GraphModule(torch.nn.Module(), graph)
+
+    with pytest.raises(RuntimeError, match="could not be derived"):
+        export_region(graph_module, [symbol + 1, tensor])
+
+
+def test_export_region_surfaces_export_error(monkeypatch) -> None:
+    def fail_export(*args, **kwargs):
+        raise ValueError("original export failure")
+
+    monkeypatch.setattr(torch.export, "export", fail_export)
+
+    with pytest.raises(RuntimeError, match="ValueError: original export failure"):
+        export_region(_linear_graph(), [torch.randn(3, 8)] * 3)

--- a/crates/luminal_python/tests/test_region_export.py
+++ b/crates/luminal_python/tests/test_region_export.py
@@ -219,12 +219,14 @@ def test_export_region_inside_outer_tracing_context() -> None:
         graph.call_function(torch.ops.aten.cat.default, ([left_node, right_node], 0))
     )
 
-    with tracing(TracingContext(left.fake_mode)):
+    outer_context = TracingContext(left.fake_mode)
+    with tracing(outer_context):
         result = export_region(
             fx.GraphModule(torch.nn.Module(), graph),
             [left, right],
             dynamic_range=(1, 8),
         )
+        assert TracingContext.get() is outer_context
 
     assert len(result.program.range_constraints) == 1
 

--- a/src/frontend/movement.rs
+++ b/src/frontend/movement.rs
@@ -545,6 +545,13 @@ impl GraphTensor {
                 new_dims.push(dim.min(end) - start);
             }
             new_dims.reverse();
+            // A zero-sized output has no elements to gather. Building gather indices for
+            // it would create an Iota expression containing modulo by zero, so represent
+            // the empty slice by updating its shape only.
+            if new_dims.iter().any(|dim| dim.to_usize() == Some(0)) {
+                self.shape.dims = new_dims.into_iter().collect();
+                return self;
+            }
             index_expressions.reverse();
             let index_expression = flatten_strides(&new_dims, &index_expressions);
             let iota = self.graph().iota(index_expression, new_dims);
@@ -986,6 +993,16 @@ mod tests {
             |a| a.concat_along(a, 0),
             |a| Tensor::cat(&[a.clone(), a], 0).unwrap(),
         );
+    }
+
+    #[test]
+    fn empty_offset_slice_is_a_metadata_only_view() {
+        let mut cx = Graph::new();
+        let input = cx.tensor((1, 4, 64));
+        let empty = input.slice_along(64.., 2);
+
+        assert_eq!(empty.dims(), &[1, 4, 0]);
+        assert_eq!(empty.id, input.id, "an empty slice must not create an Iota");
     }
 
     #[test]


### PR DESCRIPTION
- Creates fx to pt2 path for vLLM regions
- Frontend can export and synchronously compile regions from FakeTensor metadata 
- Compiled regions can preserve symbolic input relationships
- Supports exact and bounded token lengths for vLLM bucketing 
