### PR TITLE
Untrack the vendor/egglog-checkout symlink committed in #427

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,5 @@ dist/
 build/
 uv.lock
 crates/luminal_training/examples/mnist_data/
-vendor/egglog-checkout/
+# the local egglog clone (dir, or a symlink to one) — never tracked; recipe in vendor/README.md
+vendor/egglog-checkout

--- a/vendor/egglog-checkout
+++ b/vendor/egglog-checkout
@@ -1,1 +1,0 @@
-/Users/austin/Desktop/luminal-logical-ssa/vendor/egglog-checkout


### PR DESCRIPTION
**My mistake in #427 (`d29d0dbc`), and it breaks every fresh checkout of the branch.**

`vendor/egglog-checkout` was committed as a **symlink** (mode `120000`) whose target is the absolute macOS path `/Users/austin/Desktop/luminal-logical-ssa/vendor/egglog-checkout`. It got in because `.gitignore` had `vendor/egglog-checkout/` with a trailing slash, which ignores only a *directory*, and the reconciliation worktree carried the local clone as a symlink, so `git add -A` staged it.

What that does to anyone who pulls:

- A **fresh clone** gets a dangling link and every `cargo` command fails with `failed to read vendor/egglog-checkout/Cargo.toml`. The A100 box hit exactly this after `git pull` today.
- The **checkout the link points into** has its real egglog clone silently replaced by a self-referential link, because git overwrites *ignored* directories on checkout without a warning. The primary checkout on this machine was hit; the clone has been recreated from the recipe.

The fix is two lines: `git rm --cached` the entry, and change the ignore rule to `vendor/egglog-checkout` with no trailing slash so a directory, a file, or a symlink at that path is all ignored.

After merging, anyone whose checkout now has the link should recreate the clone per `vendor/README.md`:

```
cd vendor && rm -f egglog-checkout && \
git clone https://github.com/egraphs-good/egglog egglog-checkout && \
cd egglog-checkout && git checkout c2c0f1510a3633b768fb3d30ad284b211290e4b2 && \
git apply ../egglog-add-subsumed.patch
```

This is also the strongest argument yet for giving the patched engine a shared home (a `luminal-ai/egglog` fork the `[patch]` can point at by URL) — a gitignored local directory is what made this failure mode possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)