### PR TITLE
Preserve concrete dtypes through loop rolling

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -836,6 +836,12 @@ impl Graph {
         }
 
         let mut created = 0usize;
+        // Loop markers cross the HLIR -> egglog -> LLIR boundary and therefore
+        // carry the same concrete dtype as the tensor they represent. Compute
+        // those dtypes from the still-unmodified graph before inserting any
+        // markers; an unknown or inconsistent dtype is a compile error, never
+        // an F32 default.
+        let dtype_map = self.concrete_node_dtypes();
         // Track all NodeIndex slots we newly assign for loop-marker ops.
         // StableGraph reuses freed node indices; removals later in this
         // function might target slots that happen to coincide with a new
@@ -858,19 +864,26 @@ impl Graph {
             let initial = candidate.occurrences[0].boundary_inputs[p];
             let body_state_out = candidate.occurrences[0].output_nodes[out_pos];
             let last_state_out = candidate.occurrences[n_iters - 1].output_nodes[out_pos];
+            let dtype = dtype_map[&initial];
+            for (role, node) in [
+                ("loop body state output", body_state_out),
+                ("loop final state output", last_state_out),
+            ] {
+                let actual = dtype_map[&node];
+                assert_eq!(
+                    actual,
+                    dtype,
+                    "loop {loop_id} slot {slot_idx} changes dtype: initial node {} is {dtype:?}, {role} node {} is {actual:?}",
+                    initial.index(),
+                    node.index(),
+                );
+            }
 
-            // Marker dtype fields are placeholders: the e-graph derives each
-            // marker's dtype fact from its input via dtype_prop (see hlir.rs).
-            // Marker dtype fields are placeholders, not sources of truth:
-            // each marker's dtype fact is derived inside the e-graph from
-            // its input by the generic dtype_prop propagation rule (see the
-            // marker EgglogOp impls in hlir.rs). Nothing downstream reads
-            // the field semantically.
             let loop_start = self.graph.add_node(Box::new(LoopStart {
                 loop_id,
                 slot_idx,
                 iters: Expression::from(n_iters as i32),
-                dtype: DType::F32,
+                dtype,
             }));
             added_loop_ops.insert(loop_start);
             self.graph.add_edge(initial, loop_start, ());
@@ -889,7 +902,7 @@ impl Graph {
             let loop_end = self.graph.add_node(Box::new(LoopEnd {
                 loop_id,
                 slot_idx,
-                dtype: DType::F32,
+                dtype,
             }));
             added_loop_ops.insert(loop_end);
             self.graph.add_edge(body_state_out, loop_end, ());
@@ -925,6 +938,15 @@ impl Graph {
             }
 
             let body_input = candidate.occurrences[0].boundary_inputs[p];
+            let dtype = self.uniform_node_dtype(
+                &per_iter_sources,
+                &dtype_map,
+                &format!("loop {loop_id} input stream {p}"),
+            );
+            assert_eq!(
+                dtype, dtype_map[&body_input],
+                "loop {loop_id} input stream {p} body input has a different concrete dtype"
+            );
             if log {
                 println!(
                     "   {:>6}  loop {loop_id} stream {p}: per-iter sources {:?}",
@@ -938,7 +960,7 @@ impl Graph {
             let loop_input = self.graph.add_node(Box::new(LoopInput {
                 loop_id,
                 stream_id: p,
-                dtype: DType::F32,
+                dtype,
             }));
             added_loop_ops.insert(loop_input);
             // Deferred: added at the end with fresh ascending edge ids —
@@ -1023,11 +1045,20 @@ impl Graph {
 
             // Iter-0 body producer feeds the LoopOutput marker.
             let body_output = per_iter_plan[0].0;
+            let per_iter_outputs: Vec<NodeIndex> = per_iter_plan
+                .iter()
+                .map(|(producer, _)| *producer)
+                .collect();
+            let dtype = self.uniform_node_dtype(
+                &per_iter_outputs,
+                &dtype_map,
+                &format!("loop {loop_id} output stream {q}"),
+            );
 
             let loop_output = self.graph.add_node(Box::new(LoopOutput {
                 loop_id,
                 stream_id: q,
-                dtype: DType::F32,
+                dtype,
             }));
             self.graph.add_edge(body_output, loop_output, ());
             added_loop_ops.insert(loop_output);
@@ -1039,7 +1070,7 @@ impl Graph {
                     loop_id,
                     stream_id: q,
                     iter: i,
-                    dtype: DType::F32,
+                    dtype,
                 }));
                 self.graph.add_edge(loop_output, select, ());
                 added_loop_ops.insert(select);
@@ -1092,6 +1123,70 @@ impl Graph {
             );
         }
         created
+    }
+
+    /// Resolve every HLIR node's concrete dtype in topological order.
+    ///
+    /// Each operation owns its dtype contract through
+    /// [`HLIROp::output_dtype`]. There is no graph-level opcode table and no
+    /// fallback dtype: malformed graphs fail before a transform can stamp
+    /// incorrect metadata onto a structural marker.
+    fn concrete_node_dtypes(&self) -> FxHashMap<NodeIndex, DType> {
+        let order = petgraph::algo::toposort(&self.graph, None).unwrap_or_else(|cycle| {
+            panic!("HLIR contains a cycle at node {}", cycle.node_id().index())
+        });
+        let mut dtypes = FxHashMap::default();
+        for node in order {
+            let sources = self.get_sources(node);
+            let input_dtypes: Vec<_> = sources
+                .iter()
+                .map(|source| {
+                    dtypes.get(source).copied().unwrap_or_else(|| {
+                        panic!(
+                            "HLIR node {} ({}) depends on node {} before its concrete dtype is known",
+                            node.index(),
+                            self.graph[node],
+                            source.index(),
+                        )
+                    })
+                })
+                .collect();
+            let dtype = self.graph[node].output_dtype(&input_dtypes);
+            if let Some((_, metadata_dtype)) = self.input_meta.get(&node) {
+                assert_eq!(
+                    dtype,
+                    *metadata_dtype,
+                    "HLIR node {} ({}) has conflicting concrete dtypes: op={dtype:?}, metadata={metadata_dtype:?}",
+                    node.index(),
+                    self.graph[node],
+                );
+            }
+            dtypes.insert(node, dtype);
+        }
+        dtypes
+    }
+
+    fn uniform_node_dtype(
+        &self,
+        nodes: &[NodeIndex],
+        dtypes: &FxHashMap<NodeIndex, DType>,
+        context: &str,
+    ) -> DType {
+        let (&first, rest) = nodes
+            .split_first()
+            .unwrap_or_else(|| panic!("{context} has no tensor sources"));
+        let dtype = dtypes[&first];
+        for &node in rest {
+            let actual = dtypes[&node];
+            assert_eq!(
+                actual,
+                dtype,
+                "{context} mixes concrete dtypes: node {} is {dtype:?}, node {} is {actual:?}",
+                first.index(),
+                node.index(),
+            );
+        }
+        dtype
     }
 
     /// Set a runtime dimension
@@ -4675,7 +4770,9 @@ mod tests {
         api::{Rule, SortDef, sort},
         base::OP_KIND,
     };
-    use crate::hlir::{Input, LoopEnd, LoopStart, Output, ReferenceData, ReferenceOp, Sin};
+    use crate::hlir::{
+        Input, LoopEnd, LoopInput, LoopStart, Output, ReferenceData, ReferenceOp, Sin,
+    };
     use rand::SeedableRng;
 
     // A rolling candidate is only collapsible if every non-state boundary input
@@ -6350,6 +6447,94 @@ mod tests {
             })
             .collect();
         assert_close(rt.get_f32(out.id), &expected);
+    }
+
+    #[test]
+    fn loop_rolling_stamps_concrete_varying_stream_dtypes() {
+        // A transformer-style recurrence carries F32 activations while every
+        // repeated layer receives a distinct BF16 weight. The weight casts are
+        // part of the repeated body, so the rolled boundary itself must retain
+        // BF16 rather than a placeholder chosen independently of its sources.
+        let mut cx = Graph::new();
+        let x = cx.tensor(8);
+        let weights: Vec<GraphTensor> =
+            (0..4).map(|_| cx.tensor(8).as_dtype(DType::Bf16)).collect();
+        let mut y = x;
+        for weight in weights {
+            y = (y * weight.cast(DType::F32)).sin();
+        }
+        let _ = y.output();
+
+        assert!(
+            cx.auto_roll_loops_prepass_with_log(true) > 0,
+            "expected the repeated weighted recurrence to roll"
+        );
+
+        let loop_inputs: Vec<_> = cx
+            .graph
+            .node_indices()
+            .filter_map(|node| cx.try_get_op::<LoopInput>(node))
+            .collect();
+        assert!(!loop_inputs.is_empty(), "expected a varying weight stream");
+        assert!(
+            loop_inputs.iter().any(|input| input.dtype == DType::Bf16),
+            "expected a concrete BF16 LoopInput, got {loop_inputs:?}"
+        );
+        assert!(
+            cx.graph.node_indices().all(|node| {
+                cx.try_get_op::<LoopStart>(node)
+                    .is_none_or(|start| start.dtype == DType::F32)
+            }),
+            "the carried F32 activation must remain concretely F32"
+        );
+
+        // The concrete field remains the source of truth through egglog
+        // construction; this used to turn every marker field into F32.
+        cx.build_search_space::<ReferenceRuntime>(CompileOptions::default());
+    }
+
+    #[test]
+    fn loop_rolling_preserves_integer_gather_stream_dtypes() {
+        // Regression for mixed-type repeated regions: Gather consumes Int
+        // indexes but produces the dtype of its F32 data input. Both facts
+        // must survive rolling without one eclass overwriting the other.
+        let mut cx = Graph::new();
+        let x = cx.tensor(8);
+        let indexes: Vec<GraphTensor> = (0..4)
+            .map(|layer| {
+                cx.named_tensor(format!("indexes.{layer}"), 8)
+                    .as_dtype(DType::Int)
+            })
+            .collect();
+        let mut y = x;
+        for index in indexes {
+            y = y.gather(index).sin();
+        }
+        let _ = y.output();
+
+        assert!(
+            cx.auto_roll_loops_prepass_with_log(true) > 0,
+            "expected the repeated gather recurrence to roll"
+        );
+
+        let loop_inputs: Vec<_> = cx
+            .graph
+            .node_indices()
+            .filter_map(|node| cx.try_get_op::<LoopInput>(node))
+            .collect();
+        assert!(
+            loop_inputs.iter().any(|input| input.dtype == DType::Int),
+            "expected a concrete Int LoopInput, got {loop_inputs:?}"
+        );
+        assert!(
+            cx.graph.node_indices().all(|node| {
+                cx.try_get_op::<LoopStart>(node)
+                    .is_none_or(|start| start.dtype == DType::F32)
+            }),
+            "Gather must preserve the carried F32 activation dtype"
+        );
+
+        cx.build_search_space::<ReferenceRuntime>(CompileOptions::default());
     }
 
     #[test]

--- a/src/hlir.rs
+++ b/src/hlir.rs
@@ -85,6 +85,19 @@ fn dtype_fixed_op(kind_sort: &SortDef, dtype_sort: &SortDef) -> Rule {
         .ruleset("dtype_prop")
 }
 
+/// Validate a structural marker's declared dtype against every tensor source.
+/// Marker metadata is a concrete contract, never an inference placeholder.
+fn marker_output_dtype(op: &dyn Display, declared: DType, inputs: &[DType]) -> DType {
+    assert!(!inputs.is_empty(), "{op} has no tensor source");
+    for (index, &actual) in inputs.iter().enumerate() {
+        assert_eq!(
+            actual, declared,
+            "{op} declares {declared:?}, but input {index} is {actual:?}"
+        );
+    }
+    declared
+}
+
 /// Build an IList egglog string from input variable names.
 fn ilist_egglog(inputs: &[&str]) -> String {
     list_to_egglog(inputs, "ICons", "INil")
@@ -316,6 +329,14 @@ impl HLIROp for Input {
             self.node, self.label, self.dtype
         )
     }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        assert!(
+            input_dtypes.is_empty(),
+            "Input cannot consume tensor inputs"
+        );
+        self.dtype
+    }
 }
 
 impl ReferenceOp for Input {
@@ -430,6 +451,10 @@ impl HLIROp for CustomOpKind {
             list_to_egglog(&inp.iter().map(|i| &i.1).collect_vec(), "ICons", "INil"),
         )
     }
+
+    fn output_dtype(&self, _input_dtypes: &[DType]) -> DType {
+        self.dtype
+    }
 }
 
 impl ReferenceOp for CustomOpKind {
@@ -495,12 +520,7 @@ impl EgglogOp for LoopStart {
     }
 
     fn rewrites(&self) -> Vec<Rule> {
-        vec![
-            // Derived from the `inp` field's class inside the e-graph
-            // (initial value / body producer); the serialized dtype field is
-            // a placeholder. See LoopInput.
-            dtype_propagation_rule(&self.sort(), "inp"),
-        ]
+        vec![dtype_from_field_rule(&self.sort(), "dtype")]
     }
 
     fn extract<'a>(
@@ -546,6 +566,10 @@ impl HLIROp for LoopStart {
             self.dtype,
         )
     }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        marker_output_dtype(self, self.dtype, input_dtypes)
+    }
 }
 
 impl ReferenceOp for LoopStart {
@@ -590,12 +614,7 @@ impl EgglogOp for LoopEnd {
     }
 
     fn rewrites(&self) -> Vec<Rule> {
-        vec![
-            // Derived from the `inp` field's class inside the e-graph
-            // (initial value / body producer); the serialized dtype field is
-            // a placeholder. See LoopInput.
-            dtype_propagation_rule(&self.sort(), "inp"),
-        ]
+        vec![dtype_from_field_rule(&self.sort(), "dtype")]
     }
 
     fn extract<'a>(
@@ -634,6 +653,10 @@ impl HLIROp for LoopEnd {
             "(LoopEnd {} {} {} ({:?}))",
             inp[0].1, self.loop_id, self.slot_idx, self.dtype,
         )
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        marker_output_dtype(self, self.dtype, input_dtypes)
     }
 }
 
@@ -680,12 +703,10 @@ impl EgglogOp for LoopInput {
         // that expect raw op kinds at boundary positions can match via the
         // unioned eclass.
         vec![
-            // The marker's class dtype is DERIVED from its input inside the
-            // e-graph (generic first-input propagation) — the serialized
-            // field is not a source of truth. Declaring the field here let a
-            // wrongly-stamped marker corrupt its source class's dtype fact
-            // through the inline union (`:merge new` is last-write-wins).
-            dtype_propagation_op(&self.sort()),
+            // Loop rolling stamps the concrete stream dtype into the marker;
+            // the field is the same type contract consumed by rewrites and
+            // extracted into LLIR.
+            dtype_from_kind_field(&self.sort(), "dtype"),
             Rule::raw(
                 r#"
             (relation identical_inputs (IList))
@@ -767,6 +788,10 @@ impl HLIROp for LoopInput {
             list_to_egglog(&inp.iter().map(|i| &i.1).collect_vec(), "ICons", "INil"),
         )
     }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        marker_output_dtype(self, self.dtype, input_dtypes)
+    }
 }
 
 impl ReferenceOp for LoopInput {
@@ -814,10 +839,7 @@ impl EgglogOp for LoopInputStatic {
     }
 
     fn rewrites(&self) -> Vec<Rule> {
-        vec![
-            // Derived from the input inside the e-graph; see LoopInput.
-            dtype_propagation_op(&self.sort()),
-        ]
+        vec![dtype_from_kind_field(&self.sort(), "dtype")]
     }
 
     fn extract<'a>(
@@ -859,6 +881,10 @@ impl HLIROp for LoopInputStatic {
             self.dtype,
             list_to_egglog(&inp.iter().map(|i| &i.1).collect_vec(), "ICons", "INil"),
         )
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        marker_output_dtype(self, self.dtype, input_dtypes)
     }
 }
 
@@ -904,10 +930,7 @@ impl EgglogOp for LoopOutput {
     }
 
     fn rewrites(&self) -> Vec<Rule> {
-        vec![
-            // Derived from the input inside the e-graph; see LoopInput.
-            dtype_propagation_op(&self.sort()),
-        ]
+        vec![dtype_from_kind_field(&self.sort(), "dtype")]
     }
 
     fn extract<'a>(
@@ -949,6 +972,10 @@ impl HLIROp for LoopOutput {
             self.dtype,
             list_to_egglog(&inp.iter().map(|i| &i.1).collect_vec(), "ICons", "INil"),
         )
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        marker_output_dtype(self, self.dtype, input_dtypes)
     }
 }
 
@@ -1001,10 +1028,7 @@ impl EgglogOp for LoopOutputSelect {
     }
 
     fn rewrites(&self) -> Vec<Rule> {
-        vec![
-            // Derived from the input inside the e-graph; see LoopInput.
-            dtype_propagation_op(&self.sort()),
-        ]
+        vec![dtype_from_kind_field(&self.sort(), "dtype")]
     }
 
     fn extract<'a>(
@@ -1054,6 +1078,10 @@ impl HLIROp for LoopOutputSelect {
             list_to_egglog(&inp.iter().map(|i| &i.1).collect_vec(), "ICons", "INil"),
         )
     }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        marker_output_dtype(self, self.dtype, input_dtypes)
+    }
 }
 
 impl ReferenceOp for LoopOutputSelect {
@@ -1080,6 +1108,14 @@ impl Display for Constant {
 impl HLIROp for Constant {
     fn to_egglog(&self, _: &[(NodeIndex, String)]) -> String {
         format!("(Op (Constant {:?}) (INil))", self.0)
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        assert!(
+            input_dtypes.is_empty(),
+            "Constant cannot consume tensor inputs"
+        );
+        DType::F32
     }
 }
 
@@ -1143,6 +1179,14 @@ impl HLIROp for ConstantF64 {
     fn to_egglog(&self, _: &[(NodeIndex, String)]) -> String {
         format!("(Op (ConstantF64 {:?}) (INil))", self.0)
     }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        assert!(
+            input_dtypes.is_empty(),
+            "ConstantF64 cannot consume tensor inputs"
+        );
+        DType::F64
+    }
 }
 
 impl EgglogOp for ConstantF64 {
@@ -1199,6 +1243,11 @@ impl HLIROp for Iota {
             self.0.to_egglog(),
             self.1.to_egglog()
         )
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        assert!(input_dtypes.is_empty(), "Iota cannot consume tensor inputs");
+        DType::Int
     }
 }
 impl EgglogOp for Iota {
@@ -1261,6 +1310,11 @@ impl HLIROp for Cast {
             self.1,
             inp[0].1,
         )
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        assert_eq!(input_dtypes.len(), 1, "Cast must consume one tensor input");
+        self.1
     }
 }
 impl EgglogOp for Cast {
@@ -2105,6 +2159,19 @@ impl HLIROp for LessThan {
             ilist_egglog(&[&inputs[0].1, &inputs[1].1]),
         )
     }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        assert_eq!(
+            input_dtypes.len(),
+            2,
+            "LessThan must consume two tensor inputs"
+        );
+        assert_eq!(
+            input_dtypes[0], input_dtypes[1],
+            "LessThan inputs must have the same concrete dtype"
+        );
+        DType::Bool
+    }
 }
 
 impl EgglogOp for LessThan {
@@ -2211,6 +2278,12 @@ impl HLIROp for Gather {
             elist_to_egglog(&self.input_shapes[1].strides),
             ilist_egglog(&[&inputs[0].1, &inputs[1].1]),
         )
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        *input_dtypes
+            .get(1)
+            .unwrap_or_else(|| panic!("Gather has no data input at position 1"))
     }
 }
 
@@ -2385,6 +2458,12 @@ impl HLIROp for Scatter {
             elist_to_egglog(&self.src_strides),
             ilist_egglog(&[&inputs[0].1, &inputs[1].1, &inputs[2].1]),
         )
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        *input_dtypes
+            .get(2)
+            .unwrap_or_else(|| panic!("Scatter has no source input at position 2"))
     }
 }
 

--- a/src/op.rs
+++ b/src/op.rs
@@ -395,11 +395,29 @@ pub trait CustomOp: Debug {
 /// Defines an HLIROp that implements a logical operation.
 pub trait HLIROp: Debug + Display + as_any::AsAny {
     fn to_egglog(&self, inputs: &[(NodeIndex, String)]) -> String;
+
+    /// Return this operation's concrete output dtype from the concrete dtypes
+    /// of its ordered inputs.
+    ///
+    /// Most logical operations preserve the dtype of their first input.
+    /// Operations with different dtype semantics override this method. Keeping
+    /// the rule on the operation makes graph transforms such as loop rolling
+    /// consume the same type contract as the op itself instead of maintaining
+    /// a second opcode-specific inference table.
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        *input_dtypes
+            .first()
+            .unwrap_or_else(|| panic!("{self} has no input and does not declare an output dtype"))
+    }
 }
 
 impl<T: HLIROp> HLIROp for Box<T> {
     fn to_egglog(&self, inputs: &[(NodeIndex, String)]) -> String {
         <T as HLIROp>::to_egglog(self, inputs)
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        <T as HLIROp>::output_dtype(self, input_dtypes)
     }
 }
 


### PR DESCRIPTION
Loop rolling now computes and validates concrete dtypes before inserting marker ops, stamps every marker with its real dtype, and preserves the contract through LLIR extraction. This prevents placeholder F32 metadata from leaking across the graph/egglog boundary.

Includes coverage for integer gather streams and varying typed loop inputs.

Validation: `cargo fmt --check`; `cargo test -p luminal --lib` (182 passed).