### PR TITLE
Add persistent compiled artifact reuse for Python and CUDA backends

### DIFF
--- a/crates/luminal_cuda_lite/Cargo.toml
+++ b/crates/luminal_cuda_lite/Cargo.toml
@@ -27,6 +27,10 @@ rustc-hash = "2.1.1"
 libc = "0.2"
 libloading = "0.8"
 colorize = "*"
+base64 = "0.22"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
 
 [dev-dependencies]
 candle-core = { version = "0.9.2", features = ["cuda"] }

--- a/crates/luminal_cuda_lite/src/artifact.rs
+++ b/crates/luminal_cuda_lite/src/artifact.rs
@@ -8,10 +8,12 @@ use std::{
 
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use cudarc::driver::CudaContext;
+use luminal::op::IntoEgglogOp;
+use luminal::prelude::Graph;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::{cuda_nvrtc_compile_options, loaded_nvrtc_version};
+use crate::{cuda_nvrtc_compile_options, loaded_nvrtc_version, runtime::CudaRuntimeImpl};
 
 thread_local! {
     static MODULE_ARTIFACT_SESSION: RefCell<Option<Arc<Mutex<ModuleArtifact>>>> =
@@ -110,6 +112,24 @@ pub(crate) fn finish_module_artifact_capture(artifact: &Mutex<ModuleArtifact>) {
     let mut artifact = artifact.lock().unwrap();
     artifact.loading = true;
     artifact.capturing = false;
+}
+
+/// Recompile the selected schedule into a fresh capture so rejected search
+/// candidates are not included in the saved artifact.
+pub(crate) fn capture_selected_schedule<O: IntoEgglogOp + 'static>(
+    graph: &mut Graph,
+    runtime: &mut CudaRuntimeImpl<O>,
+    artifact: &Mutex<ModuleArtifact>,
+) -> Result<(), String> {
+    if module_artifact_is_loading(artifact) {
+        return Ok(());
+    }
+
+    begin_module_artifact_capture(artifact);
+    runtime.clear_kernel_cache();
+    graph.load_selected_schedule(runtime)?;
+    finish_module_artifact_capture(artifact);
+    Ok(())
 }
 
 pub(crate) fn module_key(source: &str) -> String {

--- a/crates/luminal_cuda_lite/src/artifact.rs
+++ b/crates/luminal_cuda_lite/src/artifact.rs
@@ -1,0 +1,273 @@
+//! CUDA module artifact capture, serialization, and loading.
+
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use cudarc::driver::CudaContext;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{cuda_nvrtc_compile_options, loaded_nvrtc_version};
+
+thread_local! {
+    static MODULE_ARTIFACT_SESSION: RefCell<Option<Arc<Mutex<ModuleArtifact>>>> =
+        const { RefCell::new(None) };
+}
+
+const MODULE_ARTIFACT_VERSION: u32 = 2;
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+struct ModuleArtifactSignature {
+    target_arch: String,
+    nvrtc_options: Vec<String>,
+    nvrtc_version: Option<u32>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct SerializedModuleArtifact {
+    version: u32,
+    signature: ModuleArtifactSignature,
+    images: HashMap<String, String>,
+}
+
+pub(crate) struct ModuleArtifact {
+    signature: ModuleArtifactSignature,
+    images: HashMap<String, Vec<u8>>,
+    loading: bool,
+    capturing: bool,
+}
+
+pub(crate) enum ModuleImageLookup {
+    Compile,
+    Hit(Vec<u8>),
+    Missing { available: usize },
+}
+
+pub(crate) fn module_artifact_session(
+    ctx: &Arc<CudaContext>,
+    data: Option<&str>,
+) -> Result<Arc<Mutex<ModuleArtifact>>, String> {
+    let signature = module_artifact_signature(ctx)?;
+    let artifact = if let Some(data) = data {
+        deserialize_module_artifact(data, signature)?
+    } else {
+        ModuleArtifact {
+            signature,
+            images: HashMap::new(),
+            loading: false,
+            capturing: false,
+        }
+    };
+    Ok(Arc::new(Mutex::new(artifact)))
+}
+
+pub(crate) fn with_module_artifact_session<T>(
+    session: Arc<Mutex<ModuleArtifact>>,
+    run: impl FnOnce() -> T,
+) -> T {
+    struct SessionGuard(Option<Arc<Mutex<ModuleArtifact>>>);
+    impl Drop for SessionGuard {
+        fn drop(&mut self) {
+            MODULE_ARTIFACT_SESSION.with(|current| current.replace(self.0.take()));
+        }
+    }
+
+    let previous = MODULE_ARTIFACT_SESSION.with(|current| current.replace(Some(session)));
+    let _guard = SessionGuard(previous);
+    run()
+}
+
+pub(crate) fn serialize_module_artifact(session: &Mutex<ModuleArtifact>) -> String {
+    let artifact = session.lock().unwrap();
+    let serialized = SerializedModuleArtifact {
+        version: MODULE_ARTIFACT_VERSION,
+        signature: artifact.signature.clone(),
+        images: artifact
+            .images
+            .iter()
+            .map(|(key, image)| (key.clone(), BASE64.encode(image)))
+            .collect(),
+    };
+    serde_json::to_string(&serialized).unwrap()
+}
+
+pub(crate) fn module_artifact_is_loading(artifact: &Mutex<ModuleArtifact>) -> bool {
+    artifact.lock().unwrap().loading
+}
+
+pub(crate) fn begin_module_artifact_capture(artifact: &Mutex<ModuleArtifact>) {
+    let mut artifact = artifact.lock().unwrap();
+    artifact.images.clear();
+    artifact.loading = false;
+    artifact.capturing = true;
+}
+
+pub(crate) fn finish_module_artifact_capture(artifact: &Mutex<ModuleArtifact>) {
+    let mut artifact = artifact.lock().unwrap();
+    artifact.loading = true;
+    artifact.capturing = false;
+}
+
+pub(crate) fn module_key(source: &str) -> String {
+    format!("{:x}", Sha256::digest(source.as_bytes()))
+}
+
+pub(crate) fn lookup_module_image(key: &str) -> ModuleImageLookup {
+    MODULE_ARTIFACT_SESSION.with(|current| {
+        let session = current.borrow();
+        let Some(session) = session.as_ref() else {
+            return ModuleImageLookup::Compile;
+        };
+        let artifact = session.lock().unwrap();
+        match artifact.images.get(key) {
+            Some(image) => ModuleImageLookup::Hit(image.clone()),
+            None if artifact.loading => ModuleImageLookup::Missing {
+                available: artifact.images.len(),
+            },
+            None => ModuleImageLookup::Compile,
+        }
+    })
+}
+
+pub(crate) fn record_module_image(key: &str, image: &[u8]) {
+    MODULE_ARTIFACT_SESSION.with(|current| {
+        if let Some(session) = current.borrow().as_ref() {
+            let mut artifact = session.lock().unwrap();
+            if artifact.capturing {
+                artifact.images.insert(key.to_owned(), image.to_vec());
+            }
+        }
+    });
+}
+
+fn module_artifact_signature(ctx: &Arc<CudaContext>) -> Result<ModuleArtifactSignature, String> {
+    let (major, minor) = ctx
+        .compute_capability()
+        .map_err(|error| error.to_string())?;
+    let target_arch = format!("sm_{major}{minor}");
+    Ok(ModuleArtifactSignature {
+        nvrtc_options: cuda_nvrtc_compile_options(&target_arch),
+        target_arch,
+        nvrtc_version: loaded_nvrtc_version(),
+    })
+}
+
+fn deserialize_module_artifact(
+    data: &str,
+    signature: ModuleArtifactSignature,
+) -> Result<ModuleArtifact, String> {
+    let serialized: SerializedModuleArtifact =
+        serde_json::from_str(data).map_err(|error| error.to_string())?;
+    if serialized.version != MODULE_ARTIFACT_VERSION {
+        return Err(format!(
+            "unsupported CUDA module artifact version {}, expected {}",
+            serialized.version, MODULE_ARTIFACT_VERSION
+        ));
+    }
+    if serialized.signature != signature {
+        return Err("CUDA module artifact is incompatible with this device".to_string());
+    }
+    let images = serialized
+        .images
+        .into_iter()
+        .map(|(key, image)| {
+            BASE64
+                .decode(image)
+                .map(|image| (key, image))
+                .map_err(|error| error.to_string())
+        })
+        .collect::<Result<_, _>>()?;
+    Ok(ModuleArtifact {
+        signature,
+        images,
+        loading: true,
+        capturing: false,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn signature() -> ModuleArtifactSignature {
+        ModuleArtifactSignature {
+            target_arch: "sm_90".to_string(),
+            nvrtc_options: vec!["--gpu-architecture=sm_90".to_string()],
+            nvrtc_version: Some(12080),
+        }
+    }
+
+    #[test]
+    fn module_artifact_round_trip() {
+        let session = Mutex::new(ModuleArtifact {
+            signature: signature(),
+            images: HashMap::from([("kernel".to_string(), vec![1, 2, 3])]),
+            loading: false,
+            capturing: false,
+        });
+
+        let data = serialize_module_artifact(&session);
+        let loaded = deserialize_module_artifact(&data, signature()).unwrap();
+
+        assert!(loaded.loading);
+        assert_eq!(loaded.images["kernel"], [1, 2, 3]);
+    }
+
+    #[test]
+    fn module_artifact_rejects_incompatible_device() {
+        let session = Mutex::new(ModuleArtifact {
+            signature: signature(),
+            images: HashMap::new(),
+            loading: false,
+            capturing: false,
+        });
+        let data = serialize_module_artifact(&session);
+        let mut incompatible = signature();
+        incompatible.target_arch = "sm_80".to_string();
+
+        assert!(deserialize_module_artifact(&data, incompatible).is_err());
+    }
+
+    #[test]
+    fn loaded_artifact_does_not_fall_back_to_compilation() {
+        let session = Arc::new(Mutex::new(ModuleArtifact {
+            signature: signature(),
+            images: HashMap::new(),
+            loading: true,
+            capturing: false,
+        }));
+
+        with_module_artifact_session(session, || {
+            assert!(matches!(
+                lookup_module_image("missing"),
+                ModuleImageLookup::Missing { available: 0 }
+            ));
+        });
+    }
+
+    #[test]
+    fn selected_capture_discards_search_candidates() {
+        let session = Mutex::new(ModuleArtifact {
+            signature: signature(),
+            images: HashMap::from([("candidate".to_string(), vec![1])]),
+            loading: false,
+            capturing: false,
+        });
+
+        begin_module_artifact_capture(&session);
+        {
+            let artifact = session.lock().unwrap();
+            assert!(artifact.images.is_empty());
+            assert!(artifact.capturing);
+        }
+
+        finish_module_artifact_capture(&session);
+        let artifact = session.lock().unwrap();
+        assert!(artifact.loading);
+        assert!(!artifact.capturing);
+    }
+}

--- a/crates/luminal_cuda_lite/src/dyn_backend.rs
+++ b/crates/luminal_cuda_lite/src/dyn_backend.rs
@@ -5,6 +5,12 @@ use luminal::dyn_backend::{BackendCompileArgs, DynBackend, compile_backend};
 use luminal::op::IntoEgglogOp;
 use luminal::prelude::*;
 
+use std::sync::{Arc, Mutex};
+
+use crate::artifact::{
+    ModuleArtifact, capture_selected_schedule, module_artifact_session, serialize_module_artifact,
+    with_module_artifact_session,
+};
 use crate::cudarc::driver::CudaContext;
 use crate::runtime::{CudaRuntimeImpl, DefaultCudaOps};
 
@@ -12,11 +18,15 @@ use crate::runtime::{CudaRuntimeImpl, DefaultCudaOps};
 pub struct CudaDynBackend<O = DefaultCudaOps> {
     pub runtime: CudaRuntimeImpl<O>,
     backend_name: &'static str,
+    module_artifact: Arc<Mutex<ModuleArtifact>>,
 }
 
 impl<O: IntoEgglogOp + 'static> DynBackend for CudaDynBackend<O> {
     fn name(&self) -> &str {
         self.backend_name
+    }
+    fn artifact_data(&self) -> Option<String> {
+        Some(serialize_module_artifact(&self.module_artifact))
     }
     fn device_type(&self) -> &str {
         "cuda"
@@ -110,25 +120,32 @@ pub fn cuda_factory_for<O: IntoEgglogOp + 'static>(
     let cuda_ctx = CudaContext::new(device_index).map_err(|e| format!("CUDA init failed: {e}"))?;
     let stream = cuda_ctx.default_stream();
     let external_cuda_graph = args.external_cuda_graph;
-    compile_backend::<CudaRuntimeImpl<O>>(
-        graph,
-        args,
-        || {
-            let mut runtime = CudaRuntimeImpl::<O>::initialize(stream);
-            runtime.set_external_cuda_graph(external_cuda_graph);
-            Ok(runtime)
-        },
-        |rt, node, bytes, _dtype| {
-            rt.set_data(node, bytes);
-        },
-        Some(&|rt, node, ptr, n| unsafe { rt.set_device_ptr(node, ptr, n) }),
-        |rt| {
-            Box::new(CudaDynBackend {
-                runtime: rt,
-                backend_name,
-            })
-        },
-    )
+    let module_artifact = module_artifact_session(&cuda_ctx, args.backend_artifact.as_deref())?;
+    let backend_artifact = Arc::clone(&module_artifact);
+    let capture_artifact = Arc::clone(&module_artifact);
+    with_module_artifact_session(module_artifact, || {
+        compile_backend::<CudaRuntimeImpl<O>>(
+            graph,
+            args,
+            || {
+                let mut runtime = CudaRuntimeImpl::<O>::initialize(stream);
+                runtime.set_external_cuda_graph(external_cuda_graph);
+                Ok(runtime)
+            },
+            |rt, node, bytes, _dtype| {
+                rt.set_data(node, bytes);
+            },
+            Some(&|rt, node, ptr, n| unsafe { rt.set_device_ptr(node, ptr, n) }),
+            |graph, rt| capture_selected_schedule(graph, rt, &capture_artifact),
+            |rt| {
+                Box::new(CudaDynBackend {
+                    runtime: rt,
+                    backend_name,
+                    module_artifact: backend_artifact,
+                })
+            },
+        )
+    })
 }
 
 pub type CudaLiteDynBackend = CudaDynBackend<DefaultCudaOps>;

--- a/crates/luminal_cuda_lite/src/kernel/fusion/region_codegen.rs
+++ b/crates/luminal_cuda_lite/src/kernel/fusion/region_codegen.rs
@@ -447,42 +447,24 @@ fn singleton_region(llir_graph: &LLIRGraph, fe_node: NodeIndex) -> Option<Region
 }
 
 fn compare_fusion_starts(llir_graph: &LLIRGraph, a: NodeIndex, b: NodeIndex) -> std::cmp::Ordering {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-
     let fusion_start = |node: NodeIndex| {
         let op = llir_graph[node].to_dialect::<dyn KernelOp>().unwrap();
         (***op).downcast_ref::<FusionStart>().unwrap()
     };
     let a_start = fusion_start(a);
     let b_start = fusion_start(b);
-    let hash = |start: &FusionStart| {
-        let mut hasher = DefaultHasher::new();
-        for stride in &start.strides {
-            stride.hash_intern_id(&mut hasher);
-        }
-        dtype_program_tag(start.dtype).hash(&mut hasher);
-        hasher.finish()
-    };
-    hash(a_start).cmp(&hash(b_start)).then_with(|| {
-        if a_start.dtype == b_start.dtype
-            && same_expression_slice(&a_start.strides, &b_start.strides)
-        {
-            return std::cmp::Ordering::Equal;
-        }
-        // Resolve the vanishingly rare identity-hash collision structurally.
-        a_start
-            .strides
-            .iter()
-            .map(|expression| expression.to_kernel())
-            .cmp(
-                b_start
-                    .strides
-                    .iter()
-                    .map(|expression| expression.to_kernel()),
-            )
-            .then_with(|| cuda_dtype(a_start.dtype).cmp(cuda_dtype(b_start.dtype)))
-    })
+    a_start
+        .strides
+        .iter()
+        .map(|expression| expression.to_kernel())
+        .cmp(
+            b_start
+                .strides
+                .iter()
+                .map(|expression| expression.to_kernel()),
+        )
+        .then_with(|| cuda_dtype(a_start.dtype).cmp(cuda_dtype(b_start.dtype)))
+        .then_with(|| a.index().cmp(&b.index()))
 }
 
 // =========================================================================
@@ -1453,6 +1435,31 @@ mod tests {
         assert!(source.contains("const float *in0"));
         assert!(!source.contains("in1"));
         assert!(source.contains("v_0 + v_0"));
+    }
+
+    #[test]
+    fn singleton_region_orders_inputs_by_structure() {
+        let shape = vec![8.into()];
+        let mut graph = LLIRGraph::default();
+        let indexed = graph.add_node(llir_of(FusionStart {
+            shape: shape.clone(),
+            strides: vec![Expression::from('z')],
+            dtype: DType::F32,
+        }));
+        let broadcast = graph.add_node(llir_of(FusionStart {
+            shape,
+            strides: vec![0.into()],
+            dtype: DType::F32,
+        }));
+
+        assert_eq!(
+            compare_fusion_starts(&graph, broadcast, indexed),
+            std::cmp::Ordering::Less,
+        );
+        assert_eq!(
+            compare_fusion_starts(&graph, indexed, broadcast),
+            std::cmp::Ordering::Greater,
+        );
     }
 
     #[test]

--- a/crates/luminal_cuda_lite/src/lib.rs
+++ b/crates/luminal_cuda_lite/src/lib.rs
@@ -3,6 +3,7 @@
 // `use luminal_cuda_lite::...` imports.
 extern crate self as luminal_cuda_lite;
 
+mod artifact;
 pub mod dyn_backend;
 pub mod host;
 pub mod kernel;
@@ -24,6 +25,7 @@ use cudarc::{cublaslt::CudaBlasLT, driver::CudaStream};
 #[cfg(test)]
 mod tests;
 
+use artifact::{ModuleImageLookup, lookup_module_image, module_key, record_module_image};
 use cudarc::{
     driver::{CudaContext, DriverError, sys as driver_sys},
     nvrtc::{
@@ -522,6 +524,25 @@ pub fn compile_module_image_for_current_device<S: AsRef<str>>(
     })?;
     let target_arch = format!("sm_{major}{minor}");
     let nvrtc_options = cuda_nvrtc_compile_options(&target_arch);
+    let source = src.as_ref();
+    let module_key = module_key(source);
+    match lookup_module_image(&module_key) {
+        ModuleImageLookup::Hit(image) => return Ok(Ptx::from_binary(image)),
+        ModuleImageLookup::Missing { available } => {
+            return Err(build_module_image_compile_error(
+                Some(target_arch),
+                driver_version,
+                runtime_version,
+                &nvrtc_options,
+                None,
+                CudaModuleImageCompileFailure::ArtifactMiss {
+                    key: module_key,
+                    available,
+                },
+            ));
+        }
+        ModuleImageLookup::Compile => {}
+    }
 
     // NVRTC compile time grows super-linearly with source size. The active
     // runtime installs its configured budget around compilation; direct calls
@@ -612,6 +633,7 @@ pub fn compile_module_image_for_current_device<S: AsRef<str>>(
         ));
     }
 
+    record_module_image(&module_key, &cubin);
     Ok(Ptx::from_binary(cubin))
 }
 

--- a/crates/luminal_cuda_lite/src/lib.rs
+++ b/crates/luminal_cuda_lite/src/lib.rs
@@ -120,6 +120,10 @@ pub enum CudaModuleImageCompileFailure {
         error: NvrtcError,
     },
     NoModuleImageProduced,
+    ArtifactMiss {
+        key: String,
+        available: usize,
+    },
 }
 
 #[doc(hidden)]
@@ -148,6 +152,12 @@ impl std::fmt::Display for CudaModuleImageCompileError {
             }
             CudaModuleImageCompileFailure::NoModuleImageProduced => {
                 write!(f, ": NVRTC produced no CUBIN for the selected target")?;
+            }
+            CudaModuleImageCompileFailure::ArtifactMiss { key, available } => {
+                write!(
+                    f,
+                    ": CUBIN {key} is missing from the artifact ({available} saved)"
+                )?;
             }
         }
         if let Some(version) = self.driver_version {

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -419,6 +419,7 @@ pub type DefaultCudaOps = (crate::kernel::Ops, crate::host::Ops);
 
 pub struct CudaRuntimeImpl<O> {
     _ops: PhantomData<fn() -> O>,
+    pub(crate) selected_schedule: Option<luminal::graph::SelectedSchedule>,
     // Shared state across all buckets
     // Keep this private: every mutation must go through the buffer APIs so
     // `changed_hlir` and resource-input validation stay in sync with the map.
@@ -554,6 +555,10 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
     /// caller-owned CUDA graph can capture them.
     pub fn set_external_cuda_graph(&mut self, enabled: bool) {
         self.external_cuda_graph = enabled;
+    }
+
+    pub(crate) fn clear_kernel_cache(&mut self) {
+        self.kernel_cache.clear();
     }
 
     fn select_execution_stream(&mut self, stream: Arc<CudaStream>) {
@@ -4837,6 +4842,7 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
             .expect("failed to create CUDA profiling end event");
         Self {
             _ops: PhantomData,
+            selected_schedule: None,
             hlir_buffers: FxHashMap::default(),
             hlir_host_mirrors: FxHashMap::default(),
             owned_stream: Arc::clone(&stream),
@@ -4887,9 +4893,21 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
         self.search_and_load(space, dyn_map, options, rng);
     }
 
+    fn selected_schedule(&self) -> Option<luminal::graph::SelectedSchedule> {
+        self.selected_schedule.clone()
+    }
+
     #[tracing::instrument(skip_all)]
     fn load_llir(&mut self, llir_graph: &LLIRGraph) {
         self.try_load_llir(llir_graph).unwrap();
+    }
+
+    fn load_llir_buckets(
+        &mut self,
+        dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
+        bucket_llirs: &[BucketLLIR],
+    ) {
+        CudaRuntimeImpl::load_llir_buckets(self, dim_buckets, bucket_llirs);
     }
 
     #[tracing::instrument(skip_all)]

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -74,7 +74,9 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             };
             match compiled {
                 Ok(validated) => {
-                    let _selected = lattice.select(set);
+                    let selected = lattice.select_with_genomes(set);
+                    self.selected_schedule =
+                        luminal::graph::SelectedSchedule::from_search(space, &selected);
                     self.install_validated_bucket_set(&space.dim_buckets, validated)
                         .unwrap_or_else(|error| {
                             panic!("failed to install the selected CUDA bucket set: {error}")

--- a/crates/luminal_metal/src/dyn_backend.rs
+++ b/crates/luminal_metal/src/dyn_backend.rs
@@ -77,6 +77,7 @@ pub fn metal_factory(
             rt.set_data(node, bytes_to_reference_data(bytes, dtype));
         },
         None,
+        |_, _| Ok(()),
         |rt| Box::new(MetalDynBackend { runtime: rt }),
     )
 }

--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -163,6 +163,8 @@ const ARTIFACT_SCHEMA_VERSION: u32 = 3;
 #[derive(Deserialize, Serialize)]
 struct CompiledArtifactData {
     schema_version: u32,
+    #[serde(default, rename = "luminal_artifact_key")]
+    cache_key: Option<String>,
     backend: String,
     #[serde(default)]
     backend_artifact: Option<String>,
@@ -209,6 +211,7 @@ pub struct CompiledGraph {
     pub writeback_outputs: Vec<(usize, String)>,
     tensor_sizes: HashMap<String, usize>,
     external_cuda_graph: bool,
+    serializable: bool,
 }
 
 impl CompiledGraph {
@@ -244,6 +247,7 @@ impl CompiledGraph {
             tensor_sizes,
             device_ptrs,
         } = weight_data;
+        let serializable = weights.is_empty() && device_ptrs.is_empty();
         let artifact_tensor_sizes = tensor_sizes.clone();
 
         // Build compile args from WeightData.
@@ -296,6 +300,7 @@ impl CompiledGraph {
             writeback_outputs,
             tensor_sizes: artifact_tensor_sizes,
             external_cuda_graph,
+            serializable,
         })
     }
 
@@ -306,6 +311,7 @@ impl CompiledGraph {
         device_index: Option<usize>,
         external_cuda_graph: bool,
     ) -> Result<Self, String> {
+        let serializable = device_ptrs.is_empty();
         let artifact: CompiledArtifactData =
             serde_json::from_slice(bytes).map_err(|error| error.to_string())?;
         if artifact.schema_version != ARTIFACT_SCHEMA_VERSION {
@@ -379,6 +385,7 @@ impl CompiledGraph {
             writeback_outputs: artifact.writeback_outputs,
             tensor_sizes: artifact.tensor_sizes,
             external_cuda_graph,
+            serializable,
         })
     }
 
@@ -413,7 +420,17 @@ impl CompiledGraph {
 
 #[pymethods]
 impl CompiledGraph {
-    fn serialize_artifact<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+    #[pyo3(signature = (cache_key=None))]
+    fn serialize_artifact<'py>(
+        &self,
+        py: Python<'py>,
+        cache_key: Option<String>,
+    ) -> PyResult<Bound<'py, PyBytes>> {
+        if !self.serializable {
+            return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "compiled artifacts with bound weights or input pointers are not serializable",
+            ));
+        }
         let schedule = self.graph.selected_schedule().cloned().ok_or_else(|| {
             pyo3::exceptions::PyRuntimeError::new_err("compiled graph has no selected schedule")
         })?;
@@ -433,6 +450,7 @@ impl CompiledGraph {
 
         let artifact = CompiledArtifactData {
             schema_version: ARTIFACT_SCHEMA_VERSION,
+            cache_key,
             backend: self.runtime.name().to_string(),
             backend_artifact: self.runtime.artifact_data(),
             device_index: self.runtime.device_index(),

--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -6,10 +6,12 @@ use luminal::{
 };
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::typed_data::TypedData;
+
+mod artifact;
+pub(crate) use artifact::load_compiled_artifact;
 
 /// Copy a CPU buffer into Rust-owned storage.
 ///
@@ -158,36 +160,6 @@ pub struct WeightData {
     pub device_ptrs: HashMap<String, (u64, usize)>,
 }
 
-const ARTIFACT_SCHEMA_VERSION: u32 = 3;
-
-#[derive(Deserialize, Serialize)]
-struct CompiledArtifactData {
-    schema_version: u32,
-    #[serde(default, rename = "luminal_artifact_key")]
-    cache_key: Option<String>,
-    backend: String,
-    #[serde(default)]
-    backend_artifact: Option<String>,
-    device_index: Option<usize>,
-    external_cuda_graph: bool,
-    dyn_map: DynMap,
-    input_meta: Vec<(usize, String, DType)>,
-    tensor_sizes: HashMap<String, usize>,
-    tensor_ids: Vec<(String, usize)>,
-    input_names: Vec<String>,
-    input_dtypes: Vec<u32>,
-    output_names: Vec<String>,
-    output_ids: Vec<usize>,
-    output_shapes: Vec<Vec<usize>>,
-    output_shape_exprs: Vec<Vec<Expression>>,
-    output_dtypes: Vec<u32>,
-    input_shape_exprs: Vec<Vec<Expression>>,
-    dim_param_map: DimParamMap,
-    dim_bounds: DimBoundsMap,
-    writeback_outputs: Vec<(usize, String)>,
-    schedule: luminal::graph::SelectedSchedule,
-}
-
 #[pyclass(unsendable)]
 pub struct CompiledGraph {
     pub graph: Graph,
@@ -304,91 +276,6 @@ impl CompiledGraph {
         })
     }
 
-    pub fn from_artifact(
-        bytes: &[u8],
-        factory: BackendFactory,
-        device_ptrs: HashMap<String, (u64, usize)>,
-        device_index: Option<usize>,
-        external_cuda_graph: bool,
-    ) -> Result<Self, String> {
-        let serializable = device_ptrs.is_empty();
-        let artifact: CompiledArtifactData =
-            serde_json::from_slice(bytes).map_err(|error| error.to_string())?;
-        if artifact.schema_version != ARTIFACT_SCHEMA_VERSION {
-            return Err(format!(
-                "unsupported artifact schema {}, expected {}",
-                artifact.schema_version, ARTIFACT_SCHEMA_VERSION
-            ));
-        }
-        if artifact.device_index != device_index {
-            return Err(format!(
-                "artifact device {:?} does not match requested device {:?}",
-                artifact.device_index, device_index
-            ));
-        }
-        if artifact.external_cuda_graph != external_cuda_graph {
-            return Err("artifact CUDA graph mode does not match requested mode".to_string());
-        }
-
-        let input_meta = artifact
-            .input_meta
-            .iter()
-            .map(|(node, label, dtype)| (NodeIndex::new(*node), (label.clone(), *dtype)))
-            .collect();
-        let mut graph =
-            Graph::from_selected_schedule(artifact.dyn_map, input_meta, artifact.schedule);
-        let runtime = luminal::dyn_backend::compile_backend_from_factory(
-            factory,
-            &mut graph,
-            BackendCompileArgs {
-                search_iters: 0,
-                device_index,
-                external_cuda_graph,
-                weights: Vec::new(),
-                tensor_sizes: artifact.tensor_sizes.clone(),
-                device_ptrs,
-                backend_artifact: artifact.backend_artifact,
-            },
-        )?;
-        if runtime.name() != artifact.backend {
-            return Err(format!(
-                "artifact backend '{}' does not match loaded backend '{}'",
-                artifact.backend,
-                runtime.name()
-            ));
-        }
-
-        let label_map = luminal::dyn_backend::build_label_map(&graph);
-        Ok(Self {
-            graph,
-            runtime,
-            tensor_ids: artifact
-                .tensor_ids
-                .into_iter()
-                .map(|(name, node)| (name, NodeIndex::new(node)))
-                .collect(),
-            label_map,
-            input_names: artifact.input_names,
-            input_dtypes: artifact.input_dtypes,
-            output_names: artifact.output_names,
-            output_ids: artifact
-                .output_ids
-                .into_iter()
-                .map(NodeIndex::new)
-                .collect(),
-            output_shapes: artifact.output_shapes,
-            output_shape_exprs: artifact.output_shape_exprs,
-            output_dtypes: artifact.output_dtypes,
-            input_shape_exprs: artifact.input_shape_exprs,
-            dim_param_map: artifact.dim_param_map,
-            dim_bounds: artifact.dim_bounds,
-            writeback_outputs: artifact.writeback_outputs,
-            tensor_sizes: artifact.tensor_sizes,
-            external_cuda_graph,
-            serializable,
-        })
-    }
-
     fn output_node_at(&self, position: usize) -> PyResult<NodeIndex> {
         self.output_ids.get(position).copied().ok_or_else(|| {
             pyo3::exceptions::PyIndexError::new_err(format!(
@@ -426,54 +313,8 @@ impl CompiledGraph {
         py: Python<'py>,
         cache_key: Option<String>,
     ) -> PyResult<Bound<'py, PyBytes>> {
-        if !self.serializable {
-            return Err(pyo3::exceptions::PyRuntimeError::new_err(
-                "compiled artifacts with bound weights or input pointers are not serializable",
-            ));
-        }
-        let schedule = self.graph.selected_schedule().cloned().ok_or_else(|| {
-            pyo3::exceptions::PyRuntimeError::new_err("compiled graph has no selected schedule")
-        })?;
-        let mut input_meta = self
-            .graph
-            .input_meta
-            .iter()
-            .map(|(node, (label, dtype))| (node.index(), label.clone(), *dtype))
-            .collect::<Vec<_>>();
-        input_meta.sort_by_key(|(node, _, _)| *node);
-        let mut tensor_ids = self
-            .tensor_ids
-            .iter()
-            .map(|(name, node)| (name.clone(), node.index()))
-            .collect::<Vec<_>>();
-        tensor_ids.sort_by(|left, right| left.0.cmp(&right.0));
-
-        let artifact = CompiledArtifactData {
-            schema_version: ARTIFACT_SCHEMA_VERSION,
-            cache_key,
-            backend: self.runtime.name().to_string(),
-            backend_artifact: self.runtime.artifact_data(),
-            device_index: self.runtime.device_index(),
-            external_cuda_graph: self.external_cuda_graph,
-            dyn_map: self.graph.dyn_map.clone(),
-            input_meta,
-            tensor_sizes: self.tensor_sizes.clone(),
-            tensor_ids,
-            input_names: self.input_names.clone(),
-            input_dtypes: self.input_dtypes.clone(),
-            output_names: self.output_names.clone(),
-            output_ids: self.output_ids.iter().map(|node| node.index()).collect(),
-            output_shapes: self.output_shapes.clone(),
-            output_shape_exprs: self.output_shape_exprs.clone(),
-            output_dtypes: self.output_dtypes.clone(),
-            input_shape_exprs: self.input_shape_exprs.clone(),
-            dim_param_map: self.dim_param_map.clone(),
-            dim_bounds: self.dim_bounds.clone(),
-            writeback_outputs: self.writeback_outputs.clone(),
-            schedule,
-        };
-        let bytes = serde_json::to_vec(&artifact)
-            .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))?;
+        let bytes = artifact::serialize(self, cache_key)
+            .map_err(pyo3::exceptions::PyRuntimeError::new_err)?;
         Ok(PyBytes::new(py, &bytes))
     }
 

--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -158,12 +158,14 @@ pub struct WeightData {
     pub device_ptrs: HashMap<String, (u64, usize)>,
 }
 
-const ARTIFACT_SCHEMA_VERSION: u32 = 1;
+const ARTIFACT_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Deserialize, Serialize)]
 struct CompiledArtifactData {
     schema_version: u32,
     backend: String,
+    #[serde(default)]
+    backend_artifact: Option<String>,
     device_index: Option<usize>,
     external_cuda_graph: bool,
     dyn_map: DynMap,
@@ -255,6 +257,7 @@ impl CompiledGraph {
                 .collect(),
             tensor_sizes,
             device_ptrs,
+            backend_artifact: None,
         };
 
         // Create backend via the factory directly
@@ -338,6 +341,7 @@ impl CompiledGraph {
                 weights: Vec::new(),
                 tensor_sizes: artifact.tensor_sizes.clone(),
                 device_ptrs,
+                backend_artifact: artifact.backend_artifact,
             },
         )?;
         if runtime.name() != artifact.backend {
@@ -430,6 +434,7 @@ impl CompiledGraph {
         let artifact = CompiledArtifactData {
             schema_version: ARTIFACT_SCHEMA_VERSION,
             backend: self.runtime.name().to_string(),
+            backend_artifact: self.runtime.artifact_data(),
             device_index: self.runtime.device_index(),
             external_cuda_graph: self.external_cuda_graph,
             dyn_map: self.graph.dyn_map.clone(),

--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -6,6 +6,7 @@ use luminal::{
 };
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::typed_data::TypedData;
@@ -157,6 +158,32 @@ pub struct WeightData {
     pub device_ptrs: HashMap<String, (u64, usize)>,
 }
 
+const ARTIFACT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Deserialize, Serialize)]
+struct CompiledArtifactData {
+    schema_version: u32,
+    backend: String,
+    device_index: Option<usize>,
+    external_cuda_graph: bool,
+    dyn_map: DynMap,
+    input_meta: Vec<(usize, String, DType)>,
+    tensor_sizes: HashMap<String, usize>,
+    tensor_ids: Vec<(String, usize)>,
+    input_names: Vec<String>,
+    input_dtypes: Vec<u32>,
+    output_names: Vec<String>,
+    output_ids: Vec<usize>,
+    output_shapes: Vec<Vec<usize>>,
+    output_shape_exprs: Vec<Vec<Expression>>,
+    output_dtypes: Vec<u32>,
+    input_shape_exprs: Vec<Vec<Expression>>,
+    dim_param_map: DimParamMap,
+    dim_bounds: DimBoundsMap,
+    writeback_outputs: Vec<(usize, String)>,
+    schedule: luminal::graph::SelectedSchedule,
+}
+
 #[pyclass(unsendable)]
 pub struct CompiledGraph {
     pub graph: Graph,
@@ -178,6 +205,8 @@ pub struct CompiledGraph {
     pub dim_bounds: DimBoundsMap,
     /// See [`GraphTranslation::writeback_outputs`].
     pub writeback_outputs: Vec<(usize, String)>,
+    tensor_sizes: HashMap<String, usize>,
+    external_cuda_graph: bool,
 }
 
 impl CompiledGraph {
@@ -213,6 +242,7 @@ impl CompiledGraph {
             tensor_sizes,
             device_ptrs,
         } = weight_data;
+        let artifact_tensor_sizes = tensor_sizes.clone();
 
         // Build compile args from WeightData.
         let compile_args = BackendCompileArgs {
@@ -261,6 +291,90 @@ impl CompiledGraph {
             dim_param_map,
             dim_bounds,
             writeback_outputs,
+            tensor_sizes: artifact_tensor_sizes,
+            external_cuda_graph,
+        })
+    }
+
+    pub fn from_artifact(
+        bytes: &[u8],
+        factory: BackendFactory,
+        device_ptrs: HashMap<String, (u64, usize)>,
+        device_index: Option<usize>,
+        external_cuda_graph: bool,
+    ) -> Result<Self, String> {
+        let artifact: CompiledArtifactData =
+            serde_json::from_slice(bytes).map_err(|error| error.to_string())?;
+        if artifact.schema_version != ARTIFACT_SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported artifact schema {}, expected {}",
+                artifact.schema_version, ARTIFACT_SCHEMA_VERSION
+            ));
+        }
+        if artifact.device_index != device_index {
+            return Err(format!(
+                "artifact device {:?} does not match requested device {:?}",
+                artifact.device_index, device_index
+            ));
+        }
+        if artifact.external_cuda_graph != external_cuda_graph {
+            return Err("artifact CUDA graph mode does not match requested mode".to_string());
+        }
+
+        let input_meta = artifact
+            .input_meta
+            .iter()
+            .map(|(node, label, dtype)| (NodeIndex::new(*node), (label.clone(), *dtype)))
+            .collect();
+        let mut graph =
+            Graph::from_selected_schedule(artifact.dyn_map, input_meta, artifact.schedule);
+        let runtime = luminal::dyn_backend::compile_backend_from_factory(
+            factory,
+            &mut graph,
+            BackendCompileArgs {
+                search_iters: 0,
+                device_index,
+                external_cuda_graph,
+                weights: Vec::new(),
+                tensor_sizes: artifact.tensor_sizes.clone(),
+                device_ptrs,
+            },
+        )?;
+        if runtime.name() != artifact.backend {
+            return Err(format!(
+                "artifact backend '{}' does not match loaded backend '{}'",
+                artifact.backend,
+                runtime.name()
+            ));
+        }
+
+        let label_map = luminal::dyn_backend::build_label_map(&graph);
+        Ok(Self {
+            graph,
+            runtime,
+            tensor_ids: artifact
+                .tensor_ids
+                .into_iter()
+                .map(|(name, node)| (name, NodeIndex::new(node)))
+                .collect(),
+            label_map,
+            input_names: artifact.input_names,
+            input_dtypes: artifact.input_dtypes,
+            output_names: artifact.output_names,
+            output_ids: artifact
+                .output_ids
+                .into_iter()
+                .map(NodeIndex::new)
+                .collect(),
+            output_shapes: artifact.output_shapes,
+            output_shape_exprs: artifact.output_shape_exprs,
+            output_dtypes: artifact.output_dtypes,
+            input_shape_exprs: artifact.input_shape_exprs,
+            dim_param_map: artifact.dim_param_map,
+            dim_bounds: artifact.dim_bounds,
+            writeback_outputs: artifact.writeback_outputs,
+            tensor_sizes: artifact.tensor_sizes,
+            external_cuda_graph,
         })
     }
 
@@ -295,6 +409,51 @@ impl CompiledGraph {
 
 #[pymethods]
 impl CompiledGraph {
+    fn serialize_artifact<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+        let schedule = self.graph.selected_schedule().cloned().ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err("compiled graph has no selected schedule")
+        })?;
+        let mut input_meta = self
+            .graph
+            .input_meta
+            .iter()
+            .map(|(node, (label, dtype))| (node.index(), label.clone(), *dtype))
+            .collect::<Vec<_>>();
+        input_meta.sort_by_key(|(node, _, _)| *node);
+        let mut tensor_ids = self
+            .tensor_ids
+            .iter()
+            .map(|(name, node)| (name.clone(), node.index()))
+            .collect::<Vec<_>>();
+        tensor_ids.sort_by(|left, right| left.0.cmp(&right.0));
+
+        let artifact = CompiledArtifactData {
+            schema_version: ARTIFACT_SCHEMA_VERSION,
+            backend: self.runtime.name().to_string(),
+            device_index: self.runtime.device_index(),
+            external_cuda_graph: self.external_cuda_graph,
+            dyn_map: self.graph.dyn_map.clone(),
+            input_meta,
+            tensor_sizes: self.tensor_sizes.clone(),
+            tensor_ids,
+            input_names: self.input_names.clone(),
+            input_dtypes: self.input_dtypes.clone(),
+            output_names: self.output_names.clone(),
+            output_ids: self.output_ids.iter().map(|node| node.index()).collect(),
+            output_shapes: self.output_shapes.clone(),
+            output_shape_exprs: self.output_shape_exprs.clone(),
+            output_dtypes: self.output_dtypes.clone(),
+            input_shape_exprs: self.input_shape_exprs.clone(),
+            dim_param_map: self.dim_param_map.clone(),
+            dim_bounds: self.dim_bounds.clone(),
+            writeback_outputs: self.writeback_outputs.clone(),
+            schedule,
+        };
+        let bytes = serde_json::to_vec(&artifact)
+            .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))?;
+        Ok(PyBytes::new(py, &bytes))
+    }
+
     /// Get the list of input tensor names.
     #[getter]
     fn input_names(&self) -> Vec<String> {

--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -158,7 +158,7 @@ pub struct WeightData {
     pub device_ptrs: HashMap<String, (u64, usize)>,
 }
 
-const ARTIFACT_SCHEMA_VERSION: u32 = 2;
+const ARTIFACT_SCHEMA_VERSION: u32 = 3;
 
 #[derive(Deserialize, Serialize)]
 struct CompiledArtifactData {

--- a/crates/luminal_python/rust/src/compiled_graph/artifact.rs
+++ b/crates/luminal_python/rust/src/compiled_graph/artifact.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use super::{CompiledGraph, DimBoundsMap, DimParamMap};
 use crate::pt2_compiled_model::backend_factory;
 
-const ARTIFACT_SCHEMA_VERSION: u32 = 3;
+const ARTIFACT_SCHEMA_VERSION: u32 = 4;
 
 #[derive(Deserialize, Serialize)]
 struct CompiledArtifactData {

--- a/crates/luminal_python/rust/src/compiled_graph/artifact.rs
+++ b/crates/luminal_python/rust/src/compiled_graph/artifact.rs
@@ -1,0 +1,209 @@
+//! Serialization and loading for compiled graph artifacts.
+
+use std::collections::HashMap;
+
+use luminal::{
+    dyn_backend::{BackendCompileArgs, BackendFactory},
+    prelude::*,
+    shape::Expression,
+};
+use pyo3::{prelude::*, types::PyCapsule};
+use serde::{Deserialize, Serialize};
+
+use super::{CompiledGraph, DimBoundsMap, DimParamMap};
+use crate::pt2_compiled_model::backend_factory;
+
+const ARTIFACT_SCHEMA_VERSION: u32 = 3;
+
+#[derive(Deserialize, Serialize)]
+struct CompiledArtifactData {
+    schema_version: u32,
+    #[serde(default, rename = "luminal_artifact_key")]
+    cache_key: Option<String>,
+    backend: String,
+    #[serde(default)]
+    backend_artifact: Option<String>,
+    device_index: Option<usize>,
+    external_cuda_graph: bool,
+    dyn_map: DynMap,
+    input_meta: Vec<(usize, String, DType)>,
+    tensor_sizes: HashMap<String, usize>,
+    tensor_ids: Vec<(String, usize)>,
+    input_names: Vec<String>,
+    input_dtypes: Vec<u32>,
+    output_names: Vec<String>,
+    output_ids: Vec<usize>,
+    output_shapes: Vec<Vec<usize>>,
+    output_shape_exprs: Vec<Vec<Expression>>,
+    output_dtypes: Vec<u32>,
+    input_shape_exprs: Vec<Vec<Expression>>,
+    dim_param_map: DimParamMap,
+    dim_bounds: DimBoundsMap,
+    writeback_outputs: Vec<(usize, String)>,
+    schedule: luminal::graph::SelectedSchedule,
+}
+
+pub(super) fn serialize(
+    graph: &CompiledGraph,
+    cache_key: Option<String>,
+) -> Result<Vec<u8>, String> {
+    if !graph.serializable {
+        return Err(
+            "compiled artifacts with bound weights or input pointers are not serializable"
+                .to_string(),
+        );
+    }
+    let schedule = graph
+        .graph
+        .selected_schedule()
+        .cloned()
+        .ok_or_else(|| "compiled graph has no selected schedule".to_string())?;
+    let mut input_meta = graph
+        .graph
+        .input_meta
+        .iter()
+        .map(|(node, (label, dtype))| (node.index(), label.clone(), *dtype))
+        .collect::<Vec<_>>();
+    input_meta.sort_by_key(|(node, _, _)| *node);
+    let mut tensor_ids = graph
+        .tensor_ids
+        .iter()
+        .map(|(name, node)| (name.clone(), node.index()))
+        .collect::<Vec<_>>();
+    tensor_ids.sort_by(|left, right| left.0.cmp(&right.0));
+
+    serde_json::to_vec(&CompiledArtifactData {
+        schema_version: ARTIFACT_SCHEMA_VERSION,
+        cache_key,
+        backend: graph.runtime.name().to_string(),
+        backend_artifact: graph.runtime.artifact_data(),
+        device_index: graph.runtime.device_index(),
+        external_cuda_graph: graph.external_cuda_graph,
+        dyn_map: graph.graph.dyn_map.clone(),
+        input_meta,
+        tensor_sizes: graph.tensor_sizes.clone(),
+        tensor_ids,
+        input_names: graph.input_names.clone(),
+        input_dtypes: graph.input_dtypes.clone(),
+        output_names: graph.output_names.clone(),
+        output_ids: graph.output_ids.iter().map(|node| node.index()).collect(),
+        output_shapes: graph.output_shapes.clone(),
+        output_shape_exprs: graph.output_shape_exprs.clone(),
+        output_dtypes: graph.output_dtypes.clone(),
+        input_shape_exprs: graph.input_shape_exprs.clone(),
+        dim_param_map: graph.dim_param_map.clone(),
+        dim_bounds: graph.dim_bounds.clone(),
+        writeback_outputs: graph.writeback_outputs.clone(),
+        schedule,
+    })
+    .map_err(|error| error.to_string())
+}
+
+fn deserialize(
+    bytes: &[u8],
+    factory: BackendFactory,
+    device_ptrs: HashMap<String, (u64, usize)>,
+    device_index: Option<usize>,
+    external_cuda_graph: bool,
+) -> Result<CompiledGraph, String> {
+    let serializable = device_ptrs.is_empty();
+    let artifact: CompiledArtifactData =
+        serde_json::from_slice(bytes).map_err(|error| error.to_string())?;
+    if artifact.schema_version != ARTIFACT_SCHEMA_VERSION {
+        return Err(format!(
+            "unsupported artifact schema {}, expected {}",
+            artifact.schema_version, ARTIFACT_SCHEMA_VERSION
+        ));
+    }
+    if artifact.device_index != device_index {
+        return Err(format!(
+            "artifact device {:?} does not match requested device {:?}",
+            artifact.device_index, device_index
+        ));
+    }
+    if artifact.external_cuda_graph != external_cuda_graph {
+        return Err("artifact CUDA graph mode does not match requested mode".to_string());
+    }
+
+    let input_meta = artifact
+        .input_meta
+        .iter()
+        .map(|(node, label, dtype)| (NodeIndex::new(*node), (label.clone(), *dtype)))
+        .collect();
+    let mut graph = Graph::from_selected_schedule(artifact.dyn_map, input_meta, artifact.schedule);
+    let runtime = luminal::dyn_backend::compile_backend_from_factory(
+        factory,
+        &mut graph,
+        BackendCompileArgs {
+            search_iters: 0,
+            device_index,
+            external_cuda_graph,
+            weights: Vec::new(),
+            tensor_sizes: artifact.tensor_sizes.clone(),
+            device_ptrs,
+            backend_artifact: artifact.backend_artifact,
+        },
+    )?;
+    if runtime.name() != artifact.backend {
+        return Err(format!(
+            "artifact backend '{}' does not match loaded backend '{}'",
+            artifact.backend,
+            runtime.name()
+        ));
+    }
+
+    let label_map = luminal::dyn_backend::build_label_map(&graph);
+    Ok(CompiledGraph {
+        graph,
+        runtime,
+        tensor_ids: artifact
+            .tensor_ids
+            .into_iter()
+            .map(|(name, node)| (name, NodeIndex::new(node)))
+            .collect(),
+        label_map,
+        input_names: artifact.input_names,
+        input_dtypes: artifact.input_dtypes,
+        output_names: artifact.output_names,
+        output_ids: artifact
+            .output_ids
+            .into_iter()
+            .map(NodeIndex::new)
+            .collect(),
+        output_shapes: artifact.output_shapes,
+        output_shape_exprs: artifact.output_shape_exprs,
+        output_dtypes: artifact.output_dtypes,
+        input_shape_exprs: artifact.input_shape_exprs,
+        dim_param_map: artifact.dim_param_map,
+        dim_bounds: artifact.dim_bounds,
+        writeback_outputs: artifact.writeback_outputs,
+        tensor_sizes: artifact.tensor_sizes,
+        external_cuda_graph,
+        serializable,
+    })
+}
+
+#[pyfunction]
+#[pyo3(signature = (
+    artifact,
+    factory_capsule,
+    weight_device_ptrs=None,
+    device_index=None,
+    external_cuda_graph=false,
+))]
+pub(crate) fn load_compiled_artifact(
+    artifact: &[u8],
+    factory_capsule: &Bound<'_, PyCapsule>,
+    weight_device_ptrs: Option<HashMap<String, (u64, usize)>>,
+    device_index: Option<usize>,
+    external_cuda_graph: bool,
+) -> PyResult<CompiledGraph> {
+    deserialize(
+        artifact,
+        backend_factory(factory_capsule)?,
+        weight_device_ptrs.unwrap_or_default(),
+        device_index,
+        external_cuda_graph,
+    )
+    .map_err(pyo3::exceptions::PyRuntimeError::new_err)
+}

--- a/crates/luminal_python/rust/src/lib.rs
+++ b/crates/luminal_python/rust/src/lib.rs
@@ -11,8 +11,8 @@ pub mod pt2_schema;
 mod pt2_util;
 pub mod translator;
 
-use compiled_graph::CompiledGraph;
-use pt2_compiled_model::{TranslatedModule, load_compiled_artifact, process_pt2, translate_module};
+use compiled_graph::{CompiledGraph, load_compiled_artifact};
+use pt2_compiled_model::{TranslatedModule, process_pt2, translate_module};
 use pyo3::prelude::*;
 use pyo3::types::PyCapsule;
 use std::collections::HashMap;

--- a/crates/luminal_python/rust/src/lib.rs
+++ b/crates/luminal_python/rust/src/lib.rs
@@ -12,7 +12,7 @@ mod pt2_util;
 pub mod translator;
 
 use compiled_graph::CompiledGraph;
-use pt2_compiled_model::{TranslatedModule, process_pt2, translate_module};
+use pt2_compiled_model::{TranslatedModule, load_compiled_artifact, process_pt2, translate_module};
 use pyo3::prelude::*;
 use pyo3::types::PyCapsule;
 use std::collections::HashMap;
@@ -21,6 +21,7 @@ use torch_dtype::TorchDType;
 #[pymodule]
 pub fn luminal(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(process_pt2, m)?)?;
+    m.add_function(wrap_pyfunction!(load_compiled_artifact, m)?)?;
     m.add_function(wrap_pyfunction!(translate_module, m)?)?;
     m.add_class::<TranslatedModule>()?;
     m.add_class::<CompiledGraph>()?;

--- a/crates/luminal_python/rust/src/pt2_compiled_model.rs
+++ b/crates/luminal_python/rust/src/pt2_compiled_model.rs
@@ -158,32 +158,7 @@ pub fn process_pt2(
     .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#}")))
 }
 
-#[pyfunction]
-#[pyo3(signature = (
-    artifact,
-    factory_capsule,
-    weight_device_ptrs=None,
-    device_index=None,
-    external_cuda_graph=false,
-))]
-pub fn load_compiled_artifact(
-    artifact: &[u8],
-    factory_capsule: &Bound<'_, PyCapsule>,
-    weight_device_ptrs: Option<HashMap<String, (u64, usize)>>,
-    device_index: Option<usize>,
-    external_cuda_graph: bool,
-) -> PyResult<CompiledGraph> {
-    CompiledGraph::from_artifact(
-        artifact,
-        backend_factory(factory_capsule)?,
-        weight_device_ptrs.unwrap_or_default(),
-        device_index,
-        external_cuda_graph,
-    )
-    .map_err(pyo3::exceptions::PyRuntimeError::new_err)
-}
-
-fn backend_factory(factory_capsule: &Bound<'_, PyCapsule>) -> PyResult<BackendFactory> {
+pub(crate) fn backend_factory(factory_capsule: &Bound<'_, PyCapsule>) -> PyResult<BackendFactory> {
     let expected = ::luminal::dyn_backend::BACKEND_FACTORY_CAPSULE_NAME;
     match factory_capsule.name()? {
         Some(name) => {

--- a/crates/luminal_python/rust/src/pt2_compiled_model.rs
+++ b/crates/luminal_python/rust/src/pt2_compiled_model.rs
@@ -145,41 +145,7 @@ pub fn process_pt2(
     device_index: Option<usize>,
     external_cuda_graph: bool,
 ) -> PyResult<CompiledGraph> {
-    let factory: BackendFactory = {
-        let expected = ::luminal::dyn_backend::BACKEND_FACTORY_CAPSULE_NAME;
-        match factory_capsule.name()? {
-            Some(name) => {
-                // SAFETY: the &CStr is used immediately (for a byte-wise
-                // comparison) and never stored; the capsule is borrowed for
-                // the duration of this function, so the name pointer stays
-                // valid for as long as we read it here.
-                let actual = unsafe { name.as_cstr() };
-                if actual != expected {
-                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                        "factory_capsule has wrong name: expected {:?}, got {:?}",
-                        expected, actual,
-                    )));
-                }
-            }
-            None => {
-                return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                    "factory_capsule has no name; expected {:?}",
-                    expected
-                )));
-            }
-        }
-        let wrapper_ptr = factory_capsule
-            .pointer_checked(Some(expected))
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("{e}")))?
-            .as_ptr() as *const *const std::ffi::c_void;
-        let fn_ptr = unsafe { *wrapper_ptr };
-        if fn_ptr.is_null() {
-            return Err(pyo3::exceptions::PyValueError::new_err(
-                "factory_capsule inner function pointer is null",
-            ));
-        }
-        unsafe { std::mem::transmute(fn_ptr) }
-    };
+    let factory = backend_factory(factory_capsule)?;
     compile_pt2(
         pt2_path,
         weights_path,
@@ -190,6 +156,64 @@ pub fn process_pt2(
         external_cuda_graph,
     )
     .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#}")))
+}
+
+#[pyfunction]
+#[pyo3(signature = (
+    artifact,
+    factory_capsule,
+    weight_device_ptrs=None,
+    device_index=None,
+    external_cuda_graph=false,
+))]
+pub fn load_compiled_artifact(
+    artifact: &[u8],
+    factory_capsule: &Bound<'_, PyCapsule>,
+    weight_device_ptrs: Option<HashMap<String, (u64, usize)>>,
+    device_index: Option<usize>,
+    external_cuda_graph: bool,
+) -> PyResult<CompiledGraph> {
+    CompiledGraph::from_artifact(
+        artifact,
+        backend_factory(factory_capsule)?,
+        weight_device_ptrs.unwrap_or_default(),
+        device_index,
+        external_cuda_graph,
+    )
+    .map_err(pyo3::exceptions::PyRuntimeError::new_err)
+}
+
+fn backend_factory(factory_capsule: &Bound<'_, PyCapsule>) -> PyResult<BackendFactory> {
+    let expected = ::luminal::dyn_backend::BACKEND_FACTORY_CAPSULE_NAME;
+    match factory_capsule.name()? {
+        Some(name) => {
+            // SAFETY: the capsule owns its name for the duration of this call.
+            let actual = unsafe { name.as_cstr() };
+            if actual != expected {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "factory_capsule has wrong name: expected {:?}, got {:?}",
+                    expected, actual,
+                )));
+            }
+        }
+        None => {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "factory_capsule has no name; expected {:?}",
+                expected
+            )));
+        }
+    }
+    let wrapper_ptr = factory_capsule
+        .pointer_checked(Some(expected))
+        .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?
+        .as_ptr() as *const *const std::ffi::c_void;
+    let fn_ptr = unsafe { *wrapper_ptr };
+    if fn_ptr.is_null() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "factory_capsule inner function pointer is null",
+        ));
+    }
+    Ok(unsafe { std::mem::transmute::<*const std::ffi::c_void, BackendFactory>(fn_ptr) })
 }
 
 fn compile_pt2(

--- a/crates/luminal_python/src/luminal/__init__.py
+++ b/crates/luminal_python/src/luminal/__init__.py
@@ -2,14 +2,18 @@
 
 # Import Python components
 # Register DynamicCache pytree serialization once at import time
-from .artifact_cache import ArtifactCacheStats, artifact_cache_stats
+from .artifact_cache import (
+    ArtifactCacheStats,
+    artifact_cache_stats,
+    clear_artifact_cache,
+)
 from .cache_utils import _register_cache_serialization
 from .compiled_model import CompiledModel
 
 # Import Rust extension components (built by maturin)
 from .luminal import CompiledGraph, process_pt2
 from .main import luminal_backend, register_backend
-from .region_compile import compile_region
+from .region_compile import compile_region, load_region_artifact
 
 _register_cache_serialization()
 
@@ -18,9 +22,11 @@ __all__ = [
     "CompiledModel",
     "ArtifactCacheStats",
     "artifact_cache_stats",
+    "clear_artifact_cache",
     "luminal_backend",
     "register_backend",
     "CompiledGraph",
     "compile_region",
+    "load_region_artifact",
     "process_pt2",
 ]

--- a/crates/luminal_python/src/luminal/artifact_cache.py
+++ b/crates/luminal_python/src/luminal/artifact_cache.py
@@ -58,12 +58,11 @@ class CompiledArtifact:
         return changed
 
     def serialize(self) -> bytes:
-        data = bytes(self.graph.serialize_artifact())
-        if self.cache_key is None:
-            return data
-        payload = json.loads(data)
-        payload[_CACHE_KEY_FIELD] = self.cache_key
-        return json.dumps(payload, separators=(",", ":")).encode()
+        if self.weight_refs:
+            raise RuntimeError(
+                "compiled artifacts with bound weights are not serializable"
+            )
+        return bytes(self.graph.serialize_artifact(self.cache_key))
 
     @classmethod
     def deserialize(
@@ -167,12 +166,19 @@ def get_or_load(data, load_artifact, **options):
 
     global _loads, _load_reuse_hits, _load_seconds
 
-    payload = json.loads(bytes(data))
+    data = bytes(data)
+    payload = json.loads(data)
     identity = payload.get(_CACHE_KEY_FIELD)
     if identity is None:
-        identity = hashlib.sha256(bytes(data)).hexdigest()
+        identity = hashlib.sha256(data).hexdigest()
 
-    digest = hashlib.sha256(str(identity).encode())
+    compatibility = (
+        payload.get("schema_version"),
+        payload.get("backend"),
+        payload.get("device_index"),
+        payload.get("external_cuda_graph"),
+    )
+    digest = hashlib.sha256(repr((identity, compatibility)).encode())
     digest.update(repr(sorted(options.items())).encode())
     key = f"loaded:{digest.hexdigest()}"
 

--- a/crates/luminal_python/src/luminal/artifact_cache.py
+++ b/crates/luminal_python/src/luminal/artifact_cache.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import re
+import time
 from dataclasses import dataclass
 
 import torch
@@ -15,6 +17,11 @@ _SYMBOL = re.compile(r"\b[su]\d+\b")
 _artifacts: dict[str, CompiledArtifact] = {}
 _reuse_hits = 0
 _searches = 0
+_loads = 0
+_load_reuse_hits = 0
+_search_seconds = 0.0
+_load_seconds = 0.0
+_CACHE_KEY_FIELD = "luminal_artifact_key"
 
 
 @dataclass(frozen=True)
@@ -22,14 +29,19 @@ class ArtifactCacheStats:
     unique_artifacts: int
     reuse_hits: int
     searches: int
+    loads: int = 0
+    load_reuse_hits: int = 0
+    search_seconds: float = 0.0
+    load_seconds: float = 0.0
 
 
 class CompiledArtifact:
     """Compiled runtime shared by separate positional tensor bindings."""
 
-    def __init__(self, graph, weight_refs=()):
+    def __init__(self, graph, weight_refs=(), cache_key=None):
         self.graph = graph
         self.weight_refs = tuple(weight_refs)
+        self.cache_key = cache_key
         self._active_binding = None
 
     def bind(self, **kwargs):
@@ -46,7 +58,12 @@ class CompiledArtifact:
         return changed
 
     def serialize(self) -> bytes:
-        return bytes(self.graph.serialize_artifact())
+        data = bytes(self.graph.serialize_artifact())
+        if self.cache_key is None:
+            return data
+        payload = json.loads(data)
+        payload[_CACHE_KEY_FIELD] = self.cache_key
+        return json.dumps(payload, separators=(",", ":")).encode()
 
     @classmethod
     def deserialize(
@@ -130,23 +147,67 @@ def region_artifact_key(program, **options) -> str | None:
 
 
 def get_or_compile(key, compile_artifact):
-    global _reuse_hits, _searches
+    global _reuse_hits, _searches, _search_seconds
     artifact = _artifacts.get(key)
     if artifact is not None:
         _reuse_hits += 1
         return artifact
+    started = time.perf_counter()
     artifact = compile_artifact()
+    _search_seconds += time.perf_counter() - started
+    if isinstance(artifact, CompiledArtifact):
+        artifact.cache_key = key
     _artifacts[key] = artifact
     _searches += 1
     return artifact
 
 
+def get_or_load(data, load_artifact, **options):
+    """Load identical serialized artifacts only once per process."""
+
+    global _loads, _load_reuse_hits, _load_seconds
+
+    payload = json.loads(bytes(data))
+    identity = payload.get(_CACHE_KEY_FIELD)
+    if identity is None:
+        identity = hashlib.sha256(bytes(data)).hexdigest()
+
+    digest = hashlib.sha256(str(identity).encode())
+    digest.update(repr(sorted(options.items())).encode())
+    key = f"loaded:{digest.hexdigest()}"
+
+    artifact = _artifacts.get(key)
+    if artifact is not None:
+        _load_reuse_hits += 1
+        return artifact
+
+    started = time.perf_counter()
+    artifact = load_artifact()
+    _load_seconds += time.perf_counter() - started
+    _loads += 1
+    _artifacts[key] = artifact
+    return artifact
+
+
 def artifact_cache_stats() -> ArtifactCacheStats:
-    return ArtifactCacheStats(len(_artifacts), _reuse_hits, _searches)
+    return ArtifactCacheStats(
+        len(_artifacts),
+        _reuse_hits,
+        _searches,
+        _loads,
+        _load_reuse_hits,
+        _search_seconds,
+        _load_seconds,
+    )
 
 
 def clear_artifact_cache() -> None:
-    global _reuse_hits, _searches
+    global _reuse_hits, _searches, _loads, _load_reuse_hits
+    global _search_seconds, _load_seconds
     _artifacts.clear()
     _reuse_hits = 0
     _searches = 0
+    _loads = 0
+    _load_reuse_hits = 0
+    _search_seconds = 0.0
+    _load_seconds = 0.0

--- a/crates/luminal_python/src/luminal/artifact_cache.py
+++ b/crates/luminal_python/src/luminal/artifact_cache.py
@@ -45,6 +45,28 @@ class CompiledArtifact:
         self._active_binding = binding
         return changed
 
+    def serialize(self) -> bytes:
+        return bytes(self.graph.serialize_artifact())
+
+    @classmethod
+    def deserialize(
+        cls,
+        data,
+        factory,
+        *,
+        device_index=None,
+        external_cuda_graph=False,
+    ):
+        from .luminal import load_compiled_artifact
+
+        graph = load_compiled_artifact(
+            data,
+            factory,
+            device_index=device_index,
+            external_cuda_graph=external_cuda_graph,
+        )
+        return cls(graph)
+
 
 def region_artifact_key(program, **options) -> str | None:
     """Return None when the program contains weights that cannot be rebound."""

--- a/crates/luminal_python/src/luminal/compiled_model.py
+++ b/crates/luminal_python/src/luminal/compiled_model.py
@@ -123,6 +123,11 @@ class CompiledModel:
         """Set a dynamic dimension value by its param name."""
         self._graph.set_dim(param_name, value)
 
+    def serialize_artifact(self) -> bytes:
+        if self._artifact is None:
+            raise RuntimeError("compiled model has no serializable artifact")
+        return self._artifact.serialize()
+
     @property
     def writeback_inputs(self) -> dict:
         """{output name: input name it writes back to} for the in-place input

--- a/crates/luminal_python/src/luminal/region_compile.py
+++ b/crates/luminal_python/src/luminal/region_compile.py
@@ -2,10 +2,20 @@
 
 from __future__ import annotations
 
-from .artifact_cache import region_artifact_key
+from .artifact_cache import CompiledArtifact, region_artifact_key
 from .compiled_model import CompiledModel
 from .pt2 import _save_and_compile
 from .region_export import RegionExport
+
+
+def _cuda_factory():
+    try:
+        from .luminal import _cuda_lite_factory_capsule
+    except (ImportError, AttributeError) as error:
+        raise RuntimeError(
+            "region compilation requires luminal_python built with CUDA support"
+        ) from error
+    return _cuda_lite_factory_capsule()
 
 
 def compile_region(
@@ -33,13 +43,6 @@ def compile_region(
             f"got {region.device_index}"
         )
 
-    try:
-        from .luminal import _cuda_lite_factory_capsule
-    except (ImportError, AttributeError) as error:
-        raise RuntimeError(
-            "region compilation requires luminal_python built with CUDA support"
-        ) from error
-
     artifact_key = region_artifact_key(
         region.program,
         device_type=device_type,
@@ -50,7 +53,7 @@ def compile_region(
 
     return _save_and_compile(
         region.program,
-        _cuda_lite_factory_capsule(),
+        _cuda_factory(),
         search_iterations,
         user_indices=region.input_indices,
         output_spec=region.output_spec,
@@ -60,4 +63,25 @@ def compile_region(
         static_outputs=static_outputs,
         external_cuda_graph=external_cuda_graph,
         artifact_key=artifact_key,
+    )
+
+
+def load_region_artifact(
+    data,
+    region: RegionExport,
+    *,
+    static_outputs=False,
+    external_cuda_graph=False,
+) -> CompiledModel:
+    artifact = CompiledArtifact.deserialize(
+        data,
+        _cuda_factory(),
+        device_index=region.device_index,
+        external_cuda_graph=external_cuda_graph,
+    )
+    return artifact.bind(
+        user_indices=region.input_indices,
+        output_spec=region.output_spec,
+        use_current_stream=True,
+        static_outputs=static_outputs,
     )

--- a/crates/luminal_python/src/luminal/region_compile.py
+++ b/crates/luminal_python/src/luminal/region_compile.py
@@ -68,20 +68,22 @@ def compile_region(
 
 def load_region_artifact(
     data,
-    region: RegionExport,
     *,
+    input_indices,
+    output_spec,
+    device_index,
     static_outputs=False,
     external_cuda_graph=False,
 ) -> CompiledModel:
     artifact = CompiledArtifact.deserialize(
         data,
         _cuda_factory(),
-        device_index=region.device_index,
+        device_index=device_index,
         external_cuda_graph=external_cuda_graph,
     )
     return artifact.bind(
-        user_indices=region.input_indices,
-        output_spec=region.output_spec,
+        user_indices=input_indices,
+        output_spec=output_spec,
         use_current_stream=True,
         static_outputs=static_outputs,
     )

--- a/crates/luminal_python/src/luminal/region_compile.py
+++ b/crates/luminal_python/src/luminal/region_compile.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .artifact_cache import CompiledArtifact, region_artifact_key
+from .artifact_cache import CompiledArtifact, get_or_load, region_artifact_key
 from .compiled_model import CompiledModel
 from .pt2 import _save_and_compile
 from .region_export import RegionExport
@@ -75,9 +75,15 @@ def load_region_artifact(
     static_outputs=False,
     external_cuda_graph=False,
 ) -> CompiledModel:
-    artifact = CompiledArtifact.deserialize(
+    artifact = get_or_load(
         data,
-        _cuda_factory(),
+        lambda: CompiledArtifact.deserialize(
+            data,
+            _cuda_factory(),
+            device_index=device_index,
+            external_cuda_graph=external_cuda_graph,
+        ),
+        backend="cuda",
         device_index=device_index,
         external_cuda_graph=external_cuda_graph,
     )

--- a/crates/luminal_python/tests/test_capsule_validation.py
+++ b/crates/luminal_python/tests/test_capsule_validation.py
@@ -28,7 +28,7 @@ def test_factory_capsule_uses_versioned_abi_name():
     get_name.restype = ctypes.c_char_p
     get_name.argtypes = [ctypes.py_object]
 
-    assert get_name(_reference_factory_capsule()) == b"luminal.backend_factory.v2"
+    assert get_name(_reference_factory_capsule()) == b"luminal.backend_factory.v3"
 
 
 def test_process_pt2_rejects_capsule_with_wrong_name():

--- a/crates/luminal_python/tests/test_capsule_validation.py
+++ b/crates/luminal_python/tests/test_capsule_validation.py
@@ -28,7 +28,7 @@ def test_factory_capsule_uses_versioned_abi_name():
     get_name.restype = ctypes.c_char_p
     get_name.argtypes = [ctypes.py_object]
 
-    assert get_name(_reference_factory_capsule()) == b"luminal.backend_factory.v3"
+    assert get_name(_reference_factory_capsule()) == b"luminal.backend_factory.v2"
 
 
 def test_process_pt2_rejects_capsule_with_wrong_name():

--- a/crates/luminal_python/tests/test_region_compile.py
+++ b/crates/luminal_python/tests/test_region_compile.py
@@ -152,12 +152,14 @@ def test_region_artifact_loads_once_and_binds_each_model(monkeypatch) -> None:
     monkeypatch.setattr(region_compile_module, "_cuda_factory", object)
 
     common = {"device_index": 0, "external_cuda_graph": True}
-    assert load_region_artifact(
-        b"{}", input_indices=(0,), output_spec="first", **common
-    ) == 1
-    assert load_region_artifact(
-        b"{}", input_indices=(1,), output_spec="second", **common
-    ) == 2
+    assert (
+        load_region_artifact(b"{}", input_indices=(0,), output_spec="first", **common)
+        == 1
+    )
+    assert (
+        load_region_artifact(b"{}", input_indices=(1,), output_spec="second", **common)
+        == 2
+    )
     assert loads == 1
     assert [binding["user_indices"] for binding in bindings] == [(0,), (1,)]
     stats = artifact_cache_stats()
@@ -168,8 +170,13 @@ def test_region_artifact_loads_once_and_binds_each_model(monkeypatch) -> None:
 
 def test_loaded_artifact_uses_structural_identity() -> None:
     clear_artifact_cache()
-    first = json.dumps({"luminal_artifact_key": "region", "value": 1}).encode()
-    second = json.dumps({"luminal_artifact_key": "region", "value": 2}).encode()
+    common = {
+        "luminal_artifact_key": "region",
+        "schema_version": 3,
+        "backend": "cuda_lite",
+    }
+    first = json.dumps({**common, "value": 1}).encode()
+    second = json.dumps({**common, "value": 2}).encode()
     artifact = object()
 
     assert get_or_load(first, lambda: artifact, device_index=0) is artifact
@@ -177,9 +184,29 @@ def test_loaded_artifact_uses_structural_identity() -> None:
     clear_artifact_cache()
 
 
+def test_loaded_artifact_identity_includes_compatibility() -> None:
+    clear_artifact_cache()
+    first = json.dumps(
+        {"luminal_artifact_key": "region", "schema_version": 3, "backend": "cuda_lite"}
+    ).encode()
+    second = json.dumps(
+        {"luminal_artifact_key": "region", "schema_version": 3, "backend": "reference"}
+    ).encode()
+    artifacts = [object(), object()]
+
+    assert get_or_load(first, lambda: artifacts[0]) is artifacts[0]
+    assert get_or_load(second, lambda: artifacts[1]) is artifacts[1]
+    clear_artifact_cache()
+
+
 def test_compiled_artifact_serializes_structural_identity() -> None:
     clear_artifact_cache()
-    graph = type("Graph", (), {"serialize_artifact": lambda self: b"{}"})()
+
+    class Graph:
+        def serialize_artifact(self, cache_key=None):
+            return json.dumps({"luminal_artifact_key": cache_key}).encode()
+
+    graph = Graph()
     artifact = get_or_compile("region", lambda: CompiledArtifact(graph))
 
     assert json.loads(artifact.serialize())["luminal_artifact_key"] == "region"
@@ -199,6 +226,23 @@ def test_compiled_artifact_round_trip_cpu() -> None:
 
     (actual,) = loaded(*inputs)
     torch.testing.assert_close(actual, inputs[0] + inputs[1])
+
+
+def test_compiled_artifact_rejects_bound_weights() -> None:
+    from luminal.pt2 import compile as luminal_compile
+
+    class Weighted(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.register_buffer("weight", torch.randn(4))
+
+        def forward(self, value):
+            return value * self.weight
+
+    compiled = luminal_compile(Weighted(), [torch.randn(4)], search_iterations=1)
+
+    with pytest.raises(RuntimeError, match="bound weights"):
+        compiled.serialize_artifact()
 
 
 def test_compiled_artifact_rejects_old_schema() -> None:
@@ -464,9 +508,7 @@ def test_region_artifact_round_trip_without_cuda_recompile() -> None:
         output_spec=region.output_spec,
         device_index=region.device_index,
     )
-    inputs = [
-        torch.randn((2, 4), device="cuda", dtype=torch.float16) for _ in range(2)
-    ]
+    inputs = [torch.randn((2, 4), device="cuda", dtype=torch.float16) for _ in range(2)]
 
     (actual,) = loaded(*inputs)
     torch.testing.assert_close(actual, inputs[0] + inputs[1])

--- a/crates/luminal_python/tests/test_region_compile.py
+++ b/crates/luminal_python/tests/test_region_compile.py
@@ -16,7 +16,7 @@ from luminal.artifact_cache import (
     region_artifact_key,
 )
 from luminal.compiled_model import CompiledModel
-from luminal.region_compile import compile_region
+from luminal.region_compile import compile_region, load_region_artifact
 from luminal.region_export import export_region
 
 
@@ -127,6 +127,21 @@ def test_artifact_cache_compiles_once() -> None:
         searches=1,
     )
     clear_artifact_cache()
+
+
+def test_compiled_artifact_round_trip_cpu() -> None:
+    from luminal.luminal import _reference_factory_capsule
+    from luminal.pt2 import compile as luminal_compile
+
+    inputs = [torch.randn(2, 4), torch.randn(2, 4)]
+    compiled = luminal_compile(_add_graph(), inputs, search_iterations=1)
+    loaded = CompiledArtifact.deserialize(
+        compiled.serialize_artifact(),
+        _reference_factory_capsule(),
+    ).bind()
+
+    (actual,) = loaded(*inputs)
+    torch.testing.assert_close(actual, inputs[0] + inputs[1])
 
 
 def test_shared_artifact_rebinds_inputs_between_models() -> None:
@@ -348,6 +363,29 @@ def test_compile_region_from_fake_cuda_metadata() -> None:
     ]
     (actual,) = compiled(*real_inputs)
     torch.testing.assert_close(actual, real_inputs[0] + real_inputs[1])
+
+
+@pytest.mark.skipif(
+    _CUDA_SKIP_REASON is not None, reason=_CUDA_SKIP_REASON or "CUDA is unavailable"
+)
+def test_region_artifact_round_trip() -> None:
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        fake_inputs = [
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+        ]
+        region = export_region(_add_graph(), fake_inputs)
+
+    compiled = compile_region(region, search_iterations=1)
+    loaded = load_region_artifact(compiled.serialize_artifact(), region)
+    inputs = [
+        torch.randn((2, 4), device="cuda", dtype=torch.float16) for _ in range(2)
+    ]
+
+    (actual,) = loaded(*inputs)
+    torch.testing.assert_close(actual, inputs[0] + inputs[1])
 
 
 @pytest.mark.skipif(

--- a/crates/luminal_python/tests/test_region_compile.py
+++ b/crates/luminal_python/tests/test_region_compile.py
@@ -172,7 +172,7 @@ def test_loaded_artifact_uses_structural_identity() -> None:
     clear_artifact_cache()
     common = {
         "luminal_artifact_key": "region",
-        "schema_version": 3,
+        "schema_version": 4,
         "backend": "cuda_lite",
     }
     first = json.dumps({**common, "value": 1}).encode()
@@ -187,10 +187,10 @@ def test_loaded_artifact_uses_structural_identity() -> None:
 def test_loaded_artifact_identity_includes_compatibility() -> None:
     clear_artifact_cache()
     first = json.dumps(
-        {"luminal_artifact_key": "region", "schema_version": 3, "backend": "cuda_lite"}
+        {"luminal_artifact_key": "region", "schema_version": 4, "backend": "cuda_lite"}
     ).encode()
     second = json.dumps(
-        {"luminal_artifact_key": "region", "schema_version": 3, "backend": "reference"}
+        {"luminal_artifact_key": "region", "schema_version": 4, "backend": "reference"}
     ).encode()
     artifacts = [object(), object()]
 
@@ -498,7 +498,7 @@ def test_region_artifact_round_trip_without_cuda_recompile() -> None:
     compiled = compile_region(region, search_iterations=1)
     artifact = compiled.serialize_artifact()
     payload = json.loads(artifact)
-    assert payload["schema_version"] == 3
+    assert payload["schema_version"] == 4
     backend_artifact = json.loads(payload["backend_artifact"])
     assert backend_artifact["version"] == 2
     assert backend_artifact["images"]

--- a/crates/luminal_python/tests/test_region_compile.py
+++ b/crates/luminal_python/tests/test_region_compile.py
@@ -12,11 +12,11 @@ from torch import fx
 
 import luminal.region_compile as region_compile_module
 from luminal.artifact_cache import (
-    ArtifactCacheStats,
     CompiledArtifact,
     artifact_cache_stats,
     clear_artifact_cache,
     get_or_compile,
+    get_or_load,
     region_artifact_key,
 )
 from luminal.compiled_model import CompiledModel
@@ -125,11 +125,64 @@ def test_artifact_cache_compiles_once() -> None:
     assert get_or_compile("region", compile_artifact) is artifact
     assert get_or_compile("region", compile_artifact) is artifact
     assert calls == 1
-    assert artifact_cache_stats() == ArtifactCacheStats(
-        unique_artifacts=1,
-        reuse_hits=1,
-        searches=1,
-    )
+    stats = artifact_cache_stats()
+    assert (stats.unique_artifacts, stats.reuse_hits, stats.searches) == (1, 1, 1)
+    assert stats.search_seconds > 0
+    clear_artifact_cache()
+
+
+def test_region_artifact_loads_once_and_binds_each_model(monkeypatch) -> None:
+    clear_artifact_cache()
+    bindings = []
+
+    class Artifact:
+        def bind(self, **kwargs):
+            bindings.append(kwargs)
+            return len(bindings)
+
+    artifact = Artifact()
+    loads = 0
+
+    def deserialize(*args, **kwargs):
+        nonlocal loads
+        loads += 1
+        return artifact
+
+    monkeypatch.setattr(CompiledArtifact, "deserialize", deserialize)
+    monkeypatch.setattr(region_compile_module, "_cuda_factory", object)
+
+    common = {"device_index": 0, "external_cuda_graph": True}
+    assert load_region_artifact(
+        b"{}", input_indices=(0,), output_spec="first", **common
+    ) == 1
+    assert load_region_artifact(
+        b"{}", input_indices=(1,), output_spec="second", **common
+    ) == 2
+    assert loads == 1
+    assert [binding["user_indices"] for binding in bindings] == [(0,), (1,)]
+    stats = artifact_cache_stats()
+    assert (stats.loads, stats.load_reuse_hits) == (1, 1)
+    assert stats.load_seconds > 0
+    clear_artifact_cache()
+
+
+def test_loaded_artifact_uses_structural_identity() -> None:
+    clear_artifact_cache()
+    first = json.dumps({"luminal_artifact_key": "region", "value": 1}).encode()
+    second = json.dumps({"luminal_artifact_key": "region", "value": 2}).encode()
+    artifact = object()
+
+    assert get_or_load(first, lambda: artifact, device_index=0) is artifact
+    assert get_or_load(second, lambda: object(), device_index=0) is artifact
+    clear_artifact_cache()
+
+
+def test_compiled_artifact_serializes_structural_identity() -> None:
+    clear_artifact_cache()
+    graph = type("Graph", (), {"serialize_artifact": lambda self: b"{}"})()
+    artifact = get_or_compile("region", lambda: CompiledArtifact(graph))
+
+    assert json.loads(artifact.serialize())["luminal_artifact_key"] == "region"
     clear_artifact_cache()
 
 

--- a/crates/luminal_python/tests/test_region_compile.py
+++ b/crates/luminal_python/tests/test_region_compile.py
@@ -401,8 +401,10 @@ def test_region_artifact_round_trip_without_cuda_recompile() -> None:
     compiled = compile_region(region, search_iterations=1)
     artifact = compiled.serialize_artifact()
     payload = json.loads(artifact)
-    assert payload["schema_version"] == 2
-    assert json.loads(payload["backend_artifact"])["images"]
+    assert payload["schema_version"] == 3
+    backend_artifact = json.loads(payload["backend_artifact"])
+    assert backend_artifact["version"] == 2
+    assert backend_artifact["images"]
     loaded = load_region_artifact(
         artifact,
         input_indices=region.input_indices,

--- a/crates/luminal_python/tests/test_region_compile.py
+++ b/crates/luminal_python/tests/test_region_compile.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import json
+import subprocess
+import sys
+import textwrap
 import time
 
 import pytest
@@ -142,6 +146,22 @@ def test_compiled_artifact_round_trip_cpu() -> None:
 
     (actual,) = loaded(*inputs)
     torch.testing.assert_close(actual, inputs[0] + inputs[1])
+
+
+def test_compiled_artifact_rejects_old_schema() -> None:
+    from luminal.luminal import _reference_factory_capsule
+    from luminal.pt2 import compile as luminal_compile
+
+    inputs = [torch.randn(2, 4), torch.randn(2, 4)]
+    compiled = luminal_compile(_add_graph(), inputs, search_iterations=1)
+    artifact = json.loads(compiled.serialize_artifact())
+    artifact["schema_version"] = 1
+
+    with pytest.raises(RuntimeError, match="unsupported artifact schema 1"):
+        CompiledArtifact.deserialize(
+            json.dumps(artifact).encode(),
+            _reference_factory_capsule(),
+        )
 
 
 def test_shared_artifact_rebinds_inputs_between_models() -> None:
@@ -368,7 +388,7 @@ def test_compile_region_from_fake_cuda_metadata() -> None:
 @pytest.mark.skipif(
     _CUDA_SKIP_REASON is not None, reason=_CUDA_SKIP_REASON or "CUDA is unavailable"
 )
-def test_region_artifact_round_trip() -> None:
+def test_region_artifact_round_trip_without_cuda_recompile() -> None:
     from torch._subclasses.fake_tensor import FakeTensorMode
 
     with FakeTensorMode():
@@ -379,13 +399,84 @@ def test_region_artifact_round_trip() -> None:
         region = export_region(_add_graph(), fake_inputs)
 
     compiled = compile_region(region, search_iterations=1)
-    loaded = load_region_artifact(compiled.serialize_artifact(), region)
+    artifact = compiled.serialize_artifact()
+    payload = json.loads(artifact)
+    assert payload["schema_version"] == 2
+    assert json.loads(payload["backend_artifact"])["images"]
+    loaded = load_region_artifact(
+        artifact,
+        input_indices=region.input_indices,
+        output_spec=region.output_spec,
+        device_index=region.device_index,
+    )
     inputs = [
         torch.randn((2, 4), device="cuda", dtype=torch.float16) for _ in range(2)
     ]
 
     (actual,) = loaded(*inputs)
     torch.testing.assert_close(actual, inputs[0] + inputs[1])
+
+
+@pytest.mark.skipif(
+    _CUDA_SKIP_REASON is not None, reason=_CUDA_SKIP_REASON or "CUDA is unavailable"
+)
+def test_region_artifact_loads_in_fresh_process(tmp_path) -> None:
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        fake_inputs = [
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+        ]
+        region = export_region(_add_graph(), fake_inputs)
+
+    artifact_path = tmp_path / "region.luminal"
+    artifact_path.write_bytes(
+        compile_region(region, search_iterations=1).serialize_artifact()
+    )
+    script = textwrap.dedent(
+        """
+        import sys
+        from pathlib import Path
+
+        import torch
+        from torch import fx
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from luminal.region_compile import load_region_artifact
+        from luminal.region_export import export_region
+
+        graph = fx.Graph()
+        left = graph.placeholder("left")
+        right = graph.placeholder("right")
+        result = graph.call_function(torch.ops.aten.add.Tensor, (left, right))
+        graph.output((result,))
+        module = fx.GraphModule(torch.nn.Module(), graph)
+        with FakeTensorMode():
+            fake_inputs = [
+                torch.empty((2, 4), device="cuda", dtype=torch.float16),
+                torch.empty((2, 4), device="cuda", dtype=torch.float16),
+            ]
+            region = export_region(module, fake_inputs)
+        model = load_region_artifact(
+            Path(sys.argv[1]).read_bytes(),
+            input_indices=region.input_indices,
+            output_spec=region.output_spec,
+            device_index=region.device_index,
+        )
+        inputs = [
+            torch.randn((2, 4), device="cuda", dtype=torch.float16)
+            for _ in range(2)
+        ]
+        (actual,) = model(*inputs)
+        torch.testing.assert_close(actual, inputs[0] + inputs[1])
+        """
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", script, str(artifact_path)],
+        check=True,
+        text=True,
+    )
 
 
 @pytest.mark.skipif(

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Display};
 
 /// Supported dtypes
 /// This is undergoing development. Our goal is to be as explicit as possible about dtype behavior.
-#[derive(Clone, Copy, PartialEq, Default)]
+#[derive(Clone, Copy, PartialEq, Default, serde::Deserialize, serde::Serialize)]
 pub enum DType {
     /// 32-bit float (8e23m)
     #[default]

--- a/src/dyn_backend.rs
+++ b/src/dyn_backend.rs
@@ -169,6 +169,7 @@ pub type SetDevicePtrFn<'a, Rt> = &'a dyn Fn(&mut Rt, NodeIndex, u64, usize);
 /// - `init`: create the concrete runtime
 /// - `set_raw`: upload raw bytes + dtype to a node
 /// - `set_device_ptr`: optional zero-copy device pointer setter
+/// - `finalize`: perform backend-specific finalization after schedule selection
 /// - `wrap`: wrap the final runtime in a `Box<dyn DynBackend>`
 pub fn compile_backend<Rt: Runtime + 'static>(
     graph: &mut Graph,
@@ -176,6 +177,7 @@ pub fn compile_backend<Rt: Runtime + 'static>(
     init: impl FnOnce() -> Result<Rt, String>,
     set_raw: impl Fn(&mut Rt, NodeIndex, Vec<u8>, DType),
     set_device_ptr: Option<SetDevicePtrFn<'_, Rt>>,
+    finalize: impl FnOnce(&mut Graph, &mut Rt) -> Result<(), String>,
     wrap: impl FnOnce(Rt) -> Box<dyn DynBackend>,
 ) -> Result<Box<dyn DynBackend>, String> {
     // Build label map from input_meta (plain data — no downcast needed,
@@ -222,6 +224,8 @@ pub fn compile_backend<Rt: Runtime + 'static>(
             CompileOptions::default().search_graph_limit(args.search_iters),
         );
     }
+
+    finalize(graph, &mut rt)?;
 
     // Rebuild label map after search (graph may have changed)
     let label_map = build_label_map(graph);
@@ -510,6 +514,7 @@ pub fn reference_factory(
             }
         },
         None,
+        |_, _| Ok(()),
         |rt| Box::new(ReferenceDynBackend { runtime: rt }),
     )
 }

--- a/src/dyn_backend.rs
+++ b/src/dyn_backend.rs
@@ -177,7 +177,10 @@ pub fn compile_backend<Rt: Runtime + 'static>(
     // survives cross-binary type identity mismatches with external plugins).
     let label_map = build_label_map(graph);
 
-    graph.build_search_space::<Rt>(CompileOptions::default());
+    let has_selected_schedule = graph.selected_schedule().is_some();
+    if !has_selected_schedule {
+        graph.build_search_space::<Rt>(CompileOptions::default());
+    }
 
     let mut rt = init()?;
 
@@ -205,11 +208,15 @@ pub fn compile_backend<Rt: Runtime + 'static>(
         }
     }
 
-    // Search
-    let mut rt = graph.search(
-        rt,
-        CompileOptions::default().search_graph_limit(args.search_iters),
-    );
+    let mut rt = rt;
+    if has_selected_schedule {
+        graph.load_selected_schedule(&mut rt)?;
+    } else {
+        rt = graph.search(
+            rt,
+            CompileOptions::default().search_graph_limit(args.search_iters),
+        );
+    }
 
     // Rebuild label map after search (graph may have changed)
     let label_map = build_label_map(graph);

--- a/src/dyn_backend.rs
+++ b/src/dyn_backend.rs
@@ -29,6 +29,10 @@ use crate::shape::DynMap;
 pub trait DynBackend {
     fn name(&self) -> &str;
 
+    fn artifact_data(&self) -> Option<String> {
+        None
+    }
+
     /// The device type this backend operates on (e.g. "cpu", "cuda").
     /// Used by the Python frontend to decide input tensor placement.
     fn device_type(&self) -> &str {
@@ -127,6 +131,7 @@ pub struct BackendCompileArgs {
     pub weights: Vec<(String, Vec<u8>, DType)>,
     pub tensor_sizes: HashMap<String, usize>,
     pub device_ptrs: HashMap<String, (u64, usize)>,
+    pub backend_artifact: Option<String>,
 }
 
 /// Canonical PyCapsule name for [`BackendFactory`] function-pointer capsules.
@@ -134,7 +139,7 @@ pub struct BackendCompileArgs {
 /// The version is part of the ABI: `BackendCompileArgs` crosses this boundary
 /// by value, so an older plugin must be rejected rather than reading a changed
 /// struct layout.
-pub const BACKEND_FACTORY_CAPSULE_NAME: &std::ffi::CStr = c"luminal.backend_factory.v2";
+pub const BACKEND_FACTORY_CAPSULE_NAME: &std::ffi::CStr = c"luminal.backend_factory.v3";
 
 /// A factory function that compiles a [`Graph`] into a ready-to-execute [`DynBackend`].
 pub type BackendFactory = fn(&mut Graph, BackendCompileArgs) -> Result<Box<dyn DynBackend>, String>;

--- a/src/dyn_backend.rs
+++ b/src/dyn_backend.rs
@@ -139,7 +139,7 @@ pub struct BackendCompileArgs {
 /// The version is part of the ABI: `BackendCompileArgs` crosses this boundary
 /// by value, so an older plugin must be rejected rather than reading a changed
 /// struct layout.
-pub const BACKEND_FACTORY_CAPSULE_NAME: &std::ffi::CStr = c"luminal.backend_factory.v3";
+pub const BACKEND_FACTORY_CAPSULE_NAME: &std::ffi::CStr = c"luminal.backend_factory.v2";
 
 /// A factory function that compiles a [`Graph`] into a ready-to-execute [`DynBackend`].
 pub type BackendFactory = fn(&mut Graph, BackendCompileArgs) -> Result<Box<dyn DynBackend>, String>;
@@ -219,6 +219,7 @@ pub fn compile_backend<Rt: Runtime + 'static>(
     if has_selected_schedule {
         graph.load_selected_schedule(&mut rt)?;
     } else {
+        // Search
         rt = graph.search(
             rt,
             CompileOptions::default().search_graph_limit(args.search_iters),

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -1991,8 +1991,11 @@ impl<'a> LlirExtractor<'a> {
             .map(|(index, op)| (op.sort().name, index))
             .collect();
 
+        let mut classes = egraph.eclasses.keys().collect::<Vec<_>>();
+        classes.sort_unstable_by(|left, right| left.as_ref().cmp(right.as_ref()));
+
         let mut class_to_index = FxHashMap::default();
-        for (index, class) in egraph.eclasses.keys().enumerate() {
+        for (index, class) in classes.into_iter().enumerate() {
             let index = DenseIndex::try_from(index).expect("too many e-classes to index");
             class_to_index.insert(class, index);
         }
@@ -3607,9 +3610,9 @@ fn egglog_to_llir_from_root_cached<'a>(
 #[cfg(test)]
 mod tests {
     use super::{
-        EGraphChoiceSet, LateEgglogPass, OpTextParts, SerializedEGraph, count_choice_sets_up_to,
-        egglog_setup_with_options, random_initial_choice, run_egglog_with_late_passes,
-        validate_choice_set,
+        EGraphChoiceSet, LateEgglogPass, LlirExtractor, OpTextParts, SerializedEGraph,
+        count_choice_sets_up_to, egglog_setup_with_options, random_initial_choice,
+        run_egglog_with_late_passes, validate_choice_set,
     };
     use crate::egglog_utils::api::{Rule, SortDef, sort};
     use crate::egglog_utils::base::OP_KIND;
@@ -3704,6 +3707,26 @@ mod tests {
             node_to_class: FxHashMap::default(),
             roots: Vec::new(),
         }
+    }
+
+    #[test]
+    fn llir_extractor_indexes_eclasses_by_id() {
+        let root = ClassId::from("c");
+        let mut egraph = egraph(vec![
+            eclass("c", "Shape", 1),
+            eclass("a", "Shape", 1),
+            eclass("b", "Shape", 1),
+        ]);
+        egraph.roots.push(root);
+
+        let extractor = LlirExtractor::new(&egraph, &[]);
+        let ids = extractor
+            .indexed_classes
+            .iter()
+            .map(|class| class.id.as_ref())
+            .collect::<Vec<_>>();
+
+        assert_eq!(ids, ["a", "b", "c"]);
     }
 
     #[test]

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -454,7 +454,7 @@ use crate::{
 use egglog::{ArcSort, CommandOutput, EGraph, Value};
 use egglog_reports::ReportLevel;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 ///  This is snapshot of an EGraph with Rust native hash maps and sets for enabling more native traversal / algorithm writing.
 ///  The name comes from the serialize egraph crates, which returns a ETermDAG, which caused issues, so this is a homebrew semi-static egraph
 pub struct SerializedEGraph {
@@ -2197,6 +2197,39 @@ impl<'a> LlirExtractor<'a> {
             choices: indexed,
             hash,
         }
+    }
+
+    pub(crate) fn named_choices(&self, choices: &IndexedChoiceSet) -> Vec<(String, String)> {
+        self.indexed_classes
+            .iter()
+            .enumerate()
+            .filter(|(_, class)| class.searchable)
+            .map(|(index, class)| {
+                let slot = choices.choices[index] as usize;
+                (class.id.to_string(), class.nodes[slot].to_string())
+            })
+            .collect()
+    }
+
+    pub(crate) fn index_named_choices(&self, choices: &[(String, String)]) -> IndexedChoiceSet {
+        let choices = choices
+            .iter()
+            .map(|(class, node)| {
+                let class = self
+                    .egraph
+                    .eclasses
+                    .keys()
+                    .find(|candidate| candidate.as_ref() == class)
+                    .unwrap_or_else(|| panic!("artifact references unknown e-class '{class}'"));
+                let node = self.egraph.eclasses[class]
+                    .1
+                    .iter()
+                    .find(|candidate| candidate.as_ref() == node)
+                    .unwrap_or_else(|| panic!("artifact references unknown e-node '{node}'"));
+                (class, node)
+            })
+            .collect();
+        self.index_choice_set(&choices)
     }
 
     pub fn random_indexed_choice(&self, rng: &mut (impl Rng + ?Sized)) -> IndexedChoiceSet {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -20,6 +20,10 @@ use std::{
 };
 use tracing;
 
+mod artifact;
+
+pub use artifact::{ScheduleBucket, SelectedSchedule};
+
 pub type LLIRGraph = StableGraph<LLIROp, ()>;
 pub type HLIRGraph = StableGraph<Box<dyn HLIROp>, ()>;
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -97,7 +97,7 @@ impl<'a> From<&'a BucketLLIR> for BucketLLIRRef<'a> {
 
 /// A bucket for a dynamic dimension, defining a range of valid values.
 /// For an exact value, use `min == max` (zero-length range).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct DimBucket {
     pub min: usize,
     pub max: usize,
@@ -412,6 +412,7 @@ pub struct Graph {
     /// Stored as plain data so it survives cross-binary type identity mismatches
     /// when external backend plugins are compiled separately.
     pub input_meta: FxHashMap<NodeIndex, (String, DType)>,
+    selected_schedule: Option<SelectedSchedule>,
 }
 
 impl Graph {
@@ -1758,6 +1759,7 @@ impl Graph {
             "dim buckets must be configured in CompileOptions before build_search_space; search cannot change buckets after build",
         );
         runtime.compile(space, &self.dyn_map, &options, rng);
+        self.selected_schedule = runtime.selected_schedule();
         runtime
     }
 }

--- a/src/graph/artifact.rs
+++ b/src/graph/artifact.rs
@@ -1,27 +1,109 @@
-use super::{DimBucket, Graph, LlirFingerprint, fingerprint_llir, unroll_packed_llir};
+use std::{
+    collections::hash_map::DefaultHasher,
+    fmt::Write,
+    hash::{Hash, Hasher},
+};
+
+use petgraph::{
+    stable_graph::NodeIndex,
+    visit::{EdgeRef, NodeIndexable},
+};
+use rustc_hash::FxHashMap;
+
+use super::{DimBucket, Graph, LLIRGraph};
 use crate::{
     dtype::DType,
     egglog_utils::{LlirExtractor, SerializedEGraph},
     hlir::HLIROps,
     op::{IntoEgglogOp, Runtime},
+    search::{SearchSpace, SelectedProgram, unroll_packed_llir},
     shape::{DynMap, Symbol},
 };
-use petgraph::stable_graph::NodeIndex;
-use rustc_hash::FxHashMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+struct LlirFingerprint(u64, u64);
+
+fn fingerprint_llir(llir: &LLIRGraph) -> LlirFingerprint {
+    fn hash(seed: u64, llir: &LLIRGraph) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        seed.hash(&mut hasher);
+        llir.node_bound().hash(&mut hasher);
+        llir.edge_count().hash(&mut hasher);
+        for index in 0..llir.node_bound() {
+            let node = NodeIndex::new(index);
+            match llir.node_weight(node) {
+                Some(op) => {
+                    1u8.hash(&mut hasher);
+                    write!(&mut HashWriter(&mut hasher), "{op:?}").unwrap();
+                    let mut incoming = llir
+                        .edges_directed(node, petgraph::Direction::Incoming)
+                        .map(|edge| (edge.id().index(), edge.source().index()))
+                        .collect::<Vec<_>>();
+                    incoming.sort_unstable();
+                    incoming.hash(&mut hasher);
+                }
+                None => 0u8.hash(&mut hasher),
+            }
+        }
+        hasher.finish()
+    }
+
+    LlirFingerprint(
+        hash(0x243f_6a88_85a3_08d3, llir),
+        hash(0x1319_8a2e_0370_7344, llir),
+    )
+}
+
+struct HashWriter<'a>(&'a mut DefaultHasher);
+
+impl std::fmt::Write for HashWriter<'_> {
+    fn write_str(&mut self, value: &str) -> std::fmt::Result {
+        self.0.write(value.as_bytes());
+        Ok(())
+    }
+}
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct ScheduleBucket {
-    pub(super) egraph: SerializedEGraph,
-    pub(super) choices: Vec<(String, String)>,
-    pub(super) bucket_indices: DynMap,
-    pub(super) representative_dyn_map: DynMap,
-    pub(super) unrolled_llir_fingerprint: LlirFingerprint,
+    egraph: SerializedEGraph,
+    choices: Vec<(String, String)>,
+    bucket_indices: DynMap,
+    representative_dyn_map: DynMap,
+    unrolled_llir_fingerprint: LlirFingerprint,
 }
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct SelectedSchedule {
-    pub(super) dim_buckets: FxHashMap<Symbol, Vec<DimBucket>>,
-    pub(super) buckets: Vec<ScheduleBucket>,
+    dim_buckets: FxHashMap<Symbol, Vec<DimBucket>>,
+    buckets: Vec<ScheduleBucket>,
+}
+
+impl SelectedSchedule {
+    #[doc(hidden)]
+    pub fn from_search(space: &SearchSpace, selected: &[SelectedProgram]) -> Option<Self> {
+        if !space.custom_ops.is_empty() || selected.len() != space.buckets.len() {
+            return None;
+        }
+        let buckets = space
+            .buckets
+            .iter()
+            .zip(selected)
+            .map(|(bucket, selected)| {
+                let extractor = LlirExtractor::new(&bucket.egraph, &space.ops);
+                ScheduleBucket {
+                    egraph: bucket.egraph.clone(),
+                    choices: extractor.named_choices(&selected.genome),
+                    bucket_indices: selected.bucket_indices.clone(),
+                    representative_dyn_map: selected.representative_dyn_map.clone(),
+                    unrolled_llir_fingerprint: fingerprint_llir(&selected.llir),
+                }
+            })
+            .collect();
+        Some(Self {
+            dim_buckets: space.dim_buckets.clone(),
+            buckets,
+        })
+    }
 }
 
 impl Graph {
@@ -43,17 +125,13 @@ impl Graph {
     }
 
     pub fn load_selected_schedule<R: Runtime + 'static>(
-        &mut self,
+        &self,
         runtime: &mut R,
     ) -> Result<(), String> {
         let schedule = self
             .selected_schedule
             .as_ref()
             .ok_or_else(|| "graph has no selected schedule".to_string())?;
-        if !self.custom_ops.is_empty() {
-            return Err("selected schedules with custom ops are not serializable".to_string());
-        }
-
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let mut ops = R::Ops::into_vec();
             ops.extend(<HLIROps as IntoEgglogOp>::into_vec());
@@ -64,13 +142,12 @@ impl Graph {
                 .map(|(bucket_idx, bucket)| {
                     let mut extractor = LlirExtractor::new(&bucket.egraph, &ops);
                     let choices = extractor.index_named_choices(&bucket.choices);
-                    let packed = extractor.extract_indexed_packed(&choices, &[], None);
+                    let packed = extractor.extract_indexed_packed(&choices, &[]);
                     let llir = unroll_packed_llir(packed);
-                    let fingerprint = fingerprint_llir(&llir);
                     assert_eq!(
-                        fingerprint, bucket.unrolled_llir_fingerprint,
-                        "selected schedule bucket {bucket_idx} unrolled LLIR fingerprint mismatch: expected {:?}, got {:?}",
-                        bucket.unrolled_llir_fingerprint, fingerprint,
+                        fingerprint_llir(&llir),
+                        bucket.unrolled_llir_fingerprint,
+                        "selected schedule bucket {bucket_idx} unrolled LLIR fingerprint mismatch",
                     );
                     (
                         bucket.bucket_indices.clone(),
@@ -89,5 +166,56 @@ impl Graph {
                 .unwrap_or("non-string panic");
             format!("selected schedule could not be loaded: {detail}")
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{graph::CompileOptions, hlir::ReferenceRuntime};
+
+    fn selected_schedule() -> (Graph, SelectedSchedule) {
+        let mut graph = Graph::new();
+        let _ = graph.tensor(4).sin().output();
+        graph.build_search_space::<ReferenceRuntime>(CompileOptions::default());
+        let space = graph.search_space().unwrap();
+        let ctx = &space.bucket_contexts(&graph.dyn_map)[0];
+        let mut extractor = LlirExtractor::new(ctx.egraph(), &space.ops);
+        let genome = extractor.random_indexed_choice(&mut rand::rng());
+        let llir = unroll_packed_llir(extractor.extract_indexed_packed(&genome, &[]));
+        let selected = SelectedProgram {
+            bucket_indices: ctx.bucket_indices().clone(),
+            representative_dyn_map: ctx.representative_dyn_map.clone(),
+            genome,
+            llir,
+        };
+        let schedule = SelectedSchedule::from_search(space, &[selected]).unwrap();
+        (graph, schedule)
+    }
+
+    #[test]
+    fn selected_schedule_round_trip_skips_search() {
+        let (graph, schedule) = selected_schedule();
+        let bytes = serde_json::to_vec(&schedule).unwrap();
+        let schedule = serde_json::from_slice(&bytes).unwrap();
+        let loaded = Graph::from_selected_schedule(
+            graph.dyn_map.clone(),
+            graph.input_meta.clone(),
+            schedule,
+        );
+        loaded
+            .load_selected_schedule(&mut ReferenceRuntime::initialize(()))
+            .unwrap();
+    }
+
+    #[test]
+    fn selected_schedule_rejects_changed_llir() {
+        let (graph, mut schedule) = selected_schedule();
+        schedule.buckets[0].unrolled_llir_fingerprint.0 ^= 1;
+        let loaded = Graph::from_selected_schedule(graph.dyn_map, graph.input_meta, schedule);
+        let error = loaded
+            .load_selected_schedule(&mut ReferenceRuntime::initialize(()))
+            .unwrap_err();
+        assert!(error.contains("fingerprint mismatch"), "{error}");
     }
 }

--- a/src/graph/artifact.rs
+++ b/src/graph/artifact.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use petgraph::{
+    algo::toposort,
     stable_graph::NodeIndex,
     visit::{EdgeRef, NodeIndexable},
 };
@@ -20,38 +21,47 @@ use crate::{
     shape::{DynMap, Symbol},
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
 struct LlirFingerprint(u64, u64);
 
 fn fingerprint_llir(llir: &LLIRGraph) -> LlirFingerprint {
-    fn hash(seed: u64, llir: &LLIRGraph) -> u64 {
+    fn hash_node(seed: u64, op: &crate::op::LLIROp, inputs: &[LlirFingerprint]) -> u64 {
         let mut hasher = DefaultHasher::new();
         seed.hash(&mut hasher);
-        llir.node_bound().hash(&mut hasher);
-        llir.edge_count().hash(&mut hasher);
-        for index in 0..llir.node_bound() {
-            let node = NodeIndex::new(index);
-            match llir.node_weight(node) {
-                Some(op) => {
-                    1u8.hash(&mut hasher);
-                    write!(&mut HashWriter(&mut hasher), "{op:?}").unwrap();
-                    let mut incoming = llir
-                        .edges_directed(node, petgraph::Direction::Incoming)
-                        .map(|edge| (edge.id().index(), edge.source().index()))
-                        .collect::<Vec<_>>();
-                    incoming.sort_unstable();
-                    incoming.hash(&mut hasher);
-                }
-                None => 0u8.hash(&mut hasher),
-            }
-        }
+        write!(&mut HashWriter(&mut hasher), "{op:?}").unwrap();
+        inputs.hash(&mut hasher);
         hasher.finish()
     }
 
-    LlirFingerprint(
-        hash(0x243f_6a88_85a3_08d3, llir),
-        hash(0x1319_8a2e_0370_7344, llir),
-    )
+    let mut node_fingerprints = vec![None; llir.node_bound()];
+    for node in toposort(llir, None).expect("LLIR must be acyclic") {
+        let mut incoming = llir
+            .edges_directed(node, petgraph::Direction::Incoming)
+            .map(|edge| (edge.id().index(), edge.source()))
+            .collect::<Vec<_>>();
+        incoming.sort_unstable_by_key(|(edge, _)| *edge);
+        let inputs = incoming
+            .into_iter()
+            .map(|(_, source)| node_fingerprints[source.index()].unwrap())
+            .collect::<Vec<_>>();
+        let op = &llir[node];
+        node_fingerprints[node.index()] = Some(LlirFingerprint(
+            hash_node(0x243f_6a88_85a3_08d3, op, &inputs),
+            hash_node(0x1319_8a2e_0370_7344, op, &inputs),
+        ));
+    }
+
+    let mut nodes = node_fingerprints.into_iter().flatten().collect::<Vec<_>>();
+    nodes.sort_unstable_by_key(|fingerprint| (fingerprint.0, fingerprint.1));
+    let mut first = DefaultHasher::new();
+    let mut second = DefaultHasher::new();
+    0x243f_6a88_85a3_08d3_u64.hash(&mut first);
+    0x1319_8a2e_0370_7344_u64.hash(&mut second);
+    llir.edge_count().hash(&mut first);
+    llir.edge_count().hash(&mut second);
+    nodes.hash(&mut first);
+    nodes.hash(&mut second);
+    LlirFingerprint(first.finish(), second.finish())
 }
 
 struct HashWriter<'a>(&'a mut DefaultHasher);
@@ -89,13 +99,18 @@ impl SelectedSchedule {
             .iter()
             .zip(selected)
             .map(|(bucket, selected)| {
-                let extractor = LlirExtractor::new(&bucket.egraph, &space.ops);
+                let mut extractor = LlirExtractor::new(&bucket.egraph, &space.ops);
+                let choices = extractor.named_choices(&selected.genome);
+                let indexed = extractor.index_named_choices(&choices);
+                let llir = unroll_packed_llir(
+                    extractor.extract_indexed_packed(&indexed, &space.custom_ops),
+                );
                 ScheduleBucket {
                     egraph: bucket.egraph.clone(),
-                    choices: extractor.named_choices(&selected.genome),
+                    choices,
                     bucket_indices: selected.bucket_indices.clone(),
                     representative_dyn_map: selected.representative_dyn_map.clone(),
-                    unrolled_llir_fingerprint: fingerprint_llir(&selected.llir),
+                    unrolled_llir_fingerprint: fingerprint_llir(&llir),
                 }
             })
             .collect();
@@ -174,6 +189,27 @@ mod tests {
     use super::*;
     use crate::{graph::CompileOptions, hlir::ReferenceRuntime};
 
+    fn renumber_llir(llir: &LLIRGraph) -> LLIRGraph {
+        let nodes = llir.node_indices().collect::<Vec<_>>();
+        let mut rebuilt = LLIRGraph::default();
+        let mapping = nodes
+            .iter()
+            .rev()
+            .map(|&node| (node, rebuilt.add_node(llir[node].clone())))
+            .collect::<FxHashMap<_, _>>();
+        for &target in nodes.iter().rev() {
+            let mut incoming = llir
+                .edges_directed(target, petgraph::Direction::Incoming)
+                .map(|edge| (edge.id().index(), edge.source()))
+                .collect::<Vec<_>>();
+            incoming.sort_unstable_by_key(|(edge, _)| *edge);
+            for (_, source) in incoming {
+                rebuilt.add_edge(mapping[&source], mapping[&target], ());
+            }
+        }
+        rebuilt
+    }
+
     fn selected_schedule() -> (Graph, SelectedSchedule) {
         let mut graph = Graph::new();
         let _ = graph.tensor(4).sin().output();
@@ -217,5 +253,29 @@ mod tests {
             .load_selected_schedule(&mut ReferenceRuntime::initialize(()))
             .unwrap_err();
         assert!(error.contains("fingerprint mismatch"), "{error}");
+    }
+
+    #[test]
+    fn reference_compile_retains_selected_schedule() {
+        let mut graph = Graph::new();
+        let _ = graph.tensor(4).sin().output();
+        let _runtime = graph.compile(ReferenceRuntime::initialize(()), CompileOptions::default());
+
+        assert!(graph.selected_schedule().is_some());
+    }
+
+    #[test]
+    fn llir_fingerprint_ignores_graph_allocation_order() {
+        let (graph, _) = selected_schedule();
+        let space = graph.search_space().unwrap();
+        let ctx = &space.bucket_contexts(&graph.dyn_map)[0];
+        let mut extractor = LlirExtractor::new(ctx.egraph(), &space.ops);
+        let genome = extractor.random_indexed_choice(&mut rand::rng());
+        let llir = unroll_packed_llir(extractor.extract_indexed_packed(&genome, &[]));
+
+        assert_eq!(
+            fingerprint_llir(&llir),
+            fingerprint_llir(&renumber_llir(&llir))
+        );
     }
 }

--- a/src/graph/artifact.rs
+++ b/src/graph/artifact.rs
@@ -1,0 +1,93 @@
+use super::{DimBucket, Graph, LlirFingerprint, fingerprint_llir, unroll_packed_llir};
+use crate::{
+    dtype::DType,
+    egglog_utils::{LlirExtractor, SerializedEGraph},
+    hlir::HLIROps,
+    op::{IntoEgglogOp, Runtime},
+    shape::{DynMap, Symbol},
+};
+use petgraph::stable_graph::NodeIndex;
+use rustc_hash::FxHashMap;
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct ScheduleBucket {
+    pub(super) egraph: SerializedEGraph,
+    pub(super) choices: Vec<(String, String)>,
+    pub(super) bucket_indices: DynMap,
+    pub(super) representative_dyn_map: DynMap,
+    pub(super) unrolled_llir_fingerprint: LlirFingerprint,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct SelectedSchedule {
+    pub(super) dim_buckets: FxHashMap<Symbol, Vec<DimBucket>>,
+    pub(super) buckets: Vec<ScheduleBucket>,
+}
+
+impl Graph {
+    pub fn selected_schedule(&self) -> Option<&SelectedSchedule> {
+        self.selected_schedule.as_ref()
+    }
+
+    pub fn from_selected_schedule(
+        dyn_map: DynMap,
+        input_meta: FxHashMap<NodeIndex, (String, DType)>,
+        schedule: SelectedSchedule,
+    ) -> Self {
+        Self {
+            dyn_map,
+            input_meta,
+            selected_schedule: Some(schedule),
+            ..Self::default()
+        }
+    }
+
+    pub fn load_selected_schedule<R: Runtime + 'static>(
+        &mut self,
+        runtime: &mut R,
+    ) -> Result<(), String> {
+        let schedule = self
+            .selected_schedule
+            .as_ref()
+            .ok_or_else(|| "graph has no selected schedule".to_string())?;
+        if !self.custom_ops.is_empty() {
+            return Err("selected schedules with custom ops are not serializable".to_string());
+        }
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut ops = R::Ops::into_vec();
+            ops.extend(<HLIROps as IntoEgglogOp>::into_vec());
+            let bucket_llirs = schedule
+                .buckets
+                .iter()
+                .enumerate()
+                .map(|(bucket_idx, bucket)| {
+                    let mut extractor = LlirExtractor::new(&bucket.egraph, &ops);
+                    let choices = extractor.index_named_choices(&bucket.choices);
+                    let packed = extractor.extract_indexed_packed(&choices, &[], None);
+                    let llir = unroll_packed_llir(packed);
+                    let fingerprint = fingerprint_llir(&llir);
+                    assert_eq!(
+                        fingerprint, bucket.unrolled_llir_fingerprint,
+                        "selected schedule bucket {bucket_idx} unrolled LLIR fingerprint mismatch: expected {:?}, got {:?}",
+                        bucket.unrolled_llir_fingerprint, fingerprint,
+                    );
+                    (
+                        bucket.bucket_indices.clone(),
+                        bucket.representative_dyn_map.clone(),
+                        llir,
+                    )
+                })
+                .collect::<Vec<_>>();
+            runtime.load_llir_buckets(&schedule.dim_buckets, &bucket_llirs);
+        }));
+        result.map_err(|payload| {
+            let detail = payload
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .or_else(|| payload.downcast_ref::<&str>().copied())
+                .unwrap_or("non-string panic");
+            format!("selected schedule could not be loaded: {detail}")
+        })
+    }
+}

--- a/src/hlir.rs
+++ b/src/hlir.rs
@@ -3185,6 +3185,7 @@ impl_reference_data_from_array_ref!(bool, Bool);
 pub struct ReferenceRuntime {
     pub buffers: FxHashMap<NodeIndex, ReferenceData>,
     pub graph: StableGraph<Arc<Box<dyn ReferenceOp>>, ()>,
+    selected_schedule: Option<crate::graph::SelectedSchedule>,
 }
 
 impl ReferenceRuntime {
@@ -3216,6 +3217,7 @@ impl Runtime for ReferenceRuntime {
         Self {
             buffers: Default::default(),
             graph: Default::default(),
+            selected_schedule: None,
         }
     }
 
@@ -3231,8 +3233,16 @@ impl Runtime for ReferenceRuntime {
         rng: &mut dyn rand::RngCore,
     ) {
         let contexts = space.bucket_contexts(dyn_map);
-        let llir = crate::search::extract_one(space, &contexts[0], rng);
-        self.load_llir(&llir);
+        let selected = contexts
+            .iter()
+            .map(|ctx| crate::search::extract_one_selected(space, ctx, rng))
+            .collect::<Vec<_>>();
+        self.load_llir(&selected[0].llir);
+        self.selected_schedule = crate::graph::SelectedSchedule::from_search(space, &selected);
+    }
+
+    fn selected_schedule(&self) -> Option<crate::graph::SelectedSchedule> {
+        self.selected_schedule.clone()
     }
 
     fn load_llir(&mut self, llir_graph: &LLIRGraph) {
@@ -3254,6 +3264,14 @@ impl Runtime for ReferenceRuntime {
         }
 
         self.graph = graph;
+    }
+
+    fn load_llir_buckets(
+        &mut self,
+        _dim_buckets: &FxHashMap<Symbol, Vec<crate::graph::DimBucket>>,
+        bucket_llirs: &[crate::graph::BucketLLIR],
+    ) {
+        self.load_llir(&bucket_llirs[0].2);
     }
 
     fn execute(&mut self, dyn_map: &DynMap) -> Self::ExecReturn {

--- a/src/op.rs
+++ b/src/op.rs
@@ -62,10 +62,25 @@ pub trait Runtime {
         options: &crate::graph::CompileOptions,
         rng: &mut dyn rand::RngCore,
     );
+    fn selected_schedule(&self) -> Option<crate::graph::SelectedSchedule> {
+        None
+    }
     /// Load one LLIR graph as the executable. [`Runtime::compile`] normally
     /// loads what it selects; this is the direct path for callers that
     /// already hold an LLIR graph.
     fn load_llir(&mut self, llir_graph: &LLIRGraph);
+    fn load_llir_buckets(
+        &mut self,
+        _dim_buckets: &FxHashMap<Symbol, Vec<crate::graph::DimBucket>>,
+        bucket_llirs: &[crate::graph::BucketLLIR],
+    ) {
+        assert_eq!(
+            bucket_llirs.len(),
+            1,
+            "runtime does not support LLIR buckets"
+        );
+        self.load_llir(&bucket_llirs[0].2);
+    }
     fn execute(&mut self, dyn_map: &DynMap) -> Self::ExecReturn;
 }
 

--- a/src/search/finalist.rs
+++ b/src/search/finalist.rs
@@ -27,6 +27,7 @@ pub type FinalistValidator<'v, M> =
 /// A viable deployment graph and the metric its genome measured.
 pub struct Finalist<M> {
     pub metric: M,
+    pub genome: IndexedChoiceSet,
     pub llir: LLIRGraph,
     /// Rolled graph before unrolling, kept only under `LLIR_DUMP_PRE_UNROLL`.
     pub pre_unroll: Option<LLIRGraph>,
@@ -37,6 +38,7 @@ pub struct PendingFinalist<M> {
     /// 1-based rank among the measured genomes.
     pub rank: usize,
     pub metric: M,
+    pub genome: IndexedChoiceSet,
     pub llir: LLIRGraph,
     /// Dyn values the hard filter should judge the graph at: the bucket
     /// representative when bucketed, otherwise the profiling dyn map.
@@ -175,6 +177,7 @@ impl<'a, M: Clone + Debug> Finalists<'a, M> {
                     return Some(PendingFinalist {
                         rank,
                         metric,
+                        genome,
                         llir,
                         dyn_map: self.filter_dyn_map.clone(),
                         pre_unroll,
@@ -240,6 +243,7 @@ impl<'a, M: Clone + Debug> Finalists<'a, M> {
         }
         self.finalists.push(Finalist {
             metric: pending.metric,
+            genome: pending.genome,
             pre_unroll: pending.pre_unroll,
             llir: pending.llir,
         });

--- a/src/search/genetic.rs
+++ b/src/search/genetic.rs
@@ -344,10 +344,7 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
         // Losers are the most expensive candidates to evaluate: a candidate
         // whose running metric is already `factor ×` worse than the best can
         // stop early — its partial metric is ranked normally and cannot win.
-        let early_stop = self
-            .options
-            .early_stop_factor
-            .and_then(|factor| self.best_metric.clone().map(|best| (best, factor)));
+        let early_stop = self.best_metric.clone().zip(self.options.early_stop_factor);
         Candidate {
             id,
             llir,

--- a/src/search/lattice.rs
+++ b/src/search/lattice.rs
@@ -230,6 +230,13 @@ impl<'a, M: PartialOrd + Clone + Debug> BucketLattice<'a, M> {
     /// `LLIR_DUMP_DIR`) as `(bucket_indices, representative_dyn_map, llir)`
     /// per bucket.
     pub fn select(self, set: BucketSet) -> Vec<BucketLLIR> {
+        self.select_with_genomes(set)
+            .into_iter()
+            .map(super::SelectedProgram::into_bucket_llir)
+            .collect()
+    }
+
+    pub fn select_with_genomes(self, set: BucketSet) -> Vec<super::SelectedProgram> {
         if self.search_log && self.rejections > 0 {
             println!(
                 "   {:>6}  aggregate fallback: selected per-bucket finalist ranks {:?} after {} rejection(s)",
@@ -244,11 +251,12 @@ impl<'a, M: PartialOrd + Clone + Debug> BucketLattice<'a, M> {
             .map(|(bucket, idx)| {
                 let ctx = bucket.bucket_context();
                 let finalist = bucket.take(idx);
-                (
-                    ctx.bucket_indices().clone(),
-                    ctx.representative_dyn_map.clone(),
-                    finalist.llir,
-                )
+                super::SelectedProgram {
+                    bucket_indices: ctx.bucket_indices().clone(),
+                    representative_dyn_map: ctx.representative_dyn_map.clone(),
+                    genome: finalist.genome,
+                    llir: finalist.llir,
+                }
             })
             .collect()
     }

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -233,9 +233,23 @@ pub fn extract_one(
     ctx: &BucketContext<'_>,
     rng: &mut dyn RngCore,
 ) -> LLIRGraph {
+    extract_one_selected(space, ctx, rng).llir
+}
+
+pub fn extract_one_selected(
+    space: &SearchSpace,
+    ctx: &BucketContext<'_>,
+    rng: &mut dyn RngCore,
+) -> SelectedProgram {
     let mut extractor = LlirExtractor::new(ctx.egraph(), &space.ops);
     let genome = extractor.random_indexed_choice(rng);
-    unroll_packed_llir(extractor.extract_indexed_packed(&genome, &space.custom_ops))
+    let llir = unroll_packed_llir(extractor.extract_indexed_packed(&genome, &space.custom_ops));
+    SelectedProgram {
+        bucket_indices: ctx.bucket_indices().clone(),
+        representative_dyn_map: ctx.representative_dyn_map.clone(),
+        genome,
+        llir,
+    }
 }
 
 /// The stock strategy: genetic search in every bucket, lazy finalists under

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -45,6 +45,19 @@ pub use lattice::{AggregateFn, BucketLattice, BucketSet};
 pub use packed::{LlirFingerprint, PackedLLIRGraph};
 pub use unroll::{collapse_loops_to_first_iter, unroll_loops_in_llir, unroll_packed_llir};
 
+pub struct SelectedProgram {
+    pub bucket_indices: DynMap,
+    pub representative_dyn_map: DynMap,
+    pub genome: IndexedChoiceSet,
+    pub llir: LLIRGraph,
+}
+
+impl SelectedProgram {
+    pub fn into_bucket_llir(self) -> BucketLLIR {
+        (self.bucket_indices, self.representative_dyn_map, self.llir)
+    }
+}
+
 /// What core hands the runtime: the saturated e-graph of every bucket
 /// combination plus everything needed to extract programs from them.
 #[derive(Debug)]


### PR DESCRIPTION
## Summary

Adds serialization and cross-process reuse for compiled Luminal graphs, allowing cached graphs to load without rerunning search or recompiling CUDA kernels. 

## Changes

- Serialize selected schedules using:
  - Saturated e-graphs
  - Selected e-node choices
  - Dynamic-dimension bucket metadata
  - LLIR fingerprints for compatibility validation
- Preserve selected genomes through runtime-owned search.
- Reconstruct and load selected schedules without profiling or search.
- Add CUDA module artifacts containing the selected schedule’s compiled CUBINs.
- Validate CUDA artifacts against:
  - GPU architecture
  - NVRTC version
  - NVRTC compilation options
- Capture only kernels used by the final selected schedule, excluding rejected search candidates.
- Add Python APIs for serializing and loading compiled graphs.
- Add structural artifact cache keys and in-memory/disk cache reuse.
- Extend the dynamic backend boundary to pass backend-specific artifact data.
- Organize artifact logic into dedicated modules for the core graph, CUDA runtime, and Python bindings.
