### PR TITLE
View-arity tripwire moves onto the IndexMapLit (unblocks cuBLASLt on real graphs)

### DIFF
--- a/crates/luminal_cuda_lite/src/ops/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/mod.rs
@@ -121,19 +121,21 @@ pub fn cuda_registry() -> Vec<RegisteredOp> {
 /// execution row is a HOST LIBRARY CALL (`cublasLtMatmul`), never an
 /// NVRTC kernel — the third claim class (see `CudaRuntime::allow_list`).
 ///
-/// WHY A SEPARATE SURFACE (measured, Train 3): splicing the marker
-/// vocabulary into EVERY CL assembly detonates the `view-arity-lock`
-/// coherence tripwire ("Illegal merge attempted") at saturation on ALL
-/// seven runnable Train-2 minis and the ladder's llama blocks — the
-/// marker's canonicalization/sandwich rewrites weld transpose-view
-/// apply spellings into logical classes that already carry apply
-/// spellings of a different parent rank (extent-1 weld corners on real
-/// decode-step graphs; the synthetic 2D marker-board fixtures never
-/// exercise this). The .egg rule text is frozen (egglog-level design
-/// wins unmodified; changes need Austin's explicit approval), so until
-/// that ruling lands the marker joins an assembly only through this
-/// EXPLICIT seam ([`crate::CudaRuntime::load_with_cublaslt`]) — the
-/// default vocabulary stays exactly the Train-2 set, and the 2D
+/// WHY A SEPARATE SURFACE, as of 2026-09-01: the marker is RULED
+/// always-on, and the tripwire that blocked it is fixed — splicing the
+/// marker vocabulary into every assembly used to detonate the
+/// `view-arity-lock` (`Illegal merge attempted`) on all seven minis,
+/// because that lock keyed a ROUTE fact (an apply's parent rank) on a
+/// VALUE (its output class) and the collapse rule's sound union
+/// `x ≡ Tᵀ(x)` put two different-parent-rank spellings in one class.
+/// The check now lives on the `IndexMapLit` (entry count == rank of the
+/// source-shape tag) and saturation succeeds. What still keeps the
+/// default vocabulary at the Train-2 set is the SEARCH: the same union
+/// is a re-description 2-cycle, and at the 2×4 harness budget the
+/// sampler exhausts on unfit genomes on real graphs (they elect at
+/// 12×16). Until the budget/sampler decision lands, the marker joins an
+/// assembly through this EXPLICIT seam
+/// ([`crate::CudaRuntime::load_with_cublaslt`]), and the 2D
 /// canonical-form election pin runs marker-enabled.
 pub fn cuda_registry_with_cublaslt() -> Vec<RegisteredOp> {
     let mut registry = cuda_registry();

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -36,10 +36,10 @@ struct NativeParts {
 pub struct CudaRuntime {
     native: Option<NativeParts>,
     /// Train 3: assemble/search with the cuBLASLt marker vocabulary.
-    /// OFF by default — the unconditional splice detonates the
-    /// `view-arity-lock` tripwire on real model graphs (see
-    /// [`crate::ops::cuda_registry_with_cublaslt`]); enabled through
-    /// [`CudaRuntime::load_with_cublaslt`].
+    /// RULED always-on (2026-09-01); still OFF by default only until the
+    /// search budget/sampler catches up with the collapse's
+    /// re-description 2-cycle (see [`crate::ops::cuda_registry_with_cublaslt`]);
+    /// enabled through [`CudaRuntime::load_with_cublaslt`].
     cublaslt: bool,
     plan: Option<BufferIrGraph<CudaLayout>>,
     /// Host-staged input payloads by BufferLit id, H2D'd at execute.
@@ -77,12 +77,13 @@ impl CudaRuntime {
 
     /// [`CudaRuntime::load`] with the cuBLASLt marker vocabulary
     /// enabled: search assembles the marker's egg snippets and may
-    /// elect the four host-call contracts. EXPLICIT OPT-IN (Train 3):
-    /// on real model graphs the marker's canonicalization rewrites
-    /// currently detonate the `view-arity-lock` coherence tripwire at
-    /// saturation (measured on all seven Train-2 minis); callers get a
-    /// loud saturation error, never a wrong plan. The 2D canonical
-    /// matmul form searches and elects green.
+    /// elect the four host-call contracts. EXPLICIT OPT-IN for now: the
+    /// view-arity tripwire that used to kill saturation on real graphs
+    /// is fixed (it now checks the map literal); at the 2×4 harness
+    /// budget the search can still die of exhaustion on the collapse's
+    /// re-description 2-cycle — loudly, never a wrong plan. The 2D
+    /// canonical matmul form searches and elects green; real graphs
+    /// elect at 12×16.
     pub fn load_with_cublaslt(graph: &graph::Graph) -> Result<Self> {
         let mut rt = Self::load(graph)?;
         rt.cublaslt = true;

--- a/crates/luminal_cuda_lite/tests/cublaslt_election.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_election.rs
@@ -42,17 +42,24 @@ fn weights(n: usize, seed: usize) -> Vec<f32> {
 enum Row {
     /// Search completed: (marker computes elected, total computes).
     Searched { elected: usize, computes: usize },
-    /// Search died at saturation (the view-arity-lock conflict) — a
-    /// LOUD error from the runtime, never a wrong plan.
-    SaturationDied(String),
+    /// Search died before producing a plan — a LOUD error from the
+    /// runtime, never a wrong plan. Since the view-arity tripwire moved
+    /// onto the map literal (ruling 2026-09-01) saturation SUCCEEDS on
+    /// every mini; the death that remains at the harness budget is the
+    /// SEARCH refusing: no sampled genome produced an executable plan,
+    /// because the collapse's `x ≡ Tᵀ(x)` re-description 2-cycle eats the
+    /// 2×4 budget. That is a budget/sampler finding, recorded as a row.
+    SearchDied(String),
 }
 
 /// Record → load WITH the marker vocabulary → bind dyn pins → search,
-/// then count elected CublasLt* compute nodes. A saturation death is
-/// RETURNED, not panicked: on real model graphs the marker rewrites
-/// currently detonate the `view-arity-lock` coherence tripwire (the
-/// measured Train-3 finding; see `ops::cuda_registry_with_cublaslt`),
-/// and the table must record that honestly.
+/// then count elected CublasLt* compute nodes. A search death is
+/// RETURNED, not panicked, so the table records it honestly — but a
+/// SATURATION death is a hard failure: the view-arity tripwire that used
+/// to fire here was a class-keyed cell asserting a route fact (parent
+/// rank) per value, retired 2026-09-01 (`view_arity_lock.rs` in
+/// test_runtime pins both sides). If "Illegal merge" ever returns, a
+/// new class-keyed invariant has been introduced somewhere.
 fn search_and_count(name: &str, cx: &Graph, pairs: &[(NodeIndex, TypedBuffer)]) -> Row {
     search_and_count_opts(
         name,
@@ -80,13 +87,18 @@ fn search_and_count_opts(
         Ok(outcome) => outcome,
         Err(e) => {
             let msg = format!("{e:#}");
-            println!("ELECTION-TABLE {name}: marker_elected=NO — SEARCH DIED AT SATURATION: {msg}");
+            println!("ELECTION-TABLE {name}: marker_elected=NO — SEARCH DIED: {msg}");
             assert!(
-                msg.contains("view-arity-lock"),
-                "{name}: search died for a reason OTHER than the known \
-                 view-arity-lock conflict — investigate: {msg}"
+                !msg.contains("Illegal merge") && !msg.contains("saturation failed"),
+                "{name}: saturation died — a class-keyed :no-merge invariant is firing on a \
+                 sound union again (the retired view-arity-lock failure mode): {msg}"
             );
-            return Row::SaturationDied(msg);
+            assert!(
+                msg.contains("no candidate genome produced an executable plan"),
+                "{name}: search died for a reason OTHER than the known budget exhaustion on \
+                 the collapse's re-description 2-cycle — investigate: {msg}"
+            );
+            return Row::SearchDied(msg);
         }
     };
     // REFUSALS ARE REPORTED, NOT ASSERTED ZERO: the marker's
@@ -123,8 +135,10 @@ fn search_and_count_opts(
 // REGISTRY MEMBERSHIP: the four contracts are registered CL ops and the
 // marker-enabled claim set admits them through the host-call class
 // (never a codegen row, never plan-transparency). The DEFAULT claim set
-// excludes them — the vocabulary joins an assembly only through the
-// explicit `load_with_cublaslt` seam until the view-arity-lock ruling.
+// excludes them FOR NOW — the tripwire that blocked always-on is fixed;
+// what remains is that at the 2×4 harness budget the collapse's
+// re-description 2-cycle exhausts the sampler on real graphs (they elect
+// at 12×16). Always-on lands with the budget/sampler decision.
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -139,8 +153,8 @@ fn cublaslt_contracts_are_registered_host_call_claims() {
         );
         assert!(
             !default.contains(&ctor),
-            "{ctor} in the DEFAULT claim set — the marker vocabulary must stay \
-             opt-in until the view-arity-lock ruling"
+            "{ctor} in the DEFAULT claim set — the marker vocabulary stays \
+             opt-in until the budget/sampler decision lands (always-on is ruled)"
         );
     }
     // The claim is host-call-derived: no codegen row exists for the labels.
@@ -183,7 +197,7 @@ fn canonical_2d_matmul_elects_the_marker() {
     };
     let row = search_and_count_opts("matmul_2d(4x8 . 8x3)", &cx, &pairs, &options);
     let Row::Searched { elected, computes } = row else {
-        let Row::SaturationDied(msg) = row else {
+        let Row::SearchDied(msg) = row else {
             unreachable!()
         };
         panic!(

--- a/src/egglog/checkpoint_5/egglog_preamble.egg
+++ b/src/egglog/checkpoint_5/egglog_preamble.egg
@@ -4422,12 +4422,36 @@
 ; A check whose lookup finds nothing fails the program loudly at the
 ; fixpoint.
 
-; VIEW ARITY LOCK: an index map's entry count IS its input's rank. Both
-; sides are i64 primitives (lengths and ranks are computed totally for
-; every list), and primitives never sit pending-equal — but the lock
-; stays in this stratum with its peers: one discipline, one home. A
-; mismatch is a genuine authoring error and collides loudly.
-(function view-arity-lock (LogicalTensor) i64 :no-merge)
+; VIEW ARITY LOCK: an index map's entry count IS the rank of its
+; source-shape tag. That is a property of the LITERAL, and it is checked
+; on the literal: one rule, one e-node, both numbers bound from the same
+; term, no cell keyed on a LogicalTensor class. Together with MAP-TAG
+; COHERENCE below (tag == the applied parent's shape) this yields
+; entries == rank(parent) for every apply — the per-node guarantee the
+; lock always meant.
+;
+; WHY NOT A :no-merge CELL KEYED ON THE APPLY'S OUTPUT (the previous
+; form, retired 2026-09-01): the output e-class is a VALUE, and parent
+; rank is a property of the ROUTE to that value, not of the value. One
+; value legitimately has two apply spellings from parents of different
+; rank — x2 = x3[0,:,:] (3 entries, rank-3 parent) and y = x2 read
+; through the identity map (2 entries, rank-2 parent) are the same
+; tensor by definition, and their output shape/rank is one and the same
+; (shape-of is class-invariant). A class-keyed cell stored a route fact
+; in a value slot, so the first rule that ever unioned two such
+; spellings (the cuBLASLt marker's double-transpose collapse) tripped it
+; on a sound equivalence. Never store an e-node-anchored fact under a
+; class key ("never depend on spelling").
+(rule
+  (
+    (= ?map (IndexMapLit ?entries ?tag))
+    (= ?entry_count (expr-list-length-of ?entries))
+    (= ?tag_rank (rank-of ?tag))
+    (!= ?entry_count ?tag_rank)
+  )
+  ((panic "IndexMapLit entry count disagrees with the rank of its source-shape tag"))
+  :ruleset fixpoint-invariants
+)
 
 ; COORDINATE-EXTENT LOCK: DELETED (scoped-CoordVar spike). A
 ; coordinate now carries its owner shape and its extent IS the owner's

--- a/src/logical_op/index_map_apply/fixpoint.egg
+++ b/src/logical_op/index_map_apply/fixpoint.egg
@@ -1,10 +1,6 @@
-(rule
-  (
-    (= ?out_logical (LogicalIndexMapApply ?in_logical (IndexMapLit ?entry_list ?map_source_shape) ?out_shape))
-    (= ?entry_count (expr-list-length-of ?entry_list))
-  )
-  (
-    (set (view-arity-lock ?out_logical) ?entry_count)
-  )
-  :ruleset fixpoint-invariants
-)
+; The view-arity check lives in the preamble (VIEW ARITY LOCK): it is a
+; property of the IndexMapLit — entry count == rank of the source-shape
+; tag — and is checked on the literal. The per-output-class :no-merge
+; setter that used to live here was retired 2026-09-01: it keyed a route
+; fact (parent rank) on a value (the apply's output class) and fired on
+; sound unions of two apply spellings with different-rank parents.

--- a/src/logical_op/index_map_apply/fixpoint_2.egg
+++ b/src/logical_op/index_map_apply/fixpoint_2.egg
@@ -1,11 +1,6 @@
-(rule
-  (
-    (= ?out_logical (LogicalIndexMapApply ?in_logical (IndexMapLit ?entry_list ?map_source_shape) ?out_shape))
-    (= ?in_shape (shape-of ?in_logical))
-    (= ?in_rank (rank-of ?in_shape))
-  )
-  (
-    (set (view-arity-lock ?out_logical) ?in_rank)
-  )
-  :ruleset fixpoint-invariants
-)
+; The view-arity check lives in the preamble (VIEW ARITY LOCK): it is a
+; property of the IndexMapLit — entry count == rank of the source-shape
+; tag — and is checked on the literal. The per-output-class :no-merge
+; setter that used to live here was retired 2026-09-01: it keyed a route
+; fact (parent rank) on a value (the apply's output class) and fired on
+; sound unions of two apply spellings with different-rank parents.

--- a/tests/test_runtime/tests/view_arity_lock.rs
+++ b/tests/test_runtime/tests/view_arity_lock.rs
@@ -1,0 +1,167 @@
+//! THE VIEW-ARITY TRIPWIRE, pinned from both sides (ruling 2026-09-01).
+//!
+//! The tripwire asserts "an index map's entry count is the rank of its
+//! source-shape tag". It is a property of the `IndexMapLit`, and it is
+//! checked on the literal. It used to be a `:no-merge` cell keyed on the
+//! apply's OUTPUT e-class, which silently also asserted "every apply
+//! spelling in one class has a same-rank parent" — a route fact stored
+//! in a value slot. That fired on a sound equivalence the moment any
+//! rule unioned two different-parent-rank spellings (the cuBLASLt
+//! marker's double-transpose collapse was the first). These tests keep
+//! both halves honest:
+//!
+//!  * the SOUND union must saturate — `x2 = x3[0,:,:]` (3 entries over a
+//!    rank-3 parent) and `y = identity(x2)` (2 entries over a rank-2
+//!    parent) are the same tensor by definition, with ONE output shape;
+//!  * the GENUINE arity error must still fail loudly, naming the literal.
+//!
+//! Every run assembles the program itself so the egglog error is
+//! captured as text rather than panicking through `serialize_fixture`.
+
+use luminal::layout_ir::OpMatcher;
+
+const FULL: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
+const NO_INVARIANTS: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata))";
+
+/// This runtime's vocabulary WITHOUT the cuBLASLt marker estate — the
+/// tripwire's behaviour must not depend on any backend's rules.
+fn matchers_without_marker() -> Vec<Box<dyn OpMatcher>> {
+    let mut m = test_runtime::ops::functional::functional_matchers();
+    m.push(Box::new(test_runtime::IndexMapApplyViewMatcher));
+    m.push(Box::new(test_runtime::AddMulFusedMatcher));
+    m.extend(test_runtime::ops::mutating::mutating_matchers());
+    m
+}
+
+fn run(matchers: &[Box<dyn OpMatcher>], script: &str) -> Result<(), String> {
+    let preamble = luminal::egglog_snippet::assembled_program_for(matchers);
+    let mut egraph = luminal::egglog_snippet::new_egraph();
+    egraph
+        .parse_and_run_program(None, &format!("{preamble}\n\n{script}"))
+        .map(|_| ())
+        .map_err(|e| format!("{e}"))
+}
+
+/// x3 : [2,3,4]. x2 = x3[0,:,:] — 3-entry map over the RANK-3 parent, out [3,4].
+/// y = x2 through the identity map — 2-entry map over the RANK-2 parent, out [3,4].
+/// Entries are parent-outermost-first; `(CoordVar shape k)` is output coordinate
+/// k-from-the-end (axis 0 = innermost).
+const TWO_SPELLINGS: &str = r#"
+(let s3  (ShapeLit (IntExprCons (IntLit 2) (IntExprCons (IntLit 3) (IntExprCons (IntLit 4) (IntExprNil))))))
+(let s34 (ShapeLit (IntExprCons (IntLit 3) (IntExprCons (IntLit 4) (IntExprNil)))))
+(let x3 (LogicalTensorInputLit (LogicalIdLit "x3") s3 (F32)))
+(let select_map (IndexMapLit (IntExprCons (IntLit 0) (IntExprCons (CoordVar s34 1) (IntExprCons (CoordVar s34 0) (IntExprNil)))) s3))
+(let x2 (LogicalIndexMapApply x3 select_map s34))
+(let identity_map (IndexMapLit (IntExprCons (CoordVar s34 1) (IntExprCons (CoordVar s34 0) (IntExprNil))) s34))
+(let y (LogicalIndexMapApply x2 identity_map s34))
+(let x3_lt (LayoutTensorLit x3 (RightMajorContiguousElementLayoutLit s3 (bits-of (F32)))))
+(let x3_buf (BufferLit 1))
+(set (buffer-access-of x3_buf) (ReadOnly))
+(set (buffer-freed-by x3_buf) (CallerFrees))
+(let input_boundary (BufferInputLit (BufferTensorCons (BufferTensorLit x3_lt x3_buf) (BufferTensorNil))))
+(let y_lt (LayoutTensorLit y (RightMajorContiguousElementLayoutLit s34 (bits-of (F32)))))
+(let y_buf (BufferLit 2))
+(set (buffer-access-of y_buf) (ReadWrite))
+(set (buffer-freed-by y_buf) (CallerFrees))
+(let output (BufferOutputLit (BufferTensorCons (BufferTensorLit y_lt y_buf) (BufferTensorNil))))
+"#;
+
+/// The equivalence is sound and rank is a property of the VALUE: after
+/// the union both spellings have output shape [3,4], rank 2, one class.
+#[test]
+fn two_spellings_of_one_value_share_one_shape_and_one_rank() {
+    let script = format!(
+        "{TWO_SPELLINGS}\n(union y x2)\n{NO_INVARIANTS}\n\
+         (check (= (shape-of x2) s34))\n(check (= (shape-of y) s34))\n\
+         (check (= (rank-of (shape-of x2)) 2))\n(check (= x2 y))\n"
+    );
+    let r = run(&matchers_without_marker(), &script);
+    assert!(
+        r.is_ok(),
+        "the union of two spellings of one value is sound: {r:?}"
+    );
+}
+
+/// THE MISFIRE THAT WAS: a sound union of two apply spellings whose
+/// parents have different rank must saturate under the full schedule.
+#[test]
+fn sound_union_of_different_parent_rank_spellings_saturates() {
+    let script = format!("{TWO_SPELLINGS}\n(union y x2)\n{FULL}\n");
+    let r = run(&matchers_without_marker(), &script);
+    assert!(
+        r.is_ok(),
+        "a route fact (parent rank) must never be asserted per value class: {r:?}"
+    );
+}
+
+/// The collision as it actually arose: the cuBLASLt marker's
+/// double-transpose collapse unions a view-of-view back into a tensor that
+/// is itself a view from a rank-3 parent. With the marker vocabulary
+/// loaded, this must saturate too.
+#[test]
+fn marker_double_transpose_collapse_over_a_rank_changing_view_saturates() {
+    let script = r#"
+(let s3  (ShapeLit (IntExprCons (IntLit 2) (IntExprCons (IntLit 3) (IntExprCons (IntLit 4) (IntExprNil))))))
+(let s34 (ShapeLit (IntExprCons (IntLit 3) (IntExprCons (IntLit 4) (IntExprNil)))))
+(let s43 (ShapeLit (IntExprCons (IntLit 4) (IntExprCons (IntLit 3) (IntExprNil)))))
+(let x3 (LogicalTensorInputLit (LogicalIdLit "x3") s3 (F32)))
+(let select_map (IndexMapLit (IntExprCons (IntLit 0) (IntExprCons (CoordVar s34 1) (IntExprCons (CoordVar s34 0) (IntExprNil)))) s3))
+(let x2 (LogicalIndexMapApply x3 select_map s34))
+(let tmap1 (IndexMapLit (IntExprCons (CoordVar s43 0) (IntExprCons (CoordVar s43 1) (IntExprNil))) s34))
+(let t (LogicalIndexMapApply x2 tmap1 s43))
+(let tmap2 (IndexMapLit (IntExprCons (CoordVar s34 0) (IntExprCons (CoordVar s34 1) (IntExprNil))) s43))
+(let tt (LogicalIndexMapApply t tmap2 s34))
+(let x3_lt (LayoutTensorLit x3 (RightMajorContiguousElementLayoutLit s3 (bits-of (F32)))))
+(let x3_buf (BufferLit 1))
+(set (buffer-access-of x3_buf) (ReadOnly))
+(set (buffer-freed-by x3_buf) (CallerFrees))
+(let input_boundary (BufferInputLit (BufferTensorCons (BufferTensorLit x3_lt x3_buf) (BufferTensorNil))))
+(let tt_lt (LayoutTensorLit tt (RightMajorContiguousElementLayoutLit s34 (bits-of (F32)))))
+(let tt_buf (BufferLit 2))
+(set (buffer-access-of tt_buf) (ReadWrite))
+(set (buffer-freed-by tt_buf) (CallerFrees))
+(let output (BufferOutputLit (BufferTensorCons (BufferTensorLit tt_lt tt_buf) (BufferTensorNil))))
+"#
+    .to_string()
+        + FULL
+        + "\n(check (= tt x2))\n";
+    // test_runtime::matchers() carries the marker estate.
+    let r = run(&test_runtime::matchers(), &script);
+    assert!(
+        r.is_ok(),
+        "the collapse's union is sound and must be admitted: {r:?}"
+    );
+}
+
+/// THE ERROR THE TRIPWIRE EXISTS FOR: a 2-entry map tagged with (and
+/// applied to) a rank-3 parent is malformed and must fail loudly,
+/// naming the literal.
+#[test]
+fn genuine_arity_error_is_still_caught_loudly() {
+    let script = format!(
+        r#"
+(let s3  (ShapeLit (IntExprCons (IntLit 2) (IntExprCons (IntLit 3) (IntExprCons (IntLit 4) (IntExprNil))))))
+(let s34 (ShapeLit (IntExprCons (IntLit 3) (IntExprCons (IntLit 4) (IntExprNil)))))
+(let x3 (LogicalTensorInputLit (LogicalIdLit "x3") s3 (F32)))
+(let bad_map (IndexMapLit (IntExprCons (CoordVar s34 1) (IntExprCons (CoordVar s34 0) (IntExprNil))) s3))
+(let bad (LogicalIndexMapApply x3 bad_map s34))
+(let x3_lt (LayoutTensorLit x3 (RightMajorContiguousElementLayoutLit s3 (bits-of (F32)))))
+(let x3_buf (BufferLit 1))
+(set (buffer-access-of x3_buf) (ReadOnly))
+(set (buffer-freed-by x3_buf) (CallerFrees))
+(let input_boundary (BufferInputLit (BufferTensorCons (BufferTensorLit x3_lt x3_buf) (BufferTensorNil))))
+(let bad_lt (LayoutTensorLit bad (RightMajorContiguousElementLayoutLit s34 (bits-of (F32)))))
+(let bad_buf (BufferLit 2))
+(set (buffer-access-of bad_buf) (ReadWrite))
+(set (buffer-freed-by bad_buf) (CallerFrees))
+(let output (BufferOutputLit (BufferTensorCons (BufferTensorLit bad_lt bad_buf) (BufferTensorNil))))
+{FULL}
+"#
+    );
+    let r = run(&matchers_without_marker(), &script);
+    let msg = r.expect_err("a genuine arity error must be caught");
+    assert!(
+        msg.contains("IndexMapLit entry count disagrees with the rank of its source-shape tag"),
+        "the failure must name the literal and the invariant: {msg}"
+    );
+}


### PR DESCRIPTION
**Ruling 2026-09-01:** "please update the tripwire to the proposed rule." This is that change, with the minimal misfire pinned as a permanent regression test.

## What was wrong

`view-arity-lock` asserted *an index map's entry count is its input's rank* by writing two numbers, the map's entry count and the parent's rank, into one `:no-merge` cell keyed by the apply's **output e-class**. The key is a value. Parent rank is a property of the *route* to the value.

One value legitimately has apply spellings from parents of different rank. `x2 = x3[0,:,:]` (3 entries, rank-3 parent) and `y = identity(x2)` (2 entries, rank-2 parent) are the same tensor by definition, with one output shape and one rank. Unioning them is sound, and the cell fired: `Illegal merge attempted for function view-arity-lock`.

The cuBLASLt marker's double-transpose collapse (`x ≡ Tᵀ(x)`, union-only, sound) was the first rule in the tree to perform such a union, so it killed saturation on every mini: the attention output after `merge_dims` (4-entry apply, rank-4 parent) welded with a 2-entry transpose view of itself. Whisper collides 2 vs 3 with no extent-1 axis, so the "extent-1 weld corners" note in `ops/mod.rs` was a misdiagnosis. Confirmed by a 30-line fixture, by capture on all seven minis, and by two adversarial refutations.

## The fix

The invariant is a property of the **literal**: entry count equals the rank of the map's own source-shape tag. It is now checked on the literal, in one rule, with no `LogicalTensor` in the key:

```egg
(rule ((= ?map (IndexMapLit ?entries ?tag))
       (= ?entry_count (expr-list-length-of ?entries))
       (= ?tag_rank (rank-of ?tag))
       (!= ?entry_count ?tag_rank))
      ((panic "IndexMapLit entry count disagrees with the rank of its source-shape tag"))
      :ruleset fixpoint-invariants)
```

Map-tag coherence already forces the tag to equal the parent's shape, so the per-apply guarantee is unchanged, and no union of logical tensors can ever trip it. The two per-class setters are retired. Nothing read the old cell.

## Pinned both ways

`tests/test_runtime/tests/view_arity_lock.rs`, no backend rules involved except where stated:

| test | result |
|---|---|
| identity-view union, all strata but invariants, then `check` shape/rank/class | both spellings share shape `[3,4]`, rank 2, one class |
| identity-view union, full schedule | saturates |
| marker collapse over a rank-changing view (marker vocabulary loaded) | saturates |
| genuine 2-entry map on a rank-3 parent | panics, naming the literal |

## What changes downstream

The election test now treats a **saturation death as a hard failure** (the retired failure mode returning) and records a search death from budget exhaustion as a row. Post-fix at the 2×4 harness budget:

```
matmul_2d(4x8 . 8x3): marker_elected=1 computes=1
conv:                 marker_elected=1 computes=47      <- first real mini to elect cuBLASLt
gemma3, gemma4_moe, llama3, qwen3, qwen3_moe, whisper:
                      SEARCH DIED: no candidate genome produced an executable plan
```

The six deaths are the collapse's own re-description 2-cycle exhausting the tiny budget; the same graphs elect at 12×16. **Always-on cuBLASLt is ruled but deliberately not in this PR.** It lands with the budget or sampler decision, which follows immediately. The opt-in seam and its prose in `ops/mod.rs` and `runtime.rs` are corrected to say exactly that.

## Gates

fmt clean · workspace and cuda_lite `clippy -D warnings` exit 0 · build 0 errors · **62 suites / 555 passed / 0 failed** (`luminal` 226, `luminal_reference` 43, `test_runtime` 203, `luminal_cuda_lite` 60, `luminal_nn` 23). No device gate needed: the change is estate text plus CPU tests; kernels are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)