### PR TITLE
Lower inference-only native batch norm

### DIFF
--- a/crates/luminal_python/rust/src/translator/dispatch.rs
+++ b/crates/luminal_python/rust/src/translator/dispatch.rs
@@ -393,6 +393,7 @@ impl<'a> Translator<'a> {
             "torch.ops.aten.grid_sampler_2d.default" => self.translate_grid_sampler(node, 2)?,
             "torch.ops.aten.grid_sampler_3d.default" => self.translate_grid_sampler(node, 3)?,
             "torch.ops.aten._native_batch_norm_legit.no_stats"
+            | "torch.ops.aten._native_batch_norm_legit_no_training.default"
             | "torch.ops.aten._native_batch_norm_legit_functional.default"
             | "torch.ops.aten._batch_norm_with_update_functional.default" => {
                 self.translate_batch_norm_functional(node)?;

--- a/crates/luminal_python/rust/src/translator/pooling.rs
+++ b/crates/luminal_python/rust/src/translator/pooling.rs
@@ -816,15 +816,23 @@ impl<'a> Translator<'a> {
         );
         let output_names = Self::tensor_output_names(node);
         anyhow::ensure!(!output_names.is_empty(), "batch norm has no tensor outputs");
-        let functional = node.target != "torch.ops.aten._native_batch_norm_legit.no_stats";
+        let no_training =
+            node.target == "torch.ops.aten._native_batch_norm_legit_no_training.default";
+        let functional = matches!(
+            node.target.as_str(),
+            "torch.ops.aten._native_batch_norm_legit_functional.default"
+                | "torch.ops.aten._batch_norm_with_update_functional.default"
+        );
         let training = if node.target == "torch.ops.aten._batch_norm_with_update_functional.default"
         {
             true
+        } else if no_training {
+            false
         } else {
             self.named_bool_arg(node, "training").unwrap_or(true)
         };
         anyhow::ensure!(
-            training || functional,
+            training || functional || no_training,
             "batch norm without running stats requires training=true"
         );
         let momentum = self.named_float_arg(node, "momentum").unwrap_or(0.1);
@@ -839,15 +847,26 @@ impl<'a> Translator<'a> {
         let axes = (0..input.shape.len())
             .filter(|&axis| axis != 1)
             .collect::<Vec<_>>();
-        let batch_mean = compute.mean(axes.clone());
-        let expanded_mean = batch_mean.expand_to_shape_on_axes(compute.shape, axes.clone());
-        let centered = compute - expanded_mean;
-        let batch_var = centered.square().mean(axes.clone());
+        let (batch_mean, batch_var) = if training {
+            let batch_mean = compute.mean(axes.clone());
+            let expanded_mean = batch_mean.expand_to_shape_on_axes(compute.shape, axes.clone());
+            let centered = compute - expanded_mean;
+            let batch_var = centered.square().mean(axes.clone());
+            (Some(batch_mean), Some(batch_var))
+        } else {
+            // Inference uses only the stored running statistics. Besides being
+            // dead work, adding batch reductions here makes every eval-mode
+            // BatchNorm layer unnecessarily enlarge the compiler search space.
+            (None, None)
+        };
 
         let running_mean = self.named_tensor_arg(node, "running_mean")?;
         let running_var = self.named_tensor_arg(node, "running_var")?;
         let (mean, variance) = if training {
-            (batch_mean, batch_var)
+            (
+                batch_mean.context("training batch norm requires batch mean")?,
+                batch_var.context("training batch norm requires batch variance")?,
+            )
         } else {
             (
                 running_mean
@@ -879,10 +898,13 @@ impl<'a> Translator<'a> {
         self.tensors
             .insert(output_names[0].clone(), output.cast(input.dtype));
 
-        for (index, statistic) in [(1, batch_mean), (2, invstd)] {
+        for (index, statistic) in [(1, batch_mean), (2, Some(invstd))] {
             if output_names.len() > index {
                 if training {
-                    self.tensors.insert(output_names[index].clone(), statistic);
+                    self.tensors.insert(
+                        output_names[index].clone(),
+                        statistic.context("training batch norm statistic is missing")?,
+                    );
                 } else {
                     self.store_zero_for_output(&output_names[index])?;
                 }
@@ -898,6 +920,8 @@ impl<'a> Translator<'a> {
                 running_mean.context("functional batch norm requires running_mean")?;
             let running_var = running_var.context("functional batch norm requires running_var")?;
             let (mean_out, var_out) = if training {
+                let batch_mean = batch_mean.context("training batch norm requires batch mean")?;
+                let batch_var = batch_var.context("training batch norm requires batch variance")?;
                 let mean_out = running_mean * (1.0 - momentum as f32)
                     + batch_mean.cast(running_mean.dtype) * momentum as f32;
                 let count = product_of_dims(axes.iter().map(|&axis| input.dims()[axis]));

--- a/crates/luminal_python/tests/test_remaining_existing_hlir_lowerings.py
+++ b/crates/luminal_python/tests/test_remaining_existing_hlir_lowerings.py
@@ -529,6 +529,42 @@ def test_functional_batch_norm_returns_stats_and_updates() -> None:
     _check(module, *inputs)
 
 
+class InferenceBatchNorm(torch.nn.Module):
+    def __init__(self, affine: bool):
+        super().__init__()
+        self.affine = affine
+
+    def forward(self, value, weight, bias, running_mean, running_var):
+        return torch.ops.aten._native_batch_norm_legit_no_training.default(
+            value,
+            weight if self.affine else None,
+            bias if self.affine else None,
+            running_mean,
+            running_var,
+            0.2,
+            1e-5,
+        )
+
+
+def test_inference_batch_norm_uses_running_stats_and_returns_empty_saved_stats() -> (
+    None
+):
+    torch.manual_seed(11)
+    inputs = (
+        torch.randn(2, 3, 4, 5),
+        torch.randn(3),
+        torch.randn(3),
+        torch.randn(3) + 3.0,
+        torch.rand(3) + 0.5,
+    )
+    for affine in (False, True):
+        module = InferenceBatchNorm(affine)
+        expected = module(*inputs)
+        assert expected[1].numel() == 0
+        assert expected[2].numel() == 0
+        _check(module, *inputs)
+
+
 class OrderingAndDistances(torch.nn.Module):
     def forward(self, value, other, points, points2):
         return (


### PR DESCRIPTION
## Summary
- dispatch `aten._native_batch_norm_legit_no_training.default` through the existing BatchNorm translator
- force inference semantics for this schema, using running mean/variance instead of batch statistics
- avoid constructing unused batch-statistic reductions in inference mode, keeping eval BatchNorm nodes out of the search space
- preserve PyTorch empty saved-mean and saved-inverse-standard-deviation outputs
- cover affine and non-affine calls with an exact-op regression against PyTorch

This is the unsupported operator shared by the Top-100 MobileNetV3, EfficientNet-B3, and CLAP compile failures.

## Validation
- exact new Python regression passes through rebuilt native extension
- existing functional and new inference BatchNorm regressions: 2 passed
- `cargo test --release -p luminal_python`: 16 passed
- workspace clippy with CI exclusions and `-D warnings`
- `cargo fmt --all -- --check`
- `ruff format --check` on the changed Python test
- `git diff --check`

## Top-100 smoke
A production H200 run of `timm/mobilenetv3_small_100.lamb_in1k` gets past translation with this lowering, but still reaches the jobs independent 600-second compiler-search timeout (624.6 seconds total) before matching can run. The former unsupported-op failure is resolved; the remaining model result is a separate search-performance issue.