### PR TITLE
Add CUDA serving runtime support for vLLM integration

### DIFF
--- a/crates/luminal_cuda_lite/Cargo.toml
+++ b/crates/luminal_cuda_lite/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 luminal = { path = "../.." }
 luminal_tracing = { path = "../luminal_tracing" }
-cudarc = { git = "https://github.com/jonahsamost/cudarc.git", rev = "a42f3897b6d00aded8e6ac7ad258c72d8bad5596", features = ["cuda-version-from-build-system", "fallback-latest"] }
+cudarc = { git = "https://github.com/luminal-ai/cudarc.git", rev = "a42f3897b6d00aded8e6ac7ad258c72d8bad5596", features = ["cuda-version-from-build-system", "fallback-latest"] }
 anyhow = "1.0"
 as-any = "0.3.2"
 itertools = "0.12.1"

--- a/crates/luminal_cuda_lite/Cargo.toml
+++ b/crates/luminal_cuda_lite/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 luminal = { path = "../.." }
 luminal_tracing = { path = "../luminal_tracing" }
-cudarc = { version = "0.19.8", features = ["cuda-version-from-build-system", "fallback-latest"] }
+cudarc = { git = "https://github.com/jonahsamost/cudarc.git", rev = "a42f3897b6d00aded8e6ac7ad258c72d8bad5596", features = ["cuda-version-from-build-system", "fallback-latest"] }
 anyhow = "1.0"
 as-any = "0.3.2"
 itertools = "0.12.1"

--- a/crates/luminal_cuda_lite/src/dyn_backend.rs
+++ b/crates/luminal_cuda_lite/src/dyn_backend.rs
@@ -105,10 +105,15 @@ pub fn cuda_lite_factory(
     }
     let cuda_ctx = CudaContext::new(device_index).map_err(|e| format!("CUDA init failed: {e}"))?;
     let stream = cuda_ctx.default_stream();
+    let external_cuda_graph = args.external_cuda_graph;
     compile_backend::<CudaRuntime>(
         graph,
         args,
-        || Ok(CudaRuntime::initialize(stream)),
+        || {
+            let mut runtime = CudaRuntime::initialize(stream);
+            runtime.external_cuda_graph = external_cuda_graph;
+            Ok(runtime)
+        },
         |rt, node, bytes, _dtype| {
             rt.set_data(node, bytes);
         },

--- a/crates/luminal_cuda_lite/src/dyn_backend.rs
+++ b/crates/luminal_cuda_lite/src/dyn_backend.rs
@@ -19,6 +19,9 @@ impl DynBackend for CudaLiteDynBackend {
     fn device_type(&self) -> &str {
         "cuda"
     }
+    fn device_index(&self) -> Option<usize> {
+        Some(self.runtime.device_index())
+    }
 
     fn set_data_bytes(&mut self, node: NodeIndex, bytes: Vec<u8>, _dtype: DType) {
         self.runtime.set_data(node, bytes);
@@ -87,7 +90,15 @@ pub fn cuda_lite_factory(
     graph: &mut Graph,
     args: BackendCompileArgs,
 ) -> Result<Box<dyn DynBackend>, String> {
-    let cuda_ctx = CudaContext::new(0).map_err(|e| format!("CUDA init failed: {e}"))?;
+    let device_index = args
+        .device_index
+        .ok_or_else(|| "CUDA backend requires a device index".to_string())?;
+    if device_index != 0 {
+        return Err(format!(
+            "CUDA backend currently supports only logical device 0, got {device_index}"
+        ));
+    }
+    let cuda_ctx = CudaContext::new(device_index).map_err(|e| format!("CUDA init failed: {e}"))?;
     let stream = cuda_ctx.default_stream();
     compile_backend::<CudaRuntime>(
         graph,

--- a/crates/luminal_cuda_lite/src/dyn_backend.rs
+++ b/crates/luminal_cuda_lite/src/dyn_backend.rs
@@ -59,7 +59,12 @@ impl DynBackend for CudaLiteDynBackend {
     fn get_output_bool(&self, node: NodeIndex) -> Vec<bool> {
         self.runtime.get_bool(node)
     }
-    fn execute(&mut self, dyn_map: &DynMap) {
+    fn execute(&mut self, dyn_map: &DynMap, stream: Option<u64>) {
+        if let Some(stream) = stream {
+            unsafe { self.runtime.use_borrowed_stream(stream) };
+        } else {
+            self.runtime.use_owned_stream();
+        }
         self.runtime.execute(dyn_map);
     }
     fn supports_device_ptrs(&self) -> bool {

--- a/crates/luminal_cuda_lite/src/kernel/to_host.rs
+++ b/crates/luminal_cuda_lite/src/kernel/to_host.rs
@@ -528,6 +528,8 @@ struct CudaGraphOpState {
     flashinfer_prepare_cache: Vec<CachedFlashInferPrepare>,
     /// Shared device buffer for dynamic dimensions
     dyn_dims_buffer: Option<CudaSlice<i32>>,
+    /// Cached before external capture to avoid CudaSlice's cross-stream event wait.
+    dyn_dims_ptr: u64,
     /// CUDA graph handle
     cuda_graph: Option<CudaGraphHandle>,
     /// CUDA graph exec handle
@@ -576,6 +578,7 @@ impl CudaGraphOpState {
             cublaslt_workspace_pool: Vec::new(),
             flashinfer_prepare_cache: Vec::new(),
             dyn_dims_buffer: None,
+            dyn_dims_ptr: 0,
             cuda_graph: None,
             cuda_graph_exec: None,
             kernel_params: Vec::new(),
@@ -1658,6 +1661,7 @@ impl CudaGraphOp {
             kernel.internal_bufs.clear();
         }
         state.dyn_dims_buffer = None;
+        state.dyn_dims_ptr = 0;
     }
 
     /// Patch a CUDA graph from an exact set of changed bindings without
@@ -1901,11 +1905,11 @@ impl CudaGraphOp {
 
         // Allocate dyn_dims_buffer if needed
         if !self.dyn_dims_order.is_empty() && state.dyn_dims_buffer.is_none() {
-            state.dyn_dims_buffer = Some(
-                stream
-                    .alloc_zeros::<i32>(self.dyn_dims_order.len())
-                    .expect("Failed to allocate dyn_dims buffer"),
-            );
+            let buffer = stream
+                .alloc_zeros::<i32>(self.dyn_dims_order.len())
+                .expect("Failed to allocate dyn_dims buffer");
+            state.dyn_dims_ptr = buffer.device_ptr(stream).0;
+            state.dyn_dims_buffer = Some(buffer);
         }
 
         // Update shared dyn_dims buffer if dyn_map changed
@@ -2485,6 +2489,140 @@ impl CudaGraphOp {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("CUDA graph launch requested before materialization"))?
             .launch(stream)?;
+        Ok(())
+    }
+
+    /// Enqueue prepared work directly so a caller-owned CUDA graph can capture it.
+    pub(crate) fn launch_steps(
+        &self,
+        stream: &Arc<CudaStream>,
+        buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
+        dyn_map: &DynMap,
+    ) -> anyhow::Result<()> {
+        stream.context().bind_to_thread()?;
+        let mut state = self.state.borrow_mut();
+        anyhow::ensure!(
+            state.last_dyn_values == *dyn_map,
+            "external CUDA graph capture requires a same-shape warmup"
+        );
+
+        let mut buffer_ptrs = FxHashMap::default();
+        for &node in &self.buffer_nodes {
+            if let Some(buffer) = buffers.get(&node) {
+                buffer_ptrs.insert(node, buffer.ptr());
+            }
+        }
+        for &(input, output) in &self.output_aliases {
+            if let Some(&ptr) = buffer_ptrs.get(&input) {
+                buffer_ptrs.insert(output, ptr);
+            }
+        }
+        let dyn_dims_ptr = state.dyn_dims_ptr;
+
+        for step_index in 0..state.steps.len() {
+            let step_name = match state.steps[step_index] {
+                CompiledStep::Kernel(index) => {
+                    let kernel = &mut state.kernels[index];
+                    kernel.kernel_op.pre_execute(
+                        stream,
+                        &mut kernel.internal_bufs,
+                        &mut kernel.constants,
+                        &buffer_ptrs,
+                        dyn_map,
+                    );
+                    let output_ptr = buffer_ptrs.get(&kernel.node).copied().unwrap_or(0);
+                    let input_ptrs = kernel
+                        .inputs
+                        .iter()
+                        .map(|node| buffer_ptrs.get(node).copied().unwrap_or(0))
+                        .collect_vec();
+                    Self::validate_kernel_pointers(kernel, output_ptr, &input_ptrs, dyn_map)?;
+                    let kernel_dyn_dims_ptr = kernel
+                        .has_dyn_dims_param
+                        .then_some(dyn_dims_ptr)
+                        .unwrap_or(0);
+                    anyhow::ensure!(
+                        !kernel.has_dyn_dims_param || kernel_dyn_dims_ptr != 0,
+                        "dynamic-dimension buffer was not prepared before capture"
+                    );
+                    let mut params = UnifiedKernelParams::new(kernel.kernel_op.build_params(
+                        stream,
+                        output_ptr,
+                        &input_ptrs,
+                        &kernel.internal_bufs,
+                        kernel_dyn_dims_ptr,
+                    ));
+                    let function = unsafe { kernel.function.raw_function() };
+                    let launch = Self::kernel_launch_config(kernel, dyn_map)?;
+                    unsafe {
+                        cudarc::driver::result::launch_kernel(
+                            function,
+                            launch.grid,
+                            launch.block,
+                            launch.shared_mem,
+                            stream.cu_stream(),
+                            &mut params.ptrs,
+                        )
+                        .map_err(|error| {
+                            anyhow::anyhow!(
+                                "external kernel step {step_index} ({}) failed: {error}",
+                                kernel.kernel_name
+                            )
+                        })?;
+                    }
+                    kernel.kernel_name
+                }
+                CompiledStep::CuBlasLt(index) => {
+                    let op = &state.cublaslt_ops[index];
+                    let signature = op
+                        .cublaslt()
+                        .resolve_for_graph(op.node, &op.inputs, buffers, dyn_map)?
+                        .signature();
+                    let prepared = op
+                        .prepared
+                        .as_ref()
+                        .ok_or_else(|| anyhow::anyhow!("cuBLASLt step is not prepared"))?;
+                    anyhow::ensure!(
+                        op.signature
+                            .as_ref()
+                            .is_some_and(|old| old.spec == signature.spec),
+                        "cuBLASLt shape changed after warmup"
+                    );
+                    prepared.enqueue(stream, signature.ptrs).map_err(|error| {
+                        anyhow::anyhow!("external cuBLASLt step {step_index} failed: {error}")
+                    })?;
+                    "cuBLASLt"
+                }
+                CompiledStep::FlashInferDecode(index) => {
+                    let op = &state.flashinfer_ops[index];
+                    let prepared = op
+                        .prepared
+                        .as_ref()
+                        .ok_or_else(|| anyhow::anyhow!("FlashInfer step is not prepared"))?;
+                    let resolved = op
+                        .flashinfer()
+                        .resolve_for_graph(op.node, &op.inputs, buffers, dyn_map)?;
+                    let signature = resolved.signature_for_graph_plan(prepared.plan_c());
+                    anyhow::ensure!(
+                        op.signature
+                            .as_ref()
+                            .is_some_and(|old| old.spec == signature.spec),
+                        "FlashInfer shape changed after warmup"
+                    );
+                    prepared
+                        .enqueue(stream, signature.ptrs, true)
+                        .map_err(|error| {
+                            anyhow::anyhow!("external FlashInfer step {step_index} failed: {error}")
+                        })?;
+                    "FlashInfer"
+                }
+            };
+            anyhow::ensure!(
+                stream.capture_status()?
+                    != cudarc::driver::sys::CUstreamCaptureStatus::CU_STREAM_CAPTURE_STATUS_INVALIDATED,
+                "external CUDA capture was invalidated by {step_name} step {step_index}"
+            );
+        }
         Ok(())
     }
 

--- a/crates/luminal_cuda_lite/src/kernel/to_host.rs
+++ b/crates/luminal_cuda_lite/src/kernel/to_host.rs
@@ -170,6 +170,29 @@ impl CompiledFlashInferDecode {
             .downcast_ref::<FlashInferAttention>()
             .expect("CompiledFlashInferDecode only stores FlashInfer host ops")
     }
+
+    fn enqueue_prepared(
+        &self,
+        stream: &Arc<CudaStream>,
+        buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
+        dyn_map: &DynMap,
+    ) -> anyhow::Result<()> {
+        let prepared = self
+            .prepared
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("FlashInfer step is not prepared"))?;
+        let resolved =
+            self.flashinfer()
+                .resolve_for_graph(self.node, &self.inputs, buffers, dyn_map)?;
+        let signature = resolved.signature_for_graph_plan(prepared.plan_c());
+        anyhow::ensure!(
+            self.signature
+                .as_ref()
+                .is_some_and(|old| old.spec == signature.spec),
+            "FlashInfer shape changed after warmup"
+        );
+        prepared.enqueue(stream, signature.ptrs, true)
+    }
 }
 
 struct PendingFlashInferDecodeRecapture {
@@ -347,6 +370,29 @@ impl CompiledCuBlasLt {
             .downcast_ref::<CuBlasLt>()
             .expect("CompiledCuBlasLt only stores CuBlasLt host ops")
     }
+
+    fn enqueue_prepared(
+        &self,
+        stream: &Arc<CudaStream>,
+        buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
+        dyn_map: &DynMap,
+    ) -> anyhow::Result<()> {
+        let signature = self
+            .cublaslt()
+            .resolve_for_graph(self.node, &self.inputs, buffers, dyn_map)?
+            .signature();
+        let prepared = self
+            .prepared
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("cuBLASLt step is not prepared"))?;
+        anyhow::ensure!(
+            self.signature
+                .as_ref()
+                .is_some_and(|old| old.spec == signature.spec),
+            "cuBLASLt shape changed after warmup"
+        );
+        prepared.enqueue(stream, signature.ptrs)
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -457,6 +503,123 @@ impl CompiledKernel {
             static_shared_memory_bytes: function_facts.static_shared_memory_bytes,
             function_max_threads_per_block: Some(function_facts.max_threads_per_block),
         })
+    }
+
+    fn requires_output_buffer(&self, dyn_map: &DynMap) -> bool {
+        self.kernel_op.output_size().exec(dyn_map).unwrap_or(1) != 0
+            && self.kernel_op.output_aliases_input().is_none()
+    }
+
+    fn launch_config(&self, dyn_map: &DynMap) -> anyhow::Result<KernelLaunchConfig> {
+        let config = KernelLaunchConfig {
+            grid: (
+                self.grid.0.exec(dyn_map).unwrap() as u32,
+                self.grid.1.exec(dyn_map).unwrap() as u32,
+                self.grid.2.exec(dyn_map).unwrap() as u32,
+            ),
+            block: (
+                self.block.0.exec(dyn_map).unwrap() as u32,
+                self.block.1.exec(dyn_map).unwrap() as u32,
+                self.block.2.exec(dyn_map).unwrap() as u32,
+            ),
+            shared_mem: self.shared_mem.exec(dyn_map).unwrap() as u32,
+        };
+        if config.grid.0 == 0
+            || config.grid.1 == 0
+            || config.grid.2 == 0
+            || config.block.0 == 0
+            || config.block.1 == 0
+            || config.block.2 == 0
+        {
+            anyhow::bail!(
+                "invalid CUDA launch dimensions for kernel {} at LLIR node {:?}: grid={:?} block={:?}",
+                self.kernel_name,
+                self.node,
+                config.grid,
+                config.block,
+            );
+        }
+        Ok(config)
+    }
+
+    fn validate_pointers(
+        &self,
+        output_ptr: u64,
+        input_ptrs: &[u64],
+        dyn_map: &DynMap,
+    ) -> anyhow::Result<()> {
+        if self.requires_output_buffer(dyn_map) && output_ptr == 0 {
+            anyhow::bail!(
+                "missing output buffer for CUDA kernel {} at LLIR node {:?}",
+                self.kernel_name,
+                self.node,
+            );
+        }
+
+        for (idx, (input_node, input_ptr)) in self.inputs.iter().zip(input_ptrs).enumerate() {
+            if *input_ptr == 0 {
+                anyhow::bail!(
+                    "missing input buffer {idx} for CUDA kernel {} at LLIR node {:?}; input LLIR node {:?}",
+                    self.kernel_name,
+                    self.node,
+                    input_node,
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn enqueue_prepared(
+        &mut self,
+        stream: &Arc<CudaStream>,
+        buffer_ptrs: &FxHashMap<NodeIndex, u64>,
+        dyn_map: &DynMap,
+        dyn_dims_ptr: u64,
+    ) -> anyhow::Result<()> {
+        self.kernel_op.pre_execute(
+            stream,
+            &mut self.internal_bufs,
+            &mut self.constants,
+            buffer_ptrs,
+            dyn_map,
+        );
+        let output_ptr = buffer_ptrs.get(&self.node).copied().unwrap_or(0);
+        let input_ptrs = self
+            .inputs
+            .iter()
+            .map(|node| buffer_ptrs.get(node).copied().unwrap_or(0))
+            .collect_vec();
+        self.validate_pointers(output_ptr, &input_ptrs, dyn_map)?;
+        let kernel_dyn_dims_ptr = if self.has_dyn_dims_param {
+            dyn_dims_ptr
+        } else {
+            0
+        };
+        anyhow::ensure!(
+            !self.has_dyn_dims_param || kernel_dyn_dims_ptr != 0,
+            "dynamic-dimension buffer was not prepared before capture"
+        );
+        let mut params = UnifiedKernelParams::new(self.kernel_op.build_params(
+            stream,
+            output_ptr,
+            &input_ptrs,
+            &self.internal_bufs,
+            kernel_dyn_dims_ptr,
+        ));
+        let function = unsafe { self.function.raw_function() };
+        let launch = self.launch_config(dyn_map)?;
+        unsafe {
+            cudarc::driver::result::launch_kernel(
+                function,
+                launch.grid,
+                launch.block,
+                launch.shared_mem,
+                stream.cu_stream(),
+                &mut params.ptrs,
+            )?;
+        }
+        Ok(())
     }
 }
 
@@ -1519,74 +1682,6 @@ impl CudaGraphOp {
         }
     }
 
-    fn kernel_requires_output_buffer(kernel: &CompiledKernel, dyn_map: &DynMap) -> bool {
-        kernel.kernel_op.output_size().exec(dyn_map).unwrap_or(1) != 0
-            && kernel.kernel_op.output_aliases_input().is_none()
-    }
-
-    fn kernel_launch_config(
-        kernel: &CompiledKernel,
-        dyn_map: &DynMap,
-    ) -> anyhow::Result<KernelLaunchConfig> {
-        let config = KernelLaunchConfig {
-            grid: (
-                kernel.grid.0.exec(dyn_map).unwrap() as u32,
-                kernel.grid.1.exec(dyn_map).unwrap() as u32,
-                kernel.grid.2.exec(dyn_map).unwrap() as u32,
-            ),
-            block: (
-                kernel.block.0.exec(dyn_map).unwrap() as u32,
-                kernel.block.1.exec(dyn_map).unwrap() as u32,
-                kernel.block.2.exec(dyn_map).unwrap() as u32,
-            ),
-            shared_mem: kernel.shared_mem.exec(dyn_map).unwrap() as u32,
-        };
-        if config.grid.0 == 0
-            || config.grid.1 == 0
-            || config.grid.2 == 0
-            || config.block.0 == 0
-            || config.block.1 == 0
-            || config.block.2 == 0
-        {
-            anyhow::bail!(
-                "invalid CUDA launch dimensions for kernel {} at LLIR node {:?}: grid={:?} block={:?}",
-                kernel.kernel_name,
-                kernel.node,
-                config.grid,
-                config.block,
-            );
-        }
-        Ok(config)
-    }
-
-    fn validate_kernel_pointers(
-        kernel: &CompiledKernel,
-        output_ptr: u64,
-        input_ptrs: &[u64],
-        dyn_map: &DynMap,
-    ) -> anyhow::Result<()> {
-        if Self::kernel_requires_output_buffer(kernel, dyn_map) && output_ptr == 0 {
-            anyhow::bail!(
-                "missing output buffer for CUDA kernel {} at LLIR node {:?}",
-                kernel.kernel_name,
-                kernel.node,
-            );
-        }
-
-        for (idx, (input_node, input_ptr)) in kernel.inputs.iter().zip(input_ptrs).enumerate() {
-            if *input_ptr == 0 {
-                anyhow::bail!(
-                    "missing input buffer {idx} for CUDA kernel {} at LLIR node {:?}; input LLIR node {:?}",
-                    kernel.kernel_name,
-                    kernel.node,
-                    input_node,
-                );
-            }
-        }
-
-        Ok(())
-    }
-
     /// Forget every memory derived from a dynamic-dimension value, so the next
     /// materialize walks the same staleness paths a real dim change triggers:
     /// dyn-var kernels rebuild params, dyn-shaped cuBLASLt islands re-prepare
@@ -1754,7 +1849,7 @@ impl CudaGraphOp {
                         .unwrap_or(0)
                 })
                 .collect_vec();
-            Self::validate_kernel_pointers(kernel, output_ptr, &input_ptrs, dyn_map)?;
+            kernel.validate_pointers(output_ptr, &input_ptrs, dyn_map)?;
             let kernel_dyn_dims_ptr = if kernel.has_dyn_dims_param {
                 dyn_dims_ptr
             } else {
@@ -2006,7 +2101,7 @@ impl CudaGraphOp {
             // before touching either the mutable or executable CUDA graph.
             let mut launch_overrides = FxHashMap::default();
             for idx in launch_candidate_set {
-                let launch = Self::kernel_launch_config(&state.kernels[idx], dyn_map)?;
+                let launch = state.kernels[idx].launch_config(dyn_map)?;
                 if state.kernel_launches.get(idx) != Some(&launch) {
                     dirty_kernel_set.insert(idx);
                     launch_overrides.insert(idx, launch);
@@ -2034,7 +2129,7 @@ impl CudaGraphOp {
                     .iter()
                     .map(|inp| current_buffer_ptrs.get(inp).copied().unwrap_or(0))
                     .collect();
-                Self::validate_kernel_pointers(kernel, output_ptr, &input_ptrs, dyn_map)?;
+                kernel.validate_pointers(output_ptr, &input_ptrs, dyn_map)?;
                 let kernel_dyn_dims_ptr = if kernel.has_dyn_dims_param {
                     dyn_dims_ptr
                 } else {
@@ -2520,103 +2615,26 @@ impl CudaGraphOp {
         let dyn_dims_ptr = state.dyn_dims_ptr;
 
         for step_index in 0..state.steps.len() {
-            let step_name = match state.steps[step_index] {
+            let (step_name, result) = match state.steps[step_index] {
                 CompiledStep::Kernel(index) => {
                     let kernel = &mut state.kernels[index];
-                    kernel.kernel_op.pre_execute(
-                        stream,
-                        &mut kernel.internal_bufs,
-                        &mut kernel.constants,
-                        &buffer_ptrs,
-                        dyn_map,
-                    );
-                    let output_ptr = buffer_ptrs.get(&kernel.node).copied().unwrap_or(0);
-                    let input_ptrs = kernel
-                        .inputs
-                        .iter()
-                        .map(|node| buffer_ptrs.get(node).copied().unwrap_or(0))
-                        .collect_vec();
-                    Self::validate_kernel_pointers(kernel, output_ptr, &input_ptrs, dyn_map)?;
-                    let kernel_dyn_dims_ptr = kernel
-                        .has_dyn_dims_param
-                        .then_some(dyn_dims_ptr)
-                        .unwrap_or(0);
-                    anyhow::ensure!(
-                        !kernel.has_dyn_dims_param || kernel_dyn_dims_ptr != 0,
-                        "dynamic-dimension buffer was not prepared before capture"
-                    );
-                    let mut params = UnifiedKernelParams::new(kernel.kernel_op.build_params(
-                        stream,
-                        output_ptr,
-                        &input_ptrs,
-                        &kernel.internal_bufs,
-                        kernel_dyn_dims_ptr,
-                    ));
-                    let function = unsafe { kernel.function.raw_function() };
-                    let launch = Self::kernel_launch_config(kernel, dyn_map)?;
-                    unsafe {
-                        cudarc::driver::result::launch_kernel(
-                            function,
-                            launch.grid,
-                            launch.block,
-                            launch.shared_mem,
-                            stream.cu_stream(),
-                            &mut params.ptrs,
-                        )
-                        .map_err(|error| {
-                            anyhow::anyhow!(
-                                "external kernel step {step_index} ({}) failed: {error}",
-                                kernel.kernel_name
-                            )
-                        })?;
-                    }
-                    kernel.kernel_name
+                    (
+                        kernel.kernel_name,
+                        kernel.enqueue_prepared(stream, &buffer_ptrs, dyn_map, dyn_dims_ptr),
+                    )
                 }
-                CompiledStep::CuBlasLt(index) => {
-                    let op = &state.cublaslt_ops[index];
-                    let signature = op
-                        .cublaslt()
-                        .resolve_for_graph(op.node, &op.inputs, buffers, dyn_map)?
-                        .signature();
-                    let prepared = op
-                        .prepared
-                        .as_ref()
-                        .ok_or_else(|| anyhow::anyhow!("cuBLASLt step is not prepared"))?;
-                    anyhow::ensure!(
-                        op.signature
-                            .as_ref()
-                            .is_some_and(|old| old.spec == signature.spec),
-                        "cuBLASLt shape changed after warmup"
-                    );
-                    prepared.enqueue(stream, signature.ptrs).map_err(|error| {
-                        anyhow::anyhow!("external cuBLASLt step {step_index} failed: {error}")
-                    })?;
-                    "cuBLASLt"
-                }
-                CompiledStep::FlashInferDecode(index) => {
-                    let op = &state.flashinfer_ops[index];
-                    let prepared = op
-                        .prepared
-                        .as_ref()
-                        .ok_or_else(|| anyhow::anyhow!("FlashInfer step is not prepared"))?;
-                    let resolved = op
-                        .flashinfer()
-                        .resolve_for_graph(op.node, &op.inputs, buffers, dyn_map)?;
-                    let signature = resolved.signature_for_graph_plan(prepared.plan_c());
-                    anyhow::ensure!(
-                        op.signature
-                            .as_ref()
-                            .is_some_and(|old| old.spec == signature.spec),
-                        "FlashInfer shape changed after warmup"
-                    );
-                    prepared
-                        .enqueue(stream, signature.ptrs, true)
-                        .map_err(|error| {
-                            anyhow::anyhow!("external FlashInfer step {step_index} failed: {error}")
-                        })?;
-                    "FlashInfer"
-                }
+                CompiledStep::CuBlasLt(index) => (
+                    "cuBLASLt",
+                    state.cublaslt_ops[index].enqueue_prepared(stream, buffers, dyn_map),
+                ),
+                CompiledStep::FlashInferDecode(index) => (
+                    "FlashInfer",
+                    state.flashinfer_ops[index].enqueue_prepared(stream, buffers, dyn_map),
+                ),
             };
+            result.map_err(|error| {
+                anyhow::anyhow!("external {step_name} step {step_index} failed: {error}")
+            })?;
             anyhow::ensure!(
                 stream.capture_status()?
                     != cudarc::driver::sys::CUstreamCaptureStatus::CU_STREAM_CAPTURE_STATUS_INVALIDATED,
@@ -3110,7 +3128,7 @@ impl CudaGraphOp {
                     }
 
                     let kernel = &state.kernels[idx];
-                    let launch = Self::kernel_launch_config(kernel, dyn_map)?;
+                    let launch = kernel.launch_config(dyn_map)?;
 
                     let output_ptr = buffer_ptrs.get(&kernel.node).copied().unwrap_or(0);
                     let input_ptrs: Vec<u64> = kernel
@@ -3118,7 +3136,7 @@ impl CudaGraphOp {
                         .iter()
                         .map(|inp| buffer_ptrs.get(inp).copied().unwrap_or(0))
                         .collect();
-                    Self::validate_kernel_pointers(kernel, output_ptr, &input_ptrs, dyn_map)?;
+                    kernel.validate_pointers(output_ptr, &input_ptrs, dyn_map)?;
                     let kernel_dyn_dims_ptr = if kernel.has_dyn_dims_param {
                         dyn_dims_ptr
                     } else {

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -380,6 +380,7 @@ pub struct CudaRuntime {
     // Keep this private: every mutation must go through the buffer APIs so
     // `changed_hlir` and resource-input validation stay in sync with the map.
     hlir_buffers: FxHashMap<NodeIndex, CudaInput>,
+    owned_stream: Arc<CudaStream>,
     cuda_stream: Arc<CudaStream>,
     changed_hlir: FxHashSet<NodeIndex>,
     pub(crate) cuda_graph_timings: Vec<(CudaGraphTiming, Uuid)>,
@@ -457,7 +458,31 @@ impl CudaRuntime {
     }
 
     pub fn device_index(&self) -> usize {
-        self.cuda_stream.context().ordinal()
+        self.owned_stream.context().ordinal()
+    }
+
+    /// # Safety
+    ///
+    /// `raw_stream` must be a live CUDA stream on this runtime's context. Its
+    /// owner must keep it alive while this runtime may retain or use it.
+    pub unsafe fn use_borrowed_stream(&mut self, raw_stream: u64) {
+        let context = self.owned_stream.context();
+        let raw_stream = raw_stream as usize as sys::CUstream;
+        let stream = unsafe { context.wrap_borrowed_stream(raw_stream) };
+        self.select_execution_stream(stream);
+    }
+
+    pub fn use_owned_stream(&mut self) {
+        self.select_execution_stream(Arc::clone(&self.owned_stream));
+    }
+
+    fn select_execution_stream(&mut self, stream: Arc<CudaStream>) {
+        self.cuda_stream = Arc::clone(&stream);
+        for bucket in &mut self.compiled_buckets {
+            for op in bucket.exec_graph.node_weights_mut() {
+                op.stream = Arc::clone(&stream);
+            }
+        }
     }
 
     /// Read-only view of installed HLIR inputs.
@@ -4380,6 +4405,7 @@ impl Runtime for CudaRuntime {
             .expect("failed to create CUDA profiling end event");
         Self {
             hlir_buffers: FxHashMap::default(),
+            owned_stream: Arc::clone(&stream),
             cuda_stream: stream,
             changed_hlir: FxHashSet::default(),
             cuda_graph_timings: vec![],

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -404,6 +404,9 @@ pub struct CudaRuntime {
     /// Resource-relevant input state covered by the most recent aggregate
     /// retained-bucket validation.
     last_resource_input_signature: FxHashMap<NodeIndex, ResourceInputFootprint>,
+    /// Owned-stream execution is blocking; borrowed-stream execution leaves
+    /// completion ordered on the caller's stream.
+    synchronize_stream: bool,
     /// High-water intermediate allocation reused across candidate loads and
     /// bucket switches. At most one compiled bucket may borrow it at a time.
     persistent_arena: Option<PersistentArena>,
@@ -470,10 +473,12 @@ impl CudaRuntime {
         let raw_stream = raw_stream as usize as sys::CUstream;
         let stream = unsafe { context.wrap_borrowed_stream(raw_stream) };
         self.select_execution_stream(stream);
+        self.synchronize_stream = false;
     }
 
     pub fn use_owned_stream(&mut self) {
         self.select_execution_stream(Arc::clone(&self.owned_stream));
+        self.synchronize_stream = true;
     }
 
     fn select_execution_stream(&mut self, stream: Arc<CudaStream>) {
@@ -1255,13 +1260,14 @@ impl CudaRuntime {
         unsafe { self.copy_outputs_to_device_ptrs(&[(id.to_id(), dest_ptr, n_bytes)]) };
     }
 
-    /// Copy several output tensors to external CUDA device pointers and wait once.
+    /// Copy several output tensors to external CUDA device pointers.
     ///
     /// Resolving every source before submitting any work makes the operation
     /// all-or-nothing with respect to runtime lookup failures. More importantly,
     /// callers which need to commit many functionalized mutations (for example
-    /// every K/V tensor in a StaticCache) do not pay one stream synchronization
-    /// per tensor.
+    /// every K/V tensor in a StaticCache) enqueue one batch. Owned-stream mode
+    /// waits once for the batch; borrowed-stream mode leaves it on the caller's
+    /// stream.
     ///
     /// # Safety
     /// Every destination pointer must name a live CUDA allocation with at least
@@ -1294,7 +1300,9 @@ impl CudaRuntime {
                 .expect("cuMemcpyDtoDAsync failed");
             }
         }
-        self.cuda_stream.synchronize().unwrap();
+        if self.synchronize_stream {
+            self.cuda_stream.synchronize().unwrap();
+        }
     }
 
     fn restore_external_output_node(&mut self, data_node: NodeIndex) {
@@ -4422,6 +4430,7 @@ impl Runtime for CudaRuntime {
             max_kernel_source_bytes: Some(DEFAULT_MAX_KERNEL_SOURCE_BYTES),
             device_resource_limits,
             last_resource_input_signature: FxHashMap::default(),
+            synchronize_stream: true,
             persistent_arena: None,
             resource_length_sensitive_hlir: FxHashSet::default(),
             validated_resource_signatures: FxHashSet::default(),
@@ -4700,9 +4709,12 @@ impl Runtime for CudaRuntime {
                 .expect("failed to record CUDA profiling end event");
         }
 
-        // Single sync at end - CUDA stream ordering guarantees sequential execution
+        // Standalone execution is blocking. Embedded callers already use
+        // stream ordering and must not be synchronized here.
         let timer = std::time::Instant::now();
-        self.cuda_stream.synchronize().unwrap();
+        if self.synchronize_stream {
+            self.cuda_stream.synchronize().unwrap();
+        }
         sync_time += timer.elapsed();
         self.last_total_time_us = total_start.elapsed().as_secs_f64() * 1_000_000.0;
         if self.profiling {

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -1913,6 +1913,7 @@ impl CudaRuntime {
             bucket.materialization_fully_dirty = true;
         }
         let arena_ptr = bucket.arena.as_ref().unwrap().device_ptr(stream).0;
+        // Don't allow arena allocation to overwrite a user-provided output pointer.
         let buffer_updates = bucket
             .logical_buffer_offsets
             .iter()
@@ -2810,9 +2811,8 @@ impl CudaRuntime {
             new_arena_bytes,
             cached_ptrs_after_alloc,
         ) = {
-            // A durable external output remains authoritative across calls.
-            // Arena preparation must not replace its cached pointer before the
-            // CUDA graph is launched again.
+            // Preserve caller-provided output pointers for this bucket.
+            // Arena allocation must not replace them with internal buffer pointers.
             let external_output_nodes = if self.resolved_output_bucket == Some(bucket_idx) {
                 self.resolved_output_registrations
                     .values()
@@ -4668,6 +4668,7 @@ impl Runtime for CudaRuntime {
             if let Some(cuda_graph) = exec_op.internal.as_any().downcast_ref::<CudaGraphOp>() {
                 let timer = std::time::Instant::now();
                 let result = if self.external_cuda_graph && !self.profiling {
+                    // allow vLLM to capture kernels
                     let buffers = self
                         .buffer_map_for_exec_op(bucket, exec_op, false)
                         .unwrap_or_else(|e| panic!("CUDA execute buffer resolution failed: {e}"))

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -456,6 +456,10 @@ impl CudaRuntime {
         Ok(Self::initialize(stream))
     }
 
+    pub fn device_index(&self) -> usize {
+        self.cuda_stream.context().ordinal()
+    }
+
     /// Read-only view of installed HLIR inputs.
     ///
     /// Mutations must use `set_data`, `set_buffer`, `set_device_ptr`, or

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -407,6 +407,8 @@ pub struct CudaRuntime {
     /// Owned-stream execution is blocking; borrowed-stream execution leaves
     /// completion ordered on the caller's stream.
     synchronize_stream: bool,
+    /// Launch kernels directly so an enclosing runtime can capture them.
+    pub(crate) external_cuda_graph: bool,
     /// High-water intermediate allocation reused across candidate loads and
     /// bucket switches. At most one compiled bucket may borrow it at a time.
     persistent_arena: Option<PersistentArena>,
@@ -4453,6 +4455,7 @@ impl Runtime for CudaRuntime {
             device_resource_limits,
             last_resource_input_signature: FxHashMap::default(),
             synchronize_stream: true,
+            external_cuda_graph: false,
             persistent_arena: None,
             resource_length_sensitive_hlir: FxHashSet::default(),
             validated_resource_signatures: FxHashSet::default(),
@@ -4628,11 +4631,20 @@ impl Runtime for CudaRuntime {
         self.apply_output_ptr_registrations();
         output_registration_time += timer.elapsed();
 
-        // Materialize CUDA graphs before timed execution. The first real launch
-        // should only patch an already-instantiated graph, not build it from scratch.
+        let external_capture = self.external_cuda_graph
+            && !self.profiling
+            && self.cuda_stream.capture_status().is_ok_and(|status| {
+                status
+                    == cudarc::driver::sys::CUstreamCaptureStatus::CU_STREAM_CAPTURE_STATUS_ACTIVE
+            });
+
+        // vLLM warms up each shape before capture. Reuse those prepared
+        // resources while capturing instead of touching Luminal's private graph.
         let timer = std::time::Instant::now();
-        self.materialize_bucket_cuda_graphs(self.active_bucket, dyn_map, false)
-            .unwrap_or_else(|e| panic!("CUDA graph materialization failed: {e}"));
+        if !external_capture {
+            self.materialize_bucket_cuda_graphs(self.active_bucket, dyn_map, false)
+                .unwrap_or_else(|e| panic!("CUDA graph materialization failed: {e}"));
+        }
         materialize_time += timer.elapsed();
         if self.profiling {
             self.last_profile_device_duration = None;
@@ -4655,14 +4667,21 @@ impl Runtime for CudaRuntime {
             .entered();
             if let Some(cuda_graph) = exec_op.internal.as_any().downcast_ref::<CudaGraphOp>() {
                 let timer = std::time::Instant::now();
-                cuda_graph
-                    .launch_materialized(&exec_op.stream)
-                    .unwrap_or_else(|e| {
-                        panic!(
-                            "CUDA graph launch error in {:?}: {e}",
-                            exec_op.internal.stats_name().unwrap_or("unknown")
-                        );
-                    });
+                let result = if self.external_cuda_graph && !self.profiling {
+                    let buffers = self
+                        .buffer_map_for_exec_op(bucket, exec_op, false)
+                        .unwrap_or_else(|e| panic!("CUDA execute buffer resolution failed: {e}"))
+                        .expect("CUDA execute requires all CudaGraphOp buffers");
+                    cuda_graph.launch_steps(&exec_op.stream, &buffers, dyn_map)
+                } else {
+                    cuda_graph.launch_materialized(&exec_op.stream)
+                };
+                result.unwrap_or_else(|e| {
+                    panic!(
+                        "CUDA launch error in {:?}: {e}",
+                        exec_op.internal.stats_name().unwrap_or("unknown")
+                    );
+                });
                 graph_launch_time += timer.elapsed();
                 graph_launches += 1;
             } else {

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -1784,6 +1784,7 @@ impl CudaRuntime {
         bucket: &mut CompiledBucket,
         stream: &Arc<CudaStream>,
         dyn_dims: &DynMap,
+        external_output_nodes: &FxHashSet<NodeIndex>,
     ) {
         let profile_alloc = std::env::var_os("LUMINAL_CUDA_PROFILE_RECAPTURE").is_some();
         let alloc_profile_start = std::time::Instant::now();
@@ -1913,6 +1914,7 @@ impl CudaRuntime {
         let buffer_updates = bucket
             .logical_buffer_offsets
             .iter()
+            .filter(|(logical_node, _)| !external_output_nodes.contains(logical_node))
             .filter_map(|(logical_node, offset)| {
                 let len = bucket.logical_buffer_bytes.get(logical_node).copied()?;
                 let ptr = arena_ptr.checked_add(*offset as u64)?;
@@ -2806,6 +2808,20 @@ impl CudaRuntime {
             new_arena_bytes,
             cached_ptrs_after_alloc,
         ) = {
+            // A durable external output remains authoritative across calls.
+            // Arena preparation must not replace its cached pointer before the
+            // CUDA graph is launched again.
+            let external_output_nodes = if self.resolved_output_bucket == Some(bucket_idx) {
+                self.resolved_output_registrations
+                    .values()
+                    .filter_map(|resolved| match resolved {
+                        ResolvedOutputRegistration::External { data_node } => Some(*data_node),
+                        _ => None,
+                    })
+                    .collect()
+            } else {
+                FxHashSet::default()
+            };
             let bucket = &mut self.compiled_buckets[bucket_idx];
             let stabilize_intermediate_pointers = bucket.stabilize_intermediate_pointers;
             let was_hlir_synced = bucket.hlir_synced;
@@ -2821,6 +2837,7 @@ impl CudaRuntime {
                         bucket,
                         &self.cuda_stream,
                         &allocation_dyn_map,
+                        &external_output_nodes,
                     );
                     bucket.last_allocation_dyn_map = allocation_dyn_map.clone();
                 }
@@ -2842,7 +2859,12 @@ impl CudaRuntime {
                     bucket.cached_buffer_ptrs.len(),
                 )
             } else {
-                Self::allocate_intermediate_buffers(bucket, &self.cuda_stream, dyn_map);
+                Self::allocate_intermediate_buffers(
+                    bucket,
+                    &self.cuda_stream,
+                    dyn_map,
+                    &external_output_nodes,
+                );
                 (
                     stabilize_intermediate_pointers,
                     was_hlir_synced,

--- a/crates/luminal_metal/src/dyn_backend.rs
+++ b/crates/luminal_metal/src/dyn_backend.rs
@@ -28,7 +28,7 @@ impl DynBackend for MetalDynBackend {
     fn get_output_f32(&self, node: NodeIndex) -> Vec<f32> {
         self.runtime.get_f32(node)
     }
-    fn execute(&mut self, dyn_map: &DynMap) {
+    fn execute(&mut self, dyn_map: &DynMap, _stream: Option<u64>) {
         self.runtime.execute(dyn_map);
     }
 }

--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -192,6 +192,7 @@ impl CompiledGraph {
         factory: BackendFactory,
         search_iters: usize,
         device_index: Option<usize>,
+        external_cuda_graph: bool,
     ) -> Result<CompiledGraph, String> {
         let GraphTranslation {
             mut graph,
@@ -217,6 +218,7 @@ impl CompiledGraph {
         let compile_args = BackendCompileArgs {
             search_iters,
             device_index,
+            external_cuda_graph,
             weights: weights
                 .iter()
                 .map(|(label, td)| (label.clone(), td.bytes.clone(), td.dtype))

--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -191,6 +191,7 @@ impl CompiledGraph {
         weight_data: WeightData,
         factory: BackendFactory,
         search_iters: usize,
+        device_index: Option<usize>,
     ) -> Result<CompiledGraph, String> {
         let GraphTranslation {
             mut graph,
@@ -215,6 +216,7 @@ impl CompiledGraph {
         // Build compile args from WeightData.
         let compile_args = BackendCompileArgs {
             search_iters,
+            device_index,
             weights: weights
                 .iter()
                 .map(|(label, td)| (label.clone(), td.bytes.clone(), td.dtype))
@@ -338,6 +340,12 @@ impl CompiledGraph {
     #[getter]
     fn device_type(&self) -> &str {
         self.runtime.device_type()
+    }
+
+    /// The logical CUDA device used by this backend, or None for CPU.
+    #[getter]
+    fn device_index(&self) -> Option<usize> {
+        self.runtime.device_index()
     }
 
     /// Whether the active backend supports device pointer operations (zero-copy GPU I/O).

--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -608,8 +608,9 @@ impl CompiledGraph {
     }
 
     /// Execute the graph.
-    fn run(&mut self) {
-        self.runtime.execute(&self.graph.dyn_map);
+    #[pyo3(signature = (stream=None))]
+    fn run(&mut self, stream: Option<u64>) {
+        self.runtime.execute(&self.graph.dyn_map, stream);
     }
 
     /// Return the HLIR graph as a DOT string for visualization.

--- a/crates/luminal_python/rust/src/pt2_compiled_model.rs
+++ b/crates/luminal_python/rust/src/pt2_compiled_model.rs
@@ -134,6 +134,7 @@ pub fn translate_module(
     factory_capsule,
     weight_device_ptrs=None,
     device_index=None,
+    external_cuda_graph=false,
 ))]
 pub fn process_pt2(
     pt2_path: &str,
@@ -142,6 +143,7 @@ pub fn process_pt2(
     factory_capsule: &Bound<'_, PyCapsule>,
     weight_device_ptrs: Option<HashMap<String, (u64, usize)>>,
     device_index: Option<usize>,
+    external_cuda_graph: bool,
 ) -> PyResult<CompiledGraph> {
     let factory: BackendFactory = {
         let expected = ::luminal::dyn_backend::BACKEND_FACTORY_CAPSULE_NAME;
@@ -185,6 +187,7 @@ pub fn process_pt2(
         weight_device_ptrs.unwrap_or_default(),
         factory,
         device_index,
+        external_cuda_graph,
     )
     .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#}")))
 }
@@ -196,12 +199,20 @@ fn compile_pt2(
     weight_device_ptrs: HashMap<String, (u64, usize)>,
     factory: BackendFactory,
     device_index: Option<usize>,
+    external_cuda_graph: bool,
 ) -> anyhow::Result<CompiledGraph> {
     let (translation, mut weights) = translate_pt2(pt2_path, weights_path)?;
     weights.device_ptrs = weight_device_ptrs;
 
-    CompiledGraph::parse_graph(translation, weights, factory, search_iters, device_index)
-        .map_err(|e| anyhow::anyhow!(e))
+    CompiledGraph::parse_graph(
+        translation,
+        weights,
+        factory,
+        search_iters,
+        device_index,
+        external_cuda_graph,
+    )
+    .map_err(|e| anyhow::anyhow!(e))
 }
 
 /// Translate a PT2 exported model into a format-neutral GraphTranslation + WeightData.

--- a/crates/luminal_python/rust/src/pt2_compiled_model.rs
+++ b/crates/luminal_python/rust/src/pt2_compiled_model.rs
@@ -127,13 +127,21 @@ pub fn translate_module(
 }
 
 #[pyfunction]
-#[pyo3(signature = (pt2_path, weights_path, search_iters, factory_capsule, weight_device_ptrs=None))]
+#[pyo3(signature = (
+    pt2_path,
+    weights_path,
+    search_iters,
+    factory_capsule,
+    weight_device_ptrs=None,
+    device_index=None,
+))]
 pub fn process_pt2(
     pt2_path: &str,
     weights_path: &str,
     search_iters: usize,
     factory_capsule: &Bound<'_, PyCapsule>,
     weight_device_ptrs: Option<HashMap<String, (u64, usize)>>,
+    device_index: Option<usize>,
 ) -> PyResult<CompiledGraph> {
     let factory: BackendFactory = {
         let expected = ::luminal::dyn_backend::BACKEND_FACTORY_CAPSULE_NAME;
@@ -152,9 +160,10 @@ pub fn process_pt2(
                 }
             }
             None => {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "factory_capsule has no name; expected \"luminal.backend_factory\"",
-                ));
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "factory_capsule has no name; expected {:?}",
+                    expected
+                )));
             }
         }
         let wrapper_ptr = factory_capsule
@@ -175,6 +184,7 @@ pub fn process_pt2(
         search_iters,
         weight_device_ptrs.unwrap_or_default(),
         factory,
+        device_index,
     )
     .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#}")))
 }
@@ -185,11 +195,12 @@ fn compile_pt2(
     search_iters: usize,
     weight_device_ptrs: HashMap<String, (u64, usize)>,
     factory: BackendFactory,
+    device_index: Option<usize>,
 ) -> anyhow::Result<CompiledGraph> {
     let (translation, mut weights) = translate_pt2(pt2_path, weights_path)?;
     weights.device_ptrs = weight_device_ptrs;
 
-    CompiledGraph::parse_graph(translation, weights, factory, search_iters)
+    CompiledGraph::parse_graph(translation, weights, factory, search_iters, device_index)
         .map_err(|e| anyhow::anyhow!(e))
 }
 

--- a/crates/luminal_python/src/luminal/__init__.py
+++ b/crates/luminal_python/src/luminal/__init__.py
@@ -2,6 +2,7 @@
 
 # Import Python components
 # Register DynamicCache pytree serialization once at import time
+from .artifact_cache import ArtifactCacheStats, artifact_cache_stats
 from .cache_utils import _register_cache_serialization
 from .compiled_model import CompiledModel
 
@@ -15,6 +16,8 @@ _register_cache_serialization()
 # Re-export everything for clean package interface
 __all__ = [
     "CompiledModel",
+    "ArtifactCacheStats",
+    "artifact_cache_stats",
     "luminal_backend",
     "register_backend",
     "CompiledGraph",

--- a/crates/luminal_python/src/luminal/artifact_cache.py
+++ b/crates/luminal_python/src/luminal/artifact_cache.py
@@ -1,0 +1,130 @@
+"""Process-local reuse for structurally identical compiled regions."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+
+import torch
+import torch.fx as fx
+
+from .compiled_model import CompiledModel
+
+_SYMBOL = re.compile(r"\b[su]\d+\b")
+_artifacts: dict[str, CompiledArtifact] = {}
+_reuse_hits = 0
+_searches = 0
+
+
+@dataclass(frozen=True)
+class ArtifactCacheStats:
+    unique_artifacts: int
+    reuse_hits: int
+    searches: int
+
+
+class CompiledArtifact:
+    """Compiled runtime shared by separate positional tensor bindings."""
+
+    def __init__(self, graph, weight_refs=()):
+        self.graph = graph
+        self.weight_refs = tuple(weight_refs)
+        self._active_binding = None
+
+    def bind(self, **kwargs):
+        return CompiledModel(
+            self.graph,
+            weight_refs=self.weight_refs,
+            artifact=self,
+            **kwargs,
+        )
+
+    def activate(self, binding) -> bool:
+        changed = self._active_binding is not binding
+        self._active_binding = binding
+        return changed
+
+
+def region_artifact_key(program, **options) -> str | None:
+    """Return None when the program contains weights that cannot be rebound."""
+
+    if program.state_dict or program.constants:
+        return None
+
+    nodes = list(program.graph_module.graph.nodes)
+    indices = {node: index for index, node in enumerate(nodes)}
+    symbols = {}
+
+    def normalize_symbol(value):
+        def replace(match):
+            name = match.group(0)
+            return symbols.setdefault(name, f"s{len(symbols)}")
+
+        return _SYMBOL.sub(replace, str(value))
+
+    def normalize(value):
+        if isinstance(value, fx.Node):
+            return ("node", indices[value])
+        if isinstance(value, torch.Tensor):
+            return (
+                "tensor",
+                tuple(normalize_symbol(dim) for dim in value.shape),
+                tuple(normalize_symbol(dim) for dim in value.stride()),
+                str(value.dtype),
+                value.device.type,
+                str(value.layout),
+                normalize_symbol(value.storage_offset()),
+            )
+        if isinstance(value, (tuple, list)):
+            return tuple(normalize(item) for item in value)
+        if isinstance(value, dict):
+            items = ((str(key), normalize(item)) for key, item in value.items())
+            return tuple(sorted(items))
+        if isinstance(value, (str, torch.SymInt, torch.SymFloat, torch.SymBool)):
+            return normalize_symbol(value)
+        if value is None or isinstance(value, (bool, int, float)):
+            return value
+        return str(value)
+
+    graph = []
+    for node in nodes:
+        graph.append(
+            (
+                node.op,
+                None if node.op == "placeholder" else str(node.target),
+                normalize(node.args),
+                normalize(node.kwargs),
+                normalize(node.meta.get("val")),
+            )
+        )
+
+    ranges = sorted(
+        (normalize_symbol(symbol), normalize_symbol(bounds))
+        for symbol, bounds in program.range_constraints.items()
+    )
+    payload = repr((graph, ranges, sorted(options.items()))).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def get_or_compile(key, compile_artifact):
+    global _reuse_hits, _searches
+    artifact = _artifacts.get(key)
+    if artifact is not None:
+        _reuse_hits += 1
+        return artifact
+    artifact = compile_artifact()
+    _artifacts[key] = artifact
+    _searches += 1
+    return artifact
+
+
+def artifact_cache_stats() -> ArtifactCacheStats:
+    return ArtifactCacheStats(len(_artifacts), _reuse_hits, _searches)
+
+
+def clear_artifact_cache() -> None:
+    global _reuse_hits, _searches
+    _artifacts.clear()
+    _reuse_hits = 0
+    _searches = 0

--- a/crates/luminal_python/src/luminal/compiled_model.py
+++ b/crates/luminal_python/src/luminal/compiled_model.py
@@ -43,6 +43,7 @@ class CompiledModel:
         input_names=None,
         user_indices=None,
         scalar_output_positions=(),
+        use_current_stream=False,
     ):
         """Initialize with a compiled CompiledGraph from Rust.
 
@@ -53,6 +54,8 @@ class CompiledModel:
             user_indices: When torch.compile lifts model parameters into extra args,
                 this tells __call__ which arg positions are actual user inputs.
                 None means all args are user inputs (PT2 path).
+            use_current_stream: Run CUDA work on PyTorch's current stream instead
+                of the backend's owned stream.
         """
         self._graph = graph_result
         self._input_names = input_names or graph_result.input_names
@@ -72,6 +75,7 @@ class CompiledModel:
         self._weight_refs = weight_refs or []
         self._user_indices = user_indices
         self._scalar_output_positions = frozenset(scalar_output_positions)
+        self._use_current_stream = use_current_stream
         self.skip_input_names = frozenset()
         self._is_gpu = getattr(graph_result, "device_type", "cpu") != "cpu"
         self._device_index = getattr(graph_result, "device_index", None)
@@ -343,7 +347,11 @@ class CompiledModel:
                     )
                 output_tensors.append(out)
 
-        self._graph.run()
+        if self._use_current_stream:
+            stream = torch.cuda.current_stream(self._device_index)
+            self._graph.run(stream.cuda_stream)
+        else:
+            self._graph.run()
 
         outputs = []
         gpu_writebacks = []

--- a/crates/luminal_python/src/luminal/compiled_model.py
+++ b/crates/luminal_python/src/luminal/compiled_model.py
@@ -42,8 +42,10 @@ class CompiledModel:
         weight_refs=None,
         input_names=None,
         user_indices=None,
+        output_spec=None,
         scalar_output_positions=(),
         use_current_stream=False,
+        static_outputs=False,
     ):
         """Initialize with a compiled CompiledGraph from Rust.
 
@@ -54,8 +56,11 @@ class CompiledModel:
             user_indices: When torch.compile lifts model parameters into extra args,
                 this tells __call__ which arg positions are actual user inputs.
                 None means all args are user inputs (PT2 path).
+            output_spec: Optional pytree structure expected by the caller.
             use_current_stream: Run CUDA work on PyTorch's current stream instead
                 of the backend's owned stream.
+            static_outputs: Reuse maximum-capacity CUDA output buffers across
+                calls and return views with the current runtime shapes.
         """
         self._graph = graph_result
         self._input_names = input_names or graph_result.input_names
@@ -74,8 +79,11 @@ class CompiledModel:
         self._has_dynamic_dims = getattr(graph_result, "has_dynamic_dims", False)
         self._weight_refs = weight_refs or []
         self._user_indices = user_indices
+        self._output_spec = output_spec
         self._scalar_output_positions = frozenset(scalar_output_positions)
         self._use_current_stream = use_current_stream
+        self._static_outputs = static_outputs
+        self._static_output_tensors = None
         self.skip_input_names = frozenset()
         self._is_gpu = getattr(graph_result, "device_type", "cpu") != "cpu"
         self._device_index = getattr(graph_result, "device_index", None)
@@ -84,6 +92,8 @@ class CompiledModel:
         self._supports_device_ptrs = getattr(
             graph_result, "supports_device_ptrs", False
         )
+        if static_outputs and not (self._is_gpu and self._supports_device_ptrs):
+            raise ValueError("static outputs require CUDA device-pointer support")
         # name -> (device, pointer, required bytes, dtype, strong tensor ref).
         # CUDA bindings are persistent in the runtime; only changed metadata
         # needs to cross PyO3 on subsequent calls.
@@ -326,6 +336,22 @@ class CompiledModel:
         _use_zero_copy = self._supports_device_ptrs
         output_tensors = []
         if _use_zero_copy:
+            if self._static_outputs and self._static_output_tensors is None:
+                self._static_output_tensors = []
+                for i, (shape, out_dtype) in enumerate(
+                    zip(self._output_shapes, output_torch_dtypes)
+                ):
+                    if i in self._writeback_by_pos:
+                        self._static_output_tensors.append(None)
+                        continue
+                    if out_dtype not in _zero_copy_native_floats:
+                        raise TypeError(
+                            f"static output '{self._output_names[i]}' has "
+                            f"unsupported dtype {out_dtype}"
+                        )
+                    out = torch.empty(shape, dtype=out_dtype, device=input_device)
+                    self._static_output_tensors.append(out)
+
             for i, (name, shape) in enumerate(zip(self._output_names, output_shapes)):
                 out_dtype = output_torch_dtypes[i]
                 if i in self._writeback_by_pos:
@@ -340,8 +366,24 @@ class CompiledModel:
                         del self._cuda_writeback_bindings[i]
                     output_tensors.append(None)
                     continue
-                out = torch.empty(shape, dtype=out_dtype, device=input_device)
+                if self._static_outputs:
+                    out = self._static_output_tensors[i]
+                    capacity_shape = tuple(out.shape)
+                    shape = tuple(shape)
+                    if len(shape) != len(capacity_shape) or any(
+                        current > capacity
+                        for current, capacity in zip(shape, capacity_shape)
+                    ):
+                        raise ValueError(
+                            f"output '{name}' shape {shape} exceeds static "
+                            f"capacity {capacity_shape}"
+                        )
+                    out = out.view(-1)[: math.prod(shape)].view(shape)
+                else:
+                    out = torch.empty(shape, dtype=out_dtype, device=input_device)
                 if out_dtype in _zero_copy_native_floats:
+                    # The allocation has maximum capacity, but the runtime
+                    # needs the current logical byte length for dynamic shapes.
                     self._graph.set_output_device_ptr_at(
                         i, out.data_ptr(), out.numel() * out.element_size()
                     )
@@ -395,7 +437,10 @@ class CompiledModel:
         if gpu_writebacks:
             self._graph.copy_outputs_to_device_ptrs_at(gpu_writebacks)
 
-        return tuple(
+        flat_outputs = tuple(
             output.item() if i in self._scalar_output_positions else output
             for i, output in enumerate(outputs)
         )
+        if self._output_spec is not None:
+            return torch.utils._pytree.tree_unflatten(flat_outputs, self._output_spec)
+        return flat_outputs

--- a/crates/luminal_python/src/luminal/compiled_model.py
+++ b/crates/luminal_python/src/luminal/compiled_model.py
@@ -276,6 +276,32 @@ class CompiledModel:
             torch.bool: ("get_output_bool", torch.bool),
         }
 
+        if self._static_outputs:
+            for i in self._writeback_by_pos:
+                name = self._output_names[i]
+                target = user_inputs[self._writeback_input_pos[i]]
+                out_dtype = output_torch_dtypes[i]
+                expected_numel = math.prod(output_shapes[i])
+                if not (
+                    hasattr(self._graph, "copy_outputs_to_device_ptrs_at")
+                    and target.is_cuda
+                    and target.is_contiguous()
+                    and target.dtype == out_dtype
+                    and target.numel() == expected_numel
+                ):
+                    raise ValueError(
+                        f"static writeback '{name}' requires a contiguous CUDA "
+                        f"tensor with dtype {out_dtype} and {expected_numel} elements"
+                    )
+                n_bytes = target.numel() * target.element_size()
+                signature = _cuda_input_binding_signature(target, n_bytes)
+                previous = self._cuda_writeback_bindings.get(i)
+                if previous is not None and previous[:4] != signature:
+                    raise ValueError(
+                        f"static writeback '{name}' target allocation changed"
+                    )
+                self._cuda_writeback_bindings[i] = (*signature, target)
+
         def _read_typed_output(
             position: int, name: str, shape, out_dtype
         ) -> torch.Tensor:
@@ -361,9 +387,6 @@ class CompiledModel:
                     # front can redirect one cache writeback into another.
                     # Preserve positional semantics with the batched post-run
                     # device copies below.
-                    if i in self._cuda_writeback_bindings:
-                        self._graph.clear_output_device_ptr_at(i)
-                        del self._cuda_writeback_bindings[i]
                     output_tensors.append(None)
                     continue
                 if self._static_outputs:

--- a/crates/luminal_python/src/luminal/compiled_model.py
+++ b/crates/luminal_python/src/luminal/compiled_model.py
@@ -6,6 +6,7 @@ import torch
 
 from .dtype_util import code_to_torch_dtype
 from .dtype_util import torch_dtype_code as _torch_dtype_code
+from .main import _cuda_device_index
 
 
 def _cuda_input_binding_signature(tensor, n_bytes: int) -> tuple:
@@ -73,6 +74,9 @@ class CompiledModel:
         self._scalar_output_positions = frozenset(scalar_output_positions)
         self.skip_input_names = frozenset()
         self._is_gpu = getattr(graph_result, "device_type", "cpu") != "cpu"
+        self._device_index = getattr(graph_result, "device_index", None)
+        if self._is_gpu and self._device_index is None:
+            raise RuntimeError("CUDA CompiledGraph did not report a device index")
         self._supports_device_ptrs = getattr(
             graph_result, "supports_device_ptrs", False
         )
@@ -141,13 +145,11 @@ class CompiledModel:
                 f"Expected {len(self._input_names)} inputs, got {len(user_inputs)}"
             )
 
-        # Device for outputs: prefer any CUDA input — inputs include lifted
-        # weights, and user_inputs[0] may be a CPU-resident weight (offloaded
-        # models) while activations live on the GPU.
-        input_device = next(
-            (t.device for t in user_inputs if t.is_cuda),
-            user_inputs[0].device if user_inputs else torch.device("cpu"),
-        )
+        if self._is_gpu:
+            _cuda_device_index(user_inputs, expected=self._device_index)
+            input_device = torch.device("cuda", self._device_index)
+        else:
+            input_device = user_inputs[0].device if user_inputs else torch.device("cpu")
 
         # Auto-detect dynamic dims from input shapes
         if self._has_dynamic_dims:

--- a/crates/luminal_python/src/luminal/compiled_model.py
+++ b/crates/luminal_python/src/luminal/compiled_model.py
@@ -46,6 +46,7 @@ class CompiledModel:
         scalar_output_positions=(),
         use_current_stream=False,
         static_outputs=False,
+        artifact=None,
     ):
         """Initialize with a compiled CompiledGraph from Rust.
 
@@ -84,6 +85,8 @@ class CompiledModel:
         self._use_current_stream = use_current_stream
         self._static_outputs = static_outputs
         self._static_output_tensors = None
+        self._artifact = artifact
+        self._binding = object()
         self.skip_input_names = frozenset()
         self._is_gpu = getattr(graph_result, "device_type", "cpu") != "cpu"
         self._device_index = getattr(graph_result, "device_index", None)
@@ -148,6 +151,10 @@ class CompiledModel:
         Returns:
             Tuple of PyTorch tensors containing the model outputs
         """
+        binding_changed = self._artifact is not None and self._artifact.activate(
+            self._binding
+        )
+
         # Drop stripped SymInt args, if any.
         if self._user_indices is not None:
             user_inputs = [inputs[i] for i in self._user_indices]
@@ -202,7 +209,7 @@ class CompiledModel:
                 n_bytes = t.numel() * t.element_size()
                 signature = _cuda_input_binding_signature(t, n_bytes)
                 previous = self._cuda_input_bindings.get(name)
-                if previous is None or previous[:4] != signature:
+                if binding_changed or previous is None or previous[:4] != signature:
                     self._graph.set_input_device_ptr(name, t.data_ptr(), n_bytes)
                 # Commit only after a changed registration succeeds. Retaining
                 # the tensor prevents allocator reuse while Rust holds its

--- a/crates/luminal_python/src/luminal/main.py
+++ b/crates/luminal_python/src/luminal/main.py
@@ -9,6 +9,34 @@ from .dtype_util import torch_dtype_code as _torch_dtype_code
 # ---------------------------------------------------------------------------
 
 
+def _cuda_device_index(tensors, expected=None):
+    """Return one CUDA device index and enforce the current cuda:0 contract."""
+    indices = {
+        tensor.device.index
+        for tensor in tensors
+        if torch.is_tensor(tensor) and tensor.device.type == "cuda"
+    }
+    if None in indices:
+        raise ValueError("CUDA tensor metadata must include a logical device index")
+    if len(indices) > 1:
+        raise ValueError(
+            f"CUDA tensors span multiple logical devices: {sorted(indices)}"
+        )
+
+    observed = next(iter(indices), None)
+    if expected is not None and observed is not None and observed != expected:
+        raise ValueError(
+            f"CUDA tensor is on logical device {observed}, but the compiled "
+            f"runtime uses logical device {expected}"
+        )
+    selected = expected if expected is not None else observed
+    if selected not in (None, 0):
+        raise ValueError(
+            f"Luminal currently supports only logical CUDA device 0, got {selected}"
+        )
+    return selected
+
+
 def _detect_factory_capsule(example_inputs):
     """Pick the best built-in factory capsule based on input device."""
     # Dynamo can prefix `example_inputs` with SymInt entries when shapes are
@@ -31,7 +59,7 @@ def _detect_factory_capsule(example_inputs):
     return _reference_factory_capsule()
 
 
-def _collect_weight_pointers(weights):
+def _collect_weight_pointers(weights, device_index=None):
     """Partition weight tensors into CUDA device pointers and CPU host pointers.
 
     Preserves native dtype — no forced conversion to float32.
@@ -45,6 +73,7 @@ def _collect_weight_pointers(weights):
         - device_ptrs: {name: (device_ptr, n_bytes)}
         - cpu_ptrs: {name: (host_ptr, n_bytes, dtype_code)}
     """
+    _cuda_device_index(weights.values(), expected=device_index)
     keep_alive = []
     device_ptrs = {}
     cpu_ptrs = {}

--- a/crates/luminal_python/src/luminal/pt2.py
+++ b/crates/luminal_python/src/luminal/pt2.py
@@ -301,6 +301,7 @@ def _save_and_compile(
     input_device_ptrs=None,
     scalar_output_positions=(),
     device_index=None,
+    use_current_stream=False,
 ):
     """Compile a PT2 model via Rust, return CompiledModel.
 
@@ -354,6 +355,7 @@ def _save_and_compile(
             weight_refs=keep_alive,
             user_indices=user_indices,
             scalar_output_positions=scalar_output_positions,
+            use_current_stream=use_current_stream,
         )
     finally:
         if owns_tmpdir and tmpdir:

--- a/crates/luminal_python/src/luminal/pt2.py
+++ b/crates/luminal_python/src/luminal/pt2.py
@@ -14,7 +14,12 @@ import torch
 
 from .compiled_model import CompiledModel
 from .luminal import process_pt2
-from .main import _collect_weight_pointers, _detect_factory_capsule, _load_cpu_weights
+from .main import (
+    _collect_weight_pointers,
+    _cuda_device_index,
+    _detect_factory_capsule,
+    _load_cpu_weights,
+)
 
 # ---------------------------------------------------------------------------
 # DynamicCache <> pytree registration
@@ -198,7 +203,7 @@ def _decomp_table():
     return table
 
 
-def _collect_input_device_ptrs(ep, user_inputs):
+def _collect_input_device_ptrs(ep, user_inputs, device_index):
     """Map user-input placeholder names to (device_ptr, n_bytes) for live,
     contiguous CUDA nn.Parameters. Parameters are read-only in inference
     graphs, so the search can safely alias their memory; buffers and
@@ -208,6 +213,7 @@ def _collect_input_device_ptrs(ep, user_inputs):
     search's ones-buffer seeding."""
     from torch.export.graph_signature import InputKind
 
+    _cuda_device_index(user_inputs, expected=device_index)
     user_specs = [
         s for s in ep.graph_signature.input_specs if s.kind == InputKind.USER_INPUT
     ]
@@ -294,6 +300,7 @@ def _save_and_compile(
     user_indices=None,
     input_device_ptrs=None,
     scalar_output_positions=(),
+    device_index=None,
 ):
     """Compile a PT2 model via Rust, return CompiledModel.
 
@@ -322,15 +329,21 @@ def _save_and_compile(
             weight_source = {}
 
         # Collect weight pointers for Rust (avoids duplicate GPU buffer allocation)
+        device_index = _cuda_device_index(weight_source.values(), expected=device_index)
         keep_alive, weight_device_ptrs, cpu_weights = _collect_weight_pointers(
-            weight_source
+            weight_source, device_index=device_index
         )
         if input_device_ptrs:
             weight_device_ptrs.update(input_device_ptrs)
 
         # Compile with device pointers — search uses actual weight memory (zero-copy)
         compiled = process_pt2(
-            pt2_path, "", search_iterations, factory, weight_device_ptrs
+            pt2_path,
+            "",
+            search_iterations,
+            factory,
+            weight_device_ptrs,
+            device_index,
         )
 
         # Load CPU weights after compilation
@@ -582,6 +595,7 @@ def compile(
         example_args = tuple(example_input)
     else:
         example_args = (example_input,)
+    device_index = _cuda_device_index(example_args)
 
     kwargs = export_kwargs or {}
     extra = _export_kwargs()
@@ -627,7 +641,9 @@ def compile(
         )
         ep = ep.run_decompositions(_decomp_table())
 
-    return _save_and_compile(ep, factory, search_iterations)
+    return _save_and_compile(
+        ep, factory, search_iterations, device_index=device_index
+    )
 
 
 def _drop_input_guards(ep):
@@ -810,6 +826,7 @@ def _eager_pt2_compile(
     factory,
     search_iterations,
     scalar_output_positions=(),
+    device_index=None,
 ):
     """Run torch.export → save → Rust compile end-to-end. Returns CompiledModel.
 
@@ -853,7 +870,10 @@ def _eager_pt2_compile(
     # duplicating the full parameter set on device (OOM at ~2x weights for
     # whole-model compiles) and profiling with synthetic data. Nothing is
     # baked: the runtime still takes pointers per call.
-    input_device_ptrs = _collect_input_device_ptrs(ep, user_inputs)
+    device_index = _cuda_device_index(user_inputs, expected=device_index)
+    input_device_ptrs = _collect_input_device_ptrs(
+        ep, user_inputs, device_index
+    )
 
     del ep, gm
     gc.collect()
@@ -868,6 +888,7 @@ def _eager_pt2_compile(
             user_indices=user_indices,
             input_device_ptrs=input_device_ptrs,
             scalar_output_positions=scalar_output_positions,
+            device_index=device_index,
         )
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
@@ -907,6 +928,7 @@ class _LazyDynamicCompiledModel:
         factory,
         search_iterations,
         scalar_output_positions=(),
+        device_index=None,
     ):
         self._gm = gm
         self._user_inputs = user_inputs
@@ -914,6 +936,7 @@ class _LazyDynamicCompiledModel:
         self._dynamic_shapes = dynamic_shapes
         self._search_iterations = search_iterations
         self._scalar_output_positions = scalar_output_positions
+        self._device_index = device_index
         self._factory = factory
         self._compiled = None
 
@@ -927,6 +950,7 @@ class _LazyDynamicCompiledModel:
                 self._factory,
                 self._search_iterations,
                 self._scalar_output_positions,
+                self._device_index,
             )
             # Drop references we no longer need post-compile.
             self._gm = None
@@ -986,6 +1010,7 @@ def pt2_backend(gm, example_inputs, factory=None, search_iterations=None):
     user_inputs, post_strip_subindices, strip_ok = _strip_symint_placeholders(
         gm, user_inputs
     )
+    device_index = _cuda_device_index(user_inputs)
     dynamic_shapes = _build_dynamic_shapes_from_gm(gm) if strip_ok else None
 
     # Arg positions surviving the SymInt strip; None when nothing was
@@ -1009,6 +1034,7 @@ def pt2_backend(gm, example_inputs, factory=None, search_iterations=None):
             factory,
             search_iterations,
             scalar_output_positions,
+            device_index,
         )
 
     return _eager_pt2_compile(
@@ -1019,4 +1045,5 @@ def pt2_backend(gm, example_inputs, factory=None, search_iterations=None):
         factory,
         search_iterations,
         scalar_output_positions,
+        device_index,
     )

--- a/crates/luminal_python/src/luminal/pt2.py
+++ b/crates/luminal_python/src/luminal/pt2.py
@@ -649,9 +649,7 @@ def compile(
         )
         ep = ep.run_decompositions(_decomp_table())
 
-    return _save_and_compile(
-        ep, factory, search_iterations, device_index=device_index
-    )
+    return _save_and_compile(ep, factory, search_iterations, device_index=device_index)
 
 
 def _drop_input_guards(ep):
@@ -879,9 +877,7 @@ def _eager_pt2_compile(
     # whole-model compiles) and profiling with synthetic data. Nothing is
     # baked: the runtime still takes pointers per call.
     device_index = _cuda_device_index(user_inputs, expected=device_index)
-    input_device_ptrs = _collect_input_device_ptrs(
-        ep, user_inputs, device_index
-    )
+    input_device_ptrs = _collect_input_device_ptrs(ep, user_inputs, device_index)
 
     del ep, gm
     gc.collect()

--- a/crates/luminal_python/src/luminal/pt2.py
+++ b/crates/luminal_python/src/luminal/pt2.py
@@ -5,16 +5,15 @@ Provides:
   - pt2_backend(gm, example_inputs)    — torch.compile compatible backend
 """
 
-from functools import partial
 import inspect
 import os
 import shutil
 import tempfile
+from functools import partial
 
 import torch
 
 from .artifact_cache import CompiledArtifact, get_or_compile
-from .compiled_model import CompiledModel
 from .luminal import process_pt2
 from .main import (
     _collect_weight_pointers,

--- a/crates/luminal_python/src/luminal/pt2.py
+++ b/crates/luminal_python/src/luminal/pt2.py
@@ -298,10 +298,12 @@ def _save_and_compile(
     factory,
     search_iterations,
     user_indices=None,
+    output_spec=None,
     input_device_ptrs=None,
     scalar_output_positions=(),
     device_index=None,
     use_current_stream=False,
+    static_outputs=False,
 ):
     """Compile a PT2 model via Rust, return CompiledModel.
 
@@ -354,8 +356,10 @@ def _save_and_compile(
             compiled,
             weight_refs=keep_alive,
             user_indices=user_indices,
+            output_spec=output_spec,
             scalar_output_positions=scalar_output_positions,
             use_current_stream=use_current_stream,
+            static_outputs=static_outputs,
         )
     finally:
         if owns_tmpdir and tmpdir:

--- a/crates/luminal_python/src/luminal/pt2.py
+++ b/crates/luminal_python/src/luminal/pt2.py
@@ -304,6 +304,7 @@ def _save_and_compile(
     device_index=None,
     use_current_stream=False,
     static_outputs=False,
+    external_cuda_graph=False,
 ):
     """Compile a PT2 model via Rust, return CompiledModel.
 
@@ -347,6 +348,7 @@ def _save_and_compile(
             factory,
             weight_device_ptrs,
             device_index,
+            external_cuda_graph,
         )
 
         # Load CPU weights after compilation

--- a/crates/luminal_python/src/luminal/pt2.py
+++ b/crates/luminal_python/src/luminal/pt2.py
@@ -5,6 +5,7 @@ Provides:
   - pt2_backend(gm, example_inputs)    — torch.compile compatible backend
 """
 
+from functools import partial
 import inspect
 import os
 import shutil
@@ -12,6 +13,7 @@ import tempfile
 
 import torch
 
+from .artifact_cache import CompiledArtifact, get_or_compile
 from .compiled_model import CompiledModel
 from .luminal import process_pt2
 from .main import (
@@ -293,6 +295,53 @@ def _lower_sym_sum(ep) -> None:
         gm.recompile()
 
 
+def _compile_artifact(
+    ep_or_path,
+    factory,
+    search_iterations,
+    input_device_ptrs,
+    device_index,
+    external_cuda_graph,
+):
+    owns_tmpdir = not isinstance(ep_or_path, str)
+    tmpdir = tempfile.mkdtemp(prefix="luminal_") if owns_tmpdir else None
+    try:
+        if owns_tmpdir:
+            pt2_path = os.path.join(tmpdir, "model.pt2")
+            # Fake example inputs are not part of the executable program.
+            ep_or_path._example_inputs = None
+            _lower_sym_sum(ep_or_path)  # serde gap workaround; see docstring
+            torch.export.save(ep_or_path, pt2_path)
+            weight_source = ep_or_path.state_dict
+        else:
+            pt2_path = ep_or_path
+            weight_source = {}
+
+        resolved_device = _cuda_device_index(
+            weight_source.values(), expected=device_index
+        )
+        keep_alive, weight_device_ptrs, cpu_weights = _collect_weight_pointers(
+            weight_source, device_index=resolved_device
+        )
+        if input_device_ptrs:
+            weight_device_ptrs.update(input_device_ptrs)
+
+        compiled = process_pt2(
+            pt2_path,
+            "",
+            search_iterations,
+            factory,
+            weight_device_ptrs,
+            resolved_device,
+            external_cuda_graph,
+        )
+        _load_cpu_weights(compiled, cpu_weights)
+        return CompiledArtifact(compiled, keep_alive)
+    finally:
+        if owns_tmpdir and tmpdir:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 def _save_and_compile(
     ep_or_path,
     factory,
@@ -305,67 +354,32 @@ def _save_and_compile(
     use_current_stream=False,
     static_outputs=False,
     external_cuda_graph=False,
+    artifact_key=None,
 ):
-    """Compile a PT2 model via Rust, return CompiledModel.
+    """Compile a PT2 model via Rust, return CompiledModel."""
 
-    Args:
-        ep_or_path: Either an ExportedProgram (will be saved to a temp file) or
-            a path to an already-saved .pt2 file. Baked weights come from
-            ep.state_dict (the AOT compile() path); torch.compile graphs carry
-            weights as ordinary inputs and have an empty state_dict.
-        factory: PyCapsule wrapping the BackendFactory to use.
-    """
-    owns_tmpdir = not isinstance(ep_or_path, str)
-    tmpdir = tempfile.mkdtemp(prefix="luminal_") if owns_tmpdir else None
-    try:
-        if owns_tmpdir:
-            pt2_path = os.path.join(tmpdir, "model.pt2")
-            # `_example_inputs` is an optional copy of the arguments used to create an
-            # ExportedProgram and is not part of the executable graph's semantics. vLLM
-            # invokes compiler backends during torch.compile tracing, so these inputs may
-            # be FakeTensors, which Luminal does not currently serialize or consume.
-            ep_or_path._example_inputs = None
-            _lower_sym_sum(ep_or_path)  # serde gap workaround; see docstring
-            torch.export.save(ep_or_path, pt2_path)
-            weight_source = ep_or_path.state_dict
-        else:
-            pt2_path = ep_or_path
-            weight_source = {}
+    compile_artifact = partial(
+        _compile_artifact,
+        ep_or_path,
+        factory,
+        search_iterations,
+        input_device_ptrs,
+        device_index,
+        external_cuda_graph,
+    )
 
-        # Collect weight pointers for Rust (avoids duplicate GPU buffer allocation)
-        device_index = _cuda_device_index(weight_source.values(), expected=device_index)
-        keep_alive, weight_device_ptrs, cpu_weights = _collect_weight_pointers(
-            weight_source, device_index=device_index
-        )
-        if input_device_ptrs:
-            weight_device_ptrs.update(input_device_ptrs)
-
-        # Compile with device pointers — search uses actual weight memory (zero-copy)
-        compiled = process_pt2(
-            pt2_path,
-            "",
-            search_iterations,
-            factory,
-            weight_device_ptrs,
-            device_index,
-            external_cuda_graph,
-        )
-
-        # Load CPU weights after compilation
-        _load_cpu_weights(compiled, cpu_weights)
-
-        return CompiledModel(
-            compiled,
-            weight_refs=keep_alive,
-            user_indices=user_indices,
-            output_spec=output_spec,
-            scalar_output_positions=scalar_output_positions,
-            use_current_stream=use_current_stream,
-            static_outputs=static_outputs,
-        )
-    finally:
-        if owns_tmpdir and tmpdir:
-            shutil.rmtree(tmpdir, ignore_errors=True)
+    artifact = (
+        get_or_compile(artifact_key, compile_artifact)
+        if artifact_key is not None
+        else compile_artifact()
+    )
+    return artifact.bind(
+        user_indices=user_indices,
+        output_spec=output_spec,
+        scalar_output_positions=scalar_output_positions,
+        use_current_stream=use_current_stream,
+        static_outputs=static_outputs,
+    )
 
 
 def _safe_int_bound(value):

--- a/crates/luminal_python/src/luminal/region_compile.py
+++ b/crates/luminal_python/src/luminal/region_compile.py
@@ -44,4 +44,5 @@ def compile_region(
         user_indices=region.input_indices,
         input_device_ptrs=None,
         device_index=region.device_index,
+        use_current_stream=True,
     )

--- a/crates/luminal_python/src/luminal/region_compile.py
+++ b/crates/luminal_python/src/luminal/region_compile.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .artifact_cache import region_artifact_key
 from .compiled_model import CompiledModel
 from .pt2 import _save_and_compile
 from .region_export import RegionExport
@@ -39,6 +40,14 @@ def compile_region(
             "region compilation requires luminal_python built with CUDA support"
         ) from error
 
+    artifact_key = region_artifact_key(
+        region.program,
+        device_type=device_type,
+        device_index=region.device_index,
+        search_iterations=search_iterations,
+        external_cuda_graph=external_cuda_graph,
+    )
+
     return _save_and_compile(
         region.program,
         _cuda_lite_factory_capsule(),
@@ -50,4 +59,5 @@ def compile_region(
         use_current_stream=True,
         static_outputs=static_outputs,
         external_cuda_graph=external_cuda_graph,
+        artifact_key=artifact_key,
     )

--- a/crates/luminal_python/src/luminal/region_compile.py
+++ b/crates/luminal_python/src/luminal/region_compile.py
@@ -12,6 +12,7 @@ def compile_region(
     *,
     device_type: str = "cuda",
     search_iterations: int = 1,
+    static_outputs: bool = False,
 ) -> CompiledModel:
     """Compile a region without borrowing storage from its example inputs.
 
@@ -42,7 +43,9 @@ def compile_region(
         _cuda_lite_factory_capsule(),
         search_iterations,
         user_indices=region.input_indices,
+        output_spec=region.output_spec,
         input_device_ptrs=None,
         device_index=region.device_index,
         use_current_stream=True,
+        static_outputs=static_outputs,
     )

--- a/crates/luminal_python/src/luminal/region_compile.py
+++ b/crates/luminal_python/src/luminal/region_compile.py
@@ -22,6 +22,13 @@ def compile_region(
 
     if device_type != "cuda":
         raise ValueError(f"unsupported region device type: {device_type!r}")
+    if region.device_index is None:
+        raise ValueError("CUDA region compilation requires CUDA tensor inputs")
+    if region.device_index != 0:
+        raise ValueError(
+            "Luminal currently supports only logical CUDA device 0, "
+            f"got {region.device_index}"
+        )
 
     try:
         from .luminal import _cuda_lite_factory_capsule
@@ -36,4 +43,5 @@ def compile_region(
         search_iterations,
         user_indices=region.input_indices,
         input_device_ptrs=None,
+        device_index=region.device_index,
     )

--- a/crates/luminal_python/src/luminal/region_compile.py
+++ b/crates/luminal_python/src/luminal/region_compile.py
@@ -13,6 +13,7 @@ def compile_region(
     device_type: str = "cuda",
     search_iterations: int = 1,
     static_outputs: bool = False,
+    external_cuda_graph: bool = False,
 ) -> CompiledModel:
     """Compile a region without borrowing storage from its example inputs.
 
@@ -48,4 +49,5 @@ def compile_region(
         device_index=region.device_index,
         use_current_stream=True,
         static_outputs=static_outputs,
+        external_cuda_graph=external_cuda_graph,
     )

--- a/crates/luminal_python/src/luminal/region_export.py
+++ b/crates/luminal_python/src/luminal/region_export.py
@@ -26,6 +26,7 @@ from .region_abi import DynamicRange
 class RegionExport:
     program: torch.export.ExportedProgram
     input_indices: tuple[int, ...]
+    output_spec: Any
     dynamic_ranges: tuple[DynamicRange, ...]
     device_index: int | None
 
@@ -44,6 +45,8 @@ def export_region(
     """
 
     graph = copy.deepcopy(graph).eval()
+    output = next(node for node in graph.graph.nodes if node.op == "output")
+    _, output_spec = torch.utils._pytree.tree_flatten(output.args[0])
     _strip_data_attr(graph)
     inputs, input_indices, strip_ok = _strip_symint_placeholders(
         graph, list(example_inputs)
@@ -82,6 +85,7 @@ def export_region(
         return RegionExport(
             program=exported,
             input_indices=tuple(input_indices),
+            output_spec=output_spec,
             dynamic_ranges=ranges,
             device_index=device_index,
         )

--- a/crates/luminal_python/src/luminal/region_export.py
+++ b/crates/luminal_python/src/luminal/region_export.py
@@ -18,6 +18,7 @@ from .pt2 import (
     _export_kwargs,
     _strip_symint_placeholders,
 )
+from .main import _cuda_device_index
 from .region_abi import DynamicRange
 
 
@@ -26,6 +27,7 @@ class RegionExport:
     program: torch.export.ExportedProgram
     input_indices: tuple[int, ...]
     dynamic_ranges: tuple[DynamicRange, ...]
+    device_index: int | None
 
 
 def export_region(
@@ -51,6 +53,7 @@ def export_region(
             "cannot export region: a SymInt input could not be derived from "
             "a tensor dimension"
         )
+    device_index = _cuda_device_index(inputs)
 
     dynamic_shapes = _build_dynamic_shapes_from_gm(graph, dynamic_range)
     export_inputs = _fresh_export_inputs(inputs)
@@ -76,7 +79,12 @@ def export_region(
         exported = exported.run_decompositions(_decomp_table())
         _drop_input_guards(exported)
         ranges = _set_range_constraints(exported, dynamic_range)
-        return RegionExport(exported, tuple(input_indices), ranges)
+        return RegionExport(
+            program=exported,
+            input_indices=tuple(input_indices),
+            dynamic_ranges=ranges,
+            device_index=device_index,
+        )
     except Exception as error:
         raise RuntimeError(
             "torch.export failed for compiler-owned FX region: "

--- a/crates/luminal_python/tests/test_capsule_validation.py
+++ b/crates/luminal_python/tests/test_capsule_validation.py
@@ -12,6 +12,7 @@ import ctypes
 import pytest
 
 from luminal import process_pt2
+from luminal.luminal import _reference_factory_capsule
 
 
 def _new_capsule(name: bytes):
@@ -20,6 +21,14 @@ def _new_capsule(name: bytes):
     PyCapsule_New.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]
     dummy = ctypes.c_void_p(0xDEADBEEF)
     return PyCapsule_New(ctypes.byref(dummy), name, None)
+
+
+def test_factory_capsule_uses_versioned_abi_name():
+    get_name = ctypes.pythonapi.PyCapsule_GetName
+    get_name.restype = ctypes.c_char_p
+    get_name.argtypes = [ctypes.py_object]
+
+    assert get_name(_reference_factory_capsule()) == b"luminal.backend_factory.v2"
 
 
 def test_process_pt2_rejects_capsule_with_wrong_name():

--- a/crates/luminal_python/tests/test_capsule_validation.py
+++ b/crates/luminal_python/tests/test_capsule_validation.py
@@ -28,7 +28,7 @@ def test_factory_capsule_uses_versioned_abi_name():
     get_name.restype = ctypes.c_char_p
     get_name.argtypes = [ctypes.py_object]
 
-    assert get_name(_reference_factory_capsule()) == b"luminal.backend_factory.v3"
+    assert get_name(_reference_factory_capsule()) == b"luminal.backend_factory.v4"
 
 
 def test_process_pt2_rejects_capsule_with_wrong_name():

--- a/crates/luminal_python/tests/test_capsule_validation.py
+++ b/crates/luminal_python/tests/test_capsule_validation.py
@@ -28,7 +28,7 @@ def test_factory_capsule_uses_versioned_abi_name():
     get_name.restype = ctypes.c_char_p
     get_name.argtypes = [ctypes.py_object]
 
-    assert get_name(_reference_factory_capsule()) == b"luminal.backend_factory.v4"
+    assert get_name(_reference_factory_capsule()) == b"luminal.backend_factory.v2"
 
 
 def test_process_pt2_rejects_capsule_with_wrong_name():

--- a/crates/luminal_python/tests/test_capsule_validation.py
+++ b/crates/luminal_python/tests/test_capsule_validation.py
@@ -28,7 +28,7 @@ def test_factory_capsule_uses_versioned_abi_name():
     get_name.restype = ctypes.c_char_p
     get_name.argtypes = [ctypes.py_object]
 
-    assert get_name(_reference_factory_capsule()) == b"luminal.backend_factory.v2"
+    assert get_name(_reference_factory_capsule()) == b"luminal.backend_factory.v3"
 
 
 def test_process_pt2_rejects_capsule_with_wrong_name():

--- a/crates/luminal_python/tests/test_region_compile.py
+++ b/crates/luminal_python/tests/test_region_compile.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import time
+
 import pytest
 import torch
 from torch import fx
@@ -52,9 +54,11 @@ def test_compile_region_preserves_runtime_input_indices(monkeypatch) -> None:
         "capsule": factory,
         "iterations": 3,
         "user_indices": region.input_indices,
+        "output_spec": region.output_spec,
         "input_device_ptrs": None,
         "device_index": 0,
         "use_current_stream": True,
+        "static_outputs": False,
     }
 
 
@@ -128,6 +132,30 @@ def test_compiled_model_passes_current_stream(monkeypatch) -> None:
     assert calls == [(1234,)]
 
 
+def test_compiled_model_restores_region_output_structure() -> None:
+    from types import SimpleNamespace
+
+    graph = SimpleNamespace(
+        input_names=[],
+        input_dtypes=[],
+        output_names=["result"],
+        output_dtypes=[7],
+        output_shapes=[[1]],
+        writeback_outputs=[],
+        has_dynamic_dims=False,
+        device_type="cpu",
+        device_index=None,
+        supports_device_ptrs=False,
+        run=lambda: None,
+        get_output_at=lambda position: [3.0],
+    )
+    _, output_spec = torch.utils._pytree.tree_flatten(torch.tensor(0))
+
+    output = CompiledModel(graph, output_spec=output_spec)()
+
+    assert torch.equal(output, torch.tensor([3.0]))
+
+
 def _cuda_skip_reason() -> str | None:
     if not torch.cuda.is_available():
         return "CUDA is not available"
@@ -179,23 +207,40 @@ def test_compile_region_uses_current_cuda_stream() -> None:
         ]
         region = export_region(_add_graph(), fake_inputs)
 
-    compiled = compile_region(region, search_iterations=1)
+    compiled = compile_region(region, search_iterations=1, static_outputs=True)
     left = torch.empty((2, 4), device="cuda", dtype=torch.float16)
     right = torch.empty((2, 4), device="cuda", dtype=torch.float16)
     stream = torch.cuda.Stream()
 
-    # Warm up any one-time runtime work before checking asynchronous behavior.
-    compiled(left, right)
+    # Warm up one-time compilation and allocation work on this stream.
+    with torch.cuda.stream(stream):
+        (actual,) = compiled(left, right)
+    stream.synchronize()
+
+    # `_sleep` cycles do not have a portable wall-clock duration, so measure the
+    # delay on this GPU before using it to test whether the host call blocks.
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    with torch.cuda.stream(stream):
+        start.record()
+        torch.cuda._sleep(1_000_000_000)
+        end.record()
+    end.synchronize()
+    sleep_ms = start.elapsed_time(end)
+    assert sleep_ms > 10, f"CUDA delay is too short to test blocking: {sleep_ms} ms"
 
     with torch.cuda.stream(stream):
         torch.cuda._sleep(1_000_000_000)
-        delayed = torch.cuda.Event()
-        delayed.record()
         left.fill_(1)
         right.fill_(2)
+        call_start = time.perf_counter()
         (actual,) = compiled(left, right)
+        call_ms = (time.perf_counter() - call_start) * 1_000
 
-    assert not delayed.query(), "Luminal synchronized the borrowed CUDA stream"
+    assert call_ms < sleep_ms / 2, (
+        "Luminal blocked on the borrowed CUDA stream "
+        f"(call={call_ms:.3f} ms, queued_delay={sleep_ms:.3f} ms)"
+    )
     stream.synchronize()
     torch.testing.assert_close(actual, torch.full_like(actual, 3))
 
@@ -230,15 +275,18 @@ def test_compile_region_enforces_dynamic_range() -> None:
         [fake_left, fake_right],
         dynamic_range=(1, 8),
     )
-    compiled = compile_region(region, search_iterations=1)
+    compiled = compile_region(region, search_iterations=1, static_outputs=True)
     assert compiled._graph.output_shapes == [[16, 8]]
 
+    output_ptrs = set()
     for size in (2, 3, 5, 8):
         left_value = torch.randn((size, 8), device="cuda", dtype=torch.float16)
         right_value = torch.randn((size, 8), device="cuda", dtype=torch.float16)
         (actual,) = compiled(left_value, right_value)
+        output_ptrs.add(actual.data_ptr())
         assert actual.shape == (size * 2, 8)
         torch.testing.assert_close(actual, torch.cat((left_value, right_value)))
+    assert len(output_ptrs) == 1
 
     for size in (1, 9):
         value = torch.randn((size, 8), device="cuda", dtype=torch.float16)

--- a/crates/luminal_python/tests/test_region_compile.py
+++ b/crates/luminal_python/tests/test_region_compile.py
@@ -81,9 +81,7 @@ def test_compiled_model_rejects_wrong_cuda_device() -> None:
     class CudaOneTensor(torch.Tensor):
         @staticmethod
         def __new__(cls):
-            return torch.Tensor._make_subclass(
-                cls, torch.empty(2), require_grad=False
-            )
+            return torch.Tensor._make_subclass(cls, torch.empty(2), require_grad=False)
 
         @property
         def device(self):

--- a/crates/luminal_python/tests/test_region_compile.py
+++ b/crates/luminal_python/tests/test_region_compile.py
@@ -7,6 +7,14 @@ import torch
 from torch import fx
 
 import luminal.region_compile as region_compile_module
+from luminal.artifact_cache import (
+    ArtifactCacheStats,
+    CompiledArtifact,
+    artifact_cache_stats,
+    clear_artifact_cache,
+    get_or_compile,
+    region_artifact_key,
+)
 from luminal.compiled_model import CompiledModel
 from luminal.region_compile import compile_region
 from luminal.region_export import export_region
@@ -60,7 +68,113 @@ def test_compile_region_preserves_runtime_input_indices(monkeypatch) -> None:
         "use_current_stream": True,
         "static_outputs": False,
         "external_cuda_graph": False,
+        "artifact_key": region_artifact_key(
+            region.program,
+            device_type="cuda",
+            device_index=0,
+            search_iterations=3,
+            external_cuda_graph=False,
+        ),
     }
+
+
+def _key_program(input_name: str, op=torch.ops.aten.relu.default):
+    from types import SimpleNamespace
+
+    graph = fx.Graph()
+    value = graph.placeholder(input_name)
+    value.meta["val"] = torch.empty(2, 4)
+    result = graph.call_function(op, (value,))
+    result.meta["val"] = torch.empty(2, 4)
+    graph.output((result,))
+    return SimpleNamespace(
+        constants={},
+        state_dict={},
+        range_constraints={},
+        graph_module=fx.GraphModule(torch.nn.Module(), graph),
+    )
+
+
+def test_artifact_key_ignores_input_names() -> None:
+    options = {"device_type": "cuda", "search_iterations": 1}
+
+    assert region_artifact_key(_key_program("layer_0"), **options) == (
+        region_artifact_key(_key_program("layer_1"), **options)
+    )
+    assert region_artifact_key(_key_program("layer_0"), **options) != (
+        region_artifact_key(
+            _key_program("layer_0", torch.ops.aten.sigmoid.default), **options
+        )
+    )
+
+
+def test_artifact_cache_compiles_once() -> None:
+    clear_artifact_cache()
+    artifact = object()
+    calls = 0
+
+    def compile_artifact():
+        nonlocal calls
+        calls += 1
+        return artifact
+
+    assert get_or_compile("region", compile_artifact) is artifact
+    assert get_or_compile("region", compile_artifact) is artifact
+    assert calls == 1
+    assert artifact_cache_stats() == ArtifactCacheStats(
+        unique_artifacts=1,
+        reuse_hits=1,
+        searches=1,
+    )
+    clear_artifact_cache()
+
+
+def test_shared_artifact_rebinds_inputs_between_models() -> None:
+    from types import SimpleNamespace
+
+    class CudaTensor(torch.Tensor):
+        @staticmethod
+        def __new__(cls):
+            return torch.Tensor._make_subclass(cls, torch.empty(2), False)
+
+        @property
+        def device(self):
+            return torch.device("cuda:0")
+
+        @property
+        def is_cuda(self):
+            return True
+
+    registrations = []
+    graph = SimpleNamespace(
+        input_names=["x"],
+        input_dtypes=[7],
+        output_names=[],
+        output_dtypes=[],
+        output_shapes=[],
+        writeback_outputs=[],
+        has_dynamic_dims=False,
+        device_type="cuda",
+        device_index=0,
+        supports_device_ptrs=True,
+        set_input_device_ptr=lambda _, ptr, __: registrations.append(ptr),
+        run=lambda: None,
+    )
+    artifact = CompiledArtifact(graph)
+    first = artifact.bind()
+    second = artifact.bind()
+    first_input = CudaTensor()
+    second_input = CudaTensor()
+
+    first(first_input)
+    second(second_input)
+    first(first_input)
+
+    assert registrations == [
+        first_input.data_ptr(),
+        second_input.data_ptr(),
+        first_input.data_ptr(),
+    ]
 
 
 def test_compile_region_rejects_nonzero_device() -> None:

--- a/crates/luminal_python/tests/test_region_compile.py
+++ b/crates/luminal_python/tests/test_region_compile.py
@@ -59,6 +59,7 @@ def test_compile_region_preserves_runtime_input_indices(monkeypatch) -> None:
         "device_index": 0,
         "use_current_stream": True,
         "static_outputs": False,
+        "external_cuda_graph": False,
     }
 
 
@@ -279,6 +280,46 @@ def test_compile_region_uses_current_cuda_stream() -> None:
     )
     stream.synchronize()
     torch.testing.assert_close(actual, torch.full_like(actual, 3))
+
+
+@pytest.mark.skipif(
+    _CUDA_SKIP_REASON is not None, reason=_CUDA_SKIP_REASON or "CUDA is unavailable"
+)
+def test_compile_region_can_be_captured_by_pytorch() -> None:
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        fake_inputs = [
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+        ]
+        region = export_region(_add_graph(), fake_inputs)
+
+    compiled = compile_region(
+        region,
+        search_iterations=1,
+        static_outputs=True,
+        external_cuda_graph=True,
+    )
+    left = torch.ones((2, 4), device="cuda", dtype=torch.float16)
+    right = torch.full((2, 4), 2, device="cuda", dtype=torch.float16)
+
+    # Prepare every Luminal resource before capture.
+    compiled(left, right)
+    torch.cuda.synchronize()
+
+    # vLLM's capture buffers need not have the same addresses as warmup.
+    capture_left = torch.full_like(left, 3)
+    capture_right = torch.full_like(right, 4)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        (actual,) = compiled(capture_left, capture_right)
+
+    capture_left.fill_(5)
+    capture_right.fill_(6)
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(actual, torch.full_like(actual, 11))
 
 
 @pytest.mark.skipif(

--- a/crates/luminal_python/tests/test_region_compile.py
+++ b/crates/luminal_python/tests/test_region_compile.py
@@ -54,6 +54,7 @@ def test_compile_region_preserves_runtime_input_indices(monkeypatch) -> None:
         "user_indices": region.input_indices,
         "input_device_ptrs": None,
         "device_index": 0,
+        "use_current_stream": True,
     }
 
 
@@ -100,6 +101,33 @@ def test_compiled_model_rejects_wrong_cuda_device() -> None:
         model(CudaOneTensor())
 
 
+def test_compiled_model_passes_current_stream(monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    calls = []
+    graph = SimpleNamespace(
+        input_names=[],
+        input_dtypes=[],
+        output_names=[],
+        output_dtypes=[],
+        output_shapes=[],
+        writeback_outputs=[],
+        has_dynamic_dims=False,
+        device_type="cuda",
+        device_index=0,
+        supports_device_ptrs=True,
+        run=lambda *args: calls.append(args),
+    )
+    monkeypatch.setattr(
+        torch.cuda,
+        "current_stream",
+        lambda device: SimpleNamespace(cuda_stream=1234),
+    )
+
+    assert CompiledModel(graph, use_current_stream=True)() == ()
+    assert calls == [(1234,)]
+
+
 def _cuda_skip_reason() -> str | None:
     if not torch.cuda.is_available():
         return "CUDA is not available"
@@ -136,6 +164,33 @@ def test_compile_region_from_fake_cuda_metadata() -> None:
     ]
     (actual,) = compiled(*real_inputs)
     torch.testing.assert_close(actual, real_inputs[0] + real_inputs[1])
+
+
+@pytest.mark.skipif(
+    _CUDA_SKIP_REASON is not None, reason=_CUDA_SKIP_REASON or "CUDA is unavailable"
+)
+def test_compile_region_uses_current_cuda_stream() -> None:
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        fake_inputs = [
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+        ]
+        region = export_region(_add_graph(), fake_inputs)
+
+    compiled = compile_region(region, search_iterations=1)
+    left = torch.empty((2, 4), device="cuda", dtype=torch.float16)
+    right = torch.empty((2, 4), device="cuda", dtype=torch.float16)
+    stream = torch.cuda.Stream()
+
+    with torch.cuda.stream(stream):
+        torch.cuda._sleep(10_000_000)
+        left.fill_(1)
+        right.fill_(2)
+        (actual,) = compiled(left, right)
+
+    torch.testing.assert_close(actual, torch.full_like(actual, 3))
 
 
 @pytest.mark.skipif(

--- a/crates/luminal_python/tests/test_region_compile.py
+++ b/crates/luminal_python/tests/test_region_compile.py
@@ -5,6 +5,7 @@ import torch
 from torch import fx
 
 import luminal.region_compile as region_compile_module
+from luminal.compiled_model import CompiledModel
 from luminal.region_compile import compile_region
 from luminal.region_export import export_region
 
@@ -19,10 +20,11 @@ def _add_graph() -> fx.GraphModule:
 
 
 def test_compile_region_preserves_runtime_input_indices(monkeypatch) -> None:
-    region = export_region(
-        _add_graph(),
-        [torch.randn(2, 4), torch.randn(2, 4)],
-    )
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        inputs = [torch.randn(2, 4, device="cuda") for _ in range(2)]
+        region = export_region(_add_graph(), inputs)
     sentinel = object()
     factory = object()
     received = {}
@@ -51,7 +53,51 @@ def test_compile_region_preserves_runtime_input_indices(monkeypatch) -> None:
         "iterations": 3,
         "user_indices": region.input_indices,
         "input_device_ptrs": None,
+        "device_index": 0,
     }
+
+
+def test_compile_region_rejects_nonzero_device() -> None:
+    from dataclasses import replace
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        inputs = [torch.randn(2, 4, device="cuda") for _ in range(2)]
+        region = export_region(_add_graph(), inputs)
+
+    with pytest.raises(ValueError, match="only logical CUDA device 0"):
+        compile_region(replace(region, device_index=1))
+
+
+def test_compiled_model_rejects_wrong_cuda_device() -> None:
+    from types import SimpleNamespace
+
+    class CudaOneTensor(torch.Tensor):
+        @staticmethod
+        def __new__(cls):
+            return torch.Tensor._make_subclass(
+                cls, torch.empty(2), require_grad=False
+            )
+
+        @property
+        def device(self):
+            return torch.device("cuda:1")
+
+    graph = SimpleNamespace(
+        input_names=["x"],
+        input_dtypes=[7],
+        output_names=[],
+        output_shapes=[],
+        writeback_outputs=[],
+        has_dynamic_dims=False,
+        device_type="cuda",
+        device_index=0,
+        supports_device_ptrs=True,
+    )
+    model = CompiledModel(graph)
+
+    with pytest.raises(ValueError, match="compiled runtime uses logical device 0"):
+        model(CudaOneTensor())
 
 
 def _cuda_skip_reason() -> str | None:

--- a/crates/luminal_python/tests/test_region_compile.py
+++ b/crates/luminal_python/tests/test_region_compile.py
@@ -171,6 +171,49 @@ def _cuda_skip_reason() -> str | None:
 _CUDA_SKIP_REASON = _cuda_skip_reason()
 
 
+def _cuda_sleep_ms(stream: torch.cuda.Stream) -> float:
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    with torch.cuda.stream(stream):
+        start.record()
+        torch.cuda._sleep(1_000_000_000)
+        end.record()
+    end.synchronize()
+    return start.elapsed_time(end)
+
+
+@pytest.mark.skipif(
+    _CUDA_SKIP_REASON is not None, reason=_CUDA_SKIP_REASON or "CUDA is unavailable"
+)
+def test_non_static_writeback_accepts_changed_target() -> None:
+    from types import SimpleNamespace
+
+    copies = []
+    graph = SimpleNamespace(
+        input_names=["target"],
+        input_dtypes=[7],
+        output_names=["mutation"],
+        output_dtypes=[7],
+        output_shapes=[[2]],
+        writeback_outputs=[(0, "target")],
+        has_dynamic_dims=False,
+        device_type="cuda",
+        device_index=0,
+        supports_device_ptrs=True,
+        set_input_device_ptr=lambda *args: None,
+        run=lambda *args: None,
+        copy_outputs_to_device_ptrs_at=lambda value: copies.append(value),
+    )
+    model = CompiledModel(graph)
+    first = torch.zeros(2, device="cuda")
+    second = torch.zeros(2, device="cuda")
+
+    model(first)
+    model(second)
+
+    assert [copy[0][1] for copy in copies] == [first.data_ptr(), second.data_ptr()]
+
+
 @pytest.mark.skipif(
     _CUDA_SKIP_REASON is not None, reason=_CUDA_SKIP_REASON or "CUDA is unavailable"
 )
@@ -219,14 +262,7 @@ def test_compile_region_uses_current_cuda_stream() -> None:
 
     # `_sleep` cycles do not have a portable wall-clock duration, so measure the
     # delay on this GPU before using it to test whether the host call blocks.
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    with torch.cuda.stream(stream):
-        start.record()
-        torch.cuda._sleep(1_000_000_000)
-        end.record()
-    end.synchronize()
-    sleep_ms = start.elapsed_time(end)
+    sleep_ms = _cuda_sleep_ms(stream)
     assert sleep_ms > 10, f"CUDA delay is too short to test blocking: {sleep_ms} ms"
 
     with torch.cuda.stream(stream):
@@ -243,6 +279,57 @@ def test_compile_region_uses_current_cuda_stream() -> None:
     )
     stream.synchronize()
     torch.testing.assert_close(actual, torch.full_like(actual, 3))
+
+
+@pytest.mark.skipif(
+    _CUDA_SKIP_REASON is not None, reason=_CUDA_SKIP_REASON or "CUDA is unavailable"
+)
+def test_static_writeback_uses_stable_target_on_current_stream() -> None:
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    graph = fx.Graph()
+    target = graph.placeholder("target")
+    update = graph.placeholder("update")
+    result = graph.call_function(torch.ops.aten.add_.Tensor, (target, update))
+    graph.output(result)
+    graph_module = fx.GraphModule(torch.nn.Module(), graph)
+
+    with FakeTensorMode():
+        fake_inputs = [
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+        ]
+        region = export_region(graph_module, fake_inputs)
+
+    compiled = compile_region(region, search_iterations=1, static_outputs=True)
+    target_value = torch.zeros((2, 4), device="cuda", dtype=torch.float16)
+    stream = torch.cuda.Stream()
+
+    with torch.cuda.stream(stream):
+        compiled(target_value, torch.ones_like(target_value))
+    stream.synchronize()
+    torch.testing.assert_close(target_value, torch.ones_like(target_value))
+
+    sleep_ms = _cuda_sleep_ms(stream)
+    assert sleep_ms > 10, f"CUDA delay is too short to test blocking: {sleep_ms} ms"
+    with torch.cuda.stream(stream):
+        torch.cuda._sleep(1_000_000_000)
+        call_start = time.perf_counter()
+        compiled(target_value, torch.full_like(target_value, 2))
+        call_ms = (time.perf_counter() - call_start) * 1_000
+
+    assert call_ms < sleep_ms / 2, (
+        "Luminal writeback blocked on the borrowed CUDA stream "
+        f"(call={call_ms:.3f} ms, queued_delay={sleep_ms:.3f} ms)"
+    )
+    stream.synchronize()
+    torch.testing.assert_close(target_value, torch.full_like(target_value, 3))
+
+    with pytest.raises(ValueError, match="requires a contiguous CUDA tensor"):
+        compiled(target_value.t(), torch.ones_like(target_value.t()))
+
+    with pytest.raises(ValueError, match="target allocation changed"):
+        compiled(torch.zeros_like(target_value), torch.ones_like(target_value))
 
 
 @pytest.mark.skipif(

--- a/crates/luminal_python/tests/test_region_compile.py
+++ b/crates/luminal_python/tests/test_region_compile.py
@@ -184,12 +184,19 @@ def test_compile_region_uses_current_cuda_stream() -> None:
     right = torch.empty((2, 4), device="cuda", dtype=torch.float16)
     stream = torch.cuda.Stream()
 
+    # Warm up any one-time runtime work before checking asynchronous behavior.
+    compiled(left, right)
+
     with torch.cuda.stream(stream):
-        torch.cuda._sleep(10_000_000)
+        torch.cuda._sleep(1_000_000_000)
+        delayed = torch.cuda.Event()
+        delayed.record()
         left.fill_(1)
         right.fill_(2)
         (actual,) = compiled(left, right)
 
+    assert not delayed.query(), "Luminal synchronized the borrowed CUDA stream"
+    stream.synchronize()
     torch.testing.assert_close(actual, torch.full_like(actual, 3))
 
 

--- a/crates/luminal_python/tests/test_region_export.py
+++ b/crates/luminal_python/tests/test_region_export.py
@@ -10,6 +10,21 @@ from torch import fx
 from luminal.region_export import _fresh_export_inputs, export_region
 
 
+def _tensor_reporting_device(device: str) -> torch.Tensor:
+    class DeviceTensor(torch.Tensor):
+        @staticmethod
+        def __new__(cls):
+            return torch.Tensor._make_subclass(
+                cls, torch.empty(1), require_grad=False
+            )
+
+        @property
+        def device(self):
+            return torch.device(device)
+
+    return DeviceTensor()
+
+
 def _linear_graph() -> fx.GraphModule:
     graph = fx.Graph()
     x = graph.placeholder("x")
@@ -290,3 +305,29 @@ def test_export_region_surfaces_export_error(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="ValueError: original export failure"):
         export_region(_linear_graph(), [torch.randn(3, 8)] * 3)
+
+
+def test_export_region_records_fake_cuda_device() -> None:
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        inputs = [torch.randn(2, 4, device="cuda:0") for _ in range(2)]
+        graph = fx.symbolic_trace(lambda left, right: left + right)
+        region = export_region(graph, inputs)
+
+    assert region.device_index == 0
+
+
+def test_export_region_rejects_multiple_cuda_devices() -> None:
+    inputs = [
+        _tensor_reporting_device("cuda:0"),
+        _tensor_reporting_device("cuda:1"),
+    ]
+    with pytest.raises(ValueError, match="span multiple logical devices"):
+        export_region(fx.symbolic_trace(lambda left, right: left + right), inputs)
+
+
+def test_export_region_rejects_nonzero_cuda_device() -> None:
+    inputs = [_tensor_reporting_device("cuda:1") for _ in range(2)]
+    with pytest.raises(ValueError, match="only logical CUDA device 0"):
+        export_region(fx.symbolic_trace(lambda left, right: left + right), inputs)

--- a/crates/luminal_python/tests/test_region_export.py
+++ b/crates/luminal_python/tests/test_region_export.py
@@ -14,9 +14,7 @@ def _tensor_reporting_device(device: str) -> torch.Tensor:
     class DeviceTensor(torch.Tensor):
         @staticmethod
         def __new__(cls):
-            return torch.Tensor._make_subclass(
-                cls, torch.empty(1), require_grad=False
-            )
+            return torch.Tensor._make_subclass(cls, torch.empty(1), require_grad=False)
 
         @property
         def device(self):

--- a/src/dyn_backend.rs
+++ b/src/dyn_backend.rs
@@ -134,7 +134,7 @@ pub struct BackendCompileArgs {
 /// The version is part of the ABI: `BackendCompileArgs` crosses this boundary
 /// by value, so an older plugin must be rejected rather than reading a changed
 /// struct layout.
-pub const BACKEND_FACTORY_CAPSULE_NAME: &std::ffi::CStr = c"luminal.backend_factory.v4";
+pub const BACKEND_FACTORY_CAPSULE_NAME: &std::ffi::CStr = c"luminal.backend_factory.v2";
 
 /// A factory function that compiles a [`Graph`] into a ready-to-execute [`DynBackend`].
 pub type BackendFactory = fn(&mut Graph, BackendCompileArgs) -> Result<Box<dyn DynBackend>, String>;

--- a/src/dyn_backend.rs
+++ b/src/dyn_backend.rs
@@ -69,7 +69,9 @@ pub trait DynBackend {
     fn get_output_bool(&self, _node: NodeIndex) -> Vec<bool> {
         panic!("get_output_bool not supported by '{}'", self.name());
     }
-    fn execute(&mut self, dyn_map: &DynMap);
+    /// Execute on the backend's owned stream, or on a borrowed raw CUDA
+    /// stream supplied by the caller.
+    fn execute(&mut self, dyn_map: &DynMap, stream: Option<u64>);
 
     // --- Optional device pointer support (GPU backends) --------------------
 
@@ -131,7 +133,7 @@ pub struct BackendCompileArgs {
 /// The version is part of the ABI: `BackendCompileArgs` crosses this boundary
 /// by value, so an older plugin must be rejected rather than reading a changed
 /// struct layout.
-pub const BACKEND_FACTORY_CAPSULE_NAME: &std::ffi::CStr = c"luminal.backend_factory.v2";
+pub const BACKEND_FACTORY_CAPSULE_NAME: &std::ffi::CStr = c"luminal.backend_factory.v3";
 
 /// A factory function that compiles a [`Graph`] into a ready-to-execute [`DynBackend`].
 pub type BackendFactory = fn(&mut Graph, BackendCompileArgs) -> Result<Box<dyn DynBackend>, String>;
@@ -448,7 +450,11 @@ impl DynBackend for ReferenceDynBackend {
         }
     }
 
-    fn execute(&mut self, dyn_map: &DynMap) {
+    fn execute(&mut self, dyn_map: &DynMap, stream: Option<u64>) {
+        assert!(
+            stream.is_none(),
+            "reference backend does not support CUDA streams"
+        );
         self.runtime.execute(dyn_map);
     }
 }

--- a/src/dyn_backend.rs
+++ b/src/dyn_backend.rs
@@ -35,6 +35,10 @@ pub trait DynBackend {
         "cpu"
     }
 
+    fn device_index(&self) -> Option<usize> {
+        None
+    }
+
     fn set_data_bytes(&mut self, node: NodeIndex, bytes: Vec<u8>, dtype: DType);
     fn set_data_f32(&mut self, node: NodeIndex, data: Vec<f32>);
     fn get_output_f32(&self, node: NodeIndex) -> Vec<f32>;
@@ -116,6 +120,7 @@ pub trait DynBackend {
 /// Arguments passed to a backend factory during compilation.
 pub struct BackendCompileArgs {
     pub search_iters: usize,
+    pub device_index: Option<usize>,
     pub weights: Vec<(String, Vec<u8>, DType)>,
     pub tensor_sizes: HashMap<String, usize>,
     pub device_ptrs: HashMap<String, (u64, usize)>,
@@ -123,9 +128,10 @@ pub struct BackendCompileArgs {
 
 /// Canonical PyCapsule name for [`BackendFactory`] function-pointer capsules.
 ///
-/// Value MUST remain `"luminal.backend_factory"` for compatibility with
-/// external plugin producers built against older versions of this crate.
-pub const BACKEND_FACTORY_CAPSULE_NAME: &std::ffi::CStr = c"luminal.backend_factory";
+/// The version is part of the ABI: `BackendCompileArgs` crosses this boundary
+/// by value, so an older plugin must be rejected rather than reading a changed
+/// struct layout.
+pub const BACKEND_FACTORY_CAPSULE_NAME: &std::ffi::CStr = c"luminal.backend_factory.v2";
 
 /// A factory function that compiles a [`Graph`] into a ready-to-execute [`DynBackend`].
 pub type BackendFactory = fn(&mut Graph, BackendCompileArgs) -> Result<Box<dyn DynBackend>, String>;

--- a/src/dyn_backend.rs
+++ b/src/dyn_backend.rs
@@ -123,6 +123,7 @@ pub trait DynBackend {
 pub struct BackendCompileArgs {
     pub search_iters: usize,
     pub device_index: Option<usize>,
+    pub external_cuda_graph: bool,
     pub weights: Vec<(String, Vec<u8>, DType)>,
     pub tensor_sizes: HashMap<String, usize>,
     pub device_ptrs: HashMap<String, (u64, usize)>,
@@ -133,7 +134,7 @@ pub struct BackendCompileArgs {
 /// The version is part of the ABI: `BackendCompileArgs` crosses this boundary
 /// by value, so an older plugin must be rejected rather than reading a changed
 /// struct layout.
-pub const BACKEND_FACTORY_CAPSULE_NAME: &std::ffi::CStr = c"luminal.backend_factory.v3";
+pub const BACKEND_FACTORY_CAPSULE_NAME: &std::ffi::CStr = c"luminal.backend_factory.v4";
 
 /// A factory function that compiles a [`Graph`] into a ready-to-execute [`DynBackend`].
 pub type BackendFactory = fn(&mut Graph, BackendCompileArgs) -> Result<Box<dyn DynBackend>, String>;


### PR DESCRIPTION
- Add explicit CUDA device selection.
- Execute Luminal regions on caller-owned CUDA streams without destroying or synchronizing those streams.
- Preserve standalone owned-stream execution and blocking semantics.
- Add reusable, fixed-capacity output buffers with dynamic shape views and stable addresses.
- Perform functionalized mutation writebacks asynchronously on the caller’s stream.
- Support external CUDA-graph capture by enqueueing prepared kernels, copies, and library operations instead of launching nested Luminal graphs.
- Add region compilation APIs and reuse compiled artifacts across structurally identical regions.
- Version the backend factory capsule ABI and move the borrowed-stream cudarc patch to `luminal-ai/cudarc`.