### PR TITLE
Fix signed integral aten.pow.Tensor_Scalar lowering

### DIFF
--- a/crates/luminal_python/rust/src/translator/binary.rs
+++ b/crates/luminal_python/rust/src/translator/binary.rs
@@ -234,6 +234,50 @@ impl<'a> Translator<'a> {
         Ok(result)
     }
 
+    pub(crate) fn translate_tensor_scalar_pow(&mut self, node: &Node) -> Result<GraphTensor> {
+        let output_dtype = self.output_meta_dtype(node)?;
+        let base = self.get_input_tensor(node, 0)?.cast(output_dtype);
+        let exponent = self.get_float_arg(node, 1)?;
+
+        // GraphTensor::pow implements the general real-valued approximation
+        // through abs(base).log(), which loses the sign of negative bases.
+        // Integral scalar exponents have exact multiplication semantics, so
+        // lower them structurally and preserve odd-power signs. Exponentiation
+        // by squaring keeps the graph logarithmic in the exponent.
+        if exponent.is_finite() && exponent.fract() == 0.0 && exponent.abs() < i64::MAX as f64 {
+            let exponent = exponent as i64;
+            if exponent == 0 {
+                return Ok(self.constant_like(base, 1.0));
+            }
+
+            let reciprocal = exponent < 0;
+            let mut remaining = exponent.unsigned_abs();
+            let mut factor = base;
+            let mut result = None;
+            while remaining > 0 {
+                if remaining & 1 == 1 {
+                    result = Some(match result {
+                        Some(value) => value * factor,
+                        None => factor,
+                    });
+                }
+                remaining >>= 1;
+                if remaining > 0 {
+                    factor = factor * factor;
+                }
+            }
+
+            let result = result.expect("nonzero integral exponent must produce a power");
+            return Ok(if reciprocal {
+                result.reciprocal()
+            } else {
+                result
+            });
+        }
+
+        Ok(base.pow(exponent as f32))
+    }
+
     /// Lower boolean OR through numeric HLIR ops until HLIR has native logical ops.
     pub(crate) fn apply_bool_or(&mut self, a: GraphTensor, b: GraphTensor) -> GraphTensor {
         let a = a.cast(DType::F32);

--- a/crates/luminal_python/rust/src/translator/dispatch.rs
+++ b/crates/luminal_python/rust/src/translator/dispatch.rs
@@ -408,15 +408,7 @@ impl<'a> Translator<'a> {
             "torch.ops.aten.masked_fill.Scalar" => self.translate_masked_fill_scalar(node)?,
 
             // Pow
-            "torch.ops.aten.pow.Tensor_Scalar" => {
-                let a = self.get_input_tensor(node, 0)?;
-                let exp = self.get_float_arg(node, 1)?;
-                if (exp - 2.0).abs() < f64::EPSILON {
-                    a * a
-                } else {
-                    a.pow(exp as f32)
-                }
-            }
+            "torch.ops.aten.pow.Tensor_Scalar" => self.translate_tensor_scalar_pow(node)?,
             "torch.ops.aten.pow.Tensor_Tensor" => {
                 let a = self.get_input_tensor(node, 0)?;
                 let b = self.get_input_tensor(node, 1)?;

--- a/crates/luminal_python/tests/test_hlir_ops.py
+++ b/crates/luminal_python/tests/test_hlir_ops.py
@@ -1495,9 +1495,7 @@ def test_pow_by_constant(device: torch.device):
 
 
 @pytest.mark.parametrize("exponent", [0.0, 1.0, 2.0, 3.0, 4.0, -3.0])
-def test_pow_by_integral_scalar_preserves_sign(
-    device: torch.device, exponent: float
-):
+def test_pow_by_integral_scalar_preserves_sign(device: torch.device, exponent: float):
     """Integral scalar powers preserve negative bases and reciprocal signs."""
     model: torch.nn.Module = PowByScalarModel(exponent).to(device)
     model_compiled: Callable = torch.compile(model, backend=luminal_backend)

--- a/crates/luminal_python/tests/test_hlir_ops.py
+++ b/crates/luminal_python/tests/test_hlir_ops.py
@@ -85,6 +85,7 @@ from test_models import (
     # GELU models
     GeluTestModel,
     GeluTanhModel,
+    Gpt2ApproxGeluModel,
     LinearGeluBatchedModel,
     # LayerNormalization model
     ConvGroupNormSiLUModel,
@@ -125,6 +126,7 @@ from test_models import (
     # Or model
     OrTestModel,
     PowByConstantModel,
+    PowByScalarModel,
     # Pow models
     PowTestModel,
     ReduceMax3DAxis1Model,
@@ -1490,6 +1492,40 @@ def test_pow_by_constant(device: torch.device):
     original: torch.Tensor = model(x)
     output: torch.Tensor = model_compiled(x)
     assert torch.allclose(output, original, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("exponent", [0.0, 1.0, 2.0, 3.0, 4.0, -3.0])
+def test_pow_by_integral_scalar_preserves_sign(
+    device: torch.device, exponent: float
+):
+    """Integral scalar powers preserve negative bases and reciprocal signs."""
+    model: torch.nn.Module = PowByScalarModel(exponent).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.tensor([-3.0, -1.0, -0.5, 0.5, 1.0, 3.0], device=device)
+    original = model(x)
+    output = model_compiled(x)
+    assert torch.allclose(output, original, rtol=1e-4, atol=1e-4)
+
+
+def test_pow_by_float_scalar_promotes_integer_base(device: torch.device):
+    """A float scalar exponent promotes an integer tensor to PyTorch's output dtype."""
+    model: torch.nn.Module = PowByScalarModel(3.0).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.tensor([-3, -1, 1, 3], dtype=torch.int32, device=device)
+    original = model(x)
+    output = model_compiled(x)
+    assert output.dtype == original.dtype
+    assert torch.equal(output, original)
+
+
+def test_gpt2_approx_gelu_preserves_cubic_sign(device: torch.device):
+    """Regression for GPT-2 logits corrupted by lowering x.pow(3) as abs(x)^3."""
+    model: torch.nn.Module = Gpt2ApproxGeluModel().to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.linspace(-5.0, 5.0, 129, device=device)
+    original = model(x)
+    output = model_compiled(x)
+    assert torch.allclose(output, original, rtol=1e-5, atol=1e-5)
 
 
 # ========== PT2 Where Node Tests ==========

--- a/crates/luminal_python/tests/test_models.py
+++ b/crates/luminal_python/tests/test_models.py
@@ -1139,6 +1139,27 @@ class PowByConstantModel(torch.nn.Module):
         return x**constant
 
 
+class PowByScalarModel(torch.nn.Module):
+    """Tests aten.pow.Tensor_Scalar with a compile-time scalar exponent."""
+
+    def __init__(self, exponent: float) -> None:
+        super().__init__()
+        self.exponent = exponent
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x.pow(self.exponent)
+
+
+class Gpt2ApproxGeluModel(torch.nn.Module):
+    """GPT-2's GELU formula, whose cubic term must preserve negative signs."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        cubic = x.pow(3.0)
+        return 0.5 * x * (
+            1.0 + torch.tanh(0.7978845608028654 * (x + 0.044715 * cubic))
+        )
+
+
 # ========== Where Node Test Models ==========
 
 

--- a/crates/luminal_python/tests/test_models.py
+++ b/crates/luminal_python/tests/test_models.py
@@ -1155,9 +1155,7 @@ class Gpt2ApproxGeluModel(torch.nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         cubic = x.pow(3.0)
-        return 0.5 * x * (
-            1.0 + torch.tanh(0.7978845608028654 * (x + 0.044715 * cubic))
-        )
+        return 0.5 * x * (1.0 + torch.tanh(0.7978845608028654 * (x + 0.044715 * cubic)))
 
 
 # ========== Where Node Test Models ==========


### PR DESCRIPTION
## Summary
- lower finite integral `aten.pow.Tensor_Scalar` exponents with exponentiation by squaring
- preserve negative-base signs, negative-exponent reciprocals, zero-exponent behavior, and PyTorch output dtype promotion
- add direct signed-power and GPT-2 approximate-GELU regressions

## Root cause
`GraphTensor::pow` implements the general real-valued approximation through `log(abs(base))`, so `x.pow(3.0)` produced `abs(x)^3`. GPT-2 uses that cubic expression in every approximate GELU, corrupting its MLPs and final logits.

## Validation
- `cargo fmt --all --check`
- `cargo clippy -p luminal_python --all-targets --features cuda -- -D warnings`
- `cargo test --release -p luminal_python --verbose`: 16 passed
- CPU power suites: 12 passed
- CUDA power suites on GH200: 12 passed
- actual CUDA top-100 GPT-2 probe: `match`, cosine 1.0, max absolute logit error 0.000061, argmax 8/8

The full local native Python CI slice completed with 284 passed and two unrelated fp16 parity failures (`cumsum` and CPU SDPA). Both failures reproduce identically on clean `origin/main`.