### PR TITLE
Clear workspace and CUDA-lite Clippy debt

### DIFF
--- a/crates/luminal_cuda_lite/src/ops/cublaslt/election.rs
+++ b/crates/luminal_cuda_lite/src/ops/cublaslt/election.rs
@@ -14,6 +14,9 @@
 
 use luminal::layout_ir::OpMatcher;
 
+type ProducerOrdering<'a> =
+    &'a dyn Fn(&[(String, luminal::extractor::ProducerChoice)], usize) -> Vec<usize>;
+
 /// Build a TOTAL genome over a fixture's produced classes: each class takes
 /// the first preference (an implementation constructor name) it can satisfy,
 /// falling back to its first candidate — the producer index is
@@ -79,7 +82,7 @@ pub fn level_admits(level: usize) -> impl Fn(&str) -> bool {
 pub fn genome_with_ordering(
     egraph: &luminal::prelude::egraph_serialize::EGraph,
     matchers: Vec<Box<dyn OpMatcher>>,
-    ordered: &dyn Fn(&[(String, luminal::extractor::ProducerChoice)], usize) -> Vec<usize>,
+    ordered: ProducerOrdering<'_>,
 ) -> luminal::extractor::Genome {
     use luminal::prelude::egraph_serialize::ClassId;
     use std::collections::{BTreeSet, HashMap};
@@ -250,7 +253,7 @@ pub fn genome_with_ordering(
         >,
         egraph: &luminal::prelude::egraph_serialize::EGraph,
         terminals: &BTreeSet<ClassId>,
-        ordered: &dyn Fn(&[(String, luminal::extractor::ProducerChoice)], usize) -> Vec<usize>,
+        ordered: ProducerOrdering<'_>,
         lit_input_lists: &dyn Fn(&ClassId) -> Vec<Vec<ClassId>>,
         path: &mut Vec<ClassId>,
         memo: &mut HashMap<(ClassId, usize), Outcome>,

--- a/crates/luminal_cuda_lite/src/ops/scatter/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/scatter/mod.rs
@@ -248,7 +248,7 @@ pub(crate) fn codegen(op: &dyn BufferTensorIrOp, ctx: &CodegenCtx) -> Result<Vec
     // layout read, and it is unaffected by any of this.
     let mut reads = String::new();
     let mut any_chain = false;
-    for axis in 0..rank {
+    for (axis, stride) in strides.iter().enumerate() {
         // The coordinate value's own extents must be src's for the
         // prelude's `c*` to be its coordinates: refuse a mismatch,
         // never reinterpret (the elementwise contract). Asked of EVERY
@@ -271,10 +271,7 @@ pub(crate) fn codegen(op: &dyn BufferTensorIrOp, ctx: &CodegenCtx) -> Result<Vec
         any_chain |= !chain.is_empty();
         reads.push_str(&chain);
         reads.push_str(&format!("    coord = (long long){name}[{idx}];\n"));
-        reads.push_str(&format!(
-            "    flat += coord * {stride}LL;\n",
-            stride = strides[axis]
-        ));
+        reads.push_str(&format!("    flat += coord * {stride}LL;\n"));
     }
     let (src_chain, src_idx) = layout_read_index(
         "src",

--- a/crates/luminal_cuda_lite/tests/codegen_identity.rs
+++ b/crates/luminal_cuda_lite/tests/codegen_identity.rs
@@ -34,7 +34,7 @@ use std::collections::HashMap;
 /// read.
 fn reads_flat(layout: &luminal_cuda_lite::layouts::CudaLayout, dims: &[usize]) -> bool {
     kernels::layout_read_index("probe", layout, dims, Coords::FlatIndex { prefix: "c" })
-        .map_or(false, |(chain, idx)| chain.is_empty() && idx == "i")
+        .is_ok_and(|(chain, idx)| chain.is_empty() && idx == "i")
 }
 
 /// The PRE-Phase-3 construction, restated for the corrected contract:
@@ -261,7 +261,6 @@ mod strided {
     use luminal::buffer_tensor_ir::BufferTensorIrOp;
     use luminal::bufferize::{BufferId, SlotDescriptor};
     use luminal::dtype::PlanDtype;
-    use luminal::index_expr::IotaExpr;
     use luminal_cuda_lite::{kernels, ops};
 
     use luminal::layouts::{
@@ -338,12 +337,6 @@ mod strided {
         let mut s = slot(dims);
         s.layout.dtype = Some(dtype);
         s
-    }
-
-    /// A layout whose read does NOT reduce to the identity, for the
-    /// write-side pins: stride 2 over the slot's own dims.
-    fn unsimplifiable(dims: &[i64]) -> CudaLayout {
-        strided_layout(dims, vec![mul(coord(0), lit(2))])
     }
 
     /// Generate the single kernel source for `op` with the given
@@ -930,8 +923,12 @@ fn descriptor_ctx_bails_loudly_on_unusable_layouts() {
         },
         ..filled.clone()
     };
-    let err = kernels::CodegenCtx::from_descriptors("ProbeOp", &[symbolic], &[filled.clone()])
-        .expect_err("symbolic layout extents must refuse");
+    let err = kernels::CodegenCtx::from_descriptors(
+        "ProbeOp",
+        &[symbolic],
+        std::slice::from_ref(&filled),
+    )
+    .expect_err("symbolic layout extents must refuse");
     assert!(
         err.to_string().contains("symbolic layout extents"),
         "got: {err}"
@@ -943,14 +940,19 @@ fn descriptor_ctx_bails_loudly_on_unusable_layouts() {
         },
         ..filled.clone()
     };
-    let err = kernels::CodegenCtx::from_descriptors("ProbeOp", &[filled.clone()], &[untyped])
-        .expect_err("a missing dtype fact must refuse");
+    let err =
+        kernels::CodegenCtx::from_descriptors("ProbeOp", std::slice::from_ref(&filled), &[untyped])
+            .expect_err("a missing dtype fact must refuse");
     assert!(
         err.to_string().contains("carries no dtype fact"),
         "got: {err}"
     );
-    let ok = kernels::CodegenCtx::from_descriptors("ProbeOp", &[filled.clone()], &[filled])
-        .expect("filled descriptors build");
+    let ok = kernels::CodegenCtx::from_descriptors(
+        "ProbeOp",
+        std::slice::from_ref(&filled),
+        std::slice::from_ref(&filled),
+    )
+    .expect("filled descriptors build");
     assert_eq!(ok.operand_dims, vec![vec![2, 3]]);
     assert!(
         reads_flat(ok.operand_layout(0), &ok.operand_dims[0]),

--- a/crates/luminal_cuda_lite/tests/composed_read_families.rs
+++ b/crates/luminal_cuda_lite/tests/composed_read_families.rs
@@ -96,7 +96,7 @@ fn rendered(
                     &ctx.operand_dims[k],
                     kernels::Coords::FlatIndex { prefix: "c" },
                 )
-                .map_or(false, |(chain, idx)| chain.is_empty() && idx == "i")
+                .is_ok_and(|(chain, idx)| chain.is_empty() && idx == "i")
             })
             .collect();
         let sources: Vec<String> = (kernel.codegen)(op.as_ref(), &ctx)

--- a/crates/luminal_cuda_lite/tests/view_admission.rs
+++ b/crates/luminal_cuda_lite/tests/view_admission.rs
@@ -132,7 +132,7 @@ fn audit(
                         &dims,
                         luminal_cuda_lite::kernels::Coords::FlatIndex { prefix: "c" },
                     )
-                    .map_or(false, |(chain, idx)| chain.is_empty() && idx == "i");
+                    .is_ok_and(|(chain, idx)| chain.is_empty() && idx == "i");
                     if !flat {
                         composed.push((label.to_string(), slot, info.layout.clone()));
                     }
@@ -159,7 +159,7 @@ fn audit(
                         &dims,
                         luminal_cuda_lite::kernels::Coords::FlatIndex { prefix: "c" },
                     )
-                    .map_or(false, |(chain, idx)| chain.is_empty() && idx == "i");
+                    .is_ok_and(|(chain, idx)| chain.is_empty() && idx == "i");
                     assert!(
                         flat,
                         "{label}: a compute RESULT is produced by the node, never read \

--- a/crates/luminal_nn/src/attention.rs
+++ b/crates/luminal_nn/src/attention.rs
@@ -338,7 +338,7 @@ fn paged_attention_core(
             .lt(row_vals - (window as f32 - 1.0))
             .cast(DType::F32)
             * -1e9;
-        mask = mask + outside;
+        mask += outside;
     }
 
     // Broadcast (s, ctx) → (n_kv_heads, kv_groups, s, ctx) — ONE apply.
@@ -575,6 +575,11 @@ pub fn attention(
     head_dim: usize,
 ) -> GraphTensor {
     let scale = 1.0 / (head_dim as f32).sqrt();
+    assert_eq!(
+        q.dims()[1],
+        n_heads * head_dim,
+        "query width must equal n_heads * head_dim"
+    );
     let sq = q.dims()[0];
     let sk = k.dims()[0];
     // ONE apply per operand reshape (ruling 2026-08-26).

--- a/crates/luminal_nn/src/models.rs
+++ b/crates/luminal_nn/src/models.rs
@@ -42,6 +42,10 @@ impl Mlp {
 }
 
 /// The FFN flavor a decoder block carries.
+#[expect(
+    clippy::large_enum_variant,
+    reason = "the public model API keeps both feed-forward variants directly constructible"
+)]
 pub enum FeedForward {
     /// up → relu → down.
     Dense { up: Linear, down: Linear },
@@ -1049,7 +1053,8 @@ mod tests {
             weights(D * D, 4),
             weights(D * D, 5),
         );
-        let ff: Box<dyn Fn(&[f32]) -> Vec<f32>> = match &fx.block.ff {
+        type ScalarFfn = dyn Fn(&[f32]) -> Vec<f32>;
+        let ff: Box<ScalarFfn> = match &fx.block.ff {
             FeedForward::Dense { .. } => {
                 let (up, down) = (weights(D * FF_HIDDEN, 9), weights(FF_HIDDEN * D, 10));
                 Box::new(move |x: &[f32]| {

--- a/crates/luminal_nn/src/moe.rs
+++ b/crates/luminal_nn/src/moe.rs
@@ -14,7 +14,6 @@ impl MoE {
         let e_dim = *self.router.dims().last().unwrap();
         let (_, in_size, out_size) = self.expert_weights.dims3();
         let io = in_size * out_size;
-        let k_expr = IntExpr::from(self.k);
 
         // 1. Routing probabilities: [batch.., E]
         let routing_weights = activations.matmul(self.router).softmax(n - 1);
@@ -35,7 +34,7 @@ impl MoE {
             let mut stride = e_dim;
             let mut acc = IntExpr::from(0);
             for i in (0..n - 1).rev() {
-                acc = acc + c[i] * stride;
+                acc += c[i] * stride;
                 // Frontend simplification restored (revert ruling 2026-08-27).
                 stride = (stride * idx_dims[i]).simplify();
             }
@@ -320,7 +319,7 @@ mod topk_tests {
         for s_i in 0..S {
             let xr = &x_vals[s_i * H..(s_i + 1) * H];
             // Router logits (x @ router.t()) then softmax over E.
-            let mut logits = vec![0f32; E];
+            let mut logits = [0f32; E];
             for (e, logit) in logits.iter_mut().enumerate() {
                 *logit = (0..H).map(|j| xr[j] * router_vals[e * H + j]).sum();
             }
@@ -337,7 +336,7 @@ mod topk_tests {
                 let weight = probs[*expert] / picked_sum;
                 // Fused gate;up: (2I, H) rows.
                 let w = &gate_up_vals[expert * 2 * I * H..(expert + 1) * 2 * I * H];
-                let mut projected = vec![0f32; 2 * I];
+                let mut projected = [0f32; 2 * I];
                 for (r, slot) in projected.iter_mut().enumerate() {
                     *slot = (0..H).map(|j| xr[j] * w[r * H + j]).sum();
                 }
@@ -408,7 +407,7 @@ mod topk_tests {
         let mut expected = vec![0f32; S * H];
         for s_i in 0..S {
             let xr = &x_vals[s_i * H..(s_i + 1) * H];
-            let mut logits = vec![0f32; E];
+            let mut logits = [0f32; E];
             for (e, logit) in logits.iter_mut().enumerate() {
                 *logit = (0..H).map(|j| xr[j] * router_vals[e * H + j]).sum();
             }
@@ -423,7 +422,7 @@ mod topk_tests {
             for expert in &picked {
                 let weight = probs[*expert] / picked_sum;
                 let w = &gate_up_vals[expert * 2 * I * H..(expert + 1) * 2 * I * H];
-                let mut projected = vec![0f32; 2 * I];
+                let mut projected = [0f32; 2 * I];
                 for (r, slot) in projected.iter_mut().enumerate() {
                     *slot = (0..H).map(|j| xr[j] * w[r * H + j]).sum();
                 }

--- a/crates/luminal_reference/src/runtime.rs
+++ b/crates/luminal_reference/src/runtime.rs
@@ -132,17 +132,18 @@ impl ReferenceRuntime {
             .logical
             .bound_parts(&crate::bindings::ReferenceBindings)
             .map_err(|reason| anyhow!("native load refused: {reason}"))?;
-        let mut runtime = Self::default();
-        runtime.native = Some(NativeSpec {
-            pre_schedule,
-            input_slots,
-            output_slots,
-            post_checks,
-            labeled_checks,
-            binding_seeds: String::new(),
-            ops: None,
-        });
-        Ok(runtime)
+        Ok(Self {
+            native: Some(NativeSpec {
+                pre_schedule,
+                input_slots,
+                output_slots,
+                post_checks,
+                labeled_checks,
+                binding_seeds: String::new(),
+                ops: None,
+            }),
+            ..Self::default()
+        })
     }
 
     /// BINDING: seed a dynamic dim's range (bounds-on-vars — never a pin).
@@ -1102,8 +1103,8 @@ mod tests {
             (cx, data, row, col, out)
         };
         let data_vals: Vec<f32> = (0..12).map(|v| v as f32 * 1.5 + 1.0).collect();
-        let row_ints = vec![0i32, 2, 1, 2, 0, 1];
-        let col_ints = vec![3i32, 0, 2, 3, 1, 0];
+        let row_ints = [0i32, 2, 1, 2, 0, 1];
+        let col_ints = [3i32, 0, 2, 3, 1, 0];
         let row_vals: Vec<i32> = row_ints.to_vec();
         let col_vals: Vec<i32> = col_ints.to_vec();
 
@@ -1145,8 +1146,8 @@ mod tests {
             (cx, dest, row, col, src, out)
         };
         let dest_vals: Vec<f32> = (0..12).map(|v| v as f32).collect();
-        let row_ints = vec![0i32, 1, 2, 1];
-        let col_ints = vec![1i32, 3, 0, 0];
+        let row_ints = [0i32, 1, 2, 1];
+        let col_ints = [1i32, 3, 0, 0];
         let row_vals: Vec<i32> = row_ints.to_vec();
         let col_vals: Vec<i32> = col_ints.to_vec();
         let src_vals = vec![100.0, 200.0, 300.0, 400.0];

--- a/examples/mini/flux/src/lib.rs
+++ b/examples/mini/flux/src/lib.rs
@@ -56,7 +56,6 @@ pub struct MiniDit {
     pub single_knorm: GraphTensor,
     ln: LayerNorm, // no-affine LayerNorm, shared (stateless)
     d: usize,
-    n_heads: usize,
     head_dim: usize,
     mlp: usize,
     t_half: usize,
@@ -117,7 +116,6 @@ impl MiniDit {
             single_knorm: cx.named_tensor("SglKNorm", head_dim),
             ln: LayerNorm::new(d, false, false, true, 1e-6, &Ns::root().child("ln"), cx),
             d,
-            n_heads,
             head_dim,
             mlp,
             t_half,
@@ -254,18 +252,18 @@ impl MiniDit {
         )); // (s, d)
         let attn_txt = attn.slice_along(0..s_txt, 0);
         let attn_img = attn.slice_along(s_txt.., 0);
-        img = img + gate(self.img_out.forward(attn_img), gate0);
-        txt = txt + gate(self.txt_out.forward(attn_txt), c_gate0);
+        img += gate(self.img_out.forward(attn_img), gate0);
+        txt += gate(self.txt_out.forward(attn_txt), c_gate0);
         let ff = swiglu(
             self.ff_in
                 .forward(ada(self.ln.forward(img), scale1, shift1)),
         );
-        img = img + gate(self.ff_out.forward(ff), gate1);
+        img += gate(self.ff_out.forward(ff), gate1);
         let c_ff = swiglu(
             self.ctx_ff_in
                 .forward(ada(self.ln.forward(txt), c_scale1, c_shift1)),
         );
-        txt = txt + gate(self.ctx_ff_out.forward(c_ff), c_gate1);
+        txt += gate(self.ctx_ff_out.forward(c_ff), c_gate1);
 
         // ---- single-stream block over [txt ‖ img] ----
         // The joint sequence assembles by SCATTER writes into a zero
@@ -293,11 +291,10 @@ impl MiniDit {
         let mlp_out = swiglu(proj.slice_along(3 * d..3 * d + 2 * mlp, 1)); // (s, mlp)
                                                                            // Fused out-projection over [attn ‖ mlp], spelled as the
                                                                            // row-split sum (see the single_out_* field note).
-        hidden = hidden
-            + gate(
-                self.single_out_attn.forward(attn) + self.single_out_mlp.forward(mlp_out),
-                s_gate,
-            );
+        hidden += gate(
+            self.single_out_attn.forward(attn) + self.single_out_mlp.forward(mlp_out),
+            s_gate,
+        );
 
         // ---- AdaLayerNormContinuous head: (scale, shift) — REVERSED ----
         let img_final = hidden.slice_along(s_txt.., 0); // (s_img, d)
@@ -325,10 +322,10 @@ pub fn mini_dit_rope_tables(s_txt: usize, h: usize, w: usize) -> (Vec<f32>, Vec<
     }
     let (mut cos, mut sin) = (Vec::new(), Vec::new());
     for id in ids {
-        for axis in 0..4 {
+        for value in id {
             for _ in 0..2 {
-                cos.push(id[axis].cos());
-                sin.push(id[axis].sin());
+                cos.push(value.cos());
+                sin.push(value.sin());
             }
         }
     }

--- a/examples/mini/gemma4_moe/src/lib.rs
+++ b/examples/mini/gemma4_moe/src/lib.rs
@@ -48,6 +48,10 @@ fn moe_lm_new(
     )
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the model-spec forward boundary keeps cache and decode inputs explicit"
+)]
 fn moe_lm_forward(
     embed: &Embedding,
     blocks: &[DecoderBlock],

--- a/examples/mini/llama3/src/lib.rs
+++ b/examples/mini/llama3/src/lib.rs
@@ -12,6 +12,10 @@ use luminal_nn::{Embedding, GatedFfn, LayerNorm, LlamaBlock};
 /// family keeps its own NAMED front door (ruling 2026-08-10: minis are
 /// named for the model they represent, not parameterized as llama) so
 /// family-specific constructs accrete in one visible place.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the model-spec builder keeps each architecture hyperparameter explicit"
+)]
 fn gqa_lm_new(
     vocab: usize,
     d: usize,
@@ -42,6 +46,10 @@ fn gqa_lm_new(
     )
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the model-spec forward boundary keeps cache and decode inputs explicit"
+)]
 fn gqa_lm_forward(
     embed: &Embedding,
     blocks: &[LlamaBlock],

--- a/examples/mini/qwen3/src/lib.rs
+++ b/examples/mini/qwen3/src/lib.rs
@@ -14,6 +14,10 @@ use luminal_nn::{Embedding, GatedFfn, LayerNorm, LlamaBlock};
 /// family keeps its own NAMED front door (ruling 2026-08-10: minis are
 /// named for the model they represent, not parameterized as llama) so
 /// family-specific constructs accrete in one visible place.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the model-spec builder keeps each architecture hyperparameter explicit"
+)]
 fn gqa_lm_new(
     vocab: usize,
     d: usize,
@@ -44,6 +48,10 @@ fn gqa_lm_new(
     )
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the model-spec forward boundary keeps cache and decode inputs explicit"
+)]
 fn gqa_lm_forward(
     embed: &Embedding,
     blocks: &[LlamaBlock],

--- a/examples/mini/qwen3_moe/src/lib.rs
+++ b/examples/mini/qwen3_moe/src/lib.rs
@@ -45,6 +45,10 @@ fn moe_lm_new(
     )
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the model-spec forward boundary keeps cache and decode inputs explicit"
+)]
 fn moe_lm_forward(
     embed: &Embedding,
     blocks: &[DecoderBlock],

--- a/src/buffer_tensor_ir.rs
+++ b/src/buffer_tensor_ir.rs
@@ -62,17 +62,6 @@ impl<T: BufferTensorIrOp + Clone + 'static> CloneBufferTensorIrOp for T {
     }
 }
 
-/// What an op IS once every aliasing decision is behind it: its identity and
-/// its memory effects — the surface the BufferTensor layer, the lowering, and
-/// (eventually) the execution engine consume. Deliberately free of analysis
-/// concerns: `Bufferizable` (the aliasing contract) and `ToDps` are the
-/// ANALYSIS-time surfaces, and by this layer their questions are all answered.
-///
-/// Every value-level op is one automatically (`LayoutIrOp` has this as a
-/// supertrait); planner-synthesized ops like [`BufferCopy`] implement ONLY
-/// this trait — they have no logical semantics, no egglog constructor, and
-/// never meet the analyzer.
-
 /// Typed reference storage (rulings 2026-07-28, 2026-07-30, and the
 /// typed-buffers ruling 2026-08-11: NO value ever rides a buffer of
 /// another type — "no smuggling data in invalid types"). Floats live
@@ -413,6 +402,16 @@ impl<T: 'static> AsAnyOp for T {
     }
 }
 
+/// What an op IS once every aliasing decision is behind it: its identity and
+/// its memory effects — the surface the BufferTensor layer, the lowering, and
+/// (eventually) the execution engine consume. Deliberately free of analysis
+/// concerns: `Bufferizable` (the aliasing contract) and `ToDps` are the
+/// ANALYSIS-time surfaces, and by this layer their questions are all answered.
+///
+/// Every value-level op is one automatically (`LayoutIrOp` has this as a
+/// supertrait); planner-synthesized ops like [`BufferCopy`] implement ONLY
+/// this trait — they have no logical semantics, no egglog constructor, and
+/// never meet the analyzer.
 pub trait BufferTensorIrOp: OpSlotNames + CloneBufferTensorIrOp + AsAnyOp + Debug {
     /// The op's IR name (see the label policy in `luminal_reference::ops`).
     fn label(&self) -> &str;
@@ -1873,6 +1872,7 @@ pub(crate) fn install_anti_edges<L: PlanLayout>(bt: &mut BufferTensorIrGraph<L>)
 ///     and BEFORE B's free — otherwise some legal schedule uses storage
 ///     that does not exist yet, or has already been destroyed;
 ///   * a free has out-degree ZERO (nothing may ever depend on one).
+///
 /// A buffer without a record certifies as CallerFrees — the declared-absence
 /// semantics; real pipeline graphs always carry records (input validation
 /// requires both declarations).

--- a/src/bufferize.rs
+++ b/src/bufferize.rs
@@ -1512,7 +1512,7 @@ fn validate_input_program(graph: &ExtractedGraph) -> Result<()> {
         // named the same layout twice), not region analysis.
         for (i, a) in demanded.iter().enumerate() {
             for b in &demanded[i + 1..] {
-                if input_layouts.get(a).is_some() && input_layouts.get(a) == input_layouts.get(b) {
+                if input_layouts.contains_key(a) && input_layouts.get(a) == input_layouts.get(b) {
                     anyhow::bail!(
                         "invalid input program: output buffer {} is demanded \
                          to hold two different values ({} and {}) under the \
@@ -1565,8 +1565,8 @@ pub(crate) fn extraction_layouts<L: PlanLayout>(
     layouts: &HashMap<ClassId, L>,
 ) -> Result<HashMap<ClassId, L>> {
     let mut value_layouts: HashMap<ClassId, L> = HashMap::new();
-    let mut record = |value: &crate::layout_ir::LayoutTensorInfo,
-                      table: &mut HashMap<ClassId, L>|
+    let record = |value: &crate::layout_ir::LayoutTensorInfo,
+                  table: &mut HashMap<ClassId, L>|
      -> Result<()> {
         if table.contains_key(&value.eclass) {
             return Ok(());
@@ -2782,7 +2782,6 @@ mod tests {
             pinned,
             read_only,
             output_values: vec![cid("r")],
-            ..Default::default()
         };
         let analysis = Analyzer::new(&ops, &facts).run().unwrap();
         assert_eq!(analysis.in_place.get(&(0, 1)), Some(&false));
@@ -2850,7 +2849,6 @@ mod tests {
             reads: vec![true, false],
             in_place_operand: Some(1),
             not_conflicting,
-            ..Default::default()
         };
         let ops = vec![AnalysisOp {
             position: 0,
@@ -3137,7 +3135,6 @@ mod tests {
             reads: vec![false],
             in_place_operand: Some(0),
             not_conflicting: true,
-            ..Default::default()
         };
         let reader = MockOp {
             reads: vec![true],

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -11,6 +11,9 @@ use crate::layout_ir::{
 };
 use crate::logical_op::{LogicalRender, logical_op_for};
 
+type Bounds = (Option<i128>, Option<i128>);
+type BoundsIndex = HashMap<ClassId, Bounds>;
+
 #[derive(Debug)]
 struct Extractor<'a> {
     egraph: &'a EGraph,
@@ -48,7 +51,7 @@ struct Extractor<'a> {
     /// serialized `lower-bound-of` / `upper-bound-of` rows: IntExpr class →
     /// (lower, upper). `tensor_bytes_cache` memoizes the per-LayoutTensor
     /// byte size derived from its layout's shape and bit width.
-    bounds_index: std::cell::RefCell<Option<HashMap<ClassId, (Option<i128>, Option<i128>)>>>,
+    bounds_index: std::cell::RefCell<Option<BoundsIndex>>,
     tensor_bytes_cache: std::cell::RefCell<HashMap<ClassId, u64>>,
     /// GENOME-INDEPENDENT dtype index (typed-buffers landing A,
     /// 2026-08-11): serialized `dtype-of` rows, scanned once —
@@ -945,7 +948,7 @@ impl<'a> Extractor<'a> {
     /// recursive walk. The DFS's cycle guard made `None` contextual:
     /// not caching it re-explored whole subtrees exponentially on
     /// cycle-rich e-graphs (the 2-layer decoder hang — 15k nodes,
-    /// >150s), and caching it produced wrong refusals. Relaxation has
+    /// more than 150s), and caching it produced wrong refusals. Relaxation has
     /// neither problem: a class's plan materializes the pass after all
     /// of some candidate's children have plans, costs only improve
     /// monotonically, and cycles simply never enable — no guard, no
@@ -1222,16 +1225,16 @@ impl<'a> Extractor<'a> {
         };
 
         let children = self.op_children(&spec.inputs, op.as_ref());
-        Some(Candidate::layout_ir(
-            producer.op_class.clone(),
-            node_id,
-            producer.output_index,
-            spec.inputs.clone(),
-            spec.outputs.clone(),
-            op,
+        Some(Candidate {
+            source_eclass: Some(producer.op_class.clone()),
+            source_enode: Some(node_id.clone()),
+            selected_output_index: Some(producer.output_index),
+            input_list: spec.inputs.clone(),
+            output_list: spec.outputs.clone(),
+            kind: PlanKind::LayoutIr(op),
             children,
             metadata,
-        ))
+        })
     }
 
     fn op_children(&self, inputs: &[ClassId], op: &dyn LayoutIrOp) -> Vec<PlanChild> {
@@ -1684,28 +1687,6 @@ impl Candidate {
             kind,
             children,
             metadata: Vec::new(),
-        }
-    }
-
-    fn layout_ir(
-        source_eclass: ClassId,
-        source_enode: &NodeId,
-        selected_output_index: usize,
-        input_list: Vec<ClassId>,
-        output_list: Vec<ClassId>,
-        op: Box<dyn LayoutIrOp>,
-        children: Vec<PlanChild>,
-        metadata: Vec<PlanMeta>,
-    ) -> Self {
-        Self {
-            source_eclass: Some(source_eclass),
-            source_enode: Some(source_enode.clone()),
-            selected_output_index: Some(selected_output_index),
-            input_list,
-            output_list,
-            kind: PlanKind::LayoutIr(op),
-            children,
-            metadata,
         }
     }
 }
@@ -2976,7 +2957,10 @@ impl<'e, 'a> IrBuilder<'e, 'a> {
                 );
                 let index = self
                     .dag
-                    .add_node(ExtractedNode::BufferInput(InputNode { value, buffer }));
+                    .add_node(ExtractedNode::BufferInput(Box::new(InputNode {
+                        value,
+                        buffer,
+                    })));
                 self.value_producer.insert(class.clone(), index);
                 Ok(index)
             }
@@ -3624,7 +3608,7 @@ pub enum ChainStride {
 /// closed, never guess.
 pub fn chain_strides(egraph: &EGraph, layout: &ClassId) -> Option<Vec<Option<ChainStride>>> {
     let mut class_nodes: HashMap<ClassId, Vec<NodeId>> = HashMap::new();
-    for (node_id, node) in &egraph.nodes {
+    for node_id in egraph.nodes.keys() {
         class_nodes
             .entry(egraph.nid_to_cid(node_id).clone())
             .or_default()

--- a/src/frontend/binary.rs
+++ b/src/frontend/binary.rs
@@ -25,7 +25,7 @@ impl Add for GraphTensor {
                 self.dims(),
                 self.dtype,
             )
-            .unwrap_or_else(|| crate::graph::unrecorded_value());
+            .unwrap_or_else(crate::graph::unrecorded_value);
         GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype)
     }
 }
@@ -94,7 +94,7 @@ impl Mul for GraphTensor {
                 self.dims(),
                 self.dtype,
             )
-            .unwrap_or_else(|| crate::graph::unrecorded_value());
+            .unwrap_or_else(crate::graph::unrecorded_value);
         GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype)
     }
 }
@@ -162,7 +162,7 @@ impl Rem<GraphTensor> for GraphTensor {
                 self.dims(),
                 self.dtype,
             )
-            .unwrap_or_else(|| crate::graph::unrecorded_value());
+            .unwrap_or_else(crate::graph::unrecorded_value);
         GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype)
     }
 }
@@ -321,7 +321,7 @@ impl GraphTensor {
                 self.dims(),
                 self.dtype,
             )
-            .unwrap_or_else(|| crate::graph::unrecorded_value());
+            .unwrap_or_else(crate::graph::unrecorded_value);
         GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype)
     }
 
@@ -354,7 +354,7 @@ impl GraphTensor {
                 self.dims(),
                 DType::Bool,
             )
-            .unwrap_or_else(|| crate::graph::unrecorded_value());
+            .unwrap_or_else(crate::graph::unrecorded_value);
         // Comparison operations always output Bool
         GraphTensor::from_id(new_id, self.dims(), self.graph_ref, DType::Bool)
     }

--- a/src/frontend/movement.rs
+++ b/src/frontend/movement.rs
@@ -685,7 +685,7 @@ impl GraphTensor {
             .graph()
             .logical
             .record_gather(&data_operand, &coord_operands, out_dims.clone(), self.dtype)
-            .unwrap_or_else(|| crate::graph::unrecorded_value());
+            .unwrap_or_else(crate::graph::unrecorded_value);
         GraphTensor::from_id(id, out_dims, self.graph_ref, self.dtype)
     }
 
@@ -726,7 +726,7 @@ impl GraphTensor {
                 dims.clone(),
                 self.dtype,
             )
-            .unwrap_or_else(|| crate::graph::unrecorded_value());
+            .unwrap_or_else(crate::graph::unrecorded_value);
         GraphTensor::from_id(id, dims, self.graph_ref, self.dtype)
     }
 
@@ -971,7 +971,7 @@ impl GraphTensor {
                 .graph()
                 .logical
                 .view_op(&operand, &entries, new_dims.clone(), self.dtype)
-                .unwrap_or_else(|| crate::graph::unrecorded_value());
+                .unwrap_or_else(crate::graph::unrecorded_value);
             GraphTensor::from_id(id, new_dims, self.graph_ref, self.dtype)
         } else {
             // No start slices so no iota needed, just reduce the shape down
@@ -1063,7 +1063,7 @@ impl GraphTensor {
                 .graph()
                 .logical
                 .view_op(&operand, &entries, out_dims.clone(), self.dtype)
-                .unwrap_or_else(|| crate::graph::unrecorded_value());
+                .unwrap_or_else(crate::graph::unrecorded_value);
         }
         let clamped =
             GraphTensor::from_id(clamped_id, out_dims.clone(), self.graph_ref, self.dtype);
@@ -1072,7 +1072,7 @@ impl GraphTensor {
             .graph()
             .logical
             .record_mask_iota(&befores, &afters, &dims)
-            .unwrap_or_else(|| crate::graph::unrecorded_value());
+            .unwrap_or_else(crate::graph::unrecorded_value);
         let mask =
             GraphTensor::from_id(mask_id, out_dims, self.graph_ref, DType::Int).cast(self.dtype);
 

--- a/src/frontend/other.rs
+++ b/src/frontend/other.rs
@@ -7,7 +7,7 @@ impl Graph {
         let id = self
             .logical
             .record_iota(&expr, &[])
-            .unwrap_or_else(|| crate::graph::unrecorded_value());
+            .unwrap_or_else(crate::graph::unrecorded_value);
         GraphTensor::from_id(id, (), self, DType::Int)
     }
 
@@ -16,7 +16,7 @@ impl Graph {
         let id = self
             .logical
             .op(LogicalOp::Constant(i as f64), &[], Vec::new(), DType::F32)
-            .unwrap_or_else(|| crate::graph::unrecorded_value());
+            .unwrap_or_else(crate::graph::unrecorded_value);
         GraphTensor::from_id(id, (), self, DType::F32)
     }
 
@@ -46,7 +46,7 @@ impl Graph {
         let id = self
             .logical
             .record_iota(&expr, &sh)
-            .unwrap_or_else(|| crate::graph::unrecorded_value());
+            .unwrap_or_else(crate::graph::unrecorded_value);
         GraphTensor::from_id(id, sh, self, DType::Int)
     }
 
@@ -140,7 +140,7 @@ impl GraphTensor {
             .graph()
             .logical
             .op(LogicalOp::Cast(dtype), &[operand], out_dims, dtype)
-            .unwrap_or_else(|| crate::graph::unrecorded_value());
+            .unwrap_or_else(crate::graph::unrecorded_value);
         GraphTensor::from_id(id, self.dims(), self.graph_ref, dtype)
     }
 }

--- a/src/frontend/reduction.rs
+++ b/src/frontend/reduction.rs
@@ -42,7 +42,7 @@ impl GraphTensor {
                 .graph()
                 .logical
                 .op(op, &[(id, operand_dims)], out_dims.clone(), self.dtype)
-                .unwrap_or_else(|| crate::graph::unrecorded_value());
+                .unwrap_or_else(crate::graph::unrecorded_value);
             dims = out_dims;
             let axis = axes[dim];
             for ax in &mut axes {

--- a/src/frontend/unary.rs
+++ b/src/frontend/unary.rs
@@ -72,7 +72,7 @@ impl GraphTensor {
                 self.dims(),
                 self.dtype,
             )
-            .unwrap_or_else(|| crate::graph::unrecorded_value());
+            .unwrap_or_else(crate::graph::unrecorded_value);
         GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype)
     }
 
@@ -87,7 +87,7 @@ impl GraphTensor {
                 self.dims(),
                 self.dtype,
             )
-            .unwrap_or_else(|| crate::graph::unrecorded_value());
+            .unwrap_or_else(crate::graph::unrecorded_value);
         GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype)
     }
 
@@ -112,7 +112,7 @@ impl GraphTensor {
                 self.dims(),
                 self.dtype,
             )
-            .unwrap_or_else(|| crate::graph::unrecorded_value());
+            .unwrap_or_else(crate::graph::unrecorded_value);
         GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype)
     }
 
@@ -127,7 +127,7 @@ impl GraphTensor {
                 self.dims(),
                 self.dtype,
             )
-            .unwrap_or_else(|| crate::graph::unrecorded_value());
+            .unwrap_or_else(crate::graph::unrecorded_value);
         GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype)
     }
 
@@ -152,7 +152,7 @@ impl GraphTensor {
                 self.dims(),
                 self.dtype,
             )
-            .unwrap_or_else(|| crate::graph::unrecorded_value());
+            .unwrap_or_else(crate::graph::unrecorded_value);
         GraphTensor::from_id(new_id, self.dims(), self.graph_ref, self.dtype)
     }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1045,10 +1045,10 @@ pub(crate) fn movement_entries(
             for (q, &p) in axes.iter().enumerate() {
                 replacement[p] = MapEntry::Coord {
                     from_end: prev_rank - 1 - q,
-                    extent: prev_dims[p].clone(),
+                    extent: prev_dims[p],
                 };
             }
-            let new_dims = axes.iter().map(|&p| prev_dims[p].clone()).collect();
+            let new_dims = axes.iter().map(|&p| prev_dims[p]).collect();
             (replacement, new_dims)
         }
         Movement::ExpandDim { axis, size } => {
@@ -1061,7 +1061,7 @@ pub(crate) fn movement_entries(
                     let q = if p < axis { p } else { p + 1 };
                     MapEntry::Coord {
                         from_end: new_rank - 1 - q,
-                        extent: prev_dims[p].clone(),
+                        extent: prev_dims[p],
                     }
                 })
                 .collect();
@@ -1084,7 +1084,7 @@ pub(crate) fn movement_entries(
                         let q = if p < axis { p } else { p - 1 };
                         MapEntry::Coord {
                             from_end: new_rank - 1 - q,
-                            extent: prev_dims[p].clone(),
+                            extent: prev_dims[p],
                         }
                     }
                 })
@@ -1120,7 +1120,7 @@ pub(crate) fn movement_entries(
                         let q = if p < axis { p } else { p + 1 };
                         MapEntry::Coord {
                             from_end: new_rank - 1 - q,
-                            extent: prev_dims[p].clone(),
+                            extent: prev_dims[p],
                         }
                     }
                 })
@@ -1134,7 +1134,7 @@ pub(crate) fn movement_entries(
             if axis1 >= axis2 || axis2 >= prev_rank {
                 return Err(format!("merge_dims ({axis1},{axis2}) vs rank {prev_rank}"));
             }
-            let inner = prev_dims[axis2].clone();
+            let inner = prev_dims[axis2];
             // Frontend simplification restored (revert ruling 2026-08-27).
             let merged = (prev_dims[axis1] * prev_dims[axis2]).simplify();
             let new_rank = prev_rank - 1;
@@ -1152,7 +1152,7 @@ pub(crate) fn movement_entries(
                         let q = if p < axis2 { p } else { p - 1 };
                         MapEntry::Coord {
                             from_end: new_rank - 1 - q,
-                            extent: prev_dims[p].clone(),
+                            extent: prev_dims[p],
                         }
                     }
                 })
@@ -1174,7 +1174,7 @@ pub(crate) fn movement_entries(
                     if repeats[p].to_usize() == Some(1) {
                         MapEntry::Coord {
                             from_end: prev_rank - 1 - p,
-                            extent: prev_dims[p].clone(),
+                            extent: prev_dims[p],
                         }
                     } else {
                         // Frontend simplification restored (revert
@@ -1185,7 +1185,7 @@ pub(crate) fn movement_entries(
                                 from_end: prev_rank - 1 - p,
                                 extent: tiled,
                             }),
-                            prev_dims[p].clone(),
+                            prev_dims[p],
                         )
                     }
                 })
@@ -1207,7 +1207,7 @@ pub(crate) fn movement_entries(
             let replacement = (0..prev_rank)
                 .map(|p| MapEntry::Coord {
                     from_end: prev_rank - 1 - p,
-                    extent: new_dims[p].clone(),
+                    extent: new_dims[p],
                 })
                 .collect();
             (replacement, new_dims)

--- a/src/implementation_search.rs
+++ b/src/implementation_search.rs
@@ -179,6 +179,10 @@ impl<L: crate::bufferize::PlanLayout> PlanProfiler<L> for StaticProfiler {
 /// The runtime-owned search entry (ruling 2026-08-17): the caller
 /// supplies its OWN matcher set (None = the in-core reference
 /// registry, which Step B moves out) and its OWN profiler.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the public runtime boundary keeps each independently owned search input explicit"
+)]
 pub fn search_implementations_with_runtime<L: crate::bufferize::PlanLayout>(
     egraph: &egraph_serialize::EGraph,
     program: &LogicalProgram,
@@ -546,6 +550,10 @@ pub struct BucketPlan<L: crate::bufferize::PlanLayout> {
 /// Slice note (documented divergence from their symbolic LLIR): each
 /// winning plan is STATIC at its representative; executing at another pin
 /// re-renders — genome transfer across renders is future work.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "bucket search composes independently owned graph, runtime, matcher, and profiling inputs"
+)]
 pub fn bucketed_search_implementations<L: crate::bufferize::PlanLayout>(
     graph: &crate::graph::Graph,
     dim_buckets: &BTreeMap<crate::shape::Symbol, Vec<crate::graph::DimBucket>>,

--- a/src/index_expr.rs
+++ b/src/index_expr.rs
@@ -7,6 +7,8 @@
 
 use crate::layout_ir::ExtractionSite;
 
+type BinaryIotaBuilder = fn(Box<IotaExpr>, Box<IotaExpr>) -> IotaExpr;
+
 /// A numeric IntExpr tree for reference evaluation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IotaExpr {
@@ -165,7 +167,7 @@ fn parse_int_expr_uncached(
     // a saturated class holds many equal spellings, and the first node of
     // a kind may have children outside the parsed subset while a sibling
     // spelling parses fine.
-    let binary_kinds: [(&str, fn(Box<IotaExpr>, Box<IotaExpr>) -> IotaExpr); 6] = [
+    let binary_kinds: [(&str, BinaryIotaBuilder); 6] = [
         ("IntAdd", |a, b| IotaExpr::Add(a, b)),
         ("IntMul", |a, b| IotaExpr::Mul(a, b)),
         ("IntTruncDiv", |a, b| IotaExpr::TruncDiv(a, b)),

--- a/src/layout_ir/mod.rs
+++ b/src/layout_ir/mod.rs
@@ -478,7 +478,7 @@ pub struct ExtractedGraph {
 pub enum ExtractedNode {
     /// A program input boundary: a LayoutTensor backed by a pre-assigned buffer.
     /// Not a `LayoutOp` — it is a (caller-owned) storage specification.
-    BufferInput(InputNode),
+    BufferInput(Box<InputNode>),
     /// A dataflow op producing one or more LayoutTensor outputs.
     LayoutOp(OpNode),
     /// A program output boundary: final LayoutTensors that must be written into

--- a/src/shape/expression.rs
+++ b/src/shape/expression.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use crate::egglog_utils::{self, SerializedEGraph, extract_expr};
-use egglog::{ast::Span, prelude::RustSpan, var};
+use egglog::var;
 
 type ExprBox = GenerationalBox<Vec<Term>, SyncStorage>;
 

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -392,6 +392,12 @@ pub struct TestGraph {
     next: u32,
 }
 
+impl Default for TestGraph {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TestGraph {
     pub fn new() -> Self {
         TestGraph {
@@ -476,7 +482,10 @@ impl TestGraph {
         let buffer = self.buffer_info(buffer, access, freed_by);
         let node = self
             .dag
-            .add_node(ExtractedNode::BufferInput(InputNode { value, buffer }));
+            .add_node(ExtractedNode::BufferInput(Box::new(InputNode {
+                value,
+                buffer,
+            })));
         self.producers.insert(eclass.clone(), node);
         eclass
     }
@@ -2592,7 +2601,7 @@ mod stage4b_probes {
             let start = std::time::Instant::now();
             let mut egraph = luminal::egglog_snippet::new_egraph();
             egraph
-                .parse_and_run_program(None, &preamble)
+                .parse_and_run_program(None, preamble)
                 .expect("preamble loads");
             eprintln!(
                 "[prof] ===== preamble only (parse+declare, no body/schedule): {:.2}s, {} lines =====",
@@ -2878,7 +2887,7 @@ mod subst_guard_study {
         ];
         let base = luminal_reference::assembled_program();
         for var_name in ["landed", "legacy"] {
-            let varied = variant(&base, var_name);
+            let varied = variant(base, var_name);
             for (scen_name, tail) in scenarios() {
                 let verdict = run_verdict(&format!("{varied}\n{tail}"));
                 let want = expected
@@ -3904,7 +3913,7 @@ mod escape_execution_tests {
     //! discipline as `harness_tests`: every luminal type comes from the
     //! `luminal::` build luminal_reference links.
     use egraph_serialize::ClassId;
-    use luminal::buffer_tensor_ir::TypedBuffer;
+
     use luminal::bufferize::{
         Buffer, BufferEdge, BufferId, BufferIrGraph, BufferNode, EdgeKind, InputBinding,
         OutputBinding, Owner,

--- a/tests/scalar_refs/src/lib.rs
+++ b/tests/scalar_refs/src/lib.rs
@@ -39,8 +39,8 @@ pub fn ref_paged_step(
     q: &[f32],
     k_new: &[f32],
     v_new: &[f32],
-    k_cache: &mut Vec<f32>,
-    v_cache: &mut Vec<f32>,
+    k_cache: &mut [f32],
+    v_cache: &mut [f32],
     gather: &[usize],
     scatter_slot: usize,
     n_heads: usize,
@@ -116,8 +116,8 @@ pub fn ref_block_step(
     wv: &[f32],
     wo: &[f32],
     ff: &dyn Fn(&[f32]) -> Vec<f32>,
-    k_cache: &mut Vec<f32>,
-    v_cache: &mut Vec<f32>,
+    k_cache: &mut [f32],
+    v_cache: &mut [f32],
     gather: &[usize],
     scatter_slot: usize,
     n_heads: usize,
@@ -146,7 +146,6 @@ pub fn ref_block_step(
 
 /// GQA paged-attention reference, one new token: query head h reads
 /// KV head h / (n_heads / n_kv_heads).
-#[allow(clippy::too_many_arguments)]
 #[allow(clippy::too_many_arguments)]
 pub fn ref_paged_step_gqa(
     q: &[f32],
@@ -215,7 +214,7 @@ pub fn ref_silu(x: &[f32]) -> Vec<f32> {
 pub fn ref_gelu_tanh(x: &[f32]) -> Vec<f32> {
     x.iter()
         .map(|v| {
-            let scaled = 1.5957691216 * v * (1.0 + 0.044715 * v * v);
+            let scaled = 1.595_769_2 * v * (1.0 + 0.044715 * v * v);
             v / (1.0 + (-scaled).exp())
         })
         .collect()

--- a/tests/test_runtime/src/lib.rs
+++ b/tests/test_runtime/src/lib.rs
@@ -153,6 +153,9 @@ pub fn extract_fixture(script_text: &str) -> ExtractedGraph {
 // board's original signatures by passing THIS runtime's `matchers()`.
 // ---------------------------------------------------------------------------
 
+type ProducerOrdering<'a> =
+    &'a dyn Fn(&[(String, luminal::extractor::ProducerChoice)], usize) -> Vec<usize>;
+
 /// See `luminal_cuda_lite::ops::cublaslt::election::genome_preferring` —
 /// this wrapper binds the board vocabulary.
 pub fn genome_preferring(
@@ -171,7 +174,7 @@ pub use luminal_cuda_lite::ops::cublaslt::election::level_admits;
 /// signature for the board's call sites.
 pub fn genome_with_ordering(
     egraph: &luminal::prelude::egraph_serialize::EGraph,
-    ordered: &dyn Fn(&[(String, luminal::extractor::ProducerChoice)], usize) -> Vec<usize>,
+    ordered: ProducerOrdering<'_>,
 ) -> luminal::extractor::Genome {
     luminal_cuda_lite::ops::cublaslt::election::genome_with_ordering(egraph, matchers(), ordered)
 }

--- a/tests/test_runtime/tests/buf_attack_b1_lifetime.rs
+++ b/tests/test_runtime/tests/buf_attack_b1_lifetime.rs
@@ -24,8 +24,8 @@ use petgraph::algo::has_path_connecting;
 use petgraph::graph::NodeIndex;
 use petgraph::visit::EdgeRef;
 
-fn computes<'a>(
-    plan: &'a luminal::bufferize::BufferIrGraph<luminal::test_support::MockLayout>,
+fn computes(
+    plan: &luminal::bufferize::BufferIrGraph<luminal::test_support::MockLayout>,
     label: &str,
 ) -> Vec<(NodeIndex, Vec<BufferId>, Vec<BufferId>)> {
     plan.dag

--- a/tests/test_runtime/tests/buf_attack_compose.rs
+++ b/tests/test_runtime/tests/buf_attack_compose.rs
@@ -34,8 +34,8 @@ use luminal::test_support::{EmptyOp, MockOp, MockView, TestGraph};
 use petgraph::algo::has_path_connecting;
 use petgraph::graph::NodeIndex;
 
-fn computes<'a>(
-    plan: &'a luminal::bufferize::BufferIrGraph<luminal::test_support::MockLayout>,
+fn computes(
+    plan: &luminal::bufferize::BufferIrGraph<luminal::test_support::MockLayout>,
     label: &str,
 ) -> Vec<(NodeIndex, Vec<BufferId>, Vec<BufferId>)> {
     plan.dag
@@ -402,10 +402,12 @@ impl DimsGraph {
     fn input(&mut self, name: &str, buffer: &str, dims: &[i64]) -> LayoutTensorInfo {
         let value = self.value(name, "rm", dims);
         let buffer = self.buffer(buffer);
-        let node = self.dag.add_node(ExtractedNode::BufferInput(InputNode {
-            value: value.clone(),
-            buffer,
-        }));
+        let node = self
+            .dag
+            .add_node(ExtractedNode::BufferInput(Box::new(InputNode {
+                value: value.clone(),
+                buffer,
+            })));
         self.producers.insert(value.eclass.clone(), node);
         value
     }

--- a/tests/test_runtime/tests/buf_attack_p2_alias.rs
+++ b/tests/test_runtime/tests/buf_attack_p2_alias.rs
@@ -106,7 +106,7 @@ fn a_view_reader_extends_parent_lifetime_single_free() {
             .iter()
             .find(|(_, _, w)| matches!(w[0], BufferId::Boundary(_)))
             .expect("consumer into bound output (seeded)");
-        (w.clone(), c.clone())
+        (*w, *c)
     };
     let parent = writer.2[0].clone();
     assert_eq!(

--- a/tests/test_runtime/tests/cublaslt_marker.rs
+++ b/tests/test_runtime/tests/cublaslt_marker.rs
@@ -5,7 +5,7 @@
 
 use std::time::Instant;
 
-use luminal::buffer_tensor_ir::{AsAnyOp, OpSlotNames};
+use luminal::buffer_tensor_ir::OpSlotNames;
 use luminal::graph::Graph;
 use luminal::layout_ir::ExtractedNode;
 use test_runtime::cublaslt_marker::{CuEpilogue, CublasLt};
@@ -36,7 +36,7 @@ fn pinned_cublaslt_ops(text: &str) -> Vec<(CublasLt, Vec<String>)> {
         .node_weights()
         .filter_map(|node| match node {
             ExtractedNode::LayoutOp(op) if op.op.label().starts_with("CublasLt") => {
-                let concrete = (&*op.op)
+                let concrete = (*op.op)
                     .as_any()
                     .downcast_ref::<CublasLt>()
                     .expect("CublasLt instance downcasts")

--- a/tests/test_runtime/tests/cublaslt_marker_adversarial.rs
+++ b/tests/test_runtime/tests/cublaslt_marker_adversarial.rs
@@ -8,7 +8,6 @@
 //! the all-ones corner) — must not panic; readings stay bounded and
 //! every elected spec is sound.
 
-use luminal::buffer_tensor_ir::AsAnyOp;
 use luminal::layout_ir::ExtractedNode;
 use test_runtime::cublaslt_marker::CublasLt;
 
@@ -87,7 +86,7 @@ fn cublaslt_ops(graph: &luminal::layout_ir::ExtractedGraph) -> Vec<CublasLt> {
         .node_weights()
         .filter_map(|node| match node {
             ExtractedNode::LayoutOp(op) if op.op.label().starts_with("CublasLt") => {
-                (&*op.op).as_any().downcast_ref::<CublasLt>().cloned()
+                (*op.op).as_any().downcast_ref::<CublasLt>().cloned()
             }
             _ => None,
         })
@@ -236,7 +235,7 @@ fn fixture7_extent1_weld_single_canonical_reading() {
     // term; what matters is boundedness and that every elected spec is
     // sound (checked below).
     assert!(
-        sites >= 2 && sites <= 4,
+        (2..=4).contains(&sites),
         "bounded sites despite the coordinate weld: {sites}"
     );
     assert!(a_readings >= 1, "the welded bytes are read at least once");

--- a/tests/test_runtime/tests/cublaslt_marker_decorate.rs
+++ b/tests/test_runtime/tests/cublaslt_marker_decorate.rs
@@ -3,7 +3,7 @@
 
 use std::time::Instant;
 
-use luminal::buffer_tensor_ir::{AsAnyOp, OpSlotNames};
+use luminal::buffer_tensor_ir::OpSlotNames;
 use luminal::graph::Graph;
 use luminal::layout_ir::ExtractedNode;
 use test_runtime::cublaslt_marker::{CuEpilogue, CublasLt, CublasLtForm};
@@ -27,9 +27,7 @@ fn genome_flavored(
             .push(node.op.as_str());
     }
     let class_has = |class: &luminal::prelude::egraph_serialize::ClassId, op: &str| {
-        class_ops
-            .get(class)
-            .is_some_and(|ops| ops.iter().any(|o| *o == op))
+        class_ops.get(class).is_some_and(|ops| ops.contains(&op))
     };
     let child_class = |node: &luminal::prelude::egraph_serialize::Node, index: usize| {
         node.children
@@ -62,7 +60,7 @@ fn genome_flavored(
         |candidates: &[(String, luminal::extractor::ProducerChoice)], level: usize| -> Vec<usize> {
             let admitted = test_runtime::level_admits(level);
             let mut order: Vec<usize> = Vec::new();
-            let mut push_where =
+            let push_where =
                 |order: &mut Vec<usize>,
                  pred: &dyn Fn(&str, &luminal::extractor::ProducerChoice) -> bool| {
                     for (i, (name, choice)) in candidates.iter().enumerate() {
@@ -102,7 +100,7 @@ fn collect_ops(graph: &luminal::layout_ir::ExtractedGraph) -> Vec<(CublasLt, Vec
         .filter_map(|node| match node {
             ExtractedNode::LayoutOp(op) => {
                 let label = op.op.label().to_string();
-                let concrete = (&*op.op).as_any().downcast_ref::<CublasLt>().cloned();
+                let concrete = (*op.op).as_any().downcast_ref::<CublasLt>().cloned();
                 let inputs = op.inputs.iter().map(|i| i.value.to_string()).collect();
                 Some((concrete, inputs, label))
             }

--- a/tests/test_runtime/tests/cublaslt_marker_hypothesis.rs
+++ b/tests/test_runtime/tests/cublaslt_marker_hypothesis.rs
@@ -35,14 +35,13 @@ fn count_cublaslt(egraph: &luminal::prelude::egraph_serialize::EGraph) -> usize 
 }
 
 fn pinned_cublaslt(text: &str) -> Vec<test_runtime::cublaslt_marker::CublasLt> {
-    use luminal::buffer_tensor_ir::AsAnyOp;
     use luminal::layout_ir::ExtractedNode;
     let (graph, _) = test_runtime::extract_fixture_with_genome(text, PIN);
     graph
         .dag
         .node_weights()
         .filter_map(|node| match node {
-            ExtractedNode::LayoutOp(op) if op.op.label().starts_with("CublasLt") => (&*op.op)
+            ExtractedNode::LayoutOp(op) if op.op.label().starts_with("CublasLt") => (*op.op)
                 .as_any()
                 .downcast_ref::<test_runtime::cublaslt_marker::CublasLt>()
                 .cloned(),

--- a/tests/test_runtime/tests/cublaslt_marker_round2_attack.rs
+++ b/tests/test_runtime/tests/cublaslt_marker_round2_attack.rs
@@ -32,6 +32,10 @@ use test_runtime::cublaslt_marker::{
     parse_spec, CuDim, CuEpilogue, CublasLt, CublasLtForm, LtMatmulSpec,
 };
 
+type GraphBuilder = Box<dyn Fn(&mut Graph)>;
+type FormProgram = (&'static str, CublasLtForm, GraphBuilder);
+type EpilogueProgram = (&'static str, CublasLtForm, CuEpilogue, GraphBuilder);
+
 const SCHEDULE: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
 
 const PIN: &[&str] = &[
@@ -90,7 +94,7 @@ fn elected_ops(graph: &ExtractedGraph) -> Vec<Elected> {
         .node_weights()
         .filter_map(|node| match node {
             ExtractedNode::LayoutOp(op) if op.op.label().starts_with("CublasLt") => {
-                let concrete = (&*op.op).as_any().downcast_ref::<CublasLt>().cloned()?;
+                let concrete = (*op.op).as_any().downcast_ref::<CublasLt>().cloned()?;
                 let inputs = op
                     .inputs
                     .iter()
@@ -150,11 +154,8 @@ fn genome_flavored(
             .or_default()
             .push(node.op.as_str());
     }
-    let class_has = |class: &ClassId, op: &str| {
-        class_ops
-            .get(class)
-            .is_some_and(|ops| ops.iter().any(|o| *o == op))
-    };
+    let class_has =
+        |class: &ClassId, op: &str| class_ops.get(class).is_some_and(|ops| ops.contains(&op));
     let child_class = |node: &luminal::prelude::egraph_serialize::Node, index: usize| {
         node.children
             .get(index)
@@ -183,7 +184,7 @@ fn genome_flavored(
         |candidates: &[(String, luminal::extractor::ProducerChoice)], level: usize| -> Vec<usize> {
             let admitted = test_runtime::level_admits(level);
             let mut order: Vec<usize> = Vec::new();
-            let mut push_where =
+            let push_where =
                 |order: &mut Vec<usize>,
                  pred: &dyn Fn(&str, &luminal::extractor::ProducerChoice) -> bool| {
                     for (i, (name, choice)) in candidates.iter().enumerate() {
@@ -2246,7 +2247,7 @@ fn attack_e2_respelled_relu_stays_decomposed() {
 /// AccumulateBias with relu — but NEVER Accumulate + relu.
 #[test]
 fn attack_e3_four_inlined_relu_copies_agree() {
-    let programs: [(&str, CublasLtForm, CuEpilogue, Box<dyn Fn(&mut Graph)>); 4] = [
+    let programs: [EpilogueProgram; 4] = [
         (
             "base",
             CublasLtForm::Base,
@@ -3388,7 +3389,7 @@ fn attack_f1_dual_readings_are_legal_multiplicity() {
     );
     assert_eq!(a, 8, "two frames per site's a operand");
     assert_eq!(ops, 20, "the frame cross products across the four sites");
-    let classes = assert_one_lit_per_op_class(&s, "f1");
+    assert_one_lit_per_op_class(&s, "f1");
 
     let specs = specs_of_every_enode(&s, CublasLtForm::Base);
     assert_eq!(specs.len(), ops, "all candidates parse");
@@ -3662,7 +3663,7 @@ fn attack_h1_one_lit_per_op_class() {
 /// tensor the spec names for that role — the actual mis-assignment guard.
 #[test]
 fn attack_u1_lit_slot_contents_pinned() {
-    let cases: [(&str, CublasLtForm, Box<dyn Fn(&mut Graph)>); 4] = [
+    let cases: [FormProgram; 4] = [
         (
             "base",
             CublasLtForm::Base,

--- a/tests/test_runtime/tests/cublaslt_marker_round3_attack.rs
+++ b/tests/test_runtime/tests/cublaslt_marker_round3_attack.rs
@@ -639,15 +639,13 @@ fn check_reading_set_coherence(s: &EGraph) -> (Vec<String>, usize) {
                     }
                 })
                 .unwrap_or("<missing>");
-            if ctor == "LayoutTensorOpCublasLt" && epilogue == "Default" {
-                if d_logical != site_out {
-                    violations.push(format!(
-                        "{tag}: D-LEAK — undecorated base op claims logical {:?}, \
+            if ctor == "LayoutTensorOpCublasLt" && epilogue == "Default" && d_logical != site_out {
+                violations.push(format!(
+                    "{tag}: D-LEAK — undecorated base op claims logical {:?}, \
                          site out is {:?}",
-                        d_logical.as_ref().map(short),
-                        site_out.as_ref().map(short)
-                    ));
-                }
+                    d_logical.as_ref().map(short),
+                    site_out.as_ref().map(short)
+                ));
             }
             if epilogue == "<none>" || epilogue == "<missing>" {
                 violations.push(format!("{tag}: epilogue slot carries no value"));
@@ -712,7 +710,7 @@ fn genome_flavored(s: &EGraph, preferences: &[&str]) -> luminal::extractor::Geno
         |candidates: &[(String, luminal::extractor::ProducerChoice)], level: usize| -> Vec<usize> {
             let admitted = test_runtime::level_admits(level);
             let mut order: Vec<usize> = Vec::new();
-            let mut push_where = |order: &mut Vec<usize>, pred: &dyn Fn(&str) -> bool| {
+            let push_where = |order: &mut Vec<usize>, pred: &dyn Fn(&str) -> bool| {
                 for (i, (name, _)) in candidates.iter().enumerate() {
                     if admitted(name) && pred(name) && !order.contains(&i) {
                         order.push(i);
@@ -749,7 +747,7 @@ fn genome_electing(s: &EGraph, enode: &NodeId) -> (luminal::extractor::Genome, b
         |candidates: &[(String, luminal::extractor::ProducerChoice)], level: usize| -> Vec<usize> {
             let admitted = test_runtime::level_admits(level);
             let mut order: Vec<usize> = Vec::new();
-            let mut push_where = |order: &mut Vec<usize>, pred: &dyn Fn(&str) -> bool| {
+            let push_where = |order: &mut Vec<usize>, pred: &dyn Fn(&str) -> bool| {
                 for (i, (name, _)) in candidates.iter().enumerate() {
                     if admitted(name) && pred(name) && !order.contains(&i) {
                         order.push(i);
@@ -782,7 +780,7 @@ fn cublaslt_in_plan(graph: &luminal::layout_ir::ExtractedGraph) -> Vec<(CublasLt
         .node_weights()
         .filter_map(|node| match node {
             ExtractedNode::LayoutOp(op) if op.op.label().starts_with("CublasLt") => {
-                let concrete = (&*op.op).as_any().downcast_ref::<CublasLt>().cloned()?;
+                let concrete = (*op.op).as_any().downcast_ref::<CublasLt>().cloned()?;
                 let inputs = op.inputs.iter().map(|i| i.value.to_string()).collect();
                 Some((concrete, inputs))
             }
@@ -797,28 +795,6 @@ fn pinned_cublaslt(text: &str) -> Vec<CublasLt> {
         .into_iter()
         .map(|(op, _)| op)
         .collect()
-}
-
-/// The B readings (our `a` operand) over one logical tensor, as
-/// (form, operation, ld) — the shape the round-3 attacks compare.
-fn b_reading_forms(s: &EGraph, logical: &ClassId) -> Vec<(String, String, Dim)> {
-    let mut out: Vec<(String, String, Dim)> = all_readings(s)
-        .into_iter()
-        .filter(|r| r.role == "B" && &r.logical == logical)
-        .map(|r| {
-            (
-                r.operation
-                    .trim_start_matches("CublasLtOperation")
-                    .to_string(),
-                r.operation
-                    .trim_start_matches("CublasLtOperation")
-                    .to_string(),
-                r.ld,
-            )
-        })
-        .collect();
-    out.sort();
-    out
 }
 
 fn spec_of(op: &CublasLt) -> &LtMatmulSpec {

--- a/tests/test_runtime/tests/cublaslt_marker_round4.rs
+++ b/tests/test_runtime/tests/cublaslt_marker_round4.rs
@@ -2,11 +2,13 @@
 //! the B x left-major arm, relu on a symbolic-k op, and the static-pitch
 //! OUTPUT layout (creator-rewrite certified).
 
-use luminal::buffer_tensor_ir::AsAnyOp;
-use luminal::bufferize::{self, BufferId};
+use luminal::bufferize::BufferId;
 use luminal::graph::Graph;
 use luminal::layout_ir::{Bufferizable, ExtractedNode, Sharing};
 use test_runtime::cublaslt_marker::{CuDim, CuEpilogue, CublasLt, CublasLtDps, CublasLtForm};
+
+type GraphBuilder = Box<dyn Fn(&mut Graph)>;
+type FormProgram = (&'static str, CublasLtForm, GraphBuilder);
 
 const SCHEDULE: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
 
@@ -38,7 +40,7 @@ fn cublaslt_in_plan(graph: &luminal::layout_ir::ExtractedGraph) -> Vec<(CublasLt
         .node_weights()
         .filter_map(|node| match node {
             ExtractedNode::LayoutOp(op) if op.op.label().starts_with("CublasLt") => {
-                let concrete = (&*op.op).as_any().downcast_ref::<CublasLt>().cloned()?;
+                let concrete = (*op.op).as_any().downcast_ref::<CublasLt>().cloned()?;
                 let inputs = op.inputs.iter().map(|i| i.value.to_string()).collect();
                 Some((concrete, inputs))
             }
@@ -80,7 +82,7 @@ fn t4_dps_alias_tables() {
 // ===========================================================================
 #[test]
 fn t6a_bufferize_all_four_forms() {
-    let programs: [(&str, CublasLtForm, Box<dyn Fn(&mut Graph)>); 4] = [
+    let programs: [FormProgram; 4] = [
         (
             "base",
             CublasLtForm::Base,
@@ -168,7 +170,6 @@ fn t6a_bufferize_all_four_forms() {
             form.lit_arity() + 1,
             "{name}: DPS operands = contract arity + dest"
         );
-        use luminal::buffer_tensor_ir::OpSlotNames;
         assert_eq!(
             dps_op.op.operand_name(form.lit_arity()),
             "dest",

--- a/tests/test_runtime/tests/cublaslt_marker_scaling.rs
+++ b/tests/test_runtime/tests/cublaslt_marker_scaling.rs
@@ -5,7 +5,6 @@
 
 use std::time::Instant;
 
-use luminal::buffer_tensor_ir::AsAnyOp;
 use luminal::graph::Graph;
 use luminal::layout_ir::ExtractedNode;
 use test_runtime::cublaslt_marker::{CuEpilogue, CublasLt};
@@ -52,7 +51,7 @@ fn probe(name: &str, geometries: &[(usize, usize, usize)], prev_nodes: Option<us
         .node_weights()
         .filter_map(|node| match node {
             ExtractedNode::LayoutOp(op) if op.op.label().starts_with("CublasLt") => {
-                (&*op.op).as_any().downcast_ref::<CublasLt>().cloned()
+                (*op.op).as_any().downcast_ref::<CublasLt>().cloned()
             }
             _ => None,
         })

--- a/tests/test_runtime/tests/mutation.rs
+++ b/tests/test_runtime/tests/mutation.rs
@@ -18,7 +18,6 @@
 //! Several are forked copies of scripts the reference corpus also
 //! carries — the two runtimes share no files.
 
-use luminal::bufferize;
 use luminal::prelude::petgraph;
 use luminal::test_support::bufferize_mock;
 

--- a/tests/test_runtime/tests/planner.rs
+++ b/tests/test_runtime/tests/planner.rs
@@ -13,7 +13,6 @@
 //! and correct (its 28 differential tests against candle), and everything
 //! that exercises `Bufferizable` / `ToDps` / the planner lives here.
 
-use luminal::bufferize;
 use luminal::test_support::bufferize_mock;
 
 /// Idempotency: DPS forms answer to_dps() = None, so a second rewrite is a

--- a/tests/test_runtime/tests/r10_chain_bufferize_probe.rs
+++ b/tests/test_runtime/tests/r10_chain_bufferize_probe.rs
@@ -7,6 +7,7 @@
 //!      consumed mid-graph, not directly bound.
 //!   2. matmul -> matmul -> output (the chained case): the interior view
 //!      feeds the second call's operand.
+//!
 //! Observational: prints the DPS ops and the buffer plan; asserts only
 //! that bufferize succeeds and counts BufferCopy occurrences honestly.
 use luminal::graph::Graph;

--- a/tests/test_runtime/tests/r10_debug.rs
+++ b/tests/test_runtime/tests/r10_debug.rs
@@ -1,5 +1,4 @@
 //! ROUND-10 scratch debug probe (not a gate).
-use luminal::buffer_tensor_ir::AsAnyOp;
 use luminal::graph::Graph;
 use luminal::layout_ir::ExtractedNode;
 use luminal::prelude::egraph_serialize::{ClassId, EGraph};
@@ -123,7 +122,7 @@ fn r10_debug_fixture1() {
         match node {
             ExtractedNode::LayoutOp(op) => {
                 println!("PLAN op: {}", op.op.label());
-                if let Some(c) = (&*op.op).as_any().downcast_ref::<CublasLt>() {
+                if let Some(c) = (*op.op).as_any().downcast_ref::<CublasLt>() {
                     if let Some(spec) = &c.spec {
                         println!(
                             "  spec m={} n={} k={} ta={} tb={} lda={} ldb={} ldd={} a_buf={:?} b_buf={:?} d_buf={:?}",
@@ -345,7 +344,7 @@ fn r10_debug_a4() {
                 .map(|o| format!("{} (logical {})", o.eclass, o.logical.eclass))
                 .collect();
             println!("PLAN {}: ins={ins:?} outs={outs:?}", op.op.label());
-            if let Some(c) = (&*op.op).as_any().downcast_ref::<CublasLt>() {
+            if let Some(c) = (*op.op).as_any().downcast_ref::<CublasLt>() {
                 if let Some(spec) = &c.spec {
                     println!(
                         "   spec m={} n={} k={} ta={} tb={} logical_a={} logical_b={} site_out={}",

--- a/tests/test_runtime/tests/r11_diag4.rs
+++ b/tests/test_runtime/tests/r11_diag4.rs
@@ -1,5 +1,4 @@
 //! throwaway diagnostic (deleted before landing)
-use luminal::buffer_tensor_ir::AsAnyOp;
 use luminal::graph::Graph;
 use luminal::layout_ir::ExtractedNode;
 use test_runtime::cublaslt_marker::CublasLt;
@@ -12,7 +11,7 @@ const PIN: &[&str] = &[
 ];
 #[test]
 fn diag_a5() {
-    let text = {
+    {
         let mut cx = Graph::new();
         let x = cx.tensor((4usize, 4usize));
         let w1 = cx.tensor((4usize, 4usize));
@@ -20,8 +19,6 @@ fn diag_a5() {
         let y = x.matmul(w1);
         let _ = y.matmul(w2.permute((1usize, 0usize))).output();
     };
-    let text = text; // silence
-    let _ = &text;
     let program = {
         let mut cx = Graph::new();
         let x = cx.tensor((4usize, 4usize));
@@ -44,7 +41,7 @@ fn diag_a5() {
                 .collect();
             let outs: Vec<String> = op.outputs.iter().map(|o| format!("{}", o.eclass)).collect();
             println!("PLAN {}: ins={ins:?} outs={outs:?}", op.op.label());
-            if let Some(c) = (&*op.op).as_any().downcast_ref::<CublasLt>() {
+            if let Some(c) = (*op.op).as_any().downcast_ref::<CublasLt>() {
                 if let Some(spec) = &c.spec {
                     println!(
                         "  spec m={} n={} k={} ta={} tb={} lda={} ldb={} a_lt={} b_lt={}",

--- a/tests/test_runtime/tests/r9_pitched_operand_probe.rs
+++ b/tests/test_runtime/tests/r9_pitched_operand_probe.rs
@@ -25,10 +25,9 @@
 //! (:4240-4250: "a transposed contiguous layout is a bijection it could
 //! not see"). So a view-born pitched layout has no injectivity fact, and
 //! the round-9 arms fail closed on it. `pitched_view_refuses_without_an
-//! _injectivity_fact` pins that; `pitched_view_reads_N_with_the_creator
+//! _injectivity_fact` pins that; `pitched_view_reads_n_with_the_creator
 //! _certificate` pins that the fact is the ONLY thing missing.
 
-use luminal::buffer_tensor_ir::AsAnyOp;
 use luminal::layout_ir::ExtractedNode;
 use luminal::prelude::egraph_serialize::EGraph;
 use test_runtime::cublaslt_marker::CublasLt;
@@ -167,7 +166,7 @@ fn pitched_view_refuses_without_an_injectivity_fact() {
 }
 
 #[test]
-fn pitched_view_reads_N_with_the_creator_certificate() {
+fn pitched_view_reads_n_with_the_creator_certificate() {
     let s = test_runtime::serialize_fixture(&pitched_view_fixture(true));
     let readings = a_readings_over_the_pitched_view(&s);
     println!("pitched view, certificate asserted: A readings over the view = {readings:?}");
@@ -201,7 +200,7 @@ fn pitched_view_reads_N_with_the_creator_certificate() {
         .dag
         .node_weights()
         .filter_map(|node| match node {
-            ExtractedNode::LayoutOp(op) if op.op.label().starts_with("CublasLt") => (&*op.op)
+            ExtractedNode::LayoutOp(op) if op.op.label().starts_with("CublasLt") => (*op.op)
                 .as_any()
                 .downcast_ref::<CublasLt>()
                 .and_then(|c| c.spec.clone()),

--- a/tests/test_runtime/tests/rehomed.rs
+++ b/tests/test_runtime/tests/rehomed.rs
@@ -7,7 +7,7 @@
 
 use std::fs;
 
-use luminal::bufferize::{self, BufferId};
+use luminal::bufferize::BufferId;
 use luminal::layout_ir::ExtractedNode;
 
 /// The restored multi-output fixture script (deleted from

--- a/tests/test_runtime/tests/views.rs
+++ b/tests/test_runtime/tests/views.rs
@@ -13,11 +13,8 @@
 //! pointed at this crate's own `fixtures/` — including its forked copy of
 //! `basic_program.egg`. Nothing here reaches into the core script tree.
 
-use luminal::bufferize;
 use luminal::layout_ir::Access;
 use luminal::test_support::{bufferize_mock, MockOp, TestGraph};
-
-use test_runtime::IndexMapApplyView;
 
 /// THE REAL VIEW OP, plan level (Step 3): `IndexMapApplyView` feeding a
 /// compute op contributes ZERO plan nodes — the result binds its parent's


### PR DESCRIPTION
## Summary

- clear strict Clippy failures across core, the reference runtime, CUDA-lite, NN/model examples, scalar references, and runtime tests
- apply semantic/mechanical fixes for copy types, slices, iterator use, default initialization, enum layout, type complexity, and obsolete test helpers/imports
- retain stable multi-input search/model APIs with narrow, reasoned `#[expect]` annotations instead of broad lint-family allow lists

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --exclude luminal_cuda_lite --exclude luminal_metal --exclude luminal_bench --all-targets -- -D warnings`
- `cargo clippy -p luminal_cuda_lite --all-targets -- -D warnings`
- `cargo test --release -p luminal -p luminal_nn -p luminal_reference -p luminal_tracing`
- `cargo test --release -p test_runtime -p luminal_cuda_lite`

All CPU-safe tests pass. CUDA device-gated execution was not run on this Mac.

## Checkout note

The base branch currently tracks a machine-local `vendor/egglog-checkout` symlink. PR #428 removes it; local verification here used the patched checkout reconstructed according to `vendor/README.md`.