### PR TITLE
cuBLASLt bias forms: LeftMajor D premise on the bias decorators; executor refusals become a COL-order tripwire (R-B)

### DIFF
--- a/crates/luminal_cuda_lite/src/ops/cublaslt/device_call.rs
+++ b/crates/luminal_cuda_lite/src/ops/cublaslt/device_call.rs
@@ -193,22 +193,14 @@ pub fn dispatch(
     dest: &mut CudaSlice<u8>,
     stream: &Arc<CudaStream>,
 ) -> Result<()> {
-    // BIAS-EPILOGUE DEFENSE IN DEPTH: `plan_call_from_spec` refuses
-    // the bias forms (the library rejects BIAS/RELU_BIAS on a
-    // ROW-order D — the measured A100 finding), so a bias-bearing
-    // LtCall can only arrive hand-built. Refuse it here too, BEFORE
-    // any library call, with the same finding.
-    if call.bias_operand.is_some() {
-        return Err(anyhow!(
-            "cuBLASLt {:?}: bias-epilogue dispatch refused — the library does \
-             not support BIAS/RELU_BIAS with a ROW-order D (measured \
-             CUBLAS_STATUS_NOT_SUPPORTED on the A100), and no COL-order D \
-             dispatch of the marker's per-row bias has been measured on \
-             hardware; refused BEFORE dispatch for every destination order \
-             until one is",
-            call.form
-        ));
-    }
+    // BIAS/ORDER TRIPWIRE, DEFENSE IN DEPTH (ruling 2026-09-01): a
+    // planned bias form arrives with a COL D — the estate's bias
+    // decorators require a LeftMajor D and `exec::bind_destination`
+    // already ran this check. A hand-built bias call with a ROW D is
+    // the one way to reach this line with the wrong order; refuse it
+    // BEFORE any library call with the measured finding (the library
+    // rejects BIAS/RELU_BIAS on a ROW-order D).
+    super::exec::assert_bias_destination_order(call, "dispatch")?;
     // Pre-dispatch bounds gate (contract 4) — LOUD, before any library
     // call, byte counts converted to f32 element counts.
     let elems: Vec<usize> = operands.iter().map(|s| s.len() / 4).collect();

--- a/crates/luminal_cuda_lite/src/ops/cublaslt/egg/cublaslt_marker_decorate.egg
+++ b/crates/luminal_cuda_lite/src/ops/cublaslt/egg/cublaslt_marker_decorate.egg
@@ -171,6 +171,15 @@
     (= ?d_layout (BitOffsetExpressionLayoutLit ?d_expr ?d_shape2 ?d_bits2))
     (= ?composed_d (int-subst-of ?d_expr ?tmap))
     (= ?inner_L (BitOffsetExpressionLayoutLit ?composed_d ?ishape ?d_bits2))
+    ; THE LAYOUT REQUIREMENT (Austin, 2026-09-01): the bias form is minted
+    ; ONLY when the claimed D is provably LEFT-major contiguous over the
+    ; sibling frame [n, m] -- the storage order the library accepts for
+    ; BIAS/RELU_BIAS (ROW-order D is NOT_SUPPORTED, measured 2026-08-28)
+    ; and the one that puts the per-feature vector on D's rows. Two
+    ; (= ?inner_L ...) premises on one variable = the class holds BOTH
+    ; spellings; downward discovery (preamble 3a/3c + native chain
+    ; composition) supplies the literal, this rule never mints it.
+    (= ?inner_L (LeftMajorContiguousElementLayoutLit ?ishape ?d_bits2))
     (= ?d_shape (ShapeLit (IntExprCons ?m (IntExprCons ?n (IntExprNil)))))
     (= ?out2 (LogicalAdd ?y_outer ?bias_bcast))
     (= ?bias_bcast (LogicalIndexMapApply ?bias_logical ?bias_map ?d_shape))
@@ -224,6 +233,15 @@
     (= ?d_layout (BitOffsetExpressionLayoutLit ?d_expr ?d_shape2 ?d_bits2))
     (= ?composed_d (int-subst-of ?d_expr ?tmap))
     (= ?inner_L (BitOffsetExpressionLayoutLit ?composed_d ?ishape ?d_bits2))
+    ; THE LAYOUT REQUIREMENT (Austin, 2026-09-01): the bias form is minted
+    ; ONLY when the claimed D is provably LEFT-major contiguous over the
+    ; sibling frame [n, m] -- the storage order the library accepts for
+    ; BIAS/RELU_BIAS (ROW-order D is NOT_SUPPORTED, measured 2026-08-28)
+    ; and the one that puts the per-feature vector on D's rows. Two
+    ; (= ?inner_L ...) premises on one variable = the class holds BOTH
+    ; spellings; downward discovery (preamble 3a/3c + native chain
+    ; composition) supplies the literal, this rule never mints it.
+    (= ?inner_L (LeftMajorContiguousElementLayoutLit ?ishape ?d_bits2))
     (= ?d_shape (ShapeLit (IntExprCons ?m (IntExprCons ?n (IntExprNil)))))
     (= ?out2 (LogicalAdd ?y_outer ?bias_bcast))
     (= ?bias_bcast (LogicalIndexMapApply ?bias_logical ?bias_map ?d_shape))

--- a/crates/luminal_cuda_lite/src/ops/cublaslt/exec.rs
+++ b/crates/luminal_cuda_lite/src/ops/cublaslt/exec.rs
@@ -67,7 +67,25 @@
 //! defaults) is REJECTED: cuBLASLt's bias epilogue adds bias[i] to
 //! row i of the API's D, and the marker's bias contract is per-row of
 //! the call's D (length m) — a role swap would silently turn it into
-//! a per-column bias. ROW order keeps bias semantics intact.
+//! a per-column bias.
+//!
+//! THE BIAS FORMS DISPATCH ONLY UNDER A COL-ORDER D (ruling 2026-09-01,
+//! Austin: "adding the layout requirement to the rule is the correct
+//! solution"). MEASURED on the A100 (2026-08-28): the library returns
+//! CUBLAS_STATUS_NOT_SUPPORTED for CUBLASLT_EPILOGUE_BIAS / RELU_BIAS
+//! whenever D is CUBLASLT_ORDER_ROW (any A/B order). The fix is in the
+//! ESTATE, not here: the two bias decorators
+//! (`egg/cublaslt_marker_decorate.egg`) now carry the premise
+//! `(= ?inner_L (LeftMajorContiguousElementLayoutLit ?ishape ?d_bits2))`
+//! — the bias form is minted only when the claimed D is provably
+//! left-major contiguous over the sibling frame `[n, m]`, which is
+//! byte-identical to the recorder's row-major `[m, n]`, puts the
+//! per-feature vector on D's rows (the API's only bias axis), and is
+//! exactly what [`bind_destination`] resolves to `LtDesc::col`. The
+//! executor therefore no longer refuses the bias forms; it carries a
+//! TRIPWIRE instead ([`assert_bias_destination_order`]): a bias-bearing
+//! call whose D is not COL is unreachable from the estate, and reaching
+//! it is a bug to bail on, never a case to handle.
 //!
 //! THE DESTINATION FRAME IS THE PLAN'S, NOT A CONSTANT (regression fix,
 //! 2026-08-31 — see [`bind_destination`]). The paragraph above says
@@ -343,6 +361,42 @@ pub fn bind_destination(
     };
     call.d = desc;
     call.c = desc;
+    // The bias/order tripwire runs HERE — after the D order is known,
+    // never before (the spec-only default is ROW and would fire falsely).
+    assert_bias_destination_order(call, who)
+}
+
+/// THE BIAS/ORDER TRIPWIRE (ruling 2026-09-01). The estate's two bias
+/// decorators (`egg/cublaslt_marker_decorate.egg`) mint a bias form ONLY
+/// when the claimed D carries the `LeftMajorContiguousElementLayoutLit`
+/// spelling over the sibling frame, and [`bind_destination`] maps a
+/// LeftMajor election to `CUBLASLT_ORDER_COL`. A bias-bearing call whose
+/// D descriptor is not COL is therefore UNREACHABLE from a planned
+/// dispatch — it can only mean the estate premise and this bridge have
+/// drifted apart (or a hand-built call). Bail, never dispatch: the
+/// library refuses BIAS/RELU_BIAS on a ROW-order D
+/// (CUBLAS_STATUS_NOT_SUPPORTED, measured on the A100 2026-08-28), and
+/// this check names the finding BEFORE any descriptor is built.
+///
+/// Classification (see the CHECK TAXONOMY on [`bind_destination`]): a
+/// COHERENCE FENCE between the estate's premise vocabulary (the LeftMajor
+/// literal) and the call frame the executor builds (the D order) — not an
+/// e-graph re-check, and not disposable.
+pub fn assert_bias_destination_order(call: &LtCall, who: &str) -> Result<()> {
+    if call.bias_operand.is_some() && call.d.order != LtOrder::Col {
+        bail!(
+            "cuBLASLt {who}: unreachable: the bias decorators require a LeftMajor D; \
+             a bias form ({}) reached the executor with a {:?}-order D descriptor \
+             ({}x{} ld {}). The library refuses BIAS/RELU_BIAS on a ROW-order D \
+             (CUBLAS_STATUS_NOT_SUPPORTED, measured on the A100 2026-08-28) — \
+             refused BEFORE dispatch, no bytes move",
+            call.form.constructor_name(),
+            call.d.order,
+            call.d.rows,
+            call.d.cols,
+            call.d.ld
+        );
+    }
     Ok(())
 }
 
@@ -362,30 +416,14 @@ pub fn plan_call(op: &CublasLt) -> Result<LtCall> {
 
 /// [`plan_call`] over the spec alone (test seam).
 pub fn plan_call_from_spec(spec: &LtMatmulSpec) -> Result<LtCall> {
-    // BIAS-EPILOGUE REFUSAL (measured on the A100, 2026-08-28 probe —
-    // see the ROW CONVENTION module doc): cublasLtMatmulAlgoGetHeuristic
-    // returns CUBLAS_STATUS_NOT_SUPPORTED for CUBLASLT_EPILOGUE_BIAS /
-    // RELU_BIAS whenever D is CUBLASLT_ORDER_ROW (any A/B order;
-    // DEFAULT and RELU are supported under every order combination).
-    // The bias vector's length is pinned to D's ROW count by the API,
-    // and the marker's bias contract is per-row of the SIBLING call's
-    // D (length m = the recorder's feature dim) — re-expressing D as
-    // COL over the executor's row-major dest transposes the frame and
-    // would need a per-COLUMN bias, which the API does not have. Under
-    // the frozen estate + the executor's dense row-major destination
-    // there is NO correct dispatch for the bias forms: refuse loudly,
-    // never land wrong bytes.
-    if spec.form.has_bias() {
-        bail!(
-            "cuBLASLt {}: the bias-epilogue contracts are NOT dispatchable under \
-             the ROW convention — the A100 library refuses BIAS/RELU_BIAS with a \
-             ROW-order D (measured CUBLAS_STATUS_NOT_SUPPORTED), and the API's \
-             per-D-row bias cannot express the marker's per-row-of-the-sibling-D \
-             vector through a COL re-description of the row-major destination; \
-             refusing before any descriptor is built",
-            spec.form.constructor_name()
-        );
-    }
+    // NO BIAS REFUSAL HERE (ruling 2026-09-01). The unconditional
+    // bias-form refusal that stood at the top of this function is gone:
+    // the estate's bias decorators now require a LeftMajor D, so a bias
+    // form arrives with a COL destination election and dispatches. The
+    // D order is NOT known at this point (the spec-only default below is
+    // ROW), so the bias/order coherence check cannot live here — it runs
+    // in [`bind_destination`] once the plan's election has been read
+    // (see [`assert_bias_destination_order`]).
     let m = literal(&spec.m, "m")?;
     let n = literal(&spec.n, "n")?;
     let k = literal(&spec.k, "k")?;

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -165,14 +165,30 @@ impl CudaRuntime {
             .collect()
     }
 
-    /// Assemble, saturate, and search — with THIS backend's allow list.
-    /// On saturation failure the labeled post-checks are re-run in
-    /// isolation to name the door, mirroring the reference runtime.
-    pub fn search(
-        &mut self,
-        input_data: &FxHashMap<NodeIndex, TypedBuffer>,
-        options: &ImplementationSearchOptions,
-    ) -> Result<SearchOutcome<CudaLayout>> {
+    /// The SATURATED, SERIALIZED e-graph this runtime's search reads —
+    /// exactly the assembly [`CudaRuntime::search`] performs (this
+    /// backend's matcher vocabulary + the bound program + the schedule),
+    /// run to saturation and serialized, WITHOUT the genetic search. A
+    /// test seam: estate pins assert on the e-graph the search sees
+    /// (which constructors were minted, which spellings a layout class
+    /// holds) rather than on an election that depends on the budget.
+    pub fn saturated_egraph(&self) -> Result<luminal::prelude::egraph_serialize::EGraph> {
+        let (serialized, _program) = self.assemble_and_saturate()?;
+        Ok(serialized)
+    }
+
+    /// Assemble the program under this runtime's bindings and matcher
+    /// vocabulary, run it to saturation, and serialize. Shared by
+    /// [`CudaRuntime::search`] and [`CudaRuntime::saturated_egraph`] so
+    /// the two can never see different programs. On saturation failure
+    /// the labeled post-checks are re-run in isolation to name the door,
+    /// mirroring the reference runtime.
+    fn assemble_and_saturate(
+        &self,
+    ) -> Result<(
+        luminal::prelude::egraph_serialize::EGraph,
+        graph::LogicalProgram,
+    )> {
         let native = self
             .native
             .as_ref()
@@ -219,12 +235,28 @@ impl CudaRuntime {
             bail!("shape contracts failed:\n  - {}", doors.join("\n  - "));
         }
         let serialized = egraph.serialize(luminal::prelude::egglog::SerializeConfig::default());
+        Ok((serialized.egraph, program))
+    }
+
+    /// Assemble, saturate, and search — with THIS backend's allow list.
+    /// On saturation failure the labeled post-checks are re-run in
+    /// isolation to name the door, mirroring the reference runtime.
+    pub fn search(
+        &mut self,
+        input_data: &FxHashMap<NodeIndex, TypedBuffer>,
+        options: &ImplementationSearchOptions,
+    ) -> Result<SearchOutcome<CudaLayout>> {
+        let (serialized, program) = self.assemble_and_saturate()?;
+        let native = self
+            .native
+            .as_ref()
+            .ok_or_else(|| anyhow!("load before search"))?;
 
         // Own matchers, own allow list, and a profiler that never
         // touches another runtime: candidates rank by the heuristic
         // byte-move estimate (device profiling arrives with CL-3).
         let outcome = luminal::implementation_search::search_implementations_with_runtime(
-            &serialized.egraph,
+            &serialized,
             &program,
             input_data,
             options,

--- a/crates/luminal_cuda_lite/tests/cublaslt_bias_premise.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_bias_premise.rs
@@ -1,0 +1,363 @@
+//! THE LEFT-MAJOR D PREMISE on the cuBLASLt bias decorators (ruling
+//! 2026-09-01, Austin: "there is no reason to have the general rule ...
+//! There is downward discovery which will find the LeftMajor... spelling
+//! if it exists. I think adding the layout requirement to the rule is the
+//! correct solution.").
+//!
+//! The two bias decorators in `egg/cublaslt_marker_decorate.egg` now carry
+//! `(= ?inner_L (LeftMajorContiguousElementLayoutLit ?ishape ?d_bits2))`:
+//! the bias form is minted ONLY when the claimed D — the sibling site's
+//! output, the transpose VIEW of the recorder's row-major `[m, n]` out —
+//! provably holds the left-major spelling over `[n, m]`. That is the
+//! storage order the A100 library accepts for BIAS/RELU_BIAS (ROW-order D
+//! is NOT_SUPPORTED, measured 2026-08-28) and the one that puts the
+//! per-feature vector on D's rows, cuBLASLt's only bias axis.
+//!
+//! CPU-side, on the e-graph the search reads (`CudaRuntime::saturated_egraph`):
+//!  * POSITIVE: `x[4,8] @ w[8,3] + b[3]`, spelled exactly as
+//!    `luminal_nn::Linear` with bias spells it (`expand_lhs` over the batch
+//!    axis — rank-1 `[n]` applied through `(CoordVar d_shape 0)` into
+//!    `[m, n]`), mints `LayoutTensorOpCublasLtBias`, and its D layout class
+//!    holds `LeftMajorContiguousElementLayoutLit` — minted by DISCOVERY
+//!    (the preamble's native chain composition + arm 3a), never by the
+//!    decorator. The seeded search elects the bias form; `plan_call` +
+//!    `bind_destination` resolve its D to COL with ld = the recorder's n.
+//!  * LOGICAL NEGATIVE: the same matmul with the bias broadcast along the
+//!    WRONG axis (per ROW of the recorder's `[4, 3]`) mints NO bias form.
+//!
+//! The LAYOUT negative (a D whose class lacks the left-major spelling)
+//! lives in `tests/test_runtime/tests/cublaslt_bias_leftmajor_premise.rs`.
+
+use std::collections::BTreeSet;
+
+use luminal::buffer_tensor_ir::TypedBuffer;
+use luminal::bufferize::BufferNode;
+use luminal::graph::Graph;
+use luminal::prelude::egraph_serialize::{ClassId, EGraph, Node};
+use luminal::prelude::{FxHashMap, NodeIndex, Ns};
+use luminal_cuda_lite::ops::cublaslt::exec::{bind_destination, plan_call, LtOrder};
+use luminal_cuda_lite::ops::cublaslt::{CublasLt, CublasLtDps};
+use luminal_cuda_lite::CudaRuntime;
+use luminal_nn::Linear;
+
+/// Deterministic values (the shared example seeding discipline).
+fn weights(n: usize, seed: usize) -> Vec<f32> {
+    (0..n)
+        .map(|i| (((i * 37 + seed * 101 + 13) % 121) as f32 / 100.0) - 0.6)
+        .collect()
+}
+
+const M: usize = 4; // batch rows (the recorder's m)
+const K: usize = 8;
+const N: usize = 3; // features (the recorder's n = the sibling call's m)
+
+/// The pin graph PLUS a per-feature bias, spelled as `luminal_nn::Linear`
+/// with bias spells it: `y = x.matmul(w) + b.expand_lhs(&[m])`.
+fn linear_with_bias() -> (Graph, NodeIndex, NodeIndex, NodeIndex, NodeIndex) {
+    let mut cx = Graph::new();
+    let fc = Linear::new(K, N, true, &Ns::root().child("fc"), &mut cx);
+    let x = cx.tensor((M, K));
+    let out = fc.forward(x).output();
+    let bias = fc.bias.expect("Linear::new(.., true, ..) carries a bias");
+    (cx, x.id, fc.weight.id, bias.id, out.id)
+}
+
+fn count(egraph: &EGraph, op: &str) -> usize {
+    egraph.nodes.values().filter(|n| n.op == op).count()
+}
+
+fn class_ops(egraph: &EGraph, class: &ClassId) -> BTreeSet<String> {
+    egraph
+        .nodes
+        .values()
+        .filter(|n| &n.eclass == class)
+        .map(|n| n.op.clone())
+        .collect()
+}
+
+fn child_class(egraph: &EGraph, node: &Node, index: usize) -> ClassId {
+    let id = node
+        .children
+        .get(index)
+        .unwrap_or_else(|| panic!("{} has no child {index}", node.op));
+    egraph.nodes[id].eclass.clone()
+}
+
+fn node_in_class<'a>(egraph: &'a EGraph, class: &ClassId, op: &str) -> Option<&'a Node> {
+    egraph
+        .nodes
+        .values()
+        .find(|n| &n.eclass == class && n.op == op)
+}
+
+/// The D descriptor of a `LayoutTensorOpCublasLt*` enode sits at slot 3 on
+/// every form; its layout tensor is the descriptor's child 1; the
+/// LAYOUT class is that layout tensor's `LayoutTensorLit` child 1.
+fn d_layout_class(egraph: &EGraph, op_node: &Node) -> ClassId {
+    let d_desc_class = child_class(egraph, op_node, 3);
+    let desc = node_in_class(egraph, &d_desc_class, "CublasLtOutputDDescriptor")
+        .expect("slot 3 holds the D descriptor");
+    let lt_class = child_class(egraph, desc, 1);
+    let lt = node_in_class(egraph, &lt_class, "LayoutTensorLit")
+        .expect("the D descriptor names a layout tensor");
+    child_class(egraph, lt, 1)
+}
+
+fn report_forms(egraph: &EGraph, what: &str) -> (usize, usize, usize, usize) {
+    let base = count(egraph, "LayoutTensorOpCublasLt");
+    let bias = count(egraph, "LayoutTensorOpCublasLtBias");
+    let acc = count(egraph, "LayoutTensorOpCublasLtAccumulate");
+    let acc_bias = count(egraph, "LayoutTensorOpCublasLtAccumulateBias");
+    println!(
+        "BIAS-PREMISE {what}: candidates base={base} bias={bias} accumulate={acc} \
+         accumulate_bias={acc_bias}"
+    );
+    (base, bias, acc, acc_bias)
+}
+
+// ---------------------------------------------------------------------------
+// POSITIVE, e-graph half: the bias form exists and its D class holds the
+// left-major spelling — supplied by discovery.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn linear_with_bias_mints_the_bias_form_on_a_left_major_d() {
+    let (cx, _x, _w, _b, _out) = linear_with_bias();
+    let rt = CudaRuntime::load_with_cublaslt(&cx).expect("load");
+    let egraph = rt.saturated_egraph().expect("saturation");
+
+    let (base, bias, _acc, _acc_bias) = report_forms(&egraph, "linear(4x8 . 8x3)+b[3]");
+    assert!(
+        base > 0,
+        "the canonical matmul must still assemble the base form"
+    );
+    assert!(
+        bias > 0,
+        "the per-feature bias must mint LayoutTensorOpCublasLtBias (the LeftMajor \
+         premise must be SATISFIED by discovery on the recorder's own graph)"
+    );
+
+    // Every minted bias form's D layout class carries the left-major
+    // spelling — the premise, read back off the e-graph.
+    let mut d_classes: BTreeSet<ClassId> = BTreeSet::new();
+    for node in egraph
+        .nodes
+        .values()
+        .filter(|n| n.op == "LayoutTensorOpCublasLtBias")
+    {
+        d_classes.insert(d_layout_class(&egraph, node));
+    }
+    for class in &d_classes {
+        let ops = class_ops(&egraph, class);
+        let mirror = luminal::layouts::render_layout_for(&egraph, class, "bias-premise pin")
+            .expect("the D layout class renders");
+        println!("BIAS-PREMISE CublasLtBias D layout class {class:?}: ops={ops:?}");
+        println!("BIAS-PREMISE   rendered (most-structured spelling): {mirror:?}");
+        assert!(
+            ops.contains("LeftMajorContiguousElementLayoutLit"),
+            "the bias form's D class must hold the LeftMajor spelling: {ops:?}"
+        );
+        // Discovery's ladder, spelled out: the class was BORN as the
+        // composed bit-offset expression (preamble INDEX-MAP / LAYOUT
+        // COMPOSITION), gained its strided chain from NATIVE CHAIN
+        // COMPOSITION, and the left-major literal from arm (3a) —
+        // "DOWNWARD LAYOUT DISCOVERY". The decorator mints none of these.
+        assert!(
+            ops.contains("BitOffsetExpressionLayoutLit"),
+            "the composed (view) spelling the decorator ties to: {ops:?}"
+        );
+        assert!(
+            ops.contains("StridedElementLayoutLit"),
+            "the native-chain-composition rung 3a reads: {ops:?}"
+        );
+        assert!(
+            matches!(mirror, luminal::layouts::MirrorLayout::LeftMajor(_)),
+            "the renderer's most-structured spelling is LeftMajor (RightMajor is absent, \
+             as it must be: a [3,4] left-major over the bytes of a [4,3] right-major): {mirror:?}"
+        );
+    }
+
+    // For contrast: the BASE form's D classes (same sibling site) — the
+    // same class when the base and bias forms share the sibling D.
+    let mut base_classes: BTreeSet<ClassId> = BTreeSet::new();
+    for node in egraph
+        .nodes
+        .values()
+        .filter(|n| n.op == "LayoutTensorOpCublasLt")
+    {
+        base_classes.insert(d_layout_class(&egraph, node));
+    }
+    for class in &base_classes {
+        println!(
+            "BIAS-PREMISE base CublasLt D layout class {class:?}: ops={:?}",
+            class_ops(&egraph, class)
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// POSITIVE, plan half: the seeded search elects the bias form; the
+// executor's bridge resolves its D to COL, ld = the recorder's n.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn search_elects_the_bias_form_and_binds_a_col_d() {
+    let (cx, x, w, b, _out) = linear_with_bias();
+    let data: FxHashMap<NodeIndex, TypedBuffer> = [
+        (x, TypedBuffer::from(weights(M * K, 1))),
+        (w, TypedBuffer::from(weights(K * N, 2))),
+        (b, TypedBuffer::from(weights(N, 3))),
+    ]
+    .into_iter()
+    .collect();
+
+    // The 2D pin's budget (tests/cublaslt_election.rs): 12x16 / mutations
+    // 4, seeded. A seed sweep is reported so the pin stays honest about
+    // how election-dependent the plan is; the FIRST electing seed is the
+    // one the plan assertions run on.
+    let mut elected_seed = None;
+    for seed in 0..6u64 {
+        let options = luminal::implementation_search::ImplementationSearchOptions {
+            generations: 12,
+            generation_size: 16,
+            mutations: 4,
+            trials: 1,
+            seed,
+        };
+        let mut rt = CudaRuntime::load_with_cublaslt(&cx).expect("load");
+        let outcome = match rt.search(&data, &options) {
+            Ok(outcome) => outcome,
+            Err(e) => {
+                println!("BIAS-PREMISE seed {seed}: SEARCH DIED: {e:#}");
+                continue;
+            }
+        };
+        let plan = rt.plan().expect("plan");
+        let labels: Vec<String> = plan
+            .dag
+            .node_weights()
+            .filter_map(|n| match n {
+                BufferNode::Compute { op, .. } => {
+                    let l = op.label().to_string();
+                    (l != "BufferAlloc" && l != "BufferFree").then_some(l)
+                }
+                _ => None,
+            })
+            .collect();
+        println!(
+            "BIAS-PREMISE seed {seed}: computes={labels:?} refusals=[{}]",
+            outcome.refusal_breakdown.summary()
+        );
+        if labels.iter().any(|l| l == "CublasLtBias") {
+            elected_seed.get_or_insert((seed, rt));
+        }
+    }
+    let (seed, rt) = elected_seed.expect(
+        "some seed in 0..6 at the 12x16/mut-4 pin budget must elect CublasLtBias \
+         (bytes-moved cost prefers the fused bias epilogue over matmul + Add)",
+    );
+    println!("BIAS-PREMISE: asserting on the plan elected at seed {seed}");
+
+    let plan = rt.plan().expect("plan");
+    let mut checked = 0usize;
+    for node in plan.dag.node_weights() {
+        let BufferNode::Compute {
+            op, result_info, ..
+        } = node
+        else {
+            continue;
+        };
+        if op.label() != "CublasLtBias" {
+            continue;
+        }
+        // The plan holds the DPS form (the bufferizer's destination
+        // passing); its `.op` is the functional op with the parsed spec.
+        let functional: &CublasLt = match op.as_any().downcast_ref::<CublasLtDps>() {
+            Some(dps) => &dps.op,
+            None => op
+                .as_any()
+                .downcast_ref::<CublasLt>()
+                .expect("a CublasLtBias compute node is a CublasLt(Dps) instance"),
+        };
+        let spec = functional
+            .spec
+            .as_ref()
+            .expect("elected op carries its spec");
+        println!(
+            "BIAS-PREMISE elected spec: form={:?} m={} n={} k={} trans_a={} trans_b={} \
+                  lda={} ldb={} ldd={} epilogue={:?}",
+            spec.form,
+            spec.m,
+            spec.n,
+            spec.k,
+            spec.trans_a,
+            spec.trans_b,
+            spec.lda,
+            spec.ldb,
+            spec.ldd,
+            spec.epilogue
+        );
+
+        // (d) plan_call SUCCEEDS (no unconditional refusal any more)...
+        let mut call = plan_call(functional).expect("plan_call on the elected bias spec");
+        assert_eq!(
+            call.bias_operand,
+            Some(2),
+            "Bias contract order [a, b, bias]"
+        );
+        // ...and the destination binding resolves the sibling's elected
+        // LeftMajor layout to a COL descriptor with ld = call-m = the
+        // recorder's n. The tripwire inside bind_destination is the very
+        // check that would have refused a ROW D.
+        let dest = &result_info
+            .first()
+            .expect("single-destination contract")
+            .layout;
+        println!("BIAS-PREMISE elected destination layout: {:?}", dest.mirror);
+        bind_destination(&mut call, dest, "bias-premise pin")
+            .expect("a bias form binds its destination (LeftMajor -> COL)");
+        println!("BIAS-PREMISE LtCall: {call:#?}");
+        assert_eq!(
+            call.d.order,
+            LtOrder::Col,
+            "bias forms dispatch under a COL D"
+        );
+        assert_eq!(call.m, N as i64, "the sibling call's m is the recorder's n");
+        assert_eq!(call.n, M as i64, "the sibling call's n is the recorder's m");
+        assert_eq!(call.d.ld, N as i64, "COL ld = call-m = the recorder's n");
+        assert_eq!(call.c, call.d, "C rides D's frame");
+        assert!(!call.relu);
+        checked += 1;
+    }
+    assert!(checked >= 1, "at least one CublasLtBias node was checked");
+}
+
+// ---------------------------------------------------------------------------
+// LOGICAL NEGATIVE: a bias broadcast along the WRONG axis (per row of the
+// recorder's [4, 3]) is not a per-feature bias; no bias form may mint.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn per_row_bias_does_not_mint_the_bias_form() {
+    let mut cx = Graph::new();
+    let x = cx.tensor((M, K));
+    let w = cx.tensor((K, N));
+    let b_rows = cx.tensor(M);
+    // [4] -> [4, 3] along the FEATURE axis: entry (CoordVar d_shape 1),
+    // i.e. bias[i] added to every element of row i — cuBLASLt's epilogue
+    // cannot express this for the sibling call (its bias runs along the
+    // sibling's rows = the recorder's COLUMNS).
+    let _out = (x.matmul(w) + b_rows.expand_dim(1, N)).output();
+    let rt = CudaRuntime::load_with_cublaslt(&cx).expect("load");
+    let egraph = rt.saturated_egraph().expect("saturation");
+    let (base, bias, _acc, acc_bias) = report_forms(&egraph, "matmul + per-ROW b[4]");
+    assert!(base > 0, "the matmul itself still assembles");
+    assert_eq!(
+        bias, 0,
+        "a per-row broadcast must NOT mint LayoutTensorOpCublasLtBias"
+    );
+    assert_eq!(
+        acc_bias, 0,
+        "a per-row broadcast must NOT mint LayoutTensorOpCublasLtAccumulateBias"
+    );
+}

--- a/crates/luminal_cuda_lite/tests/cublaslt_contracts.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_contracts.rs
@@ -4,10 +4,13 @@
 //!
 //! Coverage:
 //!  * the four contract forms on real device buffers (direct
-//!    `device_call::dispatch` over hand-built `LtCall`s, ROW
-//!    convention): DEFAULT-epilogue forms execute green; BIAS-epilogue
-//!    forms pin the loud refusal (the measured library restriction —
-//!    no BIAS/RELU_BIAS on a ROW-order D);
+//!    `device_call::dispatch` over hand-built `LtCall`s): the
+//!    DEFAULT-epilogue forms under a ROW D and — RULING 2026-09-01,
+//!    NEEDS A100 RUN — the BIAS-epilogue forms under a COL D, all
+//!    compared tolerance-based against the host walk; a bias form with
+//!    a ROW D pins the tripwire (the measured library restriction — no
+//!    BIAS/RELU_BIAS on a ROW-order D — now unreachable from the estate,
+//!    whose bias decorators require a LeftMajor D);
 //!  * the TF32 strictness detector assertion (contract 5);
 //!  * a deliberate ld-bounds violation refused loudly BEFORE dispatch
 //!    (contract 4 — including the rows==1 case the library's own check
@@ -38,7 +41,7 @@ fn walked_dense(rt: &CudaRuntime, out: NodeIndex) -> Vec<f32> {
         .expect("the returned layout reads dense over its backing buffer")
 }
 use luminal_cuda_lite::ops::cublaslt::device_call;
-use luminal_cuda_lite::ops::cublaslt::exec::{CSource, LtCall, LtDesc};
+use luminal_cuda_lite::ops::cublaslt::exec::{CSource, LtCall, LtDesc, LtOrder};
 use luminal_cuda_lite::ops::cublaslt::CublasLtForm;
 use luminal_cuda_lite::CudaRuntime;
 use std::sync::Arc;
@@ -73,10 +76,26 @@ fn weights(n: usize, seed: usize) -> Vec<f32> {
         .collect()
 }
 
-/// Host reference for one call: ROW-order walk (the bridge's ROW
-/// convention — every descriptor is CUBLASLT_ORDER_ROW, ld = row
-/// pitch) of D = act(op(A)op(B) + beta*C + bias), alpha = 1 (the
-/// fixed literal).
+/// The seed at which the 12x16/mut-4 search elected `CublasLtBias` on
+/// the CPU pin (`tests/cublaslt_bias_premise.rs`,
+/// `search_elects_the_bias_form_and_binds_a_col_d`).
+const BIAS_ELECTING_SEED: u64 = 0;
+
+/// Element index of `(r, c)` under a descriptor's own order: ROW puts it
+/// at `r*ld + c`, COL at `c*ld + r`.
+fn at(desc: &LtDesc, r: usize, c: usize) -> usize {
+    match desc.order {
+        LtOrder::Row => r * desc.ld as usize + c,
+        LtOrder::Col => c * desc.ld as usize + r,
+    }
+}
+
+/// Host reference for one call: A and B walked in ROW order (the bridge's
+/// operand convention), C and D through THEIR descriptors' declared order
+/// (ROW for the default forms; COL for the bias forms, ruling 2026-09-01)
+/// — D = act(op(A)op(B) + beta*C + bias), alpha = 1 (the fixed literal),
+/// bias[row] added along D's rows (the API's only bias axis, independent
+/// of storage order).
 fn host_reference(
     call: &LtCall,
     a: &[f32],
@@ -104,7 +123,7 @@ fn host_reference(
                 acc += (a_v as f64) * (b_v as f64);
             }
             if let Some(c) = c {
-                acc += c[row * call.c.ld as usize + col] as f64;
+                acc += c[at(&call.c, row, col)] as f64;
             }
             if let Some(bias) = bias {
                 acc += bias[row] as f64;
@@ -113,7 +132,7 @@ fn host_reference(
             if call.relu {
                 v = v.max(0.0);
             }
-            d[row * call.d.ld as usize + col] = v;
+            d[at(&call.d, row, col)] = v;
         }
     }
     d
@@ -135,10 +154,17 @@ fn from_device(stream: &Arc<cudarc::driver::CudaStream>, slice: &CudaSlice<u8>) 
 }
 
 /// Build the canonical contiguous call for one form (m=3, n=4, k=5) —
-/// the bridge's ROW convention: dense row-major operands, ld = the
-/// row pitch (= cols).
+/// dense row-major operands (ld = the row pitch = cols); C and D in the
+/// order the plan would elect for the form: ROW (ld = n) for the default
+/// forms, COL (ld = m) for the bias forms — the estate's bias decorators
+/// require a LeftMajor D, which `bind_destination` resolves to COL.
 fn call_for(form: CublasLtForm) -> LtCall {
     let (m, n, k) = (3i64, 4i64, 5i64);
+    let cd = if form.has_bias() {
+        LtDesc::col(m, n, m)
+    } else {
+        LtDesc::row(m, n, n)
+    };
     LtCall {
         form,
         m,
@@ -148,8 +174,8 @@ fn call_for(form: CublasLtForm) -> LtCall {
         trans_b: false,
         a: LtDesc::row(m, k, k),
         b: LtDesc::row(k, n, n),
-        c: LtDesc::row(m, n, n),
-        d: LtDesc::row(m, n, n),
+        c: cd,
+        d: cd,
         c_source: if form.has_c() {
             CSource::Operand(2)
         } else {
@@ -171,17 +197,20 @@ fn tf32_strictness_detector_is_green() {
     );
 }
 
-/// The four contract forms, each under the bridge's ROW convention:
-/// the DEFAULT-epilogue forms (Base, Accumulate) execute green on real
-/// buffers, compared tolerance-based against the host walk (see
-/// `assert_close`'s reduction-order contract); the BIAS-epilogue forms
-/// (Bias, AccumulateBias) are refused LOUDLY before dispatch — the
-/// MEASURED A100 finding (2026-08-28 probe): the library returns
-/// CUBLAS_STATUS_NOT_SUPPORTED for BIAS/RELU_BIAS whenever D is
-/// CUBLASLT_ORDER_ROW (any A/B order), and the API's per-D-row bias
-/// cannot express the marker's sibling-frame bias through a COL
-/// re-description of the row-major destination. No bytes may move on a
-/// refused form.
+/// The four contract forms execute green on real buffers, compared
+/// tolerance-based against the host walk (see `assert_close`'s
+/// reduction-order contract): the DEFAULT-epilogue forms (Base,
+/// Accumulate) under a ROW D, the BIAS-epilogue forms (Bias,
+/// AccumulateBias) under a COL D.
+///
+/// RULING 2026-09-01 — NEEDS A100 RUN. The bias forms used to pin a
+/// refusal here (the 2026-08-28 finding: CUBLAS_STATUS_NOT_SUPPORTED for
+/// BIAS/RELU_BIAS whenever D is CUBLASLT_ORDER_ROW). The estate now
+/// requires a LeftMajor D on the bias decorators, so a planned bias form
+/// always dispatches with `CUBLASLT_ORDER_COL` — the order the probe
+/// measured as SUPPORTED. This test's bias rows are the first device
+/// measurement of that dispatch; the ROW-D refusal moved to
+/// `bias_form_with_a_row_d_is_refused_before_dispatch`.
 #[test]
 fn all_four_contract_forms_execute_green() {
     let ctx = CudaContext::new(0).expect("CUDA device 0");
@@ -207,23 +236,16 @@ fn all_four_contract_forms_execute_green() {
         }
         let mut dest = stream.alloc_zeros::<u8>(m * n * 4).expect("dest alloc");
 
-        if form.has_bias() {
-            let err = device_call::dispatch(&call, &operands, &mut dest, &stream)
-                .expect_err("bias-epilogue forms must be refused under the ROW convention");
-            let msg = format!("{err:#}");
-            assert!(msg.contains("refused BEFORE dispatch"), "{form:?}: {msg}");
-            assert!(
-                msg.contains("ROW-order D"),
-                "{form:?} refusal must name the finding: {msg}"
-            );
-            stream.synchronize().expect("sync");
-            assert!(
-                from_device(&stream, &dest).iter().all(|&v| v == 0.0),
-                "{form:?}: no bytes may move on a refused dispatch"
-            );
-            continue;
-        }
-
+        // Bias forms: COL D (ld = m), the order the library supports for
+        // BIAS/RELU_BIAS; the epilogue adds bias[row] along D's rows.
+        assert_eq!(
+            call.d.order,
+            if form.has_bias() {
+                LtOrder::Col
+            } else {
+                LtOrder::Row
+            }
+        );
         device_call::dispatch(&call, &operands, &mut dest, &stream)
             .unwrap_or_else(|e| panic!("{form:?} dispatch: {e:#}"));
         stream.synchronize().expect("sync");
@@ -272,6 +294,124 @@ fn ld_bounds_violation_refuses_before_dispatch() {
         from_device(&stream, &dest).iter().all(|&v| v == 0.0),
         "no bytes may move on a refused dispatch"
     );
+}
+
+/// THE TRIPWIRE ON DEVICE (ruling 2026-09-01): a bias form whose D is
+/// ROW-order is unreachable from the estate (the bias decorators require
+/// a LeftMajor D). A hand-built one is refused BEFORE any library call —
+/// the library would return CUBLAS_STATUS_NOT_SUPPORTED (measured
+/// 2026-08-28) — and no bytes move.
+#[test]
+fn bias_form_with_a_row_d_is_refused_before_dispatch() {
+    let ctx = CudaContext::new(0).expect("CUDA device 0");
+    let stream = ctx.default_stream();
+    for form in [CublasLtForm::Bias, CublasLtForm::AccumulateBias] {
+        let mut call = call_for(form);
+        let (m, n, k) = (call.m as usize, call.n as usize, call.k as usize);
+        call.c = LtDesc::row(call.m, call.n, call.n);
+        call.d = call.c;
+        let a = weights(m * k, 1);
+        let b = weights(k * n, 2);
+        let dev_a = to_device(&stream, &a);
+        let dev_b = to_device(&stream, &b);
+        let mut operands: Vec<&CudaSlice<u8>> = vec![&dev_a, &dev_b];
+        let dev_c = form.has_c().then(|| to_device(&stream, &weights(m * n, 3)));
+        let dev_bias = to_device(&stream, &weights(m, 4));
+        if let Some(dc) = dev_c.as_ref() {
+            operands.push(dc);
+        }
+        operands.push(&dev_bias);
+        let mut dest = stream.alloc_zeros::<u8>(m * n * 4).expect("dest alloc");
+        let err = device_call::dispatch(&call, &operands, &mut dest, &stream)
+            .expect_err("a ROW-order D under a bias form must trip the fence");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("unreachable"), "{form:?}: {msg}");
+        assert!(
+            msg.contains("bias decorators require a LeftMajor D"),
+            "{form:?}: {msg}"
+        );
+        assert!(msg.contains("refused BEFORE dispatch"), "{form:?}: {msg}");
+        stream.synchronize().expect("sync");
+        assert!(
+            from_device(&stream, &dest).iter().all(|&v| v == 0.0),
+            "{form:?}: no bytes may move on a refused dispatch"
+        );
+    }
+}
+
+/// THE BIAS FORM END TO END (ruling 2026-09-01 — NEEDS A100 RUN): the
+/// marker-elected plan for `x[4,8] @ w[8,3] + b[3]` (spelled as
+/// `luminal_nn::Linear` with bias spells it) executes through the
+/// host-call arm with the BIAS epilogue under the sibling's COL D, against
+/// the decomposed route, tolerance-based. The seed is the one the CPU pin
+/// (`tests/cublaslt_bias_premise.rs`) measured electing `CublasLtBias`.
+#[test]
+fn marker_elected_bias_plan_matches_decomposed_route_tolerance_based() {
+    use luminal::prelude::Ns;
+    let build = || {
+        let mut cx = luminal::graph::Graph::new();
+        let fc = luminal_nn::Linear::new(8, 3, true, &Ns::root().child("fc"), &mut cx);
+        let x = cx.tensor((4usize, 8usize));
+        let out = fc.forward(x).output();
+        let bias = fc.bias.expect("bias");
+        (cx, x.id, fc.weight.id, bias.id, out.id)
+    };
+    let data_for =
+        |x: NodeIndex, w: NodeIndex, b: NodeIndex| -> FxHashMap<NodeIndex, TypedBuffer> {
+            [
+                (x, TypedBuffer::from(weights(32, 1))),
+                (w, TypedBuffer::from(weights(24, 2))),
+                (b, TypedBuffer::from(weights(3, 3))),
+            ]
+            .into_iter()
+            .collect()
+        };
+    let options = luminal::implementation_search::ImplementationSearchOptions {
+        generations: 12,
+        generation_size: 16,
+        mutations: 4,
+        trials: 1,
+        seed: BIAS_ELECTING_SEED,
+    };
+
+    let (cx, x, w, b, out) = build();
+    let mut fused = CudaRuntime::load_with_cublaslt(&cx).expect("load fused");
+    fused
+        .search(&data_for(x, w, b), &options)
+        .expect("fused search");
+    let elected_bias = fused
+        .plan()
+        .expect("plan")
+        .dag
+        .node_weights()
+        .any(|n| matches!(n, BufferNode::Compute { op, .. } if op.label() == "CublasLtBias"));
+    assert!(
+        elected_bias,
+        "the fused route must elect CublasLtBias for this comparison (seed {BIAS_ELECTING_SEED} measured electing on the CPU pin; re-sweep tests/cublaslt_bias_premise.rs if this moves)"
+    );
+    fused.set_data(x, weights(32, 1));
+    fused.set_data(w, weights(24, 2));
+    fused.set_data(b, weights(3, 3));
+    fused
+        .execute()
+        .expect("fused execute (bias epilogue under COL D)");
+    let got = walked_dense(&fused, out);
+
+    let (cx, x, w, b, out) = build();
+    let mut plain = CudaRuntime::load(&cx).expect("load plain");
+    plain
+        .search(
+            &data_for(x, w, b),
+            &luminal::test_support::harness_search_options(),
+        )
+        .expect("plain search");
+    plain.set_data(x, weights(32, 1));
+    plain.set_data(w, weights(24, 2));
+    plain.set_data(b, weights(3, 3));
+    plain.execute().expect("plain execute");
+    let want = walked_dense(&plain, out);
+
+    assert_close(&want, &got, "marker(bias) vs decomposed 4x8x3 + b[3]");
 }
 
 /// Item 4 END TO END: the marker-elected plan (searched with the

--- a/crates/luminal_cuda_lite/tests/cublaslt_contracts_cpu.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_contracts_cpu.rs
@@ -158,31 +158,93 @@ fn c_fold_forms_read_c_from_operand_two_with_structural_beta_one() {
     assert_eq!(call.c, call.d, "C rides the D layout by rule guard");
 }
 
+fn bias_spec(form: CublasLtForm) -> LtMatmulSpec {
+    let mut spec = base_spec(4, 3, 5);
+    spec.form = form;
+    spec.has_c = form.has_c();
+    spec.has_bias = true;
+    if form.has_c() {
+        spec.c_tensor = Some(cid("c_lt"));
+    }
+    spec.bias_tensor = Some(cid("bias_lt"));
+    spec.epilogue = CuEpilogue::Bias;
+    spec
+}
+
+/// RULING 2026-09-01: the bias forms are no longer refused at plan time.
+/// The estate's bias decorators require a LeftMajor D (the premise
+/// `(= ?inner_L (LeftMajorContiguousElementLayoutLit ?ishape ?d_bits2))`
+/// in `egg/cublaslt_marker_decorate.egg`), so a planned bias form arrives
+/// with a left-major election that `bind_destination` resolves to
+/// CUBLASLT_ORDER_COL — the order the A100 library accepts for
+/// BIAS/RELU_BIAS. `plan_call` therefore SUCCEEDS on a bias spec, and the
+/// bias/order check is the TRIPWIRE at the end of `bind_destination`,
+/// where the D order is known.
 #[test]
-fn bias_epilogue_forms_refuse_at_plan_time() {
-    // THE MEASURED A100 FINDING (2026-08-28 probe): the library
-    // refuses BIAS/RELU_BIAS whenever D is CUBLASLT_ORDER_ROW, and
-    // the marker's sibling-frame per-D-row bias cannot be expressed
-    // through a COL re-description of the executor's row-major dest —
-    // the bridge refuses the bias forms LOUDLY before any descriptor
-    // is built.
+fn bias_epilogue_forms_plan_and_bind_under_a_col_d() {
     for form in [CublasLtForm::Bias, CublasLtForm::AccumulateBias] {
+        let call = plan_call_from_spec(&bias_spec(form))
+            .expect("bias forms plan: the unconditional refusal is gone");
+        assert_eq!(
+            call.bias_operand,
+            Some(if form.has_c() { 3 } else { 2 }),
+            "contract order [a, b, c?, bias]"
+        );
+        assert_eq!(call.beta_is_one, form.has_c());
+        // The plan's election for the sibling destination is LeftMajor
+        // over the call frame [m, n] = [4, 3] -> COL, ld = m.
+        let mut bound = call.clone();
+        bind_destination(&mut bound, &left_major(&[4, 3]), "pin")
+            .expect("a LeftMajor destination binds a bias form");
+        assert_eq!(bound.d, LtDesc::col(4, 3, 4), "{form:?}: COL D, ld = m");
+        assert_eq!(bound.c, bound.d, "{form:?}: C rides D's frame");
+        // The bound frame fits the destination buffer exactly (COL reach =
+        // ld*(cols-1) + rows = 4*2 + 4 = 12) and the bias buffer holds m.
+        let mut elems = vec![20usize, 15];
+        if form.has_c() {
+            elems.push(12);
+        }
+        elems.push(4);
+        bound
+            .validate_against(&elems, 12)
+            .expect("the bound bias call passes the pre-dispatch gate");
+    }
+}
+
+/// THE TRIPWIRE: a bias form whose destination election is RIGHT-major
+/// (ROW D) is unreachable from the estate — the decorators require
+/// LeftMajor — and `bind_destination` refuses it loudly, naming the
+/// measured library finding, BEFORE any descriptor is built.
+#[test]
+fn bias_epilogue_forms_with_a_row_d_trip_the_unreachable_fence() {
+    for form in [CublasLtForm::Bias, CublasLtForm::AccumulateBias] {
+        let mut call = plan_call_from_spec(&bias_spec(form)).expect("plan");
+        let err = bind_destination(&mut call, &right_major(&[4, 3]), "pin")
+            .expect_err("a ROW-order D under a bias form must be refused");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("unreachable"), "{form:?}: {msg}");
+        assert!(
+            msg.contains("bias decorators require a LeftMajor D"),
+            "{form:?}: the refusal must name the estate premise: {msg}"
+        );
+        assert!(
+            msg.contains("Row-order D descriptor"),
+            "{form:?}: the refusal must print the order it saw: {msg}"
+        );
+        assert!(msg.contains("refused BEFORE dispatch"), "{form:?}: {msg}");
+    }
+    // The default forms are untouched by the tripwire: a ROW D binds.
+    for form in [CublasLtForm::Base, CublasLtForm::Accumulate] {
         let mut spec = base_spec(4, 3, 5);
         spec.form = form;
         spec.has_c = form.has_c();
-        spec.has_bias = true;
         if form.has_c() {
             spec.c_tensor = Some(cid("c_lt"));
         }
-        spec.bias_tensor = Some(cid("bias_lt"));
-        spec.epilogue = CuEpilogue::Bias;
-        let err = plan_call_from_spec(&spec).expect_err("bias form must refuse at plan time");
-        let msg = format!("{err:#}");
-        assert!(msg.contains("NOT dispatchable under"), "{msg}");
-        assert!(
-            msg.contains("ROW"),
-            "the refusal must name the convention: {msg}"
-        );
+        let mut call = plan_call_from_spec(&spec).expect("plan");
+        bind_destination(&mut call, &right_major(&[4, 3]), "pin")
+            .expect("default-epilogue forms dispatch under either order");
+        assert_eq!(call.d, LtDesc::row(4, 3, 3));
     }
 }
 
@@ -221,15 +283,19 @@ fn row_bridge_flips_the_spec_col_readings() {
 
 #[test]
 fn beta_is_structural_per_form_and_nothing_else() {
-    // The bias forms refuse at plan time (see
-    // `bias_epilogue_forms_refuse_at_plan_time`); the structural-beta
-    // pin runs over the dispatchable forms.
-    for form in [CublasLtForm::Base, CublasLtForm::Accumulate] {
+    // All four forms plan (ruling 2026-09-01: the bias forms dispatch
+    // under a COL D — see `bias_epilogue_forms_plan_and_bind_under_a_col_d`).
+    for form in CublasLtForm::ALL {
         let mut spec = base_spec(4, 3, 5);
         spec.form = form;
         spec.has_c = form.has_c();
+        spec.has_bias = form.has_bias();
         if form.has_c() {
             spec.c_tensor = Some(cid("c_lt"));
+        }
+        if form.has_bias() {
+            spec.bias_tensor = Some(cid("bias_lt"));
+            spec.epilogue = CuEpilogue::Bias;
         }
         let call = plan_call_from_spec(&spec).expect("plan");
         assert_eq!(

--- a/tests/test_runtime/tests/cublaslt_bias_leftmajor_premise.rs
+++ b/tests/test_runtime/tests/cublaslt_bias_leftmajor_premise.rs
@@ -1,0 +1,329 @@
+//! THE LAYOUT HALF of the LeftMajor-D premise proof (ruling 2026-09-01).
+//!
+//! The bias decorators (`cublaslt_marker_decorate.egg`) mint a bias form
+//! only when the sibling D's layout class holds
+//! `LeftMajorContiguousElementLayoutLit`. This board asks, on the SAME
+//! recorded program (x[4,8] @ w[8,3] + b[3]), what happens when that
+//! spelling is present and when it is absent:
+//!
+//!  1. `contiguous_recorder_output_mints_the_bias_form` — the recorder's
+//!     row-major out: the sibling D is left-major, discovery finds it,
+//!     the bias form is minted.
+//!  2. `padded_output_binding_does_not_remove_the_row_major_route` — the
+//!     boundary out2 bound to a PADDED strided layout (ld = n + 1 = 4).
+//!     FINDING, recorded rather than wished away: the boundary binding
+//!     does NOT gate the mint, because layout tensors flow FORWARD from
+//!     the row-major inputs (`src/logical_op/*/forward_layout.egg`: a
+//!     ReduceSum out is always minted row-major; Add forwards each
+//!     operand's layout to its out), so `y_outer` and `out2` carry a
+//!     right-major layout tensor whatever the boundary says, and the
+//!     decorator's own `(= ?d_layout (RightMajorContiguousElementLayoutLit
+//!     ?d_shape ?d_bits))` premise picks it. The padded binding adds a
+//!     second route; it removes none. The test pins the mechanism.
+//!  3. `without_left_major_discovery_the_bias_form_is_not_minted` — the
+//!     ISOLATING negative: identical program, identical estate, with the
+//!     ONE preamble rule that unions a strided chain with the left-major
+//!     literal (arm 3a) ablated from the assembled text. The base form
+//!     still assembles (its D reading is chain-native and injectivity
+//!     rides the transpose transport), the bias form does not. The only
+//!     difference between 1 and 3 is whether the LeftMajor spelling
+//!     exists in the D class — which is exactly the new premise.
+
+use std::collections::BTreeSet;
+
+use egglog::SerializeConfig;
+use luminal::graph::Graph;
+use luminal::prelude::egraph_serialize::{ClassId, EGraph, Node};
+
+fn count(s: &EGraph, op: &str) -> usize {
+    s.nodes.values().filter(|n| n.op == op).count()
+}
+
+fn class_ops(s: &EGraph, class: &ClassId) -> BTreeSet<String> {
+    s.nodes
+        .values()
+        .filter(|n| &n.eclass == class)
+        .map(|n| n.op.clone())
+        .collect()
+}
+
+fn child_class(s: &EGraph, node: &Node, index: usize) -> ClassId {
+    s.nodes[&node.children[index]].eclass.clone()
+}
+
+fn node_in_class<'a>(s: &'a EGraph, class: &ClassId, op: &str) -> Option<&'a Node> {
+    s.nodes.values().find(|n| &n.eclass == class && n.op == op)
+}
+
+/// D descriptor at slot 3 -> layout tensor (child 1) -> LayoutTensorLit's
+/// layout (child 1).
+fn d_layout_class(s: &EGraph, op_node: &Node) -> ClassId {
+    let desc_class = child_class(s, op_node, 3);
+    let desc = node_in_class(s, &desc_class, "CublasLtOutputDDescriptor").expect("D descriptor");
+    let lt_class = child_class(s, desc, 1);
+    let lt = node_in_class(s, &lt_class, "LayoutTensorLit").expect("layout tensor");
+    child_class(s, lt, 1)
+}
+
+fn d_class_ops_for(s: &EGraph, op: &str) -> Vec<BTreeSet<String>> {
+    let classes: BTreeSet<ClassId> = s
+        .nodes
+        .values()
+        .filter(|n| n.op == op)
+        .map(|n| d_layout_class(s, n))
+        .collect();
+    classes.iter().map(|c| class_ops(s, c)).collect()
+}
+
+/// x[4,8] @ w[8,3] + b[3] broadcast over the batch axis — the recorder's
+/// per-feature bias spelling (rank-1 [n] applied through (CoordVar d_shape
+/// 0) into [m, n]; `expand_dim(0, 4)` and `Linear`'s `expand_lhs(&[4])`
+/// record the same map). Returns the program text and the boundary
+/// output's SSA name and slot key.
+fn recorded_bias_program() -> (String, String, usize) {
+    let mut cx = Graph::new();
+    let x = cx.tensor((4usize, 8usize));
+    let w = cx.tensor((8usize, 3usize));
+    let b = cx.tensor(3usize);
+    let out = (x.matmul(w) + b.expand_dim(0, 4usize)).output();
+    let text = cx
+        .logical
+        .bound_program(&test_runtime::TestRuntimeBindings)
+        .expect("recorder clean")
+        .text;
+    (text, format!("v{}", out.id.index()), out.id.index())
+}
+
+fn report(s: &EGraph, what: &str) -> (usize, usize) {
+    let base = count(s, "LayoutTensorOpCublasLt");
+    let bias = count(s, "LayoutTensorOpCublasLtBias");
+    let acc = count(s, "LayoutTensorOpCublasLtAccumulate");
+    let acc_bias = count(s, "LayoutTensorOpCublasLtAccumulateBias");
+    println!(
+        "LM-PREMISE {what}: base={base} bias={bias} accumulate={acc} accumulate_bias={acc_bias}"
+    );
+    for ops in d_class_ops_for(s, "LayoutTensorOpCublasLt") {
+        println!("LM-PREMISE {what}: base D layout class ops = {ops:?}");
+    }
+    for ops in d_class_ops_for(s, "LayoutTensorOpCublasLtBias") {
+        println!("LM-PREMISE {what}: bias D layout class ops = {ops:?}");
+    }
+    (base, bias)
+}
+
+// ---------------------------------------------------------------------------
+// 1. The contiguous case: minted.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn contiguous_recorder_output_mints_the_bias_form() {
+    let (text, _out_name, _key) = recorded_bias_program();
+    let s = test_runtime::serialize_fixture(&text);
+    let (base, bias) = report(&s, "contiguous");
+    assert!(base > 0);
+    assert!(
+        bias > 0,
+        "the row-major recorder out yields a left-major sibling D: minted"
+    );
+    for ops in d_class_ops_for(&s, "LayoutTensorOpCublasLtBias") {
+        assert!(
+            ops.contains("LeftMajorContiguousElementLayoutLit"),
+            "every bias form's D class holds the left-major spelling: {ops:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. The padded boundary binding: the finding.
+// ---------------------------------------------------------------------------
+
+/// Rewrite the boundary output's binding from the row-major contiguous
+/// spelling to a PADDED strided one (row pitch 4 over 3 columns), with the
+/// creator's `strided-lists` row (so the layout climbs the ladder and can
+/// be a composition parent) and the creator's injectivity certificate
+/// (pitch >= extent: a non-overlapping layout the preamble cannot prove).
+fn pad_output_binding(text: &str, key: usize) -> String {
+    let stem = format!("natout{key}");
+    let prefix = format!("(let {stem}_layout (RightMajorContiguousElementLayoutLit ");
+    let suffix = " (bits-of (F32))))";
+    let line = text
+        .lines()
+        .find(|l| l.starts_with(&prefix))
+        .unwrap_or_else(|| panic!("the boundary output binding line for {stem} exists"));
+    let shape = &line[prefix.len()..line.len() - suffix.len()];
+    let padded = format!(
+        "(let {stem}_padded_shape {shape})\n\
+         (let {stem}_layout (StridedElementLayoutLit {stem}_padded_shape\n\
+         \x20 (IntAffineExprCons (IntMul (CoordVar {stem}_padded_shape 1) (IntLit 4))\n\
+         \x20   (IntAffineExprCons (CoordVar {stem}_padded_shape 0) (IntAffineExprNil)))\n\
+         \x20 (bits-of (F32))))\n\
+         (strided-lists {stem}_layout {stem}_padded_shape\n\
+         \x20 (IntExprCons (IntLit 4) (IntExprCons (IntLit 3) (IntExprNil)))\n\
+         \x20 (IntExprCons (IntLit 4) (IntExprCons (IntLit 1) (IntExprNil)))\n\
+         \x20 (bits-of (F32)))"
+    );
+    let lt_line = format!("(let {stem}_layout_tensor (LayoutTensorLit ");
+    let mut out = String::new();
+    let mut replaced = 0;
+    for l in text.lines() {
+        if l == line {
+            out.push_str(&padded);
+            out.push('\n');
+            replaced += 1;
+        } else if l.starts_with(&lt_line) {
+            out.push_str(l);
+            out.push('\n');
+            out.push_str(&format!(
+                "(set (injectivity-of {stem}_layout_tensor) (Injective))\n"
+            ));
+        } else {
+            out.push_str(l);
+            out.push('\n');
+        }
+    }
+    assert_eq!(replaced, 1, "exactly one boundary layout line rewritten");
+    out
+}
+
+#[test]
+fn padded_output_binding_does_not_remove_the_row_major_route() {
+    let (text, out_name, key) = recorded_bias_program();
+    let padded = pad_output_binding(&text, key);
+    println!("LM-PREMISE padded binding text:\n{}", {
+        let stem = format!("natout{key}");
+        padded
+            .lines()
+            .filter(|l| l.contains(&stem))
+            .collect::<Vec<_>>()
+            .join("\n")
+    });
+    let s = test_runtime::serialize_fixture(&padded);
+    let (base, bias) = report(&s, "padded-boundary");
+    assert!(base > 0);
+
+    // THE MECHANISM, read off the e-graph: the boundary value out2 (the
+    // recorder's `v{out}`) carries MORE THAN ONE layout tensor — the
+    // padded one we bound AND a right-major one the forward-propagation
+    // rules minted from the row-major inputs. Find out2's class through
+    // the padded layout tensor we authored, then list every layout class
+    // any LayoutTensorLit gives it.
+    let padded_lt_name_class: Option<ClassId> = {
+        // The padded StridedElementLayoutLit we wrote is the ONLY strided
+        // [4,3] layout with a literal-4 pitch; its class must NOT carry the
+        // right-major spelling (pitch 4 != 3).
+        s.nodes
+            .values()
+            .filter(|n| n.op == "StridedElementLayoutLit")
+            .map(|n| n.eclass.clone())
+            .find(|c| {
+                let ops = class_ops(&s, c);
+                !ops.contains("RightMajorContiguousElementLayoutLit")
+                    && !ops.contains("LeftMajorContiguousElementLayoutLit")
+                    && s.nodes.values().any(|lt| {
+                        lt.op == "LayoutTensorLit"
+                            && lt.children.len() == 2
+                            && s.nodes[&lt.children[1]].eclass == *c
+                    })
+            })
+    };
+    let padded_class =
+        padded_lt_name_class.expect("the padded layout class exists, distinct from RM/LM");
+    println!(
+        "LM-PREMISE padded-boundary: padded layout class {padded_class:?} ops = {:?}",
+        class_ops(&s, &padded_class)
+    );
+    // out2's logical class = the logical child of a LayoutTensorLit whose
+    // layout is the padded class.
+    let out2_class: ClassId = s
+        .nodes
+        .values()
+        .find(|lt| lt.op == "LayoutTensorLit" && s.nodes[&lt.children[1]].eclass == padded_class)
+        .map(|lt| s.nodes[&lt.children[0]].eclass.clone())
+        .expect("a layout tensor rides the padded layout");
+    let out2_layout_classes: BTreeSet<ClassId> = s
+        .nodes
+        .values()
+        .filter(|lt| lt.op == "LayoutTensorLit" && s.nodes[&lt.children[0]].eclass == out2_class)
+        .map(|lt| s.nodes[&lt.children[1]].eclass.clone())
+        .collect();
+    let mut has_rm_route = false;
+    for c in &out2_layout_classes {
+        let ops = class_ops(&s, c);
+        println!("LM-PREMISE padded-boundary: {out_name} layout tensor class {c:?} ops = {ops:?}");
+        has_rm_route |= ops.contains("RightMajorContiguousElementLayoutLit");
+    }
+    assert!(
+        has_rm_route,
+        "the boundary value still carries a RIGHT-MAJOR layout tensor (forward layout \
+         propagation from the row-major inputs) — the route the bias decorator reads"
+    );
+    assert!(
+        bias > 0,
+        "and therefore the bias form is STILL minted: a boundary binding cannot remove the \
+         forward-propagated right-major route; the premise is gated by discovery, not by the \
+         boundary spelling (finding recorded 2026-09-01)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. The isolating negative: no left-major literal, no bias form.
+// ---------------------------------------------------------------------------
+
+/// The ONE preamble rule that unions a strided chain with the left-major
+/// literal — arm (3a) of DOWNWARD LAYOUT DISCOVERY
+/// (`src/egglog/checkpoint_5/egglog_preamble.egg`, "(3a) contiguous
+/// discovery"), quoted verbatim so the ablation cannot drift.
+const LEFT_MAJOR_DISCOVERY_RULE: &str = "(rule
+  (
+    (= ?layout (StridedElementLayoutLit ?shape ?chain ?bits))
+    (= ?shape (ShapeLit ?dims))
+    (= (left-major-strides-state-of ?dims)
+      (LeftMajorStridesFoldStateLit ?rank ?total ?strides))
+    (affine-zip-out ?shape ?dims ?strides ?chain)
+  )
+  (
+    (union ?layout (LeftMajorContiguousElementLayoutLit ?shape ?bits))
+  )
+)";
+
+fn serialize_with_ablated_left_major_discovery(script_text: &str) -> EGraph {
+    let preamble = luminal::egglog_snippet::assembled_program_for(&test_runtime::matchers());
+    assert_eq!(
+        preamble.matches(LEFT_MAJOR_DISCOVERY_RULE).count(),
+        1,
+        "the (3a) left-major discovery rule appears exactly once in the assembled program"
+    );
+    let ablated = preamble.replace(
+        LEFT_MAJOR_DISCOVERY_RULE,
+        "; ABLATED FOR THE LM-PREMISE NEGATIVE: (3a) Strided -> LeftMajorContiguous discovery",
+    );
+    let program = format!("{ablated}\n\n{script_text}");
+    let mut egraph = luminal::egglog_snippet::new_egraph();
+    egraph
+        .parse_and_run_program(None, &program)
+        .unwrap_or_else(|err| panic!("egglog failed on the ablated program: {err}"));
+    egraph.serialize(SerializeConfig::default()).egraph
+}
+
+#[test]
+fn without_left_major_discovery_the_bias_form_is_not_minted() {
+    let (text, _out_name, _key) = recorded_bias_program();
+    let s = serialize_with_ablated_left_major_discovery(&text);
+    let (base, bias) = report(&s, "ablated-3a");
+    assert_eq!(
+        count(&s, "LeftMajorContiguousElementLayoutLit"),
+        0,
+        "with arm 3a ablated nothing mints the left-major literal (the decorator does not)"
+    );
+    assert!(
+        base > 0,
+        "the BASE form still assembles: its D reading is chain-native (unit stride on m) and \
+         injectivity rides the transpose transport — neither needs the literal"
+    );
+    assert_eq!(
+        bias, 0,
+        "NO bias form: the only thing that changed is the LeftMajor spelling's presence in \
+         the D class, i.e. the new premise is what gates the mint"
+    );
+    assert_eq!(count(&s, "LayoutTensorOpCublasLtAccumulateBias"), 0);
+}


### PR DESCRIPTION
## What

Resolves R-B (bias epilogue on ROW-order D) the way Austin ruled on 2026-09-01: the layout requirement goes INTO the matching rule. Both bias decorators in `crates/luminal_cuda_lite/src/ops/cublaslt/egg/cublaslt_marker_decorate.egg` now carry

```
(= ?inner_L (LeftMajorContiguousElementLayoutLit ?ishape ?d_bits2))
```

so a bias form is minted only when the sibling site's D is provably left-major contiguous over `[n, m]`. That is the storage order the library accepts for `BIAS`/`RELU_BIAS` (ROW-order D is `CUBLAS_STATUS_NOT_SUPPORTED`, measured 2026-08-28) and the one that puts the per-feature vector on D's rows, the API's only bias axis. Downward discovery (preamble 3a/3c + native chain composition) supplies the literal; the decorator never mints it. No general rule.

Executor: `plan_call_from_spec` and `dispatch` no longer refuse bias forms. `assert_bias_destination_order` fences a bias call whose D is not COL as unreachable (runs at the end of `bind_destination`, after the order is known, and again in `dispatch` for hand-built calls).

One test seam: `CudaRuntime::saturated_egraph` factored from `search` so pins read exactly the e-graph the search reads.

## Proof (CPU, in-tree)

`crates/luminal_cuda_lite/tests/cublaslt_bias_premise.rs`
- Linear-with-bias (`x[4,8] @ w[8,3] + b[3]`, spelled as `luminal_nn::Linear` spells it) mints `CublasLtBias`; its D layout class holds `LeftMajorContiguousElementLayoutLit [3,4]`.
- Seeded search (12x16/mut-4) elects `CublasLtBias` as the sole compute at seed 0; `plan_call` + `bind_destination` yield `d.order == Col`, `ld == 3`, `m/n` swapped to the sibling frame.
- Logical negative: bias broadcast along the wrong axis mints no bias form.

`tests/test_runtime/tests/cublaslt_bias_leftmajor_premise.rs`
- Positive on the recorded program; padded-boundary finding pinned (layouts flow forward from the RM inputs, so a padded output binding adds a route and removes none); isolating negative: with the one preamble rule that discovers the left-major literal ablated, the base form still mints and the bias form does not.

Independent probe (4 agents, saturated e-graph walk): every `CublasLtOutputDDescriptor` class ridden by a bias form already contains the LeftMajor literal on Linear, permuted Linear, and Mlp; matches the hardware record in 0ff2f94a.

## Proof (A100, 2026-09-02, branch at 7ddd9a5e)

One-off smoke (not committed): elect the fused plan, execute, compare to a scalar CPU walk with a wrong-axis discriminator.
```
SMOKE seed 0: computes=["CublasLtBias"] refusals=[extract refusals 14 (choice-cycles 14, dead-ends 0), bufferize 13, execute 0]
SMOKE max |got - expected| = 5.9604645e-8
test bias_premise_device_smoke ... ok
```
Device contracts suite (in-tree, `--features device`):
```
test ld_bounds_violation_refuses_before_dispatch ... ok
test bias_form_with_a_row_d_is_refused_before_dispatch ... ok
test tf32_strictness_detector_is_green ... ok
test all_four_contract_forms_execute_green ... ok
test marker_elected_plan_matches_decomposed_route_tolerance_based ... ok
test marker_elected_bias_plan_matches_decomposed_route_tolerance_based ... ok
test result: ok. 6 passed; 0 failed
```
So COL-order D + BIAS epilogue is SUPPORTED by the library and numerically correct; the bias forms now execute instead of being refused.

## Gates (CPU, worktree at cc5b60a2 then rebased clean onto d015f718)
luminal lib, test_runtime, luminal_cuda_lite all green; cargo fmt clean.

## Not in this PR
- The real-model bias site (full whisper encoder) is covered by the `Linear::new_permuted(.., true)` spelling in the premise pin; the full model itself is a CL example run, not a test.
- cuBLASLt always-on default is still gated on the budget/sampler decision (2x4 exhausts on the collapse 2-cycle; 12x16 elects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)