### PR TITLE
Back logical SSA with petgraph

### DIFF
--- a/src/frontend/binary.rs
+++ b/src/frontend/binary.rs
@@ -16,19 +16,17 @@ impl Add for GraphTensor {
             "Dtypes must match to add tensors. Got {:?} and {:?}",
             self.dtype, rhs.dtype
         );
-        let new_id = self.graph().mint_id();
-        let logical = self.graph().logical.op(
-            new_id.index(),
-            "LogicalAdd",
-            &[
-                (self.logical_value, self.dims()),
-                (rhs.logical_value, rhs.dims()),
-            ],
-            "",
-            self.dims(),
-            self.dtype,
-        );
-        GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype).with_logical(logical)
+        let new_id = self
+            .graph()
+            .logical
+            .op(
+                LogicalOp::Add,
+                &[(self.id, self.dims()), (rhs.id, rhs.dims())],
+                self.dims(),
+                self.dtype,
+            )
+            .expect("logical op insertion failed");
+        GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype)
     }
 }
 
@@ -87,19 +85,17 @@ impl Mul for GraphTensor {
             "Dtypes must match to multiply tensors. Got {:?} and {:?}",
             self.dtype, rhs.dtype
         );
-        let new_id = self.graph().mint_id();
-        let logical = self.graph().logical.op(
-            new_id.index(),
-            "LogicalMul",
-            &[
-                (self.logical_value, self.dims()),
-                (rhs.logical_value, rhs.dims()),
-            ],
-            "",
-            self.dims(),
-            self.dtype,
-        );
-        GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype).with_logical(logical)
+        let new_id = self
+            .graph()
+            .logical
+            .op(
+                LogicalOp::Mul,
+                &[(self.id, self.dims()), (rhs.id, rhs.dims())],
+                self.dims(),
+                self.dtype,
+            )
+            .expect("logical op insertion failed");
+        GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype)
     }
 }
 
@@ -157,19 +153,17 @@ impl Rem<GraphTensor> for GraphTensor {
             "Dtypes must match to mod tensors. Got {:?} and {:?}",
             self.dtype, rhs.dtype
         );
-        let new_id = self.graph().mint_id();
-        let logical = self.graph().logical.op(
-            new_id.index(),
-            "LogicalMod",
-            &[
-                (self.logical_value, self.dims()),
-                (rhs.logical_value, rhs.dims()),
-            ],
-            "",
-            self.dims(),
-            self.dtype,
-        );
-        GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype).with_logical(logical)
+        let new_id = self
+            .graph()
+            .logical
+            .op(
+                LogicalOp::Mod,
+                &[(self.id, self.dims()), (rhs.id, rhs.dims())],
+                self.dims(),
+                self.dtype,
+            )
+            .expect("logical op insertion failed");
+        GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype)
     }
 }
 
@@ -306,7 +300,8 @@ impl<S: Into<IntExpr>> Rem<S> for GraphTensor {
 // Comparisons, all redurn bools (based on https://github.com/tinygrad/tinygrad/blob/3e0c2d256fe9f4f5f85cd3e4d8733a51d7b4a984/tinygrad/tensor.py#L653)
 impl GraphTensor {
     /// One strict/trunc binary op recording (typed-buffers landing D).
-    fn int_binary(self, rhs: GraphTensor, constructor: &str) -> GraphTensor {
+    fn int_binary(self, rhs: GraphTensor, op: LogicalOp) -> GraphTensor {
+        let constructor = op.constructor();
         assert_eq!(self.dims(), rhs.dims(), "{constructor}: dims must match");
         assert_eq!(
             self.dtype, rhs.dtype,
@@ -317,32 +312,29 @@ impl GraphTensor {
             "{constructor} is an INTEGER op (got {:?})",
             self.dtype
         );
-        let new_id = self.graph().mint_id();
-        let logical = self.graph().logical.op(
-            new_id.index(),
-            constructor,
-            &[
-                (self.logical_value, self.dims()),
-                (rhs.logical_value, rhs.dims()),
-            ],
-            "",
-            self.dims(),
-            self.dtype,
-        );
+        let new_id = self
+            .graph()
+            .logical
+            .op(
+                op,
+                &[(self.id, self.dims()), (rhs.id, rhs.dims())],
+                self.dims(),
+                self.dtype,
+            )
+            .expect("logical op insertion failed");
         GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype)
-            .with_logical(logical)
     }
 
     /// Integer truncated division (toward zero) — proof-gated: implements
     /// only where the divisor's value bounds exclude zero (declare input
     /// ranges with `bind_value_range` when the divisor is caller data).
     pub fn trunc_div(self, rhs: GraphTensor) -> GraphTensor {
-        self.int_binary(rhs, "LogicalTruncDiv")
+        self.int_binary(rhs, LogicalOp::TruncDiv)
     }
 
     /// Integer truncated remainder; see [`Self::trunc_div`].
     pub fn trunc_rem(self, rhs: GraphTensor) -> GraphTensor {
-        self.int_binary(rhs, "LogicalTruncRem")
+        self.int_binary(rhs, LogicalOp::TruncRem)
     }
 
     /// Less than comparison
@@ -353,21 +345,18 @@ impl GraphTensor {
             "Dtypes must match to compare tensors. Got {:?} and {:?}",
             self.dtype, rhs.dtype
         );
-        let new_id = self.graph().mint_id();
-        let logical = self.graph().logical.op(
-            new_id.index(),
-            "LogicalLessThan",
-            &[
-                (self.logical_value, self.dims()),
-                (rhs.logical_value, rhs.dims()),
-            ],
-            "",
-            self.dims(),
-            DType::Bool,
-        );
+        let new_id = self
+            .graph()
+            .logical
+            .op(
+                LogicalOp::LessThan,
+                &[(self.id, self.dims()), (rhs.id, rhs.dims())],
+                self.dims(),
+                DType::Bool,
+            )
+            .expect("logical op insertion failed");
         // Comparison operations always output Bool
         GraphTensor::from_id(new_id, self.dims(), self.graph_ref, DType::Bool)
-            .with_logical(logical)
     }
 
     /// Greater than comparison
@@ -518,7 +507,10 @@ pub(super) mod tests {
         let rhs_values = rhs_transform(random_vec(b_shape.iter().copied().product()));
         let rt = crate::test_support::run_reference(
             &cx,
-            &[(a.id, lhs_values.clone().into()), (b.id, rhs_values.clone().into())],
+            &[
+                (a.id, lhs_values.clone().into()),
+                (b.id, rhs_values.clone().into()),
+            ],
         );
 
         // Reference

--- a/src/frontend/movement.rs
+++ b/src/frontend/movement.rs
@@ -13,11 +13,14 @@ impl GraphTensor {
             self.rank()
         );
         let current_dims = self.dims();
-        self.logical_value = self.graph().logical.apply_movement(
-            self.id.index(),
-            &(self.logical_value, current_dims),
-            crate::graph::Movement::Permute(axes.clone()),
-        );
+        self.id = self
+            .graph()
+            .logical
+            .apply_movement(
+                &(self.id, current_dims),
+                crate::graph::Movement::Permute(axes.clone()),
+            )
+            .expect("logical movement insertion failed");
         self.dims = axes.iter().map(|i| self.dims[*i]).collect();
         self
     }
@@ -44,14 +47,17 @@ impl GraphTensor {
     pub fn expand_dim(mut self, axis: usize, size: impl Into<IntExpr>) -> GraphTensor {
         let size = size.into();
         let current_dims = self.dims();
-        self.logical_value = self.graph().logical.apply_movement(
-            self.id.index(),
-            &(self.logical_value, current_dims),
-            crate::graph::Movement::ExpandDim {
-                axis,
-                size: size.clone(),
-            },
-        );
+        self.id = self
+            .graph()
+            .logical
+            .apply_movement(
+                &(self.id, current_dims),
+                crate::graph::Movement::ExpandDim {
+                    axis,
+                    size: size.clone(),
+                },
+            )
+            .expect("logical movement insertion failed");
         self.dims.insert(axis, size);
         self
     }
@@ -76,11 +82,14 @@ impl GraphTensor {
             self.rank()
         );
         let current_dims = self.dims();
-        self.logical_value = self.graph().logical.apply_movement(
-            self.id.index(),
-            &(self.logical_value, current_dims),
-            crate::graph::Movement::Repeat(repeats.clone()),
-        );
+        self.id = self
+            .graph()
+            .logical
+            .apply_movement(
+                &(self.id, current_dims),
+                crate::graph::Movement::Repeat(repeats.clone()),
+            )
+            .expect("logical movement insertion failed");
         for (dim, repeat) in self.dims.iter_mut().zip(repeats) {
             if repeat == IntExpr::from(1) {
                 continue;
@@ -137,11 +146,14 @@ impl GraphTensor {
     pub fn merge_dims(mut self, axis1: usize, axis2: usize) -> GraphTensor {
         assert!(axis1 < axis2, "axis1 must be less than axis2");
         let current_dims = self.dims();
-        self.logical_value = self.graph().logical.apply_movement(
-            self.id.index(),
-            &(self.logical_value, current_dims),
-            crate::graph::Movement::MergeDims { axis1, axis2 },
-        );
+        self.id = self
+            .graph()
+            .logical
+            .apply_movement(
+                &(self.id, current_dims),
+                crate::graph::Movement::MergeDims { axis1, axis2 },
+            )
+            .expect("logical movement insertion failed");
         // Move axis2 next to axis1 if not adjacent, then fold it in.
         if axis2 != axis1 + 1 {
             let dim = self.dims.remove(axis2);
@@ -176,14 +188,17 @@ impl GraphTensor {
             "split_dims requires the old dimension ({old_dim}) to be exactly divisible by the inner dimension ({new_dim_size})"
         );
         let current_dims = self.dims();
-        self.logical_value = self.graph().logical.apply_movement(
-            self.id.index(),
-            &(self.logical_value, current_dims),
-            crate::graph::Movement::SplitDims {
-                axis,
-                inner: new_dim_size,
-            },
-        );
+        self.id = self
+            .graph()
+            .logical
+            .apply_movement(
+                &(self.id, current_dims),
+                crate::graph::Movement::SplitDims {
+                    axis,
+                    inner: new_dim_size,
+                },
+            )
+            .expect("logical movement insertion failed");
         self.dims[axis] = outer_dim;
         self.dims.insert(axis + 1, new_dim_size);
         self
@@ -214,11 +229,14 @@ impl GraphTensor {
             }
         }
         let current_dims = self.dims();
-        self.logical_value = self.graph().logical.apply_movement(
-            self.id.index(),
-            &(self.logical_value, current_dims),
-            crate::graph::Movement::RemoveDim { axis },
-        );
+        self.id = self
+            .graph()
+            .logical
+            .apply_movement(
+                &(self.id, current_dims),
+                crate::graph::Movement::RemoveDim { axis },
+            )
+            .expect("logical movement insertion failed");
         self.dims.remove(axis);
         self
     }
@@ -416,35 +434,36 @@ impl GraphTensor {
         }
         let flat_base = flat_base.unwrap();
 
-        let mut full_flat_dest = if trailing_shape.is_empty() || trailing_numel.to_usize() == Some(1) {
-            flat_base
-        } else {
-            // Expand flat_base to [batch_numel, trailing_numel]
-            let mut base_expanded = flat_base.expand_dim(1, trailing_numel);
+        let mut full_flat_dest =
+            if trailing_shape.is_empty() || trailing_numel.to_usize() == Some(1) {
+                flat_base
+            } else {
+                // Expand flat_base to [batch_numel, trailing_numel]
+                let mut base_expanded = flat_base.expand_dim(1, trailing_numel);
 
-            let trailing_rank = trailing_shape.len();
-            for (ti, d) in (k..data_rank).enumerate() {
-                let ar = self.graph().arange(data_dims[d]);
-                let mut ar_shaped = ar;
-                for _ in ti + 1..trailing_rank {
-                    let n = ar_shaped.dims().len();
-                    ar_shaped = ar_shaped.expand_dim(n, 1);
-                }
-                for _ in 0..ti {
-                    ar_shaped = ar_shaped.expand_dim(0, 1);
-                }
-                ar_shaped = ar_shaped.expand(trailing_shape.clone());
-                // Flatten trailing dims with recorded merges, then broadcast
-                let ar_flat = ar_shaped.flatten().expand_dim(0, batch_numel);
+                let trailing_rank = trailing_shape.len();
+                for (ti, d) in (k..data_rank).enumerate() {
+                    let ar = self.graph().arange(data_dims[d]);
+                    let mut ar_shaped = ar;
+                    for _ in ti + 1..trailing_rank {
+                        let n = ar_shaped.dims().len();
+                        ar_shaped = ar_shaped.expand_dim(n, 1);
+                    }
+                    for _ in 0..ti {
+                        ar_shaped = ar_shaped.expand_dim(0, 1);
+                    }
+                    ar_shaped = ar_shaped.expand(trailing_shape.clone());
+                    // Flatten trailing dims with recorded merges, then broadcast
+                    let ar_flat = ar_shaped.flatten().expand_dim(0, batch_numel);
 
-                let stride_tensor = self
-                    .graph()
-                    .constant(data_strides[d])
-                    .expand_rhs(ar_flat.dims());
-                base_expanded = base_expanded + ar_flat * stride_tensor;
-            }
-            base_expanded
-        };
+                    let stride_tensor = self
+                        .graph()
+                        .constant(data_strides[d])
+                        .expand_rhs(ar_flat.dims());
+                    base_expanded = base_expanded + ar_flat * stride_tensor;
+                }
+                base_expanded
+            };
 
         full_flat_dest = full_flat_dest.flatten();
 
@@ -474,23 +493,24 @@ impl GraphTensor {
         let out_dims = coords[0].dims();
         for coord in coords {
             assert_eq!(coord.dtype, DType::Int, "gather coordinates must be Int");
-            assert_eq!(coord.dims(), out_dims, "gather coordinates share the out shape");
+            assert_eq!(
+                coord.dims(),
+                out_dims,
+                "gather coordinates share the out shape"
+            );
         }
         let dims = self.dims();
-        let id = self.graph().mint_id();
-        let data_operand = (self.logical_value, dims);
+        let data_operand = (self.id, dims);
         let coord_operands: Vec<_> = coords
             .iter()
-            .map(|coord| (coord.logical_value, coord.dims()))
+            .map(|coord| (coord.id, coord.dims()))
             .collect();
-        let logical = self.graph().logical.record_gather(
-            id.index(),
-            &data_operand,
-            &coord_operands,
-            out_dims.clone(),
-            self.dtype,
-        );
-        GraphTensor::from_id(id, out_dims, self.graph_ref, self.dtype).with_logical(logical)
+        let id = self
+            .graph()
+            .logical
+            .record_gather(&data_operand, &coord_operands, out_dims.clone(), self.dtype)
+            .expect("logical gather insertion failed");
+        GraphTensor::from_id(id, out_dims, self.graph_ref, self.dtype)
     }
 
     /// COORDINATE-FORM scatter — THE primary (ruling 2026-07-31): self is
@@ -507,25 +527,31 @@ impl GraphTensor {
         let index_dims = src.dims();
         for coord in coords {
             assert_eq!(coord.dtype, DType::Int, "scatter coordinates must be Int");
-            assert_eq!(coord.dims(), index_dims, "scatter coordinates share src's shape");
+            assert_eq!(
+                coord.dims(),
+                index_dims,
+                "scatter coordinates share src's shape"
+            );
         }
         let dims = self.dims();
-        let id = self.graph().mint_id();
-        let init_operand = (self.logical_value, dims.clone());
-        let src_operand = (src.logical_value, index_dims);
+        let init_operand = (self.id, dims.clone());
+        let src_operand = (src.id, index_dims);
         let coord_operands: Vec<_> = coords
             .iter()
-            .map(|coord| (coord.logical_value, coord.dims()))
+            .map(|coord| (coord.id, coord.dims()))
             .collect();
-        let logical = self.graph().logical.record_scatter(
-            id.index(),
-            &init_operand,
-            &coord_operands,
-            &src_operand,
-            dims.clone(),
-            self.dtype,
-        );
-        GraphTensor::from_id(id, dims, self.graph_ref, self.dtype).with_logical(logical)
+        let id = self
+            .graph()
+            .logical
+            .record_scatter(
+                &init_operand,
+                &coord_operands,
+                &src_operand,
+                dims.clone(),
+                self.dtype,
+            )
+            .expect("logical scatter insertion failed");
+        GraphTensor::from_id(id, dims, self.graph_ref, self.dtype)
     }
 
     /// Rebuild a multi-dim shape from a flat tensor with recorded splits
@@ -572,9 +598,7 @@ impl GraphTensor {
             "scatter1d: indexes and src (self) share a shape"
         );
         let out_dims = dest.dims();
-        let flat = dest
-            .flatten()
-            .scatter(&[indexes.flatten()], self.flatten());
+        let flat = dest.flatten().scatter(&[indexes.flatten()], self.flatten());
         flat.unflatten_to(&out_dims)
     }
 
@@ -585,7 +609,6 @@ impl GraphTensor {
         strides: impl ToShape,
         dilation: impl ToShape,
     ) -> GraphTensor {
-
         let (kernel, strides, dilation) =
             (kernel.to_shape(), strides.to_shape(), dilation.to_shape());
 
@@ -630,24 +653,23 @@ impl GraphTensor {
         // structure stays first-class; UnfoldView::to_egglog reproduces the
         // legacy flat iota+gather lowering for the existing pipeline.
         let window_counts = final_shape[..n].to_vec();
-        let id = self.graph().mint_id();
         // WINDOW CONTRACTS (ruling 2026-08-13, same rail as squeeze):
         // a symbolic window count must reach 1 — the kernel fits within
         // dim + padding, or the binding's bucket refuses with the named
         // door. Static counts are checked right here, loudly.
         for (axis, count) in window_counts.iter().enumerate() {
             match count.to_usize() {
-                Some(0) => panic!(
-                    "unfold axis {axis}: kernel does not fit (window count 0)"
-                ),
+                Some(0) => panic!("unfold axis {axis}: kernel does not fit (window count 0)"),
                 Some(_) => {}
                 None => {
-                    let at = id.index();
+                    let at = self.id.index();
                     self.graph().logical.require_extent_at_least(
                         at,
                         count,
                         1,
-                        &format!("unfold window on axis {axis} (kernel must fit within dim + padding)"),
+                        &format!(
+                            "unfold window on axis {axis} (kernel must fit within dim + padding)"
+                        ),
                     );
                 }
             }
@@ -676,15 +698,13 @@ impl GraphTensor {
                 )
             })
             .collect();
-        let operand = (self.logical_value, self.dims());
-        let logical = self.graph().logical.view_op(
-            id.index(),
-            &operand,
-            &entries,
-            final_shape.clone(),
-            self.dtype,
-        );
-        GraphTensor::from_id(id, final_shape, self.graph_ref, self.dtype).with_logical(logical)
+        let operand = (self.id, self.dims());
+        let id = self
+            .graph()
+            .logical
+            .view_op(&operand, &entries, final_shape.clone(), self.dtype)
+            .expect("logical view insertion failed");
+        GraphTensor::from_id(id, final_shape, self.graph_ref, self.dtype)
     }
 
     /// Take a slice of a tensor along multiple dimensions.
@@ -715,7 +735,6 @@ impl GraphTensor {
                 starts.push(start);
                 new_dims.push(dim.min(end) - start);
             }
-            let id = self.graph().mint_id();
             // The seam node's own parameters ARE the view: parent axis p
             // reads out coordinate p plus its start.
             let rank = new_dims.len();
@@ -735,15 +754,13 @@ impl GraphTensor {
                     }
                 })
                 .collect();
-            let operand = (self.logical_value, self.dims());
-            let logical = self.graph().logical.view_op(
-                id.index(),
-                &operand,
-                &entries,
-                new_dims.clone(),
-                self.dtype,
-            );
-            GraphTensor::from_id(id, new_dims, self.graph_ref, self.dtype).with_logical(logical)
+            let operand = (self.id, self.dims());
+            let id = self
+                .graph()
+                .logical
+                .view_op(&operand, &entries, new_dims.clone(), self.dtype)
+                .expect("logical view insertion failed");
+            GraphTensor::from_id(id, new_dims, self.graph_ref, self.dtype)
         } else {
             // No start slices so no iota needed, just reduce the shape down
             let mut new_dims = self.dims();
@@ -751,13 +768,16 @@ impl GraphTensor {
                 *sh = sh.min(*end);
             }
             let current_dims = self.dims();
-            self.logical_value = self.graph().logical.apply_movement(
-                self.id.index(),
-                &(self.logical_value, current_dims),
-                crate::graph::Movement::Shrink {
-                    new_dims: new_dims.clone(),
-                },
-            );
+            self.id = self
+                .graph()
+                .logical
+                .apply_movement(
+                    &(self.id, current_dims),
+                    crate::graph::Movement::Shrink {
+                        new_dims: new_dims.clone(),
+                    },
+                )
+                .expect("logical movement insertion failed");
             for (sh, new_dim) in self.dims.iter_mut().zip(new_dims) {
                 *sh = new_dim;
             }
@@ -800,11 +820,10 @@ impl GraphTensor {
             .map(|(d, (s, e))| (*d + *s + *e).simplify())
             .collect();
 
-        let clamped_id = self.graph().mint_id();
         // Pad's read half recorded as the TOTAL clamped view — per parent
         // axis min(max(c - before, 0), dim - 1), clamp sides only where
         // padding exists.
-        let clamp_logical;
+        let clamped_id;
         {
             let rank = dims.len();
             let entries: Vec<crate::graph::MapEntry> = (0..rank)
@@ -828,39 +847,29 @@ impl GraphTensor {
                     if afters[k] != IntExpr::from(0) {
                         entry = crate::graph::MapEntry::Min(
                             Box::new(entry),
-                            Box::new(crate::graph::MapEntry::Lit(
-                                (dims[k] - 1).simplify(),
-                            )),
+                            Box::new(crate::graph::MapEntry::Lit((dims[k] - 1).simplify())),
                         );
                     }
                     entry
                 })
                 .collect();
-            let operand = (self.logical_value, dims.clone());
-            clamp_logical = self.graph().logical.view_op(
-                clamped_id.index(),
-                &operand,
-                &entries,
-                out_dims.clone(),
-                self.dtype,
-            );
+            let operand = (self.id, dims.clone());
+            clamped_id = self
+                .graph()
+                .logical
+                .view_op(&operand, &entries, out_dims.clone(), self.dtype)
+                .expect("logical view insertion failed");
         }
-        let clamped = GraphTensor::from_id(
-            clamped_id,
-            out_dims.clone(),
-            self.graph_ref,
-            self.dtype,
-        )
-        .with_logical(clamp_logical);
+        let clamped =
+            GraphTensor::from_id(clamped_id, out_dims.clone(), self.graph_ref, self.dtype);
 
-        let mask_id = self.graph().mint_id();
-        let mask_logical = self
+        let mask_id = self
             .graph()
             .logical
-            .record_mask_iota(mask_id.index(), &befores, &afters, &dims);
-        let mask = GraphTensor::from_id(mask_id, out_dims, self.graph_ref, DType::Int)
-            .with_logical(mask_logical)
-            .cast(self.dtype);
+            .record_mask_iota(&befores, &afters, &dims)
+            .expect("logical mask iota insertion failed");
+        let mask =
+            GraphTensor::from_id(mask_id, out_dims, self.graph_ref, DType::Int).cast(self.dtype);
 
         let masked = clamped * mask;
         if elem == 0.0 {
@@ -1171,7 +1180,11 @@ mod tests {
         // `* 1.0` materializes: a bare squeeze is a pure-VIEW output, and
         // view-only outputs share the input's buffer id — the 4d binding
         // gap (see stage4b_probes::pinned_pure_identity_output).
-        test_unary((2, 1, 3), |a| a.squeeze(1) * 1.0, |a| a.reshape((2, 3)).unwrap());
+        test_unary(
+            (2, 1, 3),
+            |a| a.squeeze(1) * 1.0,
+            |a| a.reshape((2, 3)).unwrap(),
+        );
         // Bare squeeze — a pure-VIEW output, no materializing op. The
         // delivery-copy fix (2026-08-05) materializes it at the boundary.
         test_unary((2, 1, 3), |a| a.squeeze(1), |a| a.reshape((2, 3)).unwrap());
@@ -1218,7 +1231,16 @@ mod tests {
         let a = cx.tensor((2, 3));
         let repeated = a.repeat((2, 2));
 
-        assert_eq!(repeated.id, a.id);
+        assert_ne!(
+            repeated.id, a.id,
+            "a logical view is its own SSA value even when it requires no materialization"
+        );
+        let graph = cx.logical.petgraph();
+        assert!(matches!(
+            graph[repeated.id].op,
+            LogicalOp::IndexMapApply { .. }
+        ));
+        assert!(graph.find_edge(a.id, repeated.id).is_some());
         assert_eq!(
             repeated.dims(),
             vec![IntExpr::from(4usize), IntExpr::from(6usize)]
@@ -1231,7 +1253,10 @@ mod tests {
         let a = cx.tensor((2, 3));
         let repeated = (a.repeat((2, 2)) * 1.0).output();
 
-        let rt = crate::test_support::run_reference(&cx, &[(a.id, vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0].into())]);
+        let rt = crate::test_support::run_reference(
+            &cx,
+            &[(a.id, vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0].into())],
+        );
 
         assert_exact(
             rt.get_f32(repeated.id).unwrap(),

--- a/src/frontend/other.rs
+++ b/src/frontend/other.rs
@@ -4,24 +4,20 @@ impl Graph {
     /// A scalar expression constant
     pub fn constant(&mut self, i: impl Into<IntExpr>) -> GraphTensor {
         let expr = i.into();
-        let id = self.mint_id();
-        let tensor = GraphTensor::from_id(id, (), self, DType::Int);
-        let logical = self.logical.record_iota(id.index(), &expr, &[]);
-        tensor.with_logical(logical)
+        let id = self
+            .logical
+            .record_iota(&expr, &[])
+            .expect("logical iota insertion failed");
+        GraphTensor::from_id(id, (), self, DType::Int)
     }
 
     /// A scalar float constant
     pub fn constant_float(&mut self, i: f32) -> GraphTensor {
-        let id = self.mint_id();
-        let tensor = GraphTensor::from_id(id, (), self, DType::F32);
-        let logical = self.logical.source_op(
-            id.index(),
-            "LogicalConstant",
-            &format!("{:?}", i as f64),
-            Vec::new(),
-            DType::F32,
-        );
-        tensor.with_logical(logical)
+        let id = self
+            .logical
+            .op(LogicalOp::Constant(i as f64), &[], Vec::new(), DType::F32)
+            .expect("logical constant insertion failed");
+        GraphTensor::from_id(id, (), self, DType::F32)
     }
 
     /// Iota as a TRUE COORDINATE FUNCTION (P1 ruling 2026-08-07): the
@@ -44,10 +40,11 @@ impl Graph {
         let sh = shape.to_shape();
         let coords: Vec<IntExpr> = (0..sh.len()).map(IntExpr::coord).collect();
         let expr = f(&coords).simplify();
-        let id = self.mint_id();
-        let tensor = GraphTensor::from_id(id, sh.clone(), self, DType::Int);
-        let logical = self.logical.record_iota(id.index(), &expr, &sh);
-        tensor.with_logical(logical)
+        let id = self
+            .logical
+            .record_iota(&expr, &sh)
+            .expect("logical iota insertion failed");
+        GraphTensor::from_id(id, sh, self, DType::Int)
     }
 
     /// ARange from 0 to N
@@ -134,21 +131,15 @@ impl GraphTensor {
             let zero_f32 = self.graph().constant_float(0.0).expand_rhs(self.dims());
             return zero_f32.lt(sum);
         }
-        let id = self.graph().mint_id();
-        let operand = (self.logical_value, self.dims());
+        let operand = (self.id, self.dims());
         let out_dims = self.dims();
-        let logical = self.graph().logical.op(
-            id.index(),
-            "LogicalCast",
-            &[operand],
-            &format!("({dtype:?})"),
-            out_dims,
-            dtype,
-        );
-        GraphTensor::from_id(id, self.dims(), self.graph_ref, dtype).with_logical(logical)
+        let id = self
+            .graph()
+            .logical
+            .op(LogicalOp::Cast(dtype), &[operand], out_dims, dtype)
+            .expect("logical cast insertion failed");
+        GraphTensor::from_id(id, self.dims(), self.graph_ref, dtype)
     }
-
-
 }
 
 #[cfg(test)]

--- a/src/frontend/reduction.rs
+++ b/src/frontend/reduction.rs
@@ -3,24 +3,22 @@ use crate::prelude::*;
 impl GraphTensor {
     /// Reduce a dimension of the tensor by summing all elements along that axis.
     pub fn sum(self, axes: impl ToAxes) -> GraphTensor {
-        self.reduce("LogicalReduceSum", axes)
+        self.reduce(false, axes)
     }
 
     /// Reduce a dimension of the tensor by taking the maximum of all elements along that axis.
     pub fn max(self, axes: impl ToAxes) -> GraphTensor {
-        self.reduce("LogicalReduceMax", axes)
+        self.reduce(true, axes)
     }
 
     /// One recorded reduce per axis; the operand for the FIRST reduce is
     /// self's value, later reduces consume the previous reduce's result.
-    fn reduce(self, constructor: &str, axes: impl ToAxes) -> GraphTensor {
+    fn reduce(self, is_max: bool, axes: impl ToAxes) -> GraphTensor {
         let (mut dims, mut id) = (self.dims(), self.id);
         let mut axes = axes.to_axes();
-        let mut operand_value = self.logical_value;
         for dim in 0..axes.len() {
             let operand_dims = dims.clone();
-            id = self.graph().mint_id();
-            if constructor == "LogicalReduceMax" {
+            if is_max {
                 // The empty max has no value (extent-0 ruling
                 // 2026-08-13): the reduced axis contracts to >= 1 —
                 // static extents discharge trivially; symbolic ones
@@ -35,14 +33,16 @@ impl GraphTensor {
             let axis_from_end = rank - 1 - axes[dim];
             let mut out_dims = operand_dims.clone();
             out_dims.remove(axes[dim]);
-            operand_value = self.graph().logical.op(
-                id.index(),
-                constructor,
-                &[(operand_value, operand_dims)],
-                &axis_from_end.to_string(),
-                out_dims.clone(),
-                self.dtype,
-            );
+            let op = if is_max {
+                LogicalOp::ReduceMax { axis_from_end }
+            } else {
+                LogicalOp::ReduceSum { axis_from_end }
+            };
+            id = self
+                .graph()
+                .logical
+                .op(op, &[(id, operand_dims)], out_dims.clone(), self.dtype)
+                .expect("logical reduce insertion failed");
             dims = out_dims;
             let axis = axes[dim];
             for ax in &mut axes {
@@ -51,7 +51,7 @@ impl GraphTensor {
                 }
             }
         }
-        GraphTensor::from_id(id, dims, self.graph_ref, self.dtype).with_logical(operand_value)
+        GraphTensor::from_id(id, dims, self.graph_ref, self.dtype)
     }
 
     /// Reduce a dimension of the tensor by taking the minimum of all elements along that axis.

--- a/src/frontend/tensor.rs
+++ b/src/frontend/tensor.rs
@@ -27,9 +27,6 @@ pub struct GraphTensor {
     /// recorder cross-checks these against its own recorded dims.
     pub(crate) dims: ArrayVec<[IntExpr; 10]>,
     pub dtype: DType,
-    /// The SSA value this handle names in the logical graph (M3 Step 4a).
-    /// `None` = unrecorded (a poisoned/uncovered path).
-    pub logical_value: Option<crate::graph::ValueId>,
 }
 
 impl From<&GraphTensor> for GraphTensor {
@@ -49,19 +46,9 @@ impl GraphTensor {
         Self {
             id,
             graph_ref,
-            logical_value: None,
             dims: shape.to_shape().into_iter().collect(),
             dtype,
         }
-    }
-
-    /// Attach the recorded logical value to this handle.
-    pub(crate) fn with_logical(
-        mut self,
-        value: Option<crate::graph::ValueId>,
-    ) -> Self {
-        self.logical_value = value;
-        self
     }
 
     /// Get a mutable reference to the graph this tensor belongs to
@@ -82,12 +69,7 @@ impl GraphTensor {
     pub fn output(&self) -> GraphTensor {
         let source = *self;
         let dims = source.dims();
-        self.graph().logical.output(
-            source.id.index(),
-            &(source.logical_value, dims),
-            source.id.index(),
-            None,
-        );
+        self.graph().logical.output(&(source.id, dims), None);
         source
     }
 
@@ -97,12 +79,7 @@ impl GraphTensor {
     pub fn output_named(&self, name: &str) -> GraphTensor {
         let source = *self;
         let dims = source.dims();
-        self.graph().logical.output(
-            source.id.index(),
-            &(source.logical_value, dims),
-            source.id.index(),
-            Some(name),
-        );
+        self.graph().logical.output(&(source.id, dims), Some(name));
         source
     }
 
@@ -117,10 +94,7 @@ impl GraphTensor {
     /// authoring surface must know it, not panic on spelling).
     pub(crate) fn dims_agree(&self, rhs: &GraphTensor) -> bool {
         let (a, b) = (self.dims(), rhs.dims());
-        a.len() == b.len()
-            && a.iter()
-                .zip(&b)
-                .all(|(x, y)| x == y || x.egglog_equal(y))
+        a.len() == b.len() && a.iter().zip(&b).all(|(x, y)| x == y || x.egglog_equal(y))
     }
 
     /// The tensor's rank — the public shape surface is dims()/rank()

--- a/src/frontend/unary.rs
+++ b/src/frontend/unary.rs
@@ -66,30 +66,32 @@ impl Neg for GraphTensor {
 impl GraphTensor {
     /// Base 2 log
     pub fn log2(self) -> GraphTensor {
-        let new_id = self.graph().mint_id();
-        let logical = self.graph().logical.op(
-            new_id.index(),
-            "LogicalLog2",
-            &[(self.logical_value, self.dims())],
-            "",
-            self.dims(),
-            self.dtype,
-        );
-        GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype).with_logical(logical)
+        let new_id = self
+            .graph()
+            .logical
+            .op(
+                LogicalOp::Log2,
+                &[(self.id, self.dims())],
+                self.dims(),
+                self.dtype,
+            )
+            .expect("logical op insertion failed");
+        GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype)
     }
 
     /// Base 2 exp
     pub fn exp2(self) -> GraphTensor {
-        let new_id = self.graph().mint_id();
-        let logical = self.graph().logical.op(
-            new_id.index(),
-            "LogicalExp2",
-            &[(self.logical_value, self.dims())],
-            "",
-            self.dims(),
-            self.dtype,
-        );
-        GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype).with_logical(logical)
+        let new_id = self
+            .graph()
+            .logical
+            .op(
+                LogicalOp::Exp2,
+                &[(self.id, self.dims())],
+                self.dims(),
+                self.dtype,
+            )
+            .expect("logical op insertion failed");
+        GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype)
     }
 
     /// Natural exp
@@ -104,30 +106,32 @@ impl GraphTensor {
 
     /// Take the reciprocal of each element
     pub fn reciprocal(self) -> GraphTensor {
-        let new_id = self.graph().mint_id();
-        let logical = self.graph().logical.op(
-            new_id.index(),
-            "LogicalRecip",
-            &[(self.logical_value, self.dims())],
-            "",
-            self.dims(),
-            self.dtype,
-        );
-        GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype).with_logical(logical)
+        let new_id = self
+            .graph()
+            .logical
+            .op(
+                LogicalOp::Recip,
+                &[(self.id, self.dims())],
+                self.dims(),
+                self.dtype,
+            )
+            .expect("logical op insertion failed");
+        GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype)
     }
 
     /// The sin(x) function
     pub fn sin(self) -> GraphTensor {
-        let new_id = self.graph().mint_id();
-        let logical = self.graph().logical.op(
-            new_id.index(),
-            "LogicalSin",
-            &[(self.logical_value, self.dims())],
-            "",
-            self.dims(),
-            self.dtype,
-        );
-        GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype).with_logical(logical)
+        let new_id = self
+            .graph()
+            .logical
+            .op(
+                LogicalOp::Sin,
+                &[(self.id, self.dims())],
+                self.dims(),
+                self.dtype,
+            )
+            .expect("logical op insertion failed");
+        GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype)
     }
 
     /// The cos(x) function
@@ -142,16 +146,17 @@ impl GraphTensor {
 
     /// The square root function
     pub fn sqrt(self) -> GraphTensor {
-        let new_id = self.graph().mint_id();
-        let logical = self.graph().logical.op(
-            new_id.index(),
-            "LogicalSqrt",
-            &[(self.logical_value, self.dims())],
-            "",
-            self.dims(),
-            self.dtype,
-        );
-        GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype).with_logical(logical)
+        let new_id = self
+            .graph()
+            .logical
+            .op(
+                LogicalOp::Sqrt,
+                &[(self.id, self.dims())],
+                self.dims(),
+                self.dtype,
+            )
+            .expect("logical op insertion failed");
+        GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype)
     }
 
     /// Scale so std is 1.0

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,11 +1,15 @@
 //! The graph a model is authored into: dynamic-dim assumptions plus the
-//! LOGICAL structure the recorder captures (M3 Step 4b: their HLIR
-//! petgraph, e-graph search spaces, and compile ladder are DELETED — the
-//! recorder is the only path to the e-graph, and runtimes own
-//! load/bind/with_ops/search).
+//! LOGICAL structure the recorder captures. The old layout-bearing HLIR
+//! graph and compile ladder are gone; this module owns the petgraph-backed
+//! logical SSA that feeds the e-graph, while runtimes own
+//! load/bind/with_ops/search.
 
-use petgraph::stable_graph::NodeIndex;
-use rustc_hash::FxHashMap;
+use petgraph::{
+    stable_graph::{NodeIndex, StableDiGraph},
+    visit::EdgeRef,
+    Direction,
+};
+use rustc_hash::FxHashSet;
 
 use crate::dtype::DType;
 use crate::frontend::GraphTensor;
@@ -66,23 +70,12 @@ pub struct Graph {
     /// logical ops here; it IS the graph (absorbed into this struct at
     /// M3 Step 4e).
     pub logical: crate::graph::LogicalGraph,
-    /// The tensor-id mint. Ids are plain sequence numbers (the NodeIndex
-    /// type is kept as the id vocabulary; the petgraph it once indexed is
-    /// gone) — they key recorder rows, binding slots, and set_data.
-    next_id: u32,
 }
 
 impl Graph {
     /// Create a new graph
     pub fn new() -> Graph {
         Graph::default()
-    }
-
-    /// Mint a fresh tensor id.
-    pub(crate) fn mint_id(&mut self) -> NodeIndex {
-        let id = NodeIndex::new(self.next_id as usize);
-        self.next_id += 1;
-        id
     }
 
     pub fn set_dim(&mut self, dimension: impl Into<crate::shape::Symbol>, val: usize) {
@@ -114,18 +107,12 @@ impl Graph {
         dtype: DType,
     ) -> GraphTensor {
         let name = name.to_string();
-        let id = self.mint_id();
-        let tensor = GraphTensor {
-            id,
-            graph_ref: self,
-            dims: shape.to_shape().into_iter().collect(),
-            dtype,
-            logical_value: None,
-        };
-        let logical = self
+        let dims = shape.to_shape();
+        let id = self
             .logical
-            .input(id.index(), &name, &tensor.dims(), tensor.dtype);
-        tensor.with_logical(logical)
+            .input(&name, &dims, dtype)
+            .expect("logical input insertion failed");
+        GraphTensor::from_id(id, dims, self, dtype)
     }
 }
 
@@ -136,16 +123,14 @@ impl Graph {
 // ---------------------------------------------------------------------
 // The LOGICAL GRAPH — the model the frontend actually builds (renamed
 // from logical_recorder, ruling 2026-07-31: this IS the durable thing;
-// absorbed into this module at Step 4e; the HLIR StableGraph it once
-// stood beside is deleted).
+// absorbed into this module at Step 4e; the layout-bearing HLIR graph it
+// once stood beside remains deleted).
 //
-// GraphTensor methods emit their LOGICAL ops here as the graph is built,
-// beside their HLIR emission — the two worlds coexist until the interim
-// translator retires family by family (each retirement gated by the
-// certification test asserting recorder ≡ translator at the e-class
-// level). The deep point (ruling 2026-07-30): movement methods emit
-// `IndexMapApply` views DIRECTLY from their own parameters, at the source
-// of truth — replacing tracker-lift reconstruction entirely.
+// GraphTensor methods insert typed logical nodes and numbered operand
+// edges here as the graph is built. There is no parallel tensor-id or
+// HLIR-node keyspace. Movement methods emit `IndexMapApply` views DIRECTLY
+// from their own parameters, at the source of truth — replacing
+// tracker-lift reconstruction entirely.
 //
 // Model/binding split (M3 Step 1): the recorder emits MODEL text only —
 // input declarations, ops, output naming, signature lists. Boundary
@@ -161,14 +146,8 @@ impl Graph {
 // frontend method can bypass the movement API) poisons instead of
 // silently mistranslating.
 
-
 use crate::shape::{IntExpr, Term};
 use anyhow::{bail, Result as AnyResult};
-
-/// Handle to a tracker-level view value. Lives on `GraphTensor` (`Copy`);
-/// `None` means "my logical value is the recorder's value for my node id".
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ViewId(pub u32);
 
 /// One index-map entry, in-memory. Movement composition happens on this
 /// tree — substituting our OWN just-emitted terms, never reconstructing
@@ -177,7 +156,10 @@ pub struct ViewId(pub u32);
 pub enum MapEntry {
     /// The consuming view's coordinate, zero-based FROM THE END (the
     /// de Bruijn house convention), with its extent.
-    Coord { from_end: usize, extent: IntExpr },
+    Coord {
+        from_end: usize,
+        extent: IntExpr,
+    },
     /// A dim-expression literal (a number or a symbolic dim var).
     Lit(IntExpr),
     Add(Box<MapEntry>, Box<MapEntry>),
@@ -193,9 +175,7 @@ impl MapEntry {
     /// replacement in the new out space — the movement-composition step.
     fn substitute(&self, replacement: &[MapEntry], prev_rank: usize) -> MapEntry {
         match self {
-            MapEntry::Coord { from_end, .. } => {
-                replacement[prev_rank - 1 - from_end].clone()
-            }
+            MapEntry::Coord { from_end, .. } => replacement[prev_rank - 1 - from_end].clone(),
             MapEntry::Lit(value) => MapEntry::Lit(value.clone()),
             MapEntry::Add(a, b) => MapEntry::Add(
                 Box::new(a.substitute(replacement, prev_rank)),
@@ -254,19 +234,110 @@ pub enum Movement {
     Shrink { new_dims: Vec<IntExpr> },
 }
 
-/// A logical VALUE id — the SSA identity every tensor handle carries
-/// (M3 Step 4a: LogicalGraph mints its own ids; HLIR node indices remain
-/// only as transitional binding-slot keys).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ValueId(pub u32);
+/// The logical SSA identity. A tensor names the node that produces its
+/// value; there is no parallel frontend-id keyspace.
+pub type ValueId = NodeIndex;
 
 /// An operand as a record call sees it: the handle's value plus its
 /// tracker dims (the divergence tripwire input).
-pub type Operand = (Option<ValueId>, Vec<IntExpr>);
+pub type Operand = (ValueId, Vec<IntExpr>);
 
-/// How a value renders: SSA rows are vocabulary-thin (constructor string
-/// + operand ids + aux text), but two constructors wrap some operands in
-/// a LogicalTensorList.
+/// Logical operation carried by an SSA node. Rendering details remain at
+/// the Egglog boundary; the graph itself stores a closed operation
+/// vocabulary rather than free-form constructor strings.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LogicalOp {
+    Input { label: String },
+    Constant(f64),
+    Iota { value_expr: String },
+    Cast(DType),
+    Sqrt,
+    Exp,
+    Exp2,
+    Log2,
+    Sin,
+    Recip,
+    Add,
+    Mul,
+    Div,
+    Mod,
+    LessThan,
+    TruncDiv,
+    TruncRem,
+    ReduceSum { axis_from_end: usize },
+    ReduceMax { axis_from_end: usize },
+    Gather,
+    Scatter,
+    IndexMapApply { entries: Vec<MapEntry> },
+}
+
+impl LogicalOp {
+    pub fn constructor(&self) -> &'static str {
+        match self {
+            Self::Input { .. } => "LogicalTensorInputLit",
+            Self::Constant(_) => "LogicalConstant",
+            Self::Iota { .. } => "LogicalIota",
+            Self::Cast(_) => "LogicalCast",
+            Self::Sqrt => "LogicalSqrt",
+            Self::Exp => "LogicalExp",
+            Self::Exp2 => "LogicalExp2",
+            Self::Log2 => "LogicalLog2",
+            Self::Sin => "LogicalSin",
+            Self::Recip => "LogicalRecip",
+            Self::Add => "LogicalAdd",
+            Self::Mul => "LogicalMul",
+            Self::Div => "LogicalDiv",
+            Self::Mod => "LogicalMod",
+            Self::LessThan => "LogicalLessThan",
+            Self::TruncDiv => "LogicalTruncDiv",
+            Self::TruncRem => "LogicalTruncRem",
+            Self::ReduceSum { .. } => "LogicalReduceSum",
+            Self::ReduceMax { .. } => "LogicalReduceMax",
+            Self::Gather => "LogicalGather",
+            Self::Scatter => "LogicalScatter",
+            Self::IndexMapApply { .. } => "LogicalIndexMapApply",
+        }
+    }
+
+    fn render_form(&self) -> RenderForm {
+        match self {
+            Self::Gather => RenderForm::GatherList,
+            Self::Scatter => RenderForm::ScatterList,
+            _ => RenderForm::Plain,
+        }
+    }
+
+    fn fixed_arity(&self) -> Option<usize> {
+        Some(match self {
+            Self::Input { .. } | Self::Constant(_) | Self::Iota { .. } => 0,
+            Self::Cast(_)
+            | Self::Sqrt
+            | Self::Exp
+            | Self::Exp2
+            | Self::Log2
+            | Self::Sin
+            | Self::Recip
+            | Self::ReduceSum { .. }
+            | Self::ReduceMax { .. }
+            | Self::IndexMapApply { .. } => 1,
+            Self::Add
+            | Self::Mul
+            | Self::Div
+            | Self::Mod
+            | Self::LessThan
+            | Self::TruncDiv
+            | Self::TruncRem => 2,
+            Self::Gather | Self::Scatter => return None,
+        })
+    }
+}
+
+/// Operand position is graph structure, not edge insertion order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct InputPort(pub usize);
+
+/// Egglog rendering form. Gather and scatter wrap coordinate operands in
+/// a `LogicalTensorList`; every other typed node uses the plain form.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RenderForm {
     /// ({constructor} {operands...} {aux})
@@ -277,41 +348,20 @@ enum RenderForm {
     ScatterList,
 }
 
-/// One SSA value: an op applied to operand values. Views are ORDINARY
-/// values (constructor = LogicalIndexMapApply) that additionally keep
-/// their map entries STRUCTURED so movement composition works on trees,
-/// never on text.
+/// One SSA value. Operands live exclusively on incoming graph edges;
+/// views keep their map entries structured in the operation payload so
+/// movement composition works on trees, never on rendered text.
 #[derive(Debug, Clone)]
-struct Value {
-    constructor: String,
-    operands: Vec<ValueId>,
-    /// Rendered trailing arguments (axis numbers, dtype terms, iota
-    /// expr+shape, map+shape for views...).
-    aux: String,
-    form: RenderForm,
-    /// Structured map entries — present exactly on movement-composed
-    /// views, consumed by apply_movement composition.
-    entries: Option<Vec<MapEntry>>,
-    dims: Vec<IntExpr>,
-    #[allow(dead_code)]
-    dtype: DType,
-    /// For inputs: the transitional binding-slot key (HLIR node index —
-    /// their set_data keying; dies with the HLIR pipeline).
-    input_slot: Option<usize>,
-    /// The PRISTINE input label — exactly the string the caller passed
-    /// to `named_tensor*` (ruling 2026-08-12: canonical labels are
-    /// stored as data, never re-derived from the rendered
-    /// "{label}_{slot}" identity string).
-    input_label: Option<String>,
+pub struct LogicalNode {
+    pub op: LogicalOp,
+    pub dims: Vec<IntExpr>,
+    pub dtype: DType,
 }
 
-/// One `.output()` designation: the value, the numeric key (the
-/// frontend tensor id — the readback handle), and the optional
-/// authored name.
+/// One `.output()` designation: the value and optional authored name.
 #[derive(Debug)]
 struct OutputRecord {
     value: ValueId,
-    key: usize,
     label: Option<String>,
 }
 
@@ -336,7 +386,7 @@ pub struct OutputSpec {
 
 #[derive(Debug, Default)]
 pub struct LogicalGraph {
-    values: Vec<Value>,
+    graph: StableDiGraph<LogicalNode, InputPort>,
     /// Output designations in .output() order.
     outputs: Vec<OutputRecord>,
     /// Anonymous-input counter — mints "arg.{k}" labels (Stage 3).
@@ -363,26 +413,25 @@ impl LogicalGraph {
         self.poisoned.as_deref()
     }
 
-    /// Read-only rows for visualization, one per value in ValueId order:
-    /// (constructor, operand ids, dims, dtype, input label).
-    #[allow(clippy::type_complexity)]
-    pub(crate) fn viz_rows(
-        &self,
-    ) -> impl Iterator<Item = (&str, &[ValueId], &[IntExpr], DType, Option<&str>)> {
-        self.values.iter().map(|value| {
-            (
-                value.constructor.as_str(),
-                value.operands.as_slice(),
-                value.dims.as_slice(),
-                value.dtype,
-                value.input_label.as_deref(),
-            )
-        })
+    /// The backing petgraph. Nodes are logical SSA values and incoming
+    /// edges are explicitly numbered operand ports.
+    pub fn petgraph(&self) -> &StableDiGraph<LogicalNode, InputPort> {
+        &self.graph
+    }
+
+    pub(crate) fn viz_nodes(&self) -> impl Iterator<Item = (ValueId, &LogicalNode)> {
+        self.graph.node_indices().map(|id| (id, &self.graph[id]))
+    }
+
+    pub(crate) fn viz_operands(&self, id: ValueId) -> Vec<(usize, ValueId)> {
+        self.operand_edges(id)
     }
 
     /// The recorded output designations, in .output() order.
     pub(crate) fn viz_outputs(&self) -> impl Iterator<Item = (ValueId, usize)> + '_ {
-        self.outputs.iter().map(|record| (record.value, record.key))
+        self.outputs
+            .iter()
+            .map(|record| (record.value, record.value.index()))
     }
 
     fn dim_term(expr: &IntExpr) -> Result<String, String> {
@@ -420,7 +469,10 @@ impl LogicalGraph {
     /// dims).
     fn entry_term(entry: &MapEntry, owner_shape: &str) -> Result<String, String> {
         Ok(match entry {
-            MapEntry::Coord { from_end, extent: _ } => {
+            MapEntry::Coord {
+                from_end,
+                extent: _,
+            } => {
                 format!("(CoordVar {owner_shape} {from_end})")
             }
             MapEntry::Lit(value) => Self::dim_term(value)?,
@@ -430,7 +482,11 @@ impl LogicalGraph {
                 Self::entry_term(b, owner_shape)?
             ),
             MapEntry::Mul(a, e) => {
-                format!("(IntMul {} {})", Self::entry_term(a, owner_shape)?, Self::dim_term(e)?)
+                format!(
+                    "(IntMul {} {})",
+                    Self::entry_term(a, owner_shape)?,
+                    Self::dim_term(e)?
+                )
             }
             MapEntry::Div(a, e) => format!(
                 "(IntTruncDiv {} {})",
@@ -455,21 +511,59 @@ impl LogicalGraph {
         })
     }
 
-    fn push(&mut self, value: Value) -> ValueId {
-        let id = ValueId(self.values.len() as u32);
-        self.values.push(value);
+    fn push(
+        &mut self,
+        op: LogicalOp,
+        operands: &[ValueId],
+        dims: Vec<IntExpr>,
+        dtype: DType,
+    ) -> ValueId {
+        if let Some(expected) = op.fixed_arity() {
+            debug_assert_eq!(
+                operands.len(),
+                expected,
+                "{} has the wrong operand count",
+                op.constructor()
+            );
+        }
+        let id = self.graph.add_node(LogicalNode { op, dims, dtype });
+        for (port, operand) in operands.iter().copied().enumerate() {
+            debug_assert!(
+                self.graph.node_weight(operand).is_some(),
+                "logical operand {operand:?} is not in the graph"
+            );
+            self.graph.add_edge(operand, id, InputPort(port));
+        }
         id
+    }
+
+    fn operand_edges(&self, id: ValueId) -> Vec<(usize, ValueId)> {
+        let mut operands: Vec<_> = self
+            .graph
+            .edges_directed(id, Direction::Incoming)
+            .map(|edge| (edge.weight().0, edge.source()))
+            .collect();
+        operands.sort_unstable_by_key(|(port, _)| *port);
+        debug_assert!(operands.iter().enumerate().all(|(i, (port, _))| i == *port));
+        operands
+    }
+
+    fn operands(&self, id: ValueId) -> Vec<ValueId> {
+        self.operand_edges(id)
+            .into_iter()
+            .map(|(_, operand)| operand)
+            .collect()
     }
 
     /// Resolve an operand: it must carry a value, and its tracker dims
     /// must agree with the recorded dims — the tripwire for tracker
     /// mutations the graph never saw.
     fn resolve(&mut self, operand: &Operand, at: &str) -> Result<ValueId, String> {
-        let (value, tracker_dims) = operand;
-        let Some(id) = value else {
-            return Err(format!("{at}: operand has no recorded logical value"));
+        let (id, tracker_dims) = operand;
+        let Some(value) = self.graph.node_weight(*id) else {
+            return Err(format!("{at}: operand {id:?} is not in the logical graph"));
         };
-        let dims = &self.values[id.0 as usize].dims;
+        let dims = &value.dims;
         if dims.len() != tracker_dims.len()
             || dims.iter().zip(tracker_dims).any(|(a, b)| {
                 // Static: value equality. Symbolic: structural equality
@@ -488,25 +582,17 @@ impl LogicalGraph {
         Ok(*id)
     }
 
-    /// Record an input declaration. Label keys keep the transitional
-    /// HLIR-node-index convention (their set_data keying).
-    pub fn input(
-        &mut self,
-        slot: usize,
-        label: &str,
-        dims: &[IntExpr],
-        dtype: DType,
-    ) -> Option<ValueId> {
+    /// Record an input declaration. The returned graph node is both its
+    /// SSA identity and its staging key.
+    pub fn input(&mut self, label: &str, dims: &[IntExpr], dtype: DType) -> Option<ValueId> {
         if self.poisoned.is_some() {
             return None;
         }
-        let shape = match Self::shape_term(dims) {
-            Ok(shape) => shape,
-            Err(reason) => {
-                self.poison(format!("input t{slot}: {reason}"));
-                return None;
-            }
-        };
+        let at = self.graph.node_count();
+        if let Err(reason) = Self::shape_term(dims) {
+            self.poison(format!("input t{at}: {reason}"));
+            return None;
+        }
         // STAGE 3 (rulings 2026-08-13): every input has a unique
         // pristine label. Anonymous inputs auto-name "arg.{k}" in
         // declaration order (the ExportedProgram/ONNX convention for
@@ -523,48 +609,16 @@ impl LogicalGraph {
         } else {
             label.to_string()
         };
-        if self
-            .values
-            .iter()
-            .any(|value| value.input_label.as_deref() == Some(&label))
-        {
+        if self.graph.node_weights().any(
+            |node| matches!(&node.op, LogicalOp::Input { label: existing } if existing == &label),
+        ) {
             self.poison(format!("duplicate input label \"{label}\""));
-            return None;
+            // Keep the authored graph structurally complete even after a
+            // fail-closed interface error. `model_text` will refuse this
+            // graph, but the returned tensor still has a real SSA node.
+            return Some(self.push(LogicalOp::Input { label }, &[], dims.to_vec(), dtype));
         }
-        // Boolean inputs cross the boundary as Bool8 (the Bool8 ruling:
-        // models compute in 1-bit Bool; bindings state the byte
-        // representation). Outputs get their boundary cast from the
-        // binding generator; INPUTS get it here — the wire tensor is
-        // declared Bool8 and a LogicalCast hands the model its Bool
-        // value, so the boundary buffer's dtype-of row (Bool8) agrees
-        // with its 8-bit layout (typed-buffers landing B, 2026-08-11).
-        let wire_dtype_term = match dtype {
-            DType::Bool => "(Bool8)".to_string(),
-            other => Self::dtype_term(other),
-        };
-        let aux = format!("(LogicalIdLit \"{label}\") {shape} {wire_dtype_term}");
-        let lit = self.push(Value {
-            constructor: "LogicalTensorInputLit".to_string(),
-            operands: Vec::new(),
-            aux,
-            form: RenderForm::Plain,
-            entries: None,
-            dims: dims.to_vec(),
-            dtype,
-            input_slot: Some(slot),
-            input_label: Some(label),
-        });
-        if dtype == DType::Bool {
-            return self.op(
-                slot,
-                "LogicalCast",
-                &[(Some(lit), dims.to_vec())],
-                "(Bool)",
-                dims.to_vec(),
-                DType::Bool,
-            );
-        }
-        Some(lit)
+        Some(self.push(LogicalOp::Input { label }, &[], dims.to_vec(), dtype))
     }
 
     /// Every bound input, in declaration order — the model's input
@@ -573,13 +627,16 @@ impl LogicalGraph {
     /// `id`). Labels are stored pristine; label uniqueness is an
     /// authoring obligation until the namespace tripwire lands.
     pub fn input_specs(&self) -> Vec<InputSpec> {
-        self.values
-            .iter()
-            .filter_map(|value| {
-                let slot = value.input_slot?;
+        self.graph
+            .node_indices()
+            .filter_map(|id| {
+                let value = &self.graph[id];
+                let LogicalOp::Input { label } = &value.op else {
+                    return None;
+                };
                 Some(InputSpec {
-                    label: value.input_label.clone()?,
-                    id: petgraph::graph::NodeIndex::new(slot),
+                    label: label.clone(),
+                    id,
                     dims: value.dims.clone(),
                     dtype: value.dtype,
                 })
@@ -595,8 +652,8 @@ impl LogicalGraph {
                 label: record
                     .label
                     .clone()
-                    .unwrap_or_else(|| format!("out_{}", record.key)),
-                id: petgraph::graph::NodeIndex::new(record.key),
+                    .unwrap_or_else(|| format!("out_{}", record.value.index())),
+                id: record.value,
             })
             .collect()
     }
@@ -604,15 +661,24 @@ impl LogicalGraph {
     /// Record an op over operand values.
     pub fn op(
         &mut self,
-        at: usize,
-        constructor: &str,
+        op: LogicalOp,
         operands: &[Operand],
-        extra: &str,
         out_dims: Vec<IntExpr>,
         out_dtype: DType,
     ) -> Option<ValueId> {
         if self.poisoned.is_some() {
             return None;
+        }
+        let constructor = op.constructor();
+        let at = self.graph.node_count();
+        if let Some(expected) = op.fixed_arity() {
+            if operands.len() != expected {
+                self.poison(format!(
+                    "{constructor} at t{at}: expected {expected} operands, got {}",
+                    operands.len()
+                ));
+                return None;
+            }
         }
         let mut ids = Vec::with_capacity(operands.len());
         for operand in operands {
@@ -624,24 +690,13 @@ impl LogicalGraph {
                 }
             }
         }
-        Some(self.push(Value {
-            constructor: constructor.to_string(),
-            operands: ids,
-            aux: extra.to_string(),
-            form: RenderForm::Plain,
-            entries: None,
-            dims: out_dims,
-            dtype: out_dtype,
-            input_slot: None,
-            input_label: None,
-        }))
+        Some(self.push(op, &ids, out_dims, out_dtype))
     }
 
     /// Record a seam-node view: an IndexMapApply of the operand through
     /// entries built from the seam's own parameters.
     pub fn view_op(
         &mut self,
-        at: usize,
         operand: &Operand,
         entries: &[MapEntry],
         out_dims: Vec<IntExpr>,
@@ -650,6 +705,7 @@ impl LogicalGraph {
         if self.poisoned.is_some() {
             return None;
         }
+        let at = self.graph.node_count();
         let base = match self.resolve(operand, &format!("view op at t{at}")) {
             Ok(id) => id,
             Err(reason) => {
@@ -657,17 +713,17 @@ impl LogicalGraph {
                 return None;
             }
         };
-        self.push_view(at, base, entries.to_vec(), out_dims, out_dtype)
+        self.push_view(base, entries.to_vec(), out_dims, out_dtype)
     }
 
     fn push_view(
         &mut self,
-        at: usize,
         base: ValueId,
         entries: Vec<MapEntry>,
         out_dims: Vec<IntExpr>,
         out_dtype: DType,
     ) -> Option<ValueId> {
+        let at = self.graph.node_count();
         let shape = match Self::shape_term(&out_dims) {
             Ok(shape) => shape,
             Err(reason) => {
@@ -679,7 +735,7 @@ impl LogicalGraph {
         // carries the source shape it substitutes into — the parent's
         // own dims, written here at the single mint site so the
         // apply/map coherence tripwire can never fire on recorder output.
-        let source_dims = self.values[base.0 as usize].dims.clone();
+        let source_dims = self.graph[base].dims.clone();
         let source_shape = match Self::shape_term(&source_dims) {
             Ok(term) => term,
             Err(reason) => {
@@ -697,42 +753,14 @@ impl LogicalGraph {
                 }
             }
         }
-        Some(self.push(Value {
-            constructor: "LogicalIndexMapApply".to_string(),
-            operands: vec![base],
-            aux: format!("(IndexMapLit {entries_term} {source_shape}) {shape}"),
-            form: RenderForm::Plain,
-            entries: Some(entries),
-            dims: out_dims,
-            dtype: out_dtype,
-            input_slot: None,
-            input_label: None,
-        }))
-    }
-
-    /// Record a source op (no operands) with pre-rendered argument text.
-    pub fn source_op(
-        &mut self,
-        _at: usize,
-        constructor: &str,
-        args: &str,
-        out_dims: Vec<IntExpr>,
-        out_dtype: DType,
-    ) -> Option<ValueId> {
-        if self.poisoned.is_some() {
-            return None;
-        }
-        Some(self.push(Value {
-            constructor: constructor.to_string(),
-            operands: Vec::new(),
-            aux: args.to_string(),
-            form: RenderForm::Plain,
-            entries: None,
-            dims: out_dims,
-            dtype: out_dtype,
-            input_slot: None,
-            input_label: None,
-        }))
+        // Validate all structured render inputs at the insertion boundary.
+        let _ = (shape, source_shape, entries_term);
+        Some(self.push(
+            LogicalOp::IndexMapApply { entries },
+            &[base],
+            out_dims,
+            out_dtype,
+        ))
     }
 
     /// Record a pad-mask indicator iota (see the pad seam): per padded
@@ -759,15 +787,11 @@ impl LogicalGraph {
     /// coordinate is identically zero); a `Coord(k)` with `k >= rank` is
     /// a leaked atom and poisons loudly. The authoring-contract bounds
     /// pair rides every iota.
-    pub fn record_iota(
-        &mut self,
-        at: usize,
-        expr: &IntExpr,
-        dims: &[IntExpr],
-    ) -> Option<ValueId> {
+    pub fn record_iota(&mut self, expr: &IntExpr, dims: &[IntExpr]) -> Option<ValueId> {
         if self.poisoned.is_some() {
             return None;
         }
+        let at = self.graph.node_count();
         let shape = match Self::shape_term(dims) {
             Ok(term) => term,
             Err(reason) => {
@@ -785,34 +809,33 @@ impl LogicalGraph {
                 }
             })
             .collect();
-        let value_expr = match int_expr_term(
-            expr,
-            &coord_terms,
-            &format!("recorder iota t{at}"),
-        ) {
+        let value_expr = match int_expr_term(expr, &coord_terms, &format!("recorder iota t{at}")) {
             Ok(text) => text,
             Err(err) => {
                 self.poison(format!("iota at t{at}: {err}"));
                 return None;
             }
         };
-        let logical = self.source_op(
-            at,
-            "LogicalIota",
-            &format!("{value_expr} {shape}"),
+        let logical = Some(self.push(
+            LogicalOp::Iota {
+                value_expr: value_expr.clone(),
+            },
+            &[],
             dims.to_vec(),
             DType::Int,
-        );
-        self.post_check(format!("iota value-bounds contract at t{at}"), &format!(
-            "(check (= ?reclo{at} (lower-bound-of {value_expr})))\n\
-             (check (= ?rechi{at} (upper-bound-of {value_expr})))\n"
         ));
+        self.post_check(
+            format!("iota value-bounds contract at t{at}"),
+            &format!(
+                "(check (= ?reclo{at} (lower-bound-of {value_expr})))\n\
+             (check (= ?rechi{at} (upper-bound-of {value_expr})))\n"
+            ),
+        );
         logical
     }
 
     pub fn record_mask_iota(
         &mut self,
-        at: usize,
         befores: &[IntExpr],
         afters: &[IntExpr],
         in_dims: &[IntExpr],
@@ -820,6 +843,7 @@ impl LogicalGraph {
         if self.poisoned.is_some() {
             return None;
         }
+        let at = self.graph.node_count();
         let rank = in_dims.len();
         let mut out_dims = Vec::with_capacity(rank);
         let mut out_terms = Vec::with_capacity(rank);
@@ -868,29 +892,30 @@ impl LogicalGraph {
         for factor in factors {
             expr = format!("(IntMul {factor} {expr})");
         }
-        let shape = match Self::shape_term(&out_dims) {
-            Ok(shape) => shape,
-            Err(reason) => {
-                self.poison(format!("mask iota at t{at}: {reason}"));
-                return None;
-            }
-        };
-        let logical =
-            self.source_op(at, "LogicalIota", &format!("{expr} {shape}"), out_dims, DType::Int);
+        let logical = Some(self.push(
+            LogicalOp::Iota {
+                value_expr: expr.clone(),
+            },
+            &[],
+            out_dims,
+            DType::Int,
+        ));
         // The authoring-contract bounds pair — uniform with record_iota
         // (Design A fold-in, 2026-08-06): every recorded iota's value
         // expression must have derivable bounds, or the fixpoint refuses.
-        self.post_check(format!("iota value-bounds contract at t{at}"), &format!(
-            "(check (= ?reclo{at} (lower-bound-of {expr})))\n\
+        self.post_check(
+            format!("iota value-bounds contract at t{at}"),
+            &format!(
+                "(check (= ?reclo{at} (lower-bound-of {expr})))\n\
              (check (= ?rechi{at} (upper-bound-of {expr})))\n"
-        ));
+            ),
+        );
         logical
     }
 
     /// Record a coordinate-form gather.
     pub fn record_gather(
         &mut self,
-        at: usize,
         data: &Operand,
         coords: &[Operand],
         out_dims: Vec<IntExpr>,
@@ -899,6 +924,7 @@ impl LogicalGraph {
         if self.poisoned.is_some() {
             return None;
         }
+        let at = self.graph.node_count();
         let mut ids = Vec::with_capacity(coords.len() + 1);
         match self.resolve(data, &format!("gather at t{at}")) {
             Ok(id) => ids.push(id),
@@ -916,23 +942,12 @@ impl LogicalGraph {
                 }
             }
         }
-        Some(self.push(Value {
-            constructor: "LogicalGather".to_string(),
-            operands: ids,
-            aux: String::new(),
-            form: RenderForm::GatherList,
-            entries: None,
-            dims: out_dims,
-            dtype: out_dtype,
-            input_slot: None,
-            input_label: None,
-        }))
+        Some(self.push(LogicalOp::Gather, &ids, out_dims, out_dtype))
     }
 
     /// Record a coordinate-form scatter (operands: init, coords..., src).
     pub fn record_scatter(
         &mut self,
-        at: usize,
         init: &Operand,
         coords: &[Operand],
         src: &Operand,
@@ -942,6 +957,7 @@ impl LogicalGraph {
         if self.poisoned.is_some() {
             return None;
         }
+        let at = self.graph.node_count();
         let mut ids = Vec::with_capacity(coords.len() + 2);
         match self.resolve(init, &format!("scatter at t{at}")) {
             Ok(id) => ids.push(id),
@@ -966,17 +982,7 @@ impl LogicalGraph {
                 return None;
             }
         }
-        Some(self.push(Value {
-            constructor: "LogicalScatter".to_string(),
-            operands: ids,
-            aux: String::new(),
-            form: RenderForm::ScatterList,
-            entries: None,
-            dims: out_dims,
-            dtype: out_dtype,
-            input_slot: None,
-            input_label: None,
-        }))
+        Some(self.push(LogicalOp::Scatter, &ids, out_dims, out_dtype))
     }
 
     /// Identity entries: parent axis p reads the like-positioned coord.
@@ -993,15 +999,11 @@ impl LogicalGraph {
     /// Apply a movement: composes onto an existing view value (a new
     /// value over the SAME base — the intermediate view goes dead and is
     /// elided at render) or wraps identity entries over a plain value.
-    pub fn apply_movement(
-        &mut self,
-        at: usize,
-        current: &Operand,
-        movement: Movement,
-    ) -> Option<ValueId> {
+    pub fn apply_movement(&mut self, current: &Operand, movement: Movement) -> Option<ValueId> {
         if self.poisoned.is_some() {
             return None;
         }
+        let at = self.graph.node_count();
         let current_id = match self.resolve(current, &format!("movement at t{at}")) {
             Ok(id) => id,
             Err(reason) => {
@@ -1009,14 +1011,14 @@ impl LogicalGraph {
                 return None;
             }
         };
-        let value = &self.values[current_id.0 as usize];
-        let (base, entries, prev_dims) = match &value.entries {
-            Some(entries) => (
-                value.operands[0],
+        let value = &self.graph[current_id];
+        let (base, entries, prev_dims) = match &value.op {
+            LogicalOp::IndexMapApply { entries } => (
+                self.operands(current_id)[0],
                 entries.clone(),
                 value.dims.clone(),
             ),
-            None => (
+            _ => (
                 current_id,
                 Self::identity_entries(&value.dims),
                 value.dims.clone(),
@@ -1156,7 +1158,10 @@ impl LogicalGraph {
             }
             Movement::Repeat(repeats) => {
                 if repeats.len() != prev_rank {
-                    self.poison(format!("repeat arity {} vs rank {prev_rank}", repeats.len()));
+                    self.poison(format!(
+                        "repeat arity {} vs rank {prev_rank}",
+                        repeats.len()
+                    ));
                     return None;
                 }
                 let replacement = (0..prev_rank)
@@ -1187,7 +1192,10 @@ impl LogicalGraph {
             }
             Movement::Shrink { new_dims } => {
                 if new_dims.len() != prev_rank {
-                    self.poison(format!("shrink arity {} vs rank {prev_rank}", new_dims.len()));
+                    self.poison(format!(
+                        "shrink arity {} vs rank {prev_rank}",
+                        new_dims.len()
+                    ));
                     return None;
                 }
                 let replacement = (0..prev_rank)
@@ -1204,7 +1212,7 @@ impl LogicalGraph {
             .iter()
             .map(|entry| entry.substitute(&replacement, prev_rank))
             .collect();
-        self.push_view(at, base, composed, new_dims, out_dtype)
+        self.push_view(base, composed, new_dims, out_dtype)
     }
 
     /// Append post-schedule authoring checks (iota bounds pairs).
@@ -1249,7 +1257,7 @@ impl LogicalGraph {
         }
     }
 
-    pub fn output(&mut self, at: usize, operand: &Operand, key: usize, label: Option<&str>) {
+    pub fn output(&mut self, operand: &Operand, label: Option<&str>) {
         if self.poisoned.is_some() {
             return;
         }
@@ -1262,7 +1270,7 @@ impl LogicalGraph {
                 return self.poison(format!("duplicate output name \"{name}\""));
             }
         }
-        let id = match self.resolve(operand, &format!("output of t{at}")) {
+        let id = match self.resolve(operand, "output") {
             Ok(id) => id,
             Err(reason) => return self.poison(reason),
         };
@@ -1272,62 +1280,114 @@ impl LogicalGraph {
         // materialize path — already poisons via its gather1d.)
         self.outputs.push(OutputRecord {
             value: id,
-            key,
             label: label.map(str::to_string),
         });
     }
 
     /// The live set: every value transitively reachable from the outputs,
     /// plus every input declaration (bindings enumerate all inputs).
-    pub(crate) fn live_set(&self) -> Vec<bool> {
-        let mut live = vec![false; self.values.len()];
+    pub(crate) fn live_set(&self) -> FxHashSet<ValueId> {
+        let mut live = FxHashSet::default();
         let mut stack: Vec<ValueId> = self.outputs.iter().map(|record| record.value).collect();
-        for (index, value) in self.values.iter().enumerate() {
-            if value.input_slot.is_some() {
-                stack.push(ValueId(index as u32));
+        for id in self.graph.node_indices() {
+            if matches!(self.graph[id].op, LogicalOp::Input { .. }) {
+                stack.push(id);
             }
         }
         while let Some(id) = stack.pop() {
-            let index = id.0 as usize;
-            if live[index] {
+            if !live.insert(id) {
                 continue;
             }
-            live[index] = true;
-            stack.extend(self.values[index].operands.iter().copied());
+            stack.extend(self.operands(id));
         }
         live
     }
 
-    fn render_value(&self, id: ValueId) -> String {
-        let value = &self.values[id.0 as usize];
-        let name = |id: &ValueId| format!("v{}", id.0);
-        match value.form {
+    fn render_value(&self, id: ValueId) -> Result<String, String> {
+        let value = &self.graph[id];
+        let operands = self.operands(id);
+        let name = |id: &ValueId| format!("v{}", id.index());
+        let shape = Self::shape_term(&value.dims)?;
+
+        if let LogicalOp::Input { label } = &value.op {
+            let wire_dtype = if value.dtype == DType::Bool {
+                "(Bool8)".to_string()
+            } else {
+                Self::dtype_term(value.dtype)
+            };
+            let literal =
+                format!("(LogicalTensorInputLit (LogicalIdLit \"{label}\") {shape} {wire_dtype})");
+            return if value.dtype == DType::Bool {
+                Ok(format!(
+                    "(let input_wire_v{} {literal})\n(let v{} (LogicalCast input_wire_v{} (Bool)))\n",
+                    id.index(),
+                    id.index(),
+                    id.index()
+                ))
+            } else {
+                Ok(format!("(let v{} {literal})\n", id.index()))
+            };
+        }
+
+        match value.op.render_form() {
             RenderForm::Plain => {
-                let mut parts: Vec<String> = value.operands.iter().map(name).collect();
-                if !value.aux.is_empty() {
-                    parts.push(value.aux.clone());
+                let mut parts: Vec<String> = operands.iter().map(name).collect();
+                match &value.op {
+                    LogicalOp::Constant(constant) => parts.push(format!("{constant:?}")),
+                    LogicalOp::Iota { value_expr } => {
+                        parts.push(value_expr.clone());
+                        parts.push(shape);
+                    }
+                    LogicalOp::Cast(dtype) => parts.push(Self::dtype_term(*dtype)),
+                    LogicalOp::ReduceSum { axis_from_end }
+                    | LogicalOp::ReduceMax { axis_from_end } => {
+                        parts.push(axis_from_end.to_string());
+                    }
+                    LogicalOp::IndexMapApply { entries } => {
+                        let source_shape = Self::shape_term(&self.graph[operands[0]].dims)?;
+                        let mut entries_term = "(IntExprNil)".to_string();
+                        for entry in entries.iter().rev() {
+                            entries_term = format!(
+                                "(IntExprCons {} {entries_term})",
+                                Self::entry_term(entry, &shape)?
+                            );
+                        }
+                        parts.push(format!("(IndexMapLit {entries_term} {source_shape})"));
+                        parts.push(shape);
+                    }
+                    _ => {}
                 }
-                format!("(let v{} ({} {}))\n", id.0, value.constructor, parts.join(" "))
+                Ok(format!(
+                    "(let v{} ({} {}))\n",
+                    id.index(),
+                    value.op.constructor(),
+                    parts.join(" ")
+                ))
             }
             RenderForm::GatherList => {
-                let data = name(&value.operands[0]);
+                let data = name(&operands[0]);
                 let mut list = "(LogicalTensorNil)".to_string();
-                for coord in value.operands[1..].iter().rev() {
+                for coord in operands[1..].iter().rev() {
                     list = format!("(LogicalTensorCons {} {list})", name(coord));
                 }
-                format!("(let v{} ({} {data} {list}))\n", id.0, value.constructor)
+                Ok(format!(
+                    "(let v{} ({} {data} {list}))\n",
+                    id.index(),
+                    value.op.constructor()
+                ))
             }
             RenderForm::ScatterList => {
-                let init = name(&value.operands[0]);
-                let src = name(value.operands.last().unwrap());
+                let init = name(&operands[0]);
+                let src = name(operands.last().unwrap());
                 let mut list = "(LogicalTensorNil)".to_string();
-                for coord in value.operands[1..value.operands.len() - 1].iter().rev() {
+                for coord in operands[1..operands.len() - 1].iter().rev() {
                     list = format!("(LogicalTensorCons {} {list})", name(coord));
                 }
-                format!(
+                Ok(format!(
                     "(let v{} ({} {init} {list} {src}))\n",
-                    id.0, value.constructor
-                )
+                    id.index(),
+                    value.op.constructor()
+                ))
             }
         }
     }
@@ -1341,19 +1401,19 @@ impl LogicalGraph {
         }
         let live = self.live_set();
         let mut text = String::new();
-        for index in 0..self.values.len() {
-            if live[index] {
-                text.push_str(&self.render_value(ValueId(index as u32)));
+        for id in self.graph.node_indices() {
+            if live.contains(&id) {
+                text.push_str(&self.render_value(id)?);
             }
         }
         for record in &self.outputs {
             let name = match &record.label {
                 Some(label) => label.clone(),
-                None => format!("out_{}", record.key),
+                None => format!("out_{}", record.value.index()),
             };
             text.push_str(&format!(
                 "(union v{} (LogicalTensorNamed (LogicalIdLit \"{name}\")))\n",
-                record.value.0
+                record.value.index()
             ));
         }
         Ok(text)
@@ -1389,32 +1449,42 @@ impl LogicalGraph {
         let mut input_slots = Vec::new();
         let mut input_buffer_tensors = Vec::new();
         let mut next_buffer: i64 = 0;
-        for (index, value) in self.values.iter().enumerate() {
-            let Some(slot) = value.input_slot else { continue };
+        for id in self.graph.node_indices() {
+            let value = &self.graph[id];
+            let LogicalOp::Input { .. } = &value.op else {
+                continue;
+            };
+            let slot = id.index();
             let shape = Self::shape_term(&value.dims)?;
             let stem = format!("nat{slot}");
             let buffer = next_buffer;
             next_buffer += 1;
+            let value_name = if value.dtype == DType::Bool {
+                format!("input_wire_v{}", id.index())
+            } else {
+                format!("v{}", id.index())
+            };
             text.push_str(&crate::reference_binding::input_binding(
                 &stem,
                 buffer as usize,
-                &format!("v{index}"),
+                &value_name,
                 &shape,
                 &crate::reference_binding::width_term(value.dtype),
             ));
             input_buffer_tensors.push(format!("{stem}_buffer_tensor"));
             input_slots.push(InputSlot {
-                tensor: petgraph::graph::NodeIndex::new(slot),
+                tensor: id,
                 buffer,
                 size: slot as u64,
-                value_name: format!("v{index}"),
+                value_name,
             });
         }
         let mut output_slots = Vec::new();
         let mut output_buffer_tensors = Vec::new();
         for record in &self.outputs {
-            let (id, key) = (record.value, record.key);
-            let value = &self.values[id.0 as usize];
+            let id = record.value;
+            let key = id.index();
+            let value = &self.graph[id];
             let shape = Self::shape_term(&value.dims)?;
             let stem = format!("natout{key}");
             let buffer = next_buffer;
@@ -1422,13 +1492,13 @@ impl LogicalGraph {
             text.push_str(&crate::reference_binding::output_binding(
                 &stem,
                 buffer as usize,
-                &format!("v{}", id.0),
+                &format!("v{}", id.index()),
                 &shape,
                 value.dtype,
             ));
             output_buffer_tensors.push(format!("{stem}_buffer_tensor"));
             output_slots.push(OutputSlot {
-                tensor: petgraph::graph::NodeIndex::new(key),
+                tensor: id,
                 buffer,
                 size: key as u64,
             });
@@ -1439,7 +1509,13 @@ impl LogicalGraph {
             "nat_input_boundary",
             "nat_output_boundary",
         ));
-        Ok((text, input_slots, output_slots, self.post_checks.clone(), self.labeled_checks.clone()))
+        Ok((
+            text,
+            input_slots,
+            output_slots,
+            self.post_checks.clone(),
+            self.labeled_checks.clone(),
+        ))
     }
 
     /// The assembled native program (model + reference-binding defaults).
@@ -1496,11 +1572,7 @@ pub struct LogicalProgram {
 /// replaced by the given coordinate term and dyn vars resolved via the
 /// pins. Add/Mul only for now (their slice path is affine); anything else
 /// bails loudly.
-pub(crate) fn int_expr_term(
-    expr: &IntExpr,
-    coord_terms: &[String],
-    at: &str,
-) -> AnyResult<String> {
+pub(crate) fn int_expr_term(expr: &IntExpr, coord_terms: &[String], at: &str) -> AnyResult<String> {
     let mut stack: Vec<String> = Vec::new();
     for term in expr.terms.read().iter() {
         match term {
@@ -1521,8 +1593,15 @@ pub(crate) fn int_expr_term(
                     coord_terms.len()
                 ),
             },
-            Term::Add | Term::Mul | Term::Sub | Term::Div | Term::Mod | Term::Min
-            | Term::Max | Term::Gte | Term::Lt => {
+            Term::Add
+            | Term::Mul
+            | Term::Sub
+            | Term::Div
+            | Term::Mod
+            | Term::Min
+            | Term::Max
+            | Term::Gte
+            | Term::Lt => {
                 // Their builders emit RHS terms first, so the stack TOP is
                 // the LEFT operand (verified against as_op + the Sub impl).
                 let (Some(left), Some(right)) = (stack.pop(), stack.pop()) else {
@@ -1550,13 +1629,53 @@ pub(crate) fn int_expr_term(
                 };
                 stack.push(rendered);
             }
-            other => bail!(
-                "hlir_to_logical: index-expression term {other:?} at {at} — later slice"
-            ),
+            other => {
+                bail!("hlir_to_logical: index-expression term {other:?} at {at} — later slice")
+            }
         }
     }
     match (stack.pop(), stack.is_empty()) {
         (Some(result), true) => Ok(result),
         _ => bail!("hlir_to_logical: malformed index expression at {at}"),
+    }
+}
+
+#[cfg(test)]
+mod logical_petgraph_tests {
+    use super::*;
+
+    #[test]
+    fn tensor_ids_are_petgraph_values_with_ported_operand_edges() {
+        let mut cx = Graph::new();
+        let lhs = cx.named_tensor("lhs", (2usize, 3usize));
+        let rhs = cx.named_tensor("rhs", (2usize, 3usize));
+        let sum = lhs + rhs;
+        let viewed = sum.expand_dim(0, 4usize).output();
+
+        let graph = cx.logical.petgraph();
+        assert_eq!(graph.node_count(), 4);
+        assert!(matches!(graph[lhs.id].op, LogicalOp::Input { .. }));
+        assert!(matches!(graph[rhs.id].op, LogicalOp::Input { .. }));
+        assert!(matches!(graph[sum.id].op, LogicalOp::Add));
+        assert!(matches!(
+            graph[viewed.id].op,
+            LogicalOp::IndexMapApply { .. }
+        ));
+
+        let mut add_inputs: Vec<_> = graph
+            .edges_directed(sum.id, Direction::Incoming)
+            .map(|edge| (edge.weight().0, edge.source()))
+            .collect();
+        add_inputs.sort_unstable_by_key(|(port, _)| *port);
+        assert_eq!(add_inputs, vec![(0, lhs.id), (1, rhs.id)]);
+
+        let view_input: Vec<_> = graph
+            .edges_directed(viewed.id, Direction::Incoming)
+            .map(|edge| (edge.weight().0, edge.source()))
+            .collect();
+        assert_eq!(view_input, vec![(0, sum.id)]);
+
+        assert_eq!(cx.logical.input_specs()[0].id, lhs.id);
+        assert_eq!(cx.logical.output_specs()[0].id, viewed.id);
     }
 }

--- a/src/visualization.rs
+++ b/src/visualization.rs
@@ -58,7 +58,11 @@ impl ToDot for crate::egglog_utils::SerializedEGraph {
         for (cluster, (class, (typ, members))) in classes.iter().enumerate() {
             let mut members: Vec<_> = members.iter().collect();
             members.sort_by_key(|node| node.to_string());
-            let border = if self.roots.contains(class) { "#2563eb" } else { "#9ca3af" };
+            let border = if self.roots.contains(class) {
+                "#2563eb"
+            } else {
+                "#9ca3af"
+            };
             out.push_str(&format!(
                 "  subgraph cluster_{cluster} {{\n    label=\"{}\";\n    color=\"{border}\";\n",
                 escape_dot_string(&format!("{typ} {class}"))
@@ -81,7 +85,9 @@ impl ToDot for crate::egglog_utils::SerializedEGraph {
                 // Children outside the retained snapshot (stripped classes)
                 // simply have no cluster to point at.
                 if let Some((cluster, anchor)) = anchors.get(child) {
-                    out.push_str(&format!("  n{src} -> n{anchor} [lhead=cluster_{cluster}];\n"));
+                    out.push_str(&format!(
+                        "  n{src} -> n{anchor} [lhead=cluster_{cluster}];\n"
+                    ));
                 }
             }
         }
@@ -101,18 +107,22 @@ impl ToDot for crate::graph::LogicalGraph {
             anyhow::bail!("logical graph poisoned: {reason}");
         }
         let live = self.live_set();
-        let mut out_keys: FxHashMap<u32, Vec<usize>> = FxHashMap::default();
+        let mut out_keys: FxHashMap<usize, Vec<usize>> = FxHashMap::default();
         for (id, key) in self.viz_outputs() {
-            out_keys.entry(id.0).or_default().push(key);
+            out_keys.entry(id.index()).or_default().push(key);
         }
         let mut out = String::from("digraph LogicalGraph {\n  node [fontname=\"Helvetica\"];\n  edge [fontname=\"Helvetica\"];\n");
-        for (index, (constructor, operands, dims, dtype, input_label)) in
-            self.viz_rows().enumerate()
-        {
-            if !live[index] {
+        for (id, node) in self.viz_nodes() {
+            if !live.contains(&id) {
                 continue;
             }
-            let dims_text = dims
+            let index = id.index();
+            let input_label = match &node.op {
+                crate::graph::LogicalOp::Input { label } => Some(label.as_str()),
+                _ => None,
+            };
+            let dims_text = node
+                .dims
                 .iter()
                 .map(|dim| dim.to_string())
                 .collect::<Vec<_>>()
@@ -120,16 +130,16 @@ impl ToDot for crate::graph::LogicalGraph {
             let mut lines = vec![
                 match input_label {
                     Some(name) => format!("v{index} = input {name}"),
-                    None => format!("v{index} = {constructor}"),
+                    None => format!("v{index} = {}", node.op.constructor()),
                 },
-                format!("[{dims_text}] {dtype:?}"),
+                format!("[{dims_text}] {:?}", node.dtype),
             ];
-            if let Some(keys) = out_keys.get(&(index as u32)) {
+            if let Some(keys) = out_keys.get(&index) {
                 for key in keys {
                     lines.push(format!("out {key}"));
                 }
             }
-            let boundary = input_label.is_some() || out_keys.contains_key(&(index as u32));
+            let boundary = input_label.is_some() || out_keys.contains_key(&index);
             let (fill, border) = if boundary {
                 ("#dbeafe", "#2563eb")
             } else {
@@ -143,12 +153,16 @@ impl ToDot for crate::graph::LogicalGraph {
             out.push_str(&format!(
                 "  n{index} [shape=box, style=\"rounded,filled\", fillcolor=\"{fill}\", color=\"{border}\", label=\"{label}\"];\n"
             ));
-            for (slot, operand) in operands.iter().enumerate() {
+            let operands = self.viz_operands(id);
+            for (slot, operand) in &operands {
                 // Position labels only where order matters (2+ operands).
                 if operands.len() > 1 {
-                    out.push_str(&format!("  n{} -> n{index} [label=\"{slot}\"];\n", operand.0));
+                    out.push_str(&format!(
+                        "  n{} -> n{index} [label=\"{slot}\"];\n",
+                        operand.index()
+                    ));
                 } else {
-                    out.push_str(&format!("  n{} -> n{index};\n", operand.0));
+                    out.push_str(&format!("  n{} -> n{index};\n", operand.index()));
                 }
             }
         }
@@ -186,10 +200,7 @@ pub fn save_html(html: &str, path: &str) -> Result<()> {
 
 /// Open a dot source in the Luminal Visualizer (browser).
 pub fn open_dot(dot: &str) {
-    let url = format!(
-        "http://viz.luminal.com/?dot={}",
-        urlencoding::encode(dot)
-    );
+    let url = format!("http://viz.luminal.com/?dot={}", urlencoding::encode(dot));
     let _ = open::that(&url);
 }
 
@@ -228,9 +239,7 @@ mod tests {
             )
             .expect("program parses");
         egraph.run_program(commands).expect("program runs");
-        let (sort, value) = egraph
-            .eval_expr(&var!("root"))
-            .expect("root resolves");
+        let (sort, value) = egraph.eval_expr(&var!("root")).expect("root resolves");
         let serialized = crate::egglog_utils::SerializedEGraph::new(&egraph, vec![(sort, value)]);
         let dot = serialized.to_dot().expect("snapshot renders");
         assert!(dot.contains("cluster_"), "eclass clusters missing:\n{dot}");


### PR DESCRIPTION
## Summary

- replace the flat logical value table with `StableDiGraph<LogicalNode, InputPort>`
- make `GraphTensor.id` the canonical logical SSA identity and represent ordered operands as numbered edges
- migrate views, I/O slots, rendering, liveness, and visualization to the petgraph representation
- preserve structured movement composition and Bool8 boundary behavior
- add regression coverage for SSA node identity and operand-port ordering

## Testing

- `cargo check --workspace`
- `cargo test -p luminal` (234 passed, 7 ignored; 3 doctests passed)
- `cargo clippy -p luminal --lib`
- focused `rustfmt --check` on all changed Rust files