### PR TITLE
Render memo + deferred display text: the extraction wall, removed

### DIFF
--- a/src/dps.rs
+++ b/src/dps.rs
@@ -77,7 +77,7 @@ pub fn dps_rewrite(graph: &ExtractedGraph) -> ExtractedGraph {
                 // number would leak into buffer labels (alloc#N[poisonNN])
                 // where alloc#N already disambiguates.
                 label: "Poison".to_string(),
-                tooltip: "poison destination (contents undefined)".to_string(),
+                tooltip: "poison destination (contents undefined)".to_string().into(),
                 shape: result.shape.clone(),
                 dtype: result.dtype.clone(),
                 dtype_enum: result.dtype_enum,
@@ -89,8 +89,8 @@ pub fn dps_rewrite(graph: &ExtractedGraph) -> ExtractedGraph {
                     eclass: ClassId::from(format!("dps$poison_logical${synth}")),
                     // Display label only — identity lives in the eclass, so
                     // every poison shows plainly as "Poison", unnumbered.
-                    label: "Poison".to_string(),
-                    tooltip: "undefined contents".to_string(),
+                    label: "Poison".to_string().into(),
+                    tooltip: "undefined contents".to_string().into(),
                     op: None,
                     children: Vec::new(),
                 },
@@ -102,7 +102,7 @@ pub fn dps_rewrite(graph: &ExtractedGraph) -> ExtractedGraph {
                 provenance: Provenance::Synthesized { id: synth },
                 inputs: Vec::new(),
                 outputs: vec![poison_value],
-                tooltip: "synthesized by dps_rewrite".to_string(),
+                tooltip: "synthesized by dps_rewrite".to_string().into(),
                 heuristic_cost: 0,
             }));
 

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -1,4 +1,6 @@
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+use std::rc::Rc;
 
 use anyhow::{Context, Result, bail};
 use egraph_serialize::{ClassId, EGraph, Node, NodeId};
@@ -6,8 +8,8 @@ use petgraph::graph::{DiGraph, NodeIndex};
 
 use crate::layout_ir::{
     Access, BufferInfo, ExtractedDag, ExtractedEdge, ExtractedGraph, ExtractedNode, ExtractionSite,
-    FreedBy, InputNode, LayoutInfo, LayoutIrOp, LayoutTensorInfo, LogicalInfo, OpInput, OpMatcher,
-    OpNode, OutputNode, OutputSlot,
+    FreedBy, InputNode, LayoutInfo, LayoutIrOp, LayoutTensorInfo, LazyText, LogicalInfo, OpInput,
+    OpMatcher, OpNode, OutputNode, OutputSlot,
 };
 use crate::logical_op::{LogicalRender, logical_op_for};
 
@@ -25,7 +27,11 @@ struct Extractor<'a> {
     /// has no entry here simply offers no implementation candidate.
     matchers: HashMap<&'static str, Box<dyn OpMatcher>>,
     class_nodes: HashMap<ClassId, Vec<NodeId>>,
-    render_class_nodes: HashMap<ClassId, Vec<NodeId>>,
+    /// The shared rendering state: the render-time class index and the
+    /// per-(class, depth, preference) render memo, behind an `Rc` so the
+    /// lazy text closures the extraction hands out can keep it alive
+    /// after this borrow of the caller's e-graph ends.
+    render: Rc<RenderCtx>,
     op_specs: HashMap<ClassId, Vec<OpSpec>>,
     producer_index: HashMap<ClassId, Vec<ProducerRef>>,
     input_terminals: HashMap<ClassId, InputInfo>,
@@ -105,6 +111,21 @@ struct PlanChild {
 struct PlanMeta {
     name: &'static str,
     class: ClassId,
+}
+
+/// Everything `ClassRenderer::op_tooltip` reads out of a [`Plan`], cloned
+/// at emission time so the DEFERRED tooltip can render long after the
+/// plan (an extractor-internal value) is gone.
+#[derive(Debug, Clone)]
+struct OpTooltipSeed {
+    class: ClassId,
+    source_eclass: Option<ClassId>,
+    source_enode: Option<NodeId>,
+    selected_output_index: Option<usize>,
+    heuristic_cost: u64,
+    input_list: Vec<ClassId>,
+    output_list: Vec<ClassId>,
+    metadata: Vec<PlanMeta>,
 }
 
 /// Extractor-internal ONLY. `PlanKind` is the selection/cost IR at *e-graph*
@@ -730,22 +751,18 @@ impl<'a> Extractor<'a> {
             .map(|matcher| (matcher.egglog_constructor(), matcher))
             .collect();
         let class_nodes = class_nodes(egraph);
-        let render_class_nodes = render_class_nodes(egraph);
-        let (op_specs, producer_index) = collect_op_specs(egraph, &render_class_nodes);
+        let render = Rc::new(RenderCtx::new(egraph));
+        let (op_specs, producer_index) = collect_op_specs(egraph, &render.class_nodes);
         let output_buffer_classes = collect_output_buffer_classes(egraph, &class_nodes);
         let input_buffer_classes = collect_input_buffer_classes(egraph, &class_nodes);
-        let input_terminals = collect_input_terminals(
-            egraph,
-            &render_class_nodes,
-            &output_buffer_classes,
-            &input_buffer_classes,
-        );
+        let input_terminals =
+            collect_input_terminals(&render, &output_buffer_classes, &input_buffer_classes);
 
         Self {
             egraph,
             matchers,
             class_nodes,
-            render_class_nodes,
+            render,
             op_specs,
             producer_index,
             input_terminals,
@@ -1280,86 +1297,20 @@ impl<'a> Extractor<'a> {
             .map(|child| child.eclass.clone())
     }
 
-    fn render_buffer_id(&self, class: &ClassId) -> String {
-        self.render_class_prefer(class, 3, Some("BufferLit"))
-    }
-
-    fn layout_tensor_details(&self, class: &ClassId) -> Vec<(String, String)> {
-        self.renderer().layout_tensor_details(class)
-    }
+    // The remaining renderer delegates are the ones the EXTRACTION path
+    // still reads. Everything the tooltips used moved onto
+    // `ClassRenderer` with them (see `Extractor::lazy_text`).
 
     fn layout_tensor_parts(&self, class: &ClassId) -> Option<(ClassId, ClassId)> {
         self.renderer().layout_tensor_parts(class)
-    }
-
-    fn buffer_tensor_parts(&self, class: &ClassId) -> Option<(ClassId, ClassId)> {
-        self.renderer().buffer_tensor_parts(class)
     }
 
     fn class_let_name(&self, class: &ClassId) -> Option<String> {
         self.renderer().class_let_name(class)
     }
 
-    fn class_type(&self, class: &ClassId) -> Option<String> {
-        self.renderer().class_type(class)
-    }
-
-    fn layout_tensor_label(&self, class: &ClassId) -> String {
-        self.renderer().layout_tensor_label(class)
-    }
-
-    fn logical_label(&self, class: &ClassId) -> String {
-        self.renderer().logical_label(class)
-    }
-
-    fn logical_details(&self, class: &ClassId) -> Vec<(String, String)> {
-        self.renderer().logical_details(class)
-    }
-
     fn logical_children(&self, class: &ClassId) -> Vec<(&'static str, ClassId)> {
         self.renderer().logical_children(class)
-    }
-
-    fn layout_label(&self, class: &ClassId) -> String {
-        self.renderer().layout_label(class)
-    }
-
-    fn canonical_layout(&self, class: &ClassId) -> String {
-        self.renderer().canonical_layout(class)
-    }
-
-    fn layout_details(&self, class: &ClassId) -> Vec<(String, String)> {
-        self.renderer().layout_details(class)
-    }
-
-    fn readable_shape(&self, class: &ClassId) -> Option<String> {
-        self.renderer().readable_shape(class)
-    }
-
-    fn readable_index_map(&self, class: &ClassId) -> Option<String> {
-        self.renderer().readable_index_map(class)
-    }
-
-    fn render_class_prefer(
-        &self,
-        class: &ClassId,
-        depth: usize,
-        preferred_op: Option<&str>,
-    ) -> String {
-        self.renderer()
-            .render_class_prefer(class, depth, preferred_op)
-    }
-
-    fn render_layout_tensor_list(&self, classes: &[ClassId]) -> String {
-        let items = classes
-            .iter()
-            .enumerate()
-            .map(|(index, class)| {
-                format!("{index}:{}", self.renderer().layout_tensor_summary(class))
-            })
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("[{items}]")
     }
 
     /// Plan preference: (cost, copies, label) as before, then a CONTENT-based
@@ -1403,10 +1354,20 @@ impl<'a> Extractor<'a> {
     }
 
     fn renderer(&self) -> ClassRenderer<'_> {
-        ClassRenderer {
-            egraph: self.egraph,
-            class_nodes: &self.render_class_nodes,
-        }
+        self.render.renderer()
+    }
+
+    /// Defer one display-text field (ruling 2026-09-01). The closure
+    /// captures an `Rc<RenderCtx>` — which owns its e-graph — so it can
+    /// still run after this `Extractor`'s borrow of the caller's e-graph
+    /// is gone, which is the normal case: the fixture harnesses drop the
+    /// deserialized e-graph the moment extraction returns, and the
+    /// visualizer reads the text long afterwards. `build` must be the
+    /// SAME code the eager version ran, so the deferred string is the
+    /// eager string.
+    fn lazy_text(&self, build: impl Fn(&ClassRenderer<'_>) -> String + 'static) -> LazyText {
+        let ctx = Rc::clone(&self.render);
+        LazyText::deferred(move || build(&ctx.renderer()))
     }
 
     // ---- bytes-moved heuristic pricing (ruling 2026-08-10): the
@@ -1691,9 +1652,59 @@ impl Candidate {
     }
 }
 
+/// The render memo's key: an e-class, the remaining render depth, and the
+/// preferred constructor. `preferred_op` is `&'static str` because every
+/// caller names a constructor literally (or goes through
+/// [`metadata_preferred_op`]), so a lookup allocates nothing; `ClassId` is
+/// an `Arc<str>`, whose clone is a refcount bump.
+type RenderKey = (ClassId, usize, Option<&'static str>);
+
+/// The rendering state every renderer view shares: the e-graph, the
+/// render-time class index (subsumed nodes INCLUDED — see
+/// [`render_class_nodes`]), and the render memo.
+///
+/// A MEMO, NEVER A SKIP (ruling 2026-09-01). Rendered text is not only
+/// display: `stable_key` renders a plan's source e-node to break
+/// selection ties, so a cached render must return EXACTLY the string the
+/// uncached computation would have produced. A class's members never
+/// change within a session, so one entry serves every genome — the ctx
+/// outlives `ExtractionSession::extract_with_genome`'s cache clearing,
+/// exactly like `op_cache` and `stable_key_cache`.
+///
+/// The e-graph here is OWNED (a clone of the caller's). Lazy text
+/// closures hold an `Rc<RenderCtx>` and are forced after extraction
+/// returns, by which time the caller's `&EGraph` is frequently gone (the
+/// fixture harnesses drop the deserialized e-graph on return), so a
+/// borrow could not carry them.
+#[derive(Debug)]
+struct RenderCtx {
+    egraph: EGraph,
+    class_nodes: HashMap<ClassId, Vec<NodeId>>,
+    memo: RefCell<HashMap<RenderKey, Rc<str>>>,
+}
+
+impl RenderCtx {
+    fn new(egraph: &EGraph) -> Self {
+        Self {
+            class_nodes: render_class_nodes(egraph),
+            egraph: egraph.clone(),
+            memo: RefCell::new(HashMap::new()),
+        }
+    }
+
+    fn renderer(&self) -> ClassRenderer<'_> {
+        ClassRenderer {
+            egraph: &self.egraph,
+            class_nodes: &self.class_nodes,
+            memo: &self.memo,
+        }
+    }
+}
+
 struct ClassRenderer<'a> {
     egraph: &'a EGraph,
     class_nodes: &'a HashMap<ClassId, Vec<NodeId>>,
+    memo: &'a RefCell<HashMap<RenderKey, Rc<str>>>,
 }
 
 /// The renderer's implementation of the [`LogicalRender`] callbacks: the
@@ -1726,7 +1737,7 @@ impl LogicalRender for LogicalRenderCtx<'_, '_, '_> {
         node: &Node,
         index: usize,
         depth: usize,
-        prefer: Option<&str>,
+        prefer: Option<&'static str>,
     ) -> Option<String> {
         child_class(self.renderer.egraph, node, index)
             .map(|class| self.renderer.render_class_prefer(&class, depth, prefer))
@@ -1764,24 +1775,45 @@ impl<'a> ClassRenderer<'a> {
             .and_then(|data| data.typ.clone())
     }
 
+    /// MEMOIZED per (class, depth, preference) for the session
+    /// (2026-09-01). Rendering recurses into every child class at
+    /// `depth - 1`, so on a convergent DAG the uncached walk re-rendered
+    /// shared subterms once per path — exponential in depth, and the
+    /// extraction wall on the deep model fixtures. A memo is the only
+    /// legal fix: the text feeds `stable_key`, so skipping or truncating
+    /// a render would change plan election. Returns the stored string
+    /// verbatim.
     fn render_class_prefer(
         &self,
         class: &ClassId,
         depth: usize,
-        preferred_op: Option<&str>,
+        preferred_op: Option<&'static str>,
     ) -> String {
         if depth == 0 {
             return class.to_string();
         }
 
-        let Some(node_ids) = self.class_nodes.get(class) else {
-            return class.to_string();
-        };
-        let Some(node_id) = choose_render_node(self.egraph, node_ids, preferred_op) else {
-            return class.to_string();
-        };
+        let key = (class.clone(), depth, preferred_op);
+        // Two statements on purpose: the `Ref` must die at this
+        // semicolon, because `render_node` below recurses straight back
+        // into this function and a live borrow would panic.
+        let hit = self.memo.borrow().get(&key).cloned();
+        if let Some(hit) = hit {
+            return hit.to_string();
+        }
 
-        self.render_node(node_id, depth)
+        let rendered = match self
+            .class_nodes
+            .get(class)
+            .and_then(|node_ids| choose_render_node(self.egraph, node_ids, preferred_op))
+        {
+            Some(node_id) => self.render_node(node_id, depth),
+            None => class.to_string(),
+        };
+        self.memo
+            .borrow_mut()
+            .insert(key, Rc::from(rendered.as_str()));
+        rendered
     }
 
     fn render_class_with_op(&self, class: &ClassId, depth: usize, op: &str) -> Option<String> {
@@ -2354,26 +2386,55 @@ impl<'a> ClassRenderer<'a> {
         details
     }
 
-    fn layout_tensor_details(&self, class: &ClassId) -> Vec<(String, String)> {
-        let Some(node_ids) = self.class_nodes.get(class) else {
-            return Vec::new();
-        };
-
-        for node_id in node_ids {
+    /// The `LayoutTensorLit` member the DETAILS table describes: the
+    /// first one whose logical and layout children both read. Distinct
+    /// from [`Self::layout_tensor_parts`], which stops at the first
+    /// `LayoutTensorLit` even when a child is missing; sharing this one
+    /// selector is what keeps [`Self::layout_tensor_shape_dtype`]
+    /// byte-identical to the `find_detail` lookup it replaced.
+    fn layout_tensor_detail_parts(&self, class: &ClassId) -> Option<(ClassId, ClassId)> {
+        for node_id in self.class_nodes.get(class)? {
             let Some(node) = self.egraph.nodes.get(node_id) else {
                 continue;
             };
             if node.op != "LayoutTensorLit" {
                 continue;
             }
-
             let Some(logical_class) = child_class(self.egraph, node, 0) else {
                 continue;
             };
             let Some(layout_class) = child_class(self.egraph, node, 1) else {
                 continue;
             };
+            return Some((logical_class, layout_class));
+        }
+        None
+    }
 
+    /// The `shape` and `dtype` a value's info carries — EXACTLY what
+    /// `find_detail(&layout_tensor_details(class), "shape"/"dtype")`
+    /// returned: the same member node, the logical side first, the
+    /// layout side only when the logical side offers none. Split out so
+    /// the two eager fields no longer force the whole details table
+    /// (whose `canonical`/`bit_offset` entries are full-depth renders).
+    fn layout_tensor_shape_dtype(&self, class: &ClassId) -> (Option<String>, Option<String>) {
+        let Some((logical_class, layout_class)) = self.layout_tensor_detail_parts(class) else {
+            return (None, None);
+        };
+        (
+            self.logical_shape(&logical_class)
+                .or_else(|| self.layout_shape(&layout_class)),
+            self.logical_dtype(&logical_class)
+                .or_else(|| self.layout_dtype(&layout_class)),
+        )
+    }
+
+    fn layout_tensor_details(&self, class: &ClassId) -> Vec<(String, String)> {
+        let Some((logical_class, layout_class)) = self.layout_tensor_detail_parts(class) else {
+            return Vec::new();
+        };
+
+        {
             let mut details = self.class_details(class);
             details.push(("logical".to_string(), self.logical_label(&logical_class)));
             details.push(("logical_eclass".to_string(), logical_class.to_string()));
@@ -2395,10 +2456,8 @@ impl<'a> ClassRenderer<'a> {
             }
             details.push(("layout".to_string(), self.canonical_layout(&layout_class)));
             details.push(("layout_eclass".to_string(), layout_class.to_string()));
-            return details;
+            details
         }
-
-        Vec::new()
     }
 
     fn logical_shape(&self, class: &ClassId) -> Option<String> {
@@ -2556,6 +2615,152 @@ impl<'a> ClassRenderer<'a> {
         }
         None
     }
+
+    // ---- tooltip builders (ported from the former GraphBuilder; they
+    // live on the renderer, not the extractor, so a DEFERRED text field
+    // can run them with nothing but the render ctx — see
+    // `Extractor::lazy_text`).
+
+    fn source_lines(&self, eclass: Option<&ClassId>, enode: Option<&NodeId>) -> Vec<String> {
+        let mut lines = Vec::new();
+        if let Some(eclass) = eclass {
+            push_detail(&mut lines, "eclass", eclass);
+            if let Some(typ) = self.class_type(eclass) {
+                push_detail(&mut lines, "type", typ);
+            }
+            if let Some(name) = self.class_let_name(eclass) {
+                push_detail(&mut lines, "let", name);
+            }
+        }
+        if let Some(enode) = enode {
+            push_detail(&mut lines, "enode", enode);
+        }
+        lines
+    }
+
+    fn render_buffer_id(&self, class: &ClassId) -> String {
+        self.render_class_prefer(class, 3, Some("BufferLit"))
+    }
+
+    fn render_layout_tensor_list(&self, classes: &[ClassId]) -> String {
+        let items = classes
+            .iter()
+            .enumerate()
+            .map(|(index, class)| format!("{index}:{}", self.layout_tensor_summary(class)))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{items}]")
+    }
+
+    fn layout_tensor_tooltip(&self, class: &ClassId) -> String {
+        let mut lines = self.source_lines(Some(class), None);
+        push_details(&mut lines, &self.layout_tensor_details(class));
+        join_tooltip(lines)
+    }
+
+    fn logical_tooltip(&self, class: &ClassId) -> String {
+        let mut lines = self.source_lines(Some(class), None);
+        push_details(&mut lines, &self.logical_details(class));
+        join_tooltip(lines)
+    }
+
+    fn layout_tooltip(&self, class: &ClassId) -> String {
+        let mut lines = self.source_lines(Some(class), None);
+        push_details(&mut lines, &self.layout_details(class));
+        join_tooltip(lines)
+    }
+
+    fn buffer_tensor_tooltip(
+        &self,
+        class: &ClassId,
+        source_enode: Option<&NodeId>,
+        tensor: &ClassId,
+        buffer_id: &ClassId,
+    ) -> String {
+        let mut lines = self.source_lines(Some(class), source_enode);
+        push_detail(&mut lines, "tensor_eclass", tensor);
+        push_detail(&mut lines, "buffer_id_eclass", buffer_id);
+        if let Some((literal_tensor, literal_buffer_id)) = self.buffer_tensor_parts(class) {
+            push_detail(&mut lines, "literal_tensor_eclass", literal_tensor);
+            push_detail(&mut lines, "literal_buffer_id_eclass", literal_buffer_id);
+        }
+        push_detail(&mut lines, "buffer_id", self.render_buffer_id(buffer_id));
+        push_details(&mut lines, &self.layout_tensor_details(tensor));
+        join_tooltip(lines)
+    }
+
+    fn buffer_id_tooltip(&self, class: &ClassId) -> String {
+        let mut lines = self.source_lines(Some(class), None);
+        push_detail(&mut lines, "value", self.render_buffer_id(class));
+        join_tooltip(lines)
+    }
+
+    fn output_tooltip(&self, class: &ClassId, source_enode: Option<&NodeId>) -> String {
+        join_tooltip(self.source_lines(Some(class), source_enode))
+    }
+
+    /// The op tooltip, from a [`OpTooltipSeed`] rather than the `Plan`:
+    /// the plan is extractor-internal and gone by the time a deferred
+    /// tooltip renders, so `ensure_value` clones the handful of fields
+    /// this reads.
+    fn op_tooltip(&self, seed: &OpTooltipSeed) -> String {
+        let mut lines = Vec::new();
+        push_detail(&mut lines, "selected_output_eclass", &seed.class);
+        if let Some(op_eclass) = &seed.source_eclass {
+            push_detail(&mut lines, "op_eclass", op_eclass);
+        }
+        if let Some(enode) = &seed.source_enode {
+            push_detail(&mut lines, "concrete_enode", enode);
+        }
+        if let Some(index) = seed.selected_output_index {
+            push_detail(&mut lines, "selected_output_index", index);
+        }
+        push_detail(&mut lines, "heuristic_cost", seed.heuristic_cost);
+        push_details(&mut lines, &self.layout_tensor_details(&seed.class));
+        if !seed.input_list.is_empty() {
+            push_detail(
+                &mut lines,
+                "input_layout_tensors",
+                self.render_layout_tensor_list(&seed.input_list),
+            );
+        }
+        if !seed.output_list.is_empty() {
+            push_detail(
+                &mut lines,
+                "output_layout_tensors",
+                self.render_layout_tensor_list(&seed.output_list),
+            );
+        }
+        for meta in &seed.metadata {
+            let value = if is_layout_metadata(meta.name) {
+                self.canonical_layout(&meta.class)
+            } else if meta.name == "shape" {
+                self.readable_shape(&meta.class).unwrap_or_else(|| {
+                    self.render_class_prefer(
+                        &meta.class,
+                        metadata_render_depth(meta.name),
+                        metadata_preferred_op(meta.name),
+                    )
+                })
+            } else if meta.name == "index_map" {
+                self.readable_index_map(&meta.class).unwrap_or_else(|| {
+                    self.render_class_prefer(
+                        &meta.class,
+                        metadata_render_depth(meta.name),
+                        metadata_preferred_op(meta.name),
+                    )
+                })
+            } else {
+                self.render_class_prefer(
+                    &meta.class,
+                    metadata_render_depth(meta.name),
+                    metadata_preferred_op(meta.name),
+                )
+            };
+            push_detail(&mut lines, meta.name, value);
+        }
+        join_tooltip(lines)
+    }
 }
 
 impl<'a> Extractor<'a> {
@@ -2586,13 +2791,16 @@ impl<'a> Extractor<'a> {
     // ---- structured info builders for the Layout IR DAG ----
 
     fn layout_tensor_info(&self, class: &ClassId) -> LayoutTensorInfo {
-        let label = self.layout_tensor_label(class);
-        let details = self.layout_tensor_details(class);
-        let shape = find_detail(&details, "shape");
-        let dtype = find_detail(&details, "dtype");
-        let mut lines = self.source_lines(Some(class), None);
-        push_details(&mut lines, &details);
-        let tooltip = join_tooltip(lines);
+        let renderer = self.renderer();
+        let label = renderer.layout_tensor_label(class);
+        // `shape`/`dtype` stay eager but no longer force the details
+        // table: `layout_tensor_shape_dtype` reproduces exactly what
+        // `find_detail(&details, ..)` returned.
+        let (shape, dtype) = renderer.layout_tensor_shape_dtype(class);
+        let tooltip = {
+            let class = class.clone();
+            self.lazy_text(move |renderer| renderer.layout_tensor_tooltip(&class))
+        };
 
         let (logical, layout) = match self.layout_tensor_parts(class) {
             Some((logical_class, layout_class)) => (
@@ -2602,22 +2810,21 @@ impl<'a> Extractor<'a> {
             None => (
                 LogicalInfo {
                     eclass: class.clone(),
-                    label: class.to_string(),
-                    tooltip: String::new(),
+                    label: LazyText::eager(class.to_string()),
+                    tooltip: LazyText::default(),
                     op: None,
                     children: Vec::new(),
                 },
                 LayoutInfo {
                     eclass: class.clone(),
-                    label: class.to_string(),
-                    tooltip: String::new(),
+                    label: LazyText::eager(class.to_string()),
+                    tooltip: LazyText::default(),
                 },
             ),
         };
 
         let (dims, element_bits, dtype_enum) = match self.layout_tensor_parts(class) {
             Some((logical_class, layout_class)) => {
-                let renderer = self.renderer();
                 (
                     renderer.numeric_layout_dims(&layout_class),
                     renderer.numeric_layout_bits(&layout_class),
@@ -2656,8 +2863,14 @@ impl<'a> Extractor<'a> {
         visiting: &mut HashSet<ClassId>,
         depth: usize,
     ) -> LogicalInfo {
-        let label = self.logical_label(class);
-        let tooltip = self.logical_tooltip(class);
+        let label = {
+            let class = class.clone();
+            self.lazy_text(move |renderer| renderer.logical_label(&class))
+        };
+        let tooltip = {
+            let class = class.clone();
+            self.lazy_text(move |renderer| renderer.logical_tooltip(&class))
+        };
         let children = if depth > 0 && visiting.insert(class.clone()) {
             let children = self
                 .logical_children(class)
@@ -2695,8 +2908,14 @@ impl<'a> Extractor<'a> {
     fn layout_info(&self, class: &ClassId) -> LayoutInfo {
         LayoutInfo {
             eclass: class.clone(),
-            label: self.layout_label(class),
-            tooltip: self.layout_tooltip(class),
+            label: {
+                let class = class.clone();
+                self.lazy_text(move |renderer| renderer.layout_label(&class))
+            },
+            tooltip: {
+                let class = class.clone();
+                self.lazy_text(move |renderer| renderer.layout_tooltip(&class))
+            },
         }
     }
 
@@ -2707,23 +2926,32 @@ impl<'a> Extractor<'a> {
         tensor_class: &ClassId,
         buffer_id_class: &ClassId,
     ) -> BufferInfo {
-        let tensor_label = self
+        let renderer = self.renderer();
+        let tensor_label = renderer
             .class_let_name(buffer_tensor_class)
             .unwrap_or_else(|| buffer_tensor_class.to_string());
-        let tensor_tooltip = self.buffer_tensor_tooltip(
-            buffer_tensor_class,
-            buffer_tensor_enode,
-            tensor_class,
-            buffer_id_class,
-        );
-        let rendered = self.render_buffer_id(buffer_id_class);
-        let id_label = match self.class_let_name(buffer_id_class) {
+        let tensor_tooltip = {
+            let (class, enode, tensor, buffer_id) = (
+                buffer_tensor_class.clone(),
+                buffer_tensor_enode.cloned(),
+                tensor_class.clone(),
+                buffer_id_class.clone(),
+            );
+            self.lazy_text(move |renderer| {
+                renderer.buffer_tensor_tooltip(&class, enode.as_ref(), &tensor, &buffer_id)
+            })
+        };
+        let rendered = renderer.render_buffer_id(buffer_id_class);
+        let id_label = match renderer.class_let_name(buffer_id_class) {
             Some(name) if name != rendered => format!("{name}\n{rendered}"),
             Some(name) => name,
             None => rendered,
         };
-        let id_tooltip = self.buffer_id_tooltip(buffer_id_class);
-        let lit = self.renderer().numeric_buffer_lit(buffer_id_class);
+        let id_tooltip = {
+            let class = buffer_id_class.clone();
+            self.lazy_text(move |renderer| renderer.buffer_id_tooltip(&class))
+        };
+        let lit = renderer.numeric_buffer_lit(buffer_id_class);
         BufferInfo {
             tensor_eclass: buffer_tensor_class.clone(),
             tensor_label,
@@ -2793,123 +3021,8 @@ impl<'a> Extractor<'a> {
         None
     }
 
-    // ---- tooltip builders (ported from the former GraphBuilder) ----
-
-    fn source_lines(&self, eclass: Option<&ClassId>, enode: Option<&NodeId>) -> Vec<String> {
-        let mut lines = Vec::new();
-        if let Some(eclass) = eclass {
-            push_detail(&mut lines, "eclass", eclass);
-            if let Some(typ) = self.class_type(eclass) {
-                push_detail(&mut lines, "type", typ);
-            }
-            if let Some(name) = self.class_let_name(eclass) {
-                push_detail(&mut lines, "let", name);
-            }
-        }
-        if let Some(enode) = enode {
-            push_detail(&mut lines, "enode", enode);
-        }
-        lines
-    }
-
-    fn logical_tooltip(&self, class: &ClassId) -> String {
-        let mut lines = self.source_lines(Some(class), None);
-        push_details(&mut lines, &self.logical_details(class));
-        join_tooltip(lines)
-    }
-
-    fn layout_tooltip(&self, class: &ClassId) -> String {
-        let mut lines = self.source_lines(Some(class), None);
-        push_details(&mut lines, &self.layout_details(class));
-        join_tooltip(lines)
-    }
-
-    fn buffer_tensor_tooltip(
-        &self,
-        class: &ClassId,
-        source_enode: Option<&NodeId>,
-        tensor: &ClassId,
-        buffer_id: &ClassId,
-    ) -> String {
-        let mut lines = self.source_lines(Some(class), source_enode);
-        push_detail(&mut lines, "tensor_eclass", tensor);
-        push_detail(&mut lines, "buffer_id_eclass", buffer_id);
-        if let Some((literal_tensor, literal_buffer_id)) = self.buffer_tensor_parts(class) {
-            push_detail(&mut lines, "literal_tensor_eclass", literal_tensor);
-            push_detail(&mut lines, "literal_buffer_id_eclass", literal_buffer_id);
-        }
-        push_detail(&mut lines, "buffer_id", self.render_buffer_id(buffer_id));
-        push_details(&mut lines, &self.layout_tensor_details(tensor));
-        join_tooltip(lines)
-    }
-
-    fn buffer_id_tooltip(&self, class: &ClassId) -> String {
-        let mut lines = self.source_lines(Some(class), None);
-        push_detail(&mut lines, "value", self.render_buffer_id(class));
-        join_tooltip(lines)
-    }
-
     fn output_tooltip(&self, class: &ClassId, source_enode: Option<&NodeId>) -> String {
-        join_tooltip(self.source_lines(Some(class), source_enode))
-    }
-
-    fn op_tooltip(&self, class: &ClassId, plan: &Plan) -> String {
-        let mut lines = Vec::new();
-        push_detail(&mut lines, "selected_output_eclass", class);
-        if let Some(op_eclass) = &plan.source_eclass {
-            push_detail(&mut lines, "op_eclass", op_eclass);
-        }
-        if let Some(enode) = &plan.source_enode {
-            push_detail(&mut lines, "concrete_enode", enode);
-        }
-        if let Some(index) = plan.selected_output_index {
-            push_detail(&mut lines, "selected_output_index", index);
-        }
-        push_detail(&mut lines, "heuristic_cost", plan.heuristic_cost);
-        push_details(&mut lines, &self.layout_tensor_details(class));
-        if !plan.input_list.is_empty() {
-            push_detail(
-                &mut lines,
-                "input_layout_tensors",
-                self.render_layout_tensor_list(&plan.input_list),
-            );
-        }
-        if !plan.output_list.is_empty() {
-            push_detail(
-                &mut lines,
-                "output_layout_tensors",
-                self.render_layout_tensor_list(&plan.output_list),
-            );
-        }
-        for meta in &plan.metadata {
-            let value = if is_layout_metadata(meta.name) {
-                self.canonical_layout(&meta.class)
-            } else if meta.name == "shape" {
-                self.readable_shape(&meta.class).unwrap_or_else(|| {
-                    self.render_class_prefer(
-                        &meta.class,
-                        metadata_render_depth(meta.name),
-                        metadata_preferred_op(meta.name),
-                    )
-                })
-            } else if meta.name == "index_map" {
-                self.readable_index_map(&meta.class).unwrap_or_else(|| {
-                    self.render_class_prefer(
-                        &meta.class,
-                        metadata_render_depth(meta.name),
-                        metadata_preferred_op(meta.name),
-                    )
-                })
-            } else {
-                self.render_class_prefer(
-                    &meta.class,
-                    metadata_render_depth(meta.name),
-                    metadata_preferred_op(meta.name),
-                )
-            };
-            push_detail(&mut lines, meta.name, value);
-        }
-        join_tooltip(lines)
+        self.renderer().output_tooltip(class, source_enode)
     }
 }
 
@@ -3007,7 +3120,20 @@ impl<'e, 'a> IrBuilder<'e, 'a> {
                         value: child.class.clone(),
                     })
                     .collect::<Vec<_>>();
-                let tooltip = self.extractor.op_tooltip(class, &plan);
+                let tooltip = {
+                    let seed = OpTooltipSeed {
+                        class: class.clone(),
+                        source_eclass: plan.source_eclass.clone(),
+                        source_enode: plan.source_enode.clone(),
+                        selected_output_index: plan.selected_output_index,
+                        heuristic_cost: plan.heuristic_cost,
+                        input_list: plan.input_list.clone(),
+                        output_list: plan.output_list.clone(),
+                        metadata: plan.metadata.clone(),
+                    };
+                    self.extractor
+                        .lazy_text(move |renderer| renderer.op_tooltip(&seed))
+                };
                 let node = OpNode {
                     op: op.clone(),
                     provenance: crate::layout_ir::Provenance::Extracted {
@@ -3135,13 +3261,6 @@ impl<'e, 'a> IrBuilder<'e, 'a> {
             other => bail!("expected BufferTensorLit at output {class}, found {other:?}"),
         }
     }
-}
-
-fn find_detail(details: &[(String, String)], key: &str) -> Option<String> {
-    details
-        .iter()
-        .find(|(name, _)| name == key)
-        .map(|(_, value)| value.clone())
 }
 
 fn only_child(plan: &Plan, port: &str) -> Result<ClassId> {
@@ -3460,16 +3579,15 @@ fn collect_buffer_list(
 }
 
 fn collect_input_terminals(
-    egraph: &EGraph,
-    class_nodes: &HashMap<ClassId, Vec<NodeId>>,
+    render: &RenderCtx,
     output_buffer_classes: &HashSet<ClassId>,
     input_buffer_classes: &HashSet<ClassId>,
 ) -> HashMap<ClassId, InputInfo> {
     let mut terminals = HashMap::new();
-    let renderer = ClassRenderer {
-        egraph,
-        class_nodes,
-    };
+    let egraph = &render.egraph;
+    // Through the session's renderer, so these session-start renders
+    // populate (and later hit) the same memo as everything else.
+    let renderer = render.renderer();
     let has_explicit_inputs = !input_buffer_classes.is_empty();
 
     for (node_id, node) in egraph
@@ -3706,4 +3824,111 @@ pub fn chain_strides(egraph: &EGraph, layout: &ClassId) -> Option<Vec<Option<Cha
 fn child_class(egraph: &EGraph, node: &Node, index: usize) -> Option<ClassId> {
     let child_id = node.children.get(index)?;
     egraph.nodes.get(child_id).map(|child| child.eclass.clone())
+}
+
+#[cfg(test)]
+mod render_memo_tests {
+    //! The render memo's two obligations (ruling 2026-09-01): it must
+    //! return the string the uncached walk would have returned, and it
+    //! must not deadlock on its own recursion.
+
+    use egraph_serialize::{ClassId, EGraph, Node, NodeId};
+
+    use super::{ClassRenderer, RenderCtx};
+
+    /// A chain `a4(a3(a2(a1(leaf, leaf), leaf), leaf), leaf)` — every level
+    /// shares one leaf class, which is exactly the shape (a convergent DAG)
+    /// that made the uncached renderer exponential in depth.
+    fn shared_child_chain() -> EGraph {
+        let mut egraph = EGraph::default();
+        let mut add = |id: &str, op: &str, children: Vec<&str>| {
+            egraph.add_node(
+                NodeId::from(id),
+                Node {
+                    op: op.to_string(),
+                    children: children.into_iter().map(NodeId::from).collect(),
+                    eclass: ClassId::from(format!("class-{id}")),
+                    cost: ordered_float::NotNan::new(1.0).unwrap(),
+                    subsumed: false,
+                },
+            );
+        };
+        add("leaf", "Leaf", vec![]);
+        add("a1", "A1", vec!["leaf", "leaf"]);
+        add("a2", "A2", vec!["a1", "leaf"]);
+        add("a3", "A3", vec!["a2", "leaf"]);
+        add("a4", "A4", vec!["a3", "leaf"]);
+        egraph
+    }
+
+    /// The memo returns the SAME text on the second call, and adds no
+    /// entries — the second call is pure lookup. (Identity is what the
+    /// ruling turns on: this text feeds `stable_key`, which breaks plan
+    /// selection ties.)
+    #[test]
+    fn memo_is_output_identical_and_does_no_second_walk() {
+        let ctx = RenderCtx::new(&shared_child_chain());
+        let renderer = ctx.renderer();
+        let root = ClassId::from("class-a4");
+
+        let first = renderer.render_class_prefer(&root, 3, None);
+        let filled = ctx.memo.borrow().len();
+        let second = renderer.render_class_prefer(&root, 3, None);
+
+        assert_eq!(first, second, "a memo hit must reproduce the render");
+        assert_eq!(
+            ctx.memo.borrow().len(),
+            filled,
+            "the second call walked the graph again instead of hitting the memo"
+        );
+        assert!(filled > 0, "nothing was memoized");
+        // Spelled out, so a change to the render grammar has to face this
+        // test rather than silently re-electing plans.
+        assert_eq!(first, "A4(A3(A2(class-a1, class-leaf), Leaf), Leaf)");
+    }
+
+    /// Depth is part of the key: the same class at a shallower depth is a
+    /// DIFFERENT string, and a memo that dropped depth would serve the
+    /// deep answer to a shallow caller.
+    #[test]
+    fn memo_keys_on_depth_and_preference() {
+        let ctx = RenderCtx::new(&shared_child_chain());
+        let renderer = ctx.renderer();
+        let root = ClassId::from("class-a4");
+
+        assert_eq!(
+            renderer.render_class_prefer(&root, 1, None),
+            "A4(class-a3, class-leaf)"
+        );
+        assert_eq!(
+            renderer.render_class_prefer(&root, 2, None),
+            "A4(A3(class-a2, class-leaf), Leaf)"
+        );
+        assert_eq!(renderer.render_class_prefer(&root, 0, None), "class-a4");
+    }
+
+    /// `render_class_prefer` recurses into itself through `render_node`.
+    /// Holding the memo's `Ref` across that call is a `BorrowMutError` at
+    /// runtime, not a compile error, so a deep render is the guard.
+    #[test]
+    fn deep_render_does_not_double_borrow_the_memo() {
+        let ctx = RenderCtx::new(&shared_child_chain());
+        let rendered = ctx
+            .renderer()
+            .render_class_prefer(&ClassId::from("class-a4"), 32, None);
+        assert!(rendered.starts_with("A4("));
+    }
+
+    /// Both renderer views over one ctx share the memo — the guarantee
+    /// that a deferred tooltip rendered later reuses the session's work.
+    #[test]
+    fn views_over_one_ctx_share_the_memo() {
+        let ctx = RenderCtx::new(&shared_child_chain());
+        let root = ClassId::from("class-a4");
+        let first = ClassRenderer::render_class_prefer(&ctx.renderer(), &root, 3, None);
+        let filled = ctx.memo.borrow().len();
+        let second = ClassRenderer::render_class_prefer(&ctx.renderer(), &root, 3, None);
+        assert_eq!(first, second);
+        assert_eq!(ctx.memo.borrow().len(), filled);
+    }
 }

--- a/src/layout_ir/mod.rs
+++ b/src/layout_ir/mod.rs
@@ -15,10 +15,135 @@
 // bufferization layer and are not yet read by the visualization.
 #![allow(dead_code)]
 
+use std::cell::OnceCell;
 use std::collections::HashMap;
+use std::fmt;
+use std::ops::Deref;
+use std::rc::Rc;
 
 use egraph_serialize::{ClassId, NodeId};
 use petgraph::graph::{DiGraph, NodeIndex};
+
+// =============================================================================
+// Deferred display text
+// =============================================================================
+
+/// A value that is either already in hand or produced ON FIRST READ and
+/// then kept forever.
+///
+/// WHY (ruling 2026-09-01, "make label, tooltip, and details lazy,
+/// leaving only the numeric readers on the hot path"): the extractor
+/// builds one info struct per value and per op output slot, on every
+/// genome of a search. Their DISPLAY text — tooltips, the logical and
+/// layout labels — costs full-depth e-graph rendering, and only the
+/// visualizer and the diagnostics ever read it. Deferring it takes that
+/// work off the search's hot path without changing a character of the
+/// result: `get()` runs the very same builder the eager code ran, so the
+/// string is identical whenever anybody asks for it.
+///
+/// NOT a cache and not a skip — a `Deferred` value is computed exactly
+/// once and never recomputed or approximated.
+///
+/// `Rc`, not `Arc`: an [`ExtractedGraph`] is single-threaded everywhere
+/// it travels (the Python holder is `#[pyclass(unsendable)]`), and the
+/// deferred builder holds extractor state that is itself `Rc`-shared.
+/// Sharing the `Rc` across clones is deliberate: an info cloned into
+/// several DAG slots (the DPS rewrite, multi-output ops) renders at most
+/// once for all of them.
+pub struct Lazy<T>(Rc<LazyInner<T>>);
+
+enum LazyInner<T> {
+    Eager(T),
+    Deferred {
+        cell: OnceCell<T>,
+        build: Box<dyn Fn() -> T>,
+    },
+}
+
+impl<T> Lazy<T> {
+    /// A value already computed (synthesized nodes, test fixtures).
+    pub fn eager(value: T) -> Self {
+        Lazy(Rc::new(LazyInner::Eager(value)))
+    }
+
+    /// A value built on first read. `build` must be a pure function of
+    /// what it captures: it may run at any later time, and its result is
+    /// what every reader sees.
+    pub fn deferred(build: impl Fn() -> T + 'static) -> Self {
+        Lazy(Rc::new(LazyInner::Deferred {
+            cell: OnceCell::new(),
+            build: Box::new(build),
+        }))
+    }
+
+    /// The value, building it if this is the first read.
+    pub fn get(&self) -> &T {
+        match &*self.0 {
+            LazyInner::Eager(value) => value,
+            LazyInner::Deferred { cell, build } => cell.get_or_init(build),
+        }
+    }
+
+    /// Whether the value is already in hand — for tests and diagnostics
+    /// that want to observe the deferral without triggering it.
+    pub fn is_rendered(&self) -> bool {
+        match &*self.0 {
+            LazyInner::Eager(_) => true,
+            LazyInner::Deferred { cell, .. } => cell.get().is_some(),
+        }
+    }
+}
+
+/// Sharing, not deep-copying: clones observe one another's rendering.
+impl<T> Clone for Lazy<T> {
+    fn clone(&self) -> Self {
+        Lazy(Rc::clone(&self.0))
+    }
+}
+
+impl<T> Deref for Lazy<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        self.get()
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for Lazy<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self.get(), f)
+    }
+}
+
+/// DOES NOT force the value: `{:?}` on a half-built graph is a debugging
+/// aid, and making it render every deferred tooltip would defeat the
+/// deferral exactly where it matters most.
+impl<T: fmt::Debug> fmt::Debug for Lazy<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &*self.0 {
+            LazyInner::Eager(value) => fmt::Debug::fmt(value, f),
+            LazyInner::Deferred { cell, .. } => match cell.get() {
+                Some(value) => fmt::Debug::fmt(value, f),
+                None => f.write_str("<unrendered>"),
+            },
+        }
+    }
+}
+
+impl<T: Default> Default for Lazy<T> {
+    fn default() -> Self {
+        Lazy::eager(T::default())
+    }
+}
+
+impl<T> From<T> for Lazy<T> {
+    fn from(value: T) -> Self {
+        Lazy::eager(value)
+    }
+}
+
+/// The deferred-text alias every info struct uses.
+pub type LazyText = Lazy<String>;
 
 // =============================================================================
 // The op interface
@@ -500,8 +625,11 @@ pub struct ExtractedEdge {
 #[derive(Debug, Clone)]
 pub struct LayoutTensorInfo {
     pub eclass: ClassId,
+    /// EAGER: semantic, not decoration — bufferization names allocations
+    /// after it and the plan summary goldens pin those names.
     pub label: String,
-    pub tooltip: String,
+    /// Deferred: visualizer/diagnostic text only (see [`Lazy`]).
+    pub tooltip: LazyText,
     pub shape: Option<String>,
     pub dtype: Option<String>,
     /// The machine-readable plan dtype, from the logical side's
@@ -524,8 +652,10 @@ pub struct LayoutTensorInfo {
 #[derive(Debug, Clone)]
 pub struct LogicalInfo {
     pub eclass: ClassId,
-    pub label: String,
-    pub tooltip: String,
+    /// Deferred: visualizer text only (see [`Lazy`]).
+    pub label: LazyText,
+    /// Deferred: visualizer text only (see [`Lazy`]).
+    pub tooltip: LazyText,
     /// The logical CONSTRUCTOR producing this tensor (e.g. `LogicalSqrt`),
     /// when it has operands — rendered as the logical op node between this
     /// tensor and its children. `None` for leaves (literals).
@@ -537,8 +667,10 @@ pub struct LogicalInfo {
 #[derive(Debug, Clone)]
 pub struct LayoutInfo {
     pub eclass: ClassId,
-    pub label: String,
-    pub tooltip: String,
+    /// Deferred: visualizer text only (see [`Lazy`]).
+    pub label: LazyText,
+    /// Deferred: visualizer text only (see [`Lazy`]).
+    pub tooltip: LazyText,
 }
 
 /// CONTENTS permission: may the program overwrite this buffer's bytes?
@@ -593,10 +725,12 @@ pub enum FreedBy {
 pub struct BufferInfo {
     pub tensor_eclass: ClassId,
     pub tensor_label: String,
-    pub tensor_tooltip: String,
+    /// Deferred: visualizer text only (see [`Lazy`]).
+    pub tensor_tooltip: LazyText,
     pub id_eclass: ClassId,
     pub id_label: String,
-    pub id_tooltip: String,
+    /// Deferred: visualizer text only (see [`Lazy`]).
+    pub id_tooltip: LazyText,
     /// The declared contents permission — `None` when the program omits the
     /// declaration, which input-program validation rejects for EVERY buffer.
     pub access: Option<Access>,
@@ -663,7 +797,9 @@ pub struct OpNode {
     pub provenance: Provenance,
     pub inputs: Vec<OpInput>,
     pub outputs: Vec<LayoutTensorInfo>,
-    pub tooltip: String,
+    /// Deferred: visualizer text only (see [`Lazy`]). The heaviest of
+    /// them — it renders the op's whole operand/result table.
+    pub tooltip: LazyText,
     pub heuristic_cost: u64,
 }
 
@@ -1037,7 +1173,7 @@ impl DotEmitter {
         // Bare label, like the BufferId notes: the note shape already says
         // "metadata", so spelling the kind would break the no-prefix rule.
         let layout_id = self.raw_node(
-            value.layout.label.clone(),
+            value.layout.label.to_string(),
             VisualKind::Layout,
             &value.layout.tooltip,
         );
@@ -1052,7 +1188,7 @@ impl DotEmitter {
             return *id;
         }
         let id = self.raw_node(
-            logical.label.clone(),
+            logical.label.to_string(),
             VisualKind::LogicalTensor,
             &logical.tooltip,
         );

--- a/src/logical_op/mod.rs
+++ b/src/logical_op/mod.rs
@@ -24,12 +24,14 @@ pub trait LogicalRender {
     fn child_expr(&mut self, node: &Node, index: usize) -> String;
     /// Depth-bounded structural rendering of the child at `index`,
     /// preferring `prefer`-named enodes when the class offers a choice.
+    /// `prefer` is `&'static str`: it names a constructor, and the
+    /// renderer keys its memo on it.
     fn child_short(
         &mut self,
         node: &Node,
         index: usize,
         depth: usize,
-        prefer: Option<&str>,
+        prefer: Option<&'static str>,
     ) -> Option<String>;
     /// Readable shape of the child at `index`.
     fn child_shape(&mut self, node: &Node, index: usize) -> Option<String>;

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -417,7 +417,7 @@ impl TestGraph {
         LayoutTensorInfo {
             eclass: ClassId::from(format!("val${name}")),
             label: name.to_string(),
-            tooltip: String::new(),
+            tooltip: Default::default(),
             shape: None,
             dtype: None,
             dtype_enum: None,
@@ -425,15 +425,15 @@ impl TestGraph {
             element_bits: None,
             logical: LogicalInfo {
                 eclass: ClassId::from(format!("logical${name}")),
-                label: name.to_string(),
-                tooltip: String::new(),
+                label: name.to_string().into(),
+                tooltip: Default::default(),
                 op: None,
                 children: Vec::new(),
             },
             layout: LayoutInfo {
                 eclass: ClassId::from(format!("layout${layout}")),
-                label: layout.to_string(),
-                tooltip: String::new(),
+                label: layout.to_string().into(),
+                tooltip: Default::default(),
             },
         }
     }
@@ -452,10 +452,10 @@ impl TestGraph {
             lit: None,
             tensor_eclass: ClassId::from(format!("buftensor${n}")),
             tensor_label: buffer.to_string(),
-            tensor_tooltip: String::new(),
+            tensor_tooltip: Default::default(),
             id_eclass: ClassId::from(format!("buf${buffer}")),
             id_label: buffer.to_string(),
-            id_tooltip: String::new(),
+            id_tooltip: Default::default(),
             access,
             freed_by,
         }
@@ -520,7 +520,7 @@ impl TestGraph {
             provenance: crate::layout_ir::Provenance::Synthesized { id: n },
             inputs: op_inputs,
             outputs: output_infos,
-            tooltip: String::new(),
+            tooltip: Default::default(),
             heuristic_cost: 1,
         }));
         for (index, value) in inputs.iter().enumerate() {
@@ -4158,5 +4158,88 @@ mod escape_execution_tests {
             err.to_string().contains("NON-ESCAPING") && err.to_string().contains("Caller"),
             "the guard names the violation and the owner: {err:#}"
         );
+    }
+}
+
+#[cfg(test)]
+mod deferred_display_text {
+    //! The deferral half of the render ruling (2026-09-01): the info
+    //! structs' display text is built on FIRST READ, not during
+    //! extraction. These pin both halves of that promise — nothing is
+    //! rendered until asked, and asking produces the real text.
+
+    use luminal::layout_ir::ExtractedNode;
+    use luminal_reference::harness::extract_fixture;
+
+    /// Extraction leaves the display text UNBUILT, and reading it builds
+    /// it. If a search-path caller starts forcing these again, the first
+    /// assertion is what notices.
+    #[test]
+    fn extraction_defers_display_text_until_it_is_read() {
+        let graph = extract_fixture("boundary_gather.egg");
+
+        let value = graph
+            .dag
+            .node_weights()
+            .find_map(|node| match node {
+                ExtractedNode::LayoutOp(op) => op.outputs.first(),
+                _ => None,
+            })
+            .expect("the fixture has an op with an output");
+
+        assert!(
+            !value.tooltip.is_rendered(),
+            "extraction rendered a value tooltip that nobody asked for"
+        );
+        assert!(
+            !value.layout.tooltip.is_rendered(),
+            "extraction rendered a layout tooltip that nobody asked for"
+        );
+
+        let tooltip = value.tooltip.to_string();
+        assert!(
+            tooltip.contains(&format!("eclass={}", value.eclass)),
+            "the deferred tooltip did not build its real text: {tooltip:?}"
+        );
+        assert!(value.tooltip.is_rendered());
+        assert_eq!(
+            tooltip,
+            value.tooltip.to_string(),
+            "a second read must return the first read's text"
+        );
+    }
+
+    /// `to_dot` forces EVERY deferred field on a real extracted graph.
+    /// That is also the runtime guard on the render memo's recursion
+    /// (`render_class_prefer` → `render_node` → `render_class_prefer`):
+    /// a `RefCell` borrow held across it is a `BorrowMutError`, and the
+    /// depth-16/32 layout tooltips are where it would fire.
+    #[test]
+    fn to_dot_forces_every_deferred_field() {
+        for script in [
+            "boundary_gather.egg",
+            "boundary_pass_through.egg",
+            "boundary_iota.egg",
+        ] {
+            let graph = extract_fixture(script);
+            let dot = graph.to_dot();
+            assert!(
+                dot.contains("tooltip=\"eclass="),
+                "{script}: no rendered tooltip reached the dot output"
+            );
+            for node in graph.dag.node_weights() {
+                if let ExtractedNode::LayoutOp(op) = node {
+                    assert!(
+                        op.tooltip.is_rendered(),
+                        "{script}: to_dot left an op tooltip unrendered"
+                    );
+                    for output in &op.outputs {
+                        assert!(output.tooltip.is_rendered());
+                        assert!(output.logical.label.is_rendered());
+                        assert!(output.layout.tooltip.is_rendered());
+                    }
+                }
+            }
+        }
     }
 }

--- a/tests/test_runtime/tests/buf_attack_compose.rs
+++ b/tests/test_runtime/tests/buf_attack_compose.rs
@@ -359,7 +359,7 @@ impl DimsGraph {
         LayoutTensorInfo {
             eclass: luminal::prelude::egraph_serialize::ClassId::from(format!("val${name}")),
             label: name.to_string(),
-            tooltip: String::new(),
+            tooltip: Default::default(),
             shape: None,
             dtype: None,
             dtype_enum: Some(PlanDtype::F32),
@@ -369,8 +369,8 @@ impl DimsGraph {
                 eclass: luminal::prelude::egraph_serialize::ClassId::from(format!(
                     "logical${name}"
                 )),
-                label: name.to_string(),
-                tooltip: String::new(),
+                label: name.to_string().into(),
+                tooltip: Default::default(),
                 op: None,
                 children: Vec::new(),
             },
@@ -378,8 +378,8 @@ impl DimsGraph {
                 eclass: luminal::prelude::egraph_serialize::ClassId::from(format!(
                     "layout${layout}"
                 )),
-                label: layout.to_string(),
-                tooltip: String::new(),
+                label: layout.to_string().into(),
+                tooltip: Default::default(),
             },
         }
     }
@@ -391,10 +391,10 @@ impl DimsGraph {
                 "buftensor${n}"
             )),
             tensor_label: name.to_string(),
-            tensor_tooltip: String::new(),
+            tensor_tooltip: Default::default(),
             id_eclass: luminal::prelude::egraph_serialize::ClassId::from(format!("buf${name}")),
             id_label: name.to_string(),
-            id_tooltip: String::new(),
+            id_tooltip: Default::default(),
             access: Some(Access::ReadWrite),
             freed_by: Some(FreedBy::Caller),
         }
@@ -434,7 +434,7 @@ impl DimsGraph {
             provenance: Provenance::Synthesized { id: n },
             inputs: op_inputs,
             outputs: vec![out.clone()],
-            tooltip: String::new(),
+            tooltip: Default::default(),
             heuristic_cost: 1,
         }));
         for (i, value) in inputs.iter().enumerate() {


### PR DESCRIPTION
## What

Austin's ruling (2026-09-01): "Memoize render_class_prefer per class, depth, and preference for the renderer's lifetime. Output-identical, linear in DAG size. The rendered text feeds stable_key tie-breaks, so this must be a memo, never a skip. Make label, tooltip, and details lazy, leaving only the numeric readers on the hot path."

- **Memo.** `render_class_prefer` is a pure function of (e-class, remaining depth, preferred constructor) and the e-graph; that triple is the key, held in a new `RenderCtx` shared by every `ClassRenderer` view and by the session-start input walk. One entry serves every genome (survives `extract_with_genome`'s cache clears).
- **Deferred text.** `Lazy<T>`/`LazyText` (once-cell + builder) on `LayoutTensorInfo.tooltip`, `LogicalInfo.{label,tooltip}`, `LayoutInfo.{label,tooltip}`, `BufferInfo.{tensor_tooltip,id_tooltip}`, `OpNode.tooltip`. Eager and unchanged: `LayoutTensorInfo.label` (semantic; bufferization names allocations after it), shape/dtype/dims/element_bits/dtype_enum, every eclass, both buffer labels, `OutputNode.tooltip`.
- 6 files, +738/-292. Six new tests (memo hit/identity, deferred fields forced by `to_dot`).

## Measured (same machine state, harness budget, 17-fixture render oracle)

| fixture | extract_ms before | after |
|---|---|---|
| conv | 10349 | 194 |
| llama3 | 20266 | 601 |
| qwen3 | 27916 | 908 |
| whisper (mini) | 15645 | 832 |
| qwen3_moe | 25341 | 892 |
| gemma4_moe | 27697 | 1024 |
| gemma3 | 55958 | 3051 |

Oracle suite wall: 295.7 s → 88.0 s.

## Identity

Every info struct of every elected graph dumped for 17 fixtures (~71k lines), old code twice and new code twice on one machine state. Raw dumps are not byte-stable even between two runs of the UNCHANGED binary (serialized e-class id strings vary per process, `plan_fingerprint` hashes them, and `choose_render_node` breaks one tie on process-volatile node order). After id normalization every new-code fixture matches an old-code run with zero residual; every remaining raw difference is inside the unchanged code's own run-to-run envelope. Adversarial review (memo-key completeness, renderer lifetime, laziness observability, linearity, oracle coverage, scope): LANDABLE, no must-fix.

## Surfaced for separate handling (not in this PR)

1. `stable_key` is not process-stable (depth-0 leaves spell volatile class ids; node-order ties) — plan election can differ run to run. Needs a ruling.
2. Next wall: `buffer_access` / `buffer_freed_by` scan all of `egraph.nodes` once per buffer per genome; fix pattern = `dtype_index`.
3. The full-size whisper oracle fixture dies in an integer `Sum` overflow: the known heuristic-cost i64 wrap, now with a reproducer.

The oracle harness (`render_oracle.rs`) stays out of the tree as an instrument.

## Gates (rebased onto #438 / 00c7e7d8)
luminal --lib 232 passed / 0 failed / 6 ignored; test_runtime all suites 0 failed; luminal_cuda_lite 0 failed; clippy clean; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)