### PR TITLE
Fix stale implementation-search comments

### DIFF
--- a/crates/luminal_nn/src/activation.rs
+++ b/crates/luminal_nn/src/activation.rs
@@ -59,8 +59,8 @@ mod tests {
     use super::{ReLU, Sigmoid};
     use luminal::prelude::*;
 
-    /// The M3 ladder end-to-end (full genetic search; scalar-constant
-    /// broadcasts route via materialize — rediagnosis 2026-08-12).
+    /// Exercise a unary activation through implementation search and
+    /// reference execution.
     fn run_unary(build: impl Fn(GraphTensor) -> GraphTensor, input: Vec<f32>) -> Vec<f32> {
         let mut cx = Graph::new();
         let x = cx.tensor(input.len());

--- a/crates/luminal_nn/src/attention.rs
+++ b/crates/luminal_nn/src/attention.rs
@@ -670,9 +670,8 @@ mod tests {
 
     /// Full paged attention, decode step: one new token (s=1) after one
     /// cached token, 2 KV heads with no grouping (kv_groups=1), head_dim 2.
-    /// Reference computed by scalar loops below; run_reference drives the full
-    /// search ladder (rediagnosis 2026-08-12: it is not a plain
-    /// extraction shortcut).
+    /// The scalar loops below provide the reference for the plan selected by
+    /// implementation search and executed by the reference runtime.
     #[test]
     fn paged_attention_decode_step_matches_scalar_reference() {
         const N_HEADS: usize = 2;


### PR DESCRIPTION
## Summary

- remove the obsolete scalar-materialization routing explanation from the activation test helper
- describe the paged-attention test in terms of the current implementation-search and reference-runtime path
- remove the retired run_reference helper name and dated rediagnosis notes

## Validation

- git diff --check
- cargo fmt --all -- --check

Tests were not run because this change only updates comments.