### PR TITLE
Rename layout rendering APIs to decoding

### DIFF
--- a/crates/luminal_cuda_lite/src/kernels.rs
+++ b/crates/luminal_cuda_lite/src/kernels.rs
@@ -35,7 +35,7 @@ use std::any::TypeId;
 /// hop-chain
 /// machinery is fully retired (corrected contract, 2026-08-31): the
 /// e-graph mints every view's composed layout at view creation, and the
-/// runtime's rendered `L` IS the read path.
+/// runtime's decoded `L` IS the read path.
 #[derive(Debug)]
 pub struct CodegenCtx {
     pub operand_dims: Vec<Vec<usize>>,
@@ -43,7 +43,7 @@ pub struct CodegenCtx {
     pub dest_dims: Vec<Vec<usize>>,
     pub dest_dtypes: Vec<PlanDtype>,
     /// Per-operand slot layouts, parallel to `operand_dims` — each
-    /// operand's OWN elected layout as the runtime's renderer minted it
+    /// operand's OWN elected layout as the runtime's decoder minted it
     /// (for a folded operand, the view's COMPOSED layout, addressing
     /// the residence's bytes directly).
     pub operand_layouts: Vec<CudaLayout>,
@@ -142,7 +142,7 @@ impl CodegenCtx {
 // PROTOTYPE (Option B): reading operands through their SLOT LAYOUTS.
 //
 // The slot's own elected layout (`SlotDescriptor::layout`, the runtime's
-// rendered `MirrorLayout`) is the ONE vocabulary for how a value
+// decoded `MirrorLayout`) is the ONE vocabulary for how a value
 // addresses its residence — for a folded operand it is the view's
 // COMPOSED layout, which the e-graph already minted (preamble view
 // BitOffset composition / native strided chains). The elementwise family
@@ -212,11 +212,11 @@ impl CodegenCtx {
 //
 // What died here: `layout_is_direct`, which answered the same question
 // by matching the mirror CONSTRUCTOR (`RightMajor` and nothing else).
-// Its own doc comment admitted the hole — "a dense class rendering
+// Its own doc comment admitted the hole — "a dense class decoding
 // otherwise takes the (correct, slower) expression read" — and a
 // decision made on a SPELLING is exactly what the e-graph is entitled
 // to break: every spelling in a layout class denotes ONE function, and
-// the renderer hands us whichever it finds. `layout_read_index` below
+// the decoder hands us whichever it finds. `layout_read_index` below
 // lowers the FUNCTION, and whatever it simplifies to is what is
 // emitted — there is no verdict to consult.
 // ===========================================================================
@@ -360,7 +360,7 @@ fn affine_of_term(expr: &luminal::layouts::IntExprTerm, rank: usize) -> Option<A
 /// value's coordinates — one `Affine` per mirror spelling, never a
 /// classification of the spelling itself. The layout's own domain must
 /// be literal and equal `dims` (its domain IS the value's shape); a
-/// foreign domain is a planner/renderer incoherence and is refused
+/// foreign domain is a planner/decoder incoherence and is refused
 /// downstream, so it yields `None` here rather than a read.
 fn read_affine(layout: &CudaLayout, dims: &[usize]) -> Option<Affine> {
     use luminal::layouts::MirrorLayout as M;
@@ -480,7 +480,7 @@ impl<'a> Coords<'a> {
 /// else — no bounds check is emitted, deliberately (see the NO RUNTIME
 /// BOUNDS TRAPS note above for what used to be here and why). The
 /// layout's own domain (its shape) must be LITERAL and equal the slot's
-/// value dims — a foreign-domain layout is a planner/renderer
+/// value dims — a foreign-domain layout is a planner/decoder
 /// incoherence and refuses loudly.
 ///
 /// THIS IS THE ONLY READ PATH, and there is no predicate in front of it.

--- a/crates/luminal_cuda_lite/src/layouts.rs
+++ b/crates/luminal_cuda_lite/src/layouts.rs
@@ -1,4 +1,4 @@
-//! The CUDA-lite runtime's LAYOUT vocabulary and renderer (resident-
+//! The CUDA-lite runtime's LAYOUT vocabulary and decoder (resident-
 //! geometry cleanup, ruling 2026-08-31; Option B rework). Core's
 //! bufferizer is generic over an opaque layout type; this backend
 //! instantiates it with a TYPED layout — the shared mirror vocabulary
@@ -12,7 +12,7 @@ use anyhow::Result;
 use luminal::layout_ir::LayoutTensorInfo;
 use luminal::prelude::egraph_serialize::EGraph;
 
-/// The CUDA-lite runtime's opaque plan-layout type: the rendered mirror
+/// The CUDA-lite runtime's opaque plan-layout type: the decoded mirror
 /// layout plus the value's dtype fact (`None` bails loudly at use,
 /// never silently).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -24,22 +24,22 @@ pub struct CudaLayout {
 /// The CUDA-lite bufferized plan.
 pub type CudaPlan = luminal::bufferize::BufferIrGraph<CudaLayout>;
 
-/// The extraction-side layout renderer: minimal-faithful — the five
-/// constructor spellings render into the mirror structs, preferring the
-/// most-structured spelling present (a rendering preference only), with
+/// The extraction-side layout decoder: minimal-faithful — the five
+/// constructor spellings decode into the mirror structs, preferring the
+/// most-structured spelling present (a decoding preference only), with
 /// the value's dtype fact carried alongside. No normalization, no
 /// analysis; failure is loud and refuses the plan. Pure in
-/// `(layout class, dtype fact)` — the renderer cache contract.
+/// `(layout class, dtype fact)` — the decoder cache contract.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct CudaLayoutRenderer;
+pub struct CudaLayoutDecoder;
 
-impl luminal::layout_ir::LayoutRenderer<CudaLayout> for CudaLayoutRenderer {
-    fn render_layout(&self, egraph: &EGraph, value: &LayoutTensorInfo) -> Result<CudaLayout> {
+impl luminal::layout_ir::LayoutDecoder<CudaLayout> for CudaLayoutDecoder {
+    fn decode(&self, egraph: &EGraph, value: &LayoutTensorInfo) -> Result<CudaLayout> {
         Ok(CudaLayout {
-            mirror: luminal::layouts::render_layout_for(
+            mirror: luminal::layouts::decode_layout_for(
                 egraph,
                 &value.layout.eclass,
-                "cuda-lite layout renderer",
+                "cuda-lite layout decoder",
             )?,
             dtype: value.dtype_enum,
         })

--- a/crates/luminal_cuda_lite/src/lib.rs
+++ b/crates/luminal_cuda_lite/src/lib.rs
@@ -37,7 +37,7 @@ pub mod runtime;
 pub mod device;
 
 pub use bindings::CudaBindings;
-pub use layouts::{CudaLayout, CudaLayoutRenderer, CudaPlan};
+pub use layouts::{CudaLayout, CudaLayoutDecoder, CudaPlan};
 pub use runtime::CudaRuntime;
 
 /// PLAN-TRANSPARENT (M4 Phase 5): claimable WITHOUT a kernel iff the

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -266,7 +266,7 @@ impl CudaRuntime {
                 Self::allow_list()
             }),
             self.matchers(),
-            &crate::layouts::CudaLayoutRenderer,
+            &crate::layouts::CudaLayoutDecoder,
             &mut luminal::implementation_search::StaticProfiler,
         )?;
 

--- a/crates/luminal_cuda_lite/tests/codegen_identity.rs
+++ b/crates/luminal_cuda_lite/tests/codegen_identity.rs
@@ -663,8 +663,8 @@ mod strided {
     // =======================================================================
     // THE TWO-SPELLING PROOF (ruling 2026-08-31).
     //
-    // The e-graph may hand the renderer ANY spelling of a layout class —
-    // all spellings of a class denote one function, and `render_layout`
+    // The e-graph may hand the decoder ANY spelling of a layout class —
+    // all spellings of a class denote one function, and `decode_layout`
     // only states a PREFERENCE among the ones it finds. So the read
     // decision may not be made on a spelling. These tests state one dense
     // function five ways and require the emitted CUDA source to be

--- a/crates/luminal_cuda_lite/tests/cublaslt_bias_premise.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_bias_premise.rs
@@ -149,10 +149,10 @@ fn linear_with_bias_mints_the_bias_form_on_a_left_major_d() {
     }
     for class in &d_classes {
         let ops = class_ops(&egraph, class);
-        let mirror = luminal::layouts::render_layout_for(&egraph, class, "bias-premise pin")
-            .expect("the D layout class renders");
+        let mirror = luminal::layouts::decode_layout_for(&egraph, class, "bias-premise pin")
+            .expect("the D layout class decodes");
         println!("BIAS-PREMISE CublasLtBias D layout class {class:?}: ops={ops:?}");
-        println!("BIAS-PREMISE   rendered (most-structured spelling): {mirror:?}");
+        println!("BIAS-PREMISE   decoded (most-structured spelling): {mirror:?}");
         assert!(
             ops.contains("LeftMajorContiguousElementLayoutLit"),
             "the bias form's D class must hold the LeftMajor spelling: {ops:?}"
@@ -172,7 +172,7 @@ fn linear_with_bias_mints_the_bias_form_on_a_left_major_d() {
         );
         assert!(
             matches!(mirror, luminal::layouts::MirrorLayout::LeftMajor(_)),
-            "the renderer's most-structured spelling is LeftMajor (RightMajor is absent, \
+            "the decoder's most-structured spelling is LeftMajor (RightMajor is absent, \
              as it must be: a [3,4] left-major over the bytes of a [4,3] right-major): {mirror:?}"
         );
     }

--- a/crates/luminal_cuda_lite/tests/view_admission.rs
+++ b/crates/luminal_cuda_lite/tests/view_admission.rs
@@ -24,7 +24,7 @@
 //!    by EVALUATING that layout to a flat parent element index and
 //!    comparing against the hand-computed map. (The hop chain is retired:
 //!    corrected contract, 2026-08-31. The e-graph composes views at view
-//!    creation; the rendered `L` IS the read path, and how it is spelled
+//!    creation; the decoded `L` IS the read path, and how it is spelled
 //!    is the e-graph's business.)
 
 use luminal::buffer_tensor_ir::TypedBuffer;

--- a/crates/luminal_reference/src/harness.rs
+++ b/crates/luminal_reference/src/harness.rs
@@ -204,12 +204,12 @@ pub fn plain_plan_exists(cx: &luminal::graph::Graph) -> anyhow::Result<()> {
     .ok_or_else(|| anyhow::anyhow!("no output boundary reached"))?;
     eprintln!("[plain-plan] extract {:?}", start.elapsed());
     let start = std::time::Instant::now();
-    // VALUE-keyed table: render over the POST-DPS graph bufferize sees.
+    // VALUE-keyed table: decode over the POST-DPS graph bufferize sees.
     let dps = luminal::dps::dps_rewrite(&extracted);
-    let layouts = extractor::rendered_layout_table(
+    let layouts = extractor::decoded_layout_table(
         &serialized,
         &dps,
-        &crate::layouts::ReferenceLayoutRenderer,
+        &crate::layouts::ReferenceLayoutDecoder,
         &mut std::collections::HashMap::new(),
     )?;
     luminal::bufferize::bufferize(&dps, &layouts)?;

--- a/crates/luminal_reference/src/layouts.rs
+++ b/crates/luminal_reference/src/layouts.rs
@@ -1,11 +1,11 @@
-//! The reference runtime's LAYOUT vocabulary and renderer (resident-
+//! The reference runtime's LAYOUT vocabulary and decoder (resident-
 //! geometry cleanup, ruling 2026-08-31; Option B rework). Core's
 //! bufferizer is generic over an opaque layout type it only clones and
 //! transports; THIS runtime instantiates it with a TYPED layout — the
 //! shared mirror vocabulary (`luminal::layouts`, a core convenience
 //! module the bufferizer itself never calls) plus the value's `dtype-of`
 //! fact. The dtype is the RUNTIME's own extraction-side knowledge folded
-//! into the runtime's own type at render time — it is not plan
+//! into the runtime's own type at decode time — it is not plan
 //! vocabulary (the plan carries `RefLayout` opaquely), and it is what
 //! makes Option-B plans self-contained for `load_plan` callers: staging,
 //! allocation, and readback all read the carried layout instead of a
@@ -15,7 +15,7 @@ use anyhow::Result;
 use egraph_serialize::EGraph;
 use luminal::layout_ir::LayoutTensorInfo;
 
-/// The reference runtime's opaque plan-layout type: the rendered mirror
+/// The reference runtime's opaque plan-layout type: the decoded mirror
 /// layout plus the value's dtype fact. `dtype: None` is representable
 /// (a value without a `dtype-of` row) and bails loudly at USE — staging,
 /// allocation typing, readback — never silently.
@@ -28,23 +28,23 @@ pub struct RefLayout {
 /// The reference runtime's bufferized plan.
 pub type ReferencePlan = luminal::bufferize::BufferIrGraph<RefLayout>;
 
-/// The extraction-side layout renderer: minimal-faithful — the five
-/// constructor spellings render into the mirror structs, preferring the
-/// most-structured spelling present (a rendering preference only; all
+/// The extraction-side layout decoder: minimal-faithful — the five
+/// constructor spellings decode into the mirror structs, preferring the
+/// most-structured spelling present (a decoding preference only; all
 /// spellings of a class denote one function), with the value's dtype
 /// fact carried alongside. No normalization, no analysis; failure is
 /// loud and refuses the plan. Pure in `(layout class, dtype fact)` —
-/// the renderer cache contract.
+/// the decoder cache contract.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct ReferenceLayoutRenderer;
+pub struct ReferenceLayoutDecoder;
 
-impl luminal::layout_ir::LayoutRenderer<RefLayout> for ReferenceLayoutRenderer {
-    fn render_layout(&self, egraph: &EGraph, value: &LayoutTensorInfo) -> Result<RefLayout> {
+impl luminal::layout_ir::LayoutDecoder<RefLayout> for ReferenceLayoutDecoder {
+    fn decode(&self, egraph: &EGraph, value: &LayoutTensorInfo) -> Result<RefLayout> {
         Ok(RefLayout {
-            mirror: luminal::layouts::render_layout_for(
+            mirror: luminal::layouts::decode_layout_for(
                 egraph,
                 &value.layout.eclass,
-                "reference layout renderer",
+                "reference layout decoder",
             )?,
             dtype: value.dtype_enum,
         })

--- a/crates/luminal_reference/src/lib.rs
+++ b/crates/luminal_reference/src/lib.rs
@@ -16,7 +16,7 @@ pub mod search;
 
 pub use bindings::ReferenceBindings;
 pub use harness::{extract_layout_ir, extract_layout_ir_with_genome, producer_index_with_ops};
-pub use layouts::{RefLayout, ReferenceLayoutRenderer, ReferencePlan};
+pub use layouts::{RefLayout, ReferenceLayoutDecoder, ReferencePlan};
 pub use runtime::{reference_allow_list, ReferenceRuntime};
 pub use search::{search_implementations, search_implementations_with_ops, ReferenceProfiler};
 

--- a/crates/luminal_reference/src/runtime.rs
+++ b/crates/luminal_reference/src/runtime.rs
@@ -1436,13 +1436,13 @@ mod tests {
         .expect("extracts")
         .expect("plan");
         let dps = luminal::dps::dps_rewrite(&extracted);
-        let layouts = luminal::extractor::rendered_layout_table(
+        let layouts = luminal::extractor::decoded_layout_table(
             &serialized,
             &dps,
-            &crate::layouts::ReferenceLayoutRenderer,
+            &crate::layouts::ReferenceLayoutDecoder,
             &mut std::collections::HashMap::new(),
         )
-        .expect("layouts render");
+        .expect("layouts decode");
         let plan = luminal::bufferize::bufferize(&dps, &layouts).expect("bufferizes");
         let mut rt = crate::ReferenceRuntime::default();
         rt.stage_slots(&program.input_slots, &program.output_slots);

--- a/crates/luminal_reference/src/search.rs
+++ b/crates/luminal_reference/src/search.rs
@@ -14,7 +14,7 @@ use luminal::implementation_search::{
     search_implementations_with_runtime, ImplementationSearchOptions, PlanProfiler, SearchOutcome,
 };
 
-use crate::layouts::{RefLayout, ReferenceLayoutRenderer};
+use crate::layouts::{RefLayout, ReferenceLayoutDecoder};
 use crate::runtime::{reference_allow_list, ReferenceRuntime};
 
 /// The historical profiler: execute on the reference host runtime.
@@ -63,7 +63,7 @@ pub fn search_implementations_with_ops(
         options,
         allow,
         crate::ops::built_in_matchers(),
-        &ReferenceLayoutRenderer,
+        &ReferenceLayoutDecoder,
         &mut ReferenceProfiler,
     )
 }

--- a/src/buffer_tensor_ir.rs
+++ b/src/buffer_tensor_ir.rs
@@ -446,7 +446,7 @@ pub trait BufferTensorIrOp: OpSlotNames + CloneBufferTensorIrOp + AsAnyOp + Debu
     /// PLAN-SIDE CONSUMPTION IS GONE (corrected contract, 2026-08-31):
     /// the bufferizer no longer records a folded access on consumer slot
     /// descriptors — the e-graph mints every view value's COMPOSED layout
-    /// at view creation, and the runtime's rendered `L` for that value is
+    /// at view creation, and the runtime's decoded `L` for that value is
     /// the read path. This hook survives as OP-RECORD business: what an
     /// op remembers from its claimed site, for its own matcher/kernel to
     /// use. `None` (the default) = no numeric map available; consumers
@@ -924,7 +924,7 @@ pub(crate) fn build_buffer_tensor_ir<L: PlanLayout>(
     let layout_of = |value: &ClassId| -> Result<L> {
         value_layouts.get(value).cloned().ok_or_else(|| {
             anyhow::anyhow!(
-                "value {value} has no rendered layout — every graph \
+                "value {value} has no decoded layout — every graph \
                  value records one before BufferTensor construction"
             )
         })

--- a/src/bufferize.rs
+++ b/src/bufferize.rs
@@ -92,8 +92,8 @@ use crate::layout_ir::{
 /// enforced in the e-graph, where all spellings of a layout class
 /// denote one function — no tripwire is re-derived here). There is no
 /// layout vocabulary in core: the RUNTIME provides the concrete type
-/// when it builds plans (its extraction-side layout renderer produces
-/// the values — see [`crate::layout_ir::LayoutRenderer`]), and backends
+/// when it builds plans (its extraction-side layout decoder produces
+/// the values — see [`crate::layout_ir::LayoutDecoder`]), and backends
 /// are free to use layouts core has never heard of.
 /// Blanket-implemented: the bound IS the whole contract.
 pub trait PlanLayout: Clone + std::fmt::Debug {}
@@ -165,7 +165,7 @@ pub struct Buffer<L: PlanLayout> {
     /// `PartialEq` on [`PlanLayout`]); the runtime owns it.
     pub backs: ClassId,
     /// PROTOTYPE (Option B): the backed tensor's elected layout — the `L`
-    /// the runtime's renderer minted for `backs`, carried VERBATIM.
+    /// the runtime's decoder minted for `backs`, carried VERBATIM.
     /// Informationally redundant for a live runtime (it knew every layout
     /// before it called bufferize); carried so plans are SELF-CONTAINED
     /// for `load_plan`/hand-built callers, who may read this instead of a
@@ -192,7 +192,7 @@ pub struct OutputBinding<L: PlanLayout> {
     pub value: ClassId,
     pub buffer: BufferId,
     /// PROTOTYPE (Option B): the output value's elected layout, carried
-    /// VERBATIM from the runtime's rendered table — for a view election,
+    /// VERBATIM from the runtime's decoded table — for a view election,
     /// the view's COMPOSED layout as the e-graph minted it, already
     /// addressing the backing buffer's bytes. Redundant for a live
     /// runtime; self-containment for loaded plans.
@@ -232,7 +232,7 @@ pub struct BufferEdge {
 // (corrected contract, 2026-08-31): recording per-slot view-fold chains
 // was the planner COMPOSING layout knowledge — the e-graph already mints
 // every view value's composed layout at view creation, and the runtime's
-// rendered `L` for that value IS the read path. The planner records
+// decoded `L` for that value IS the read path. The planner records
 // assignment, never access expressions.
 
 /// Per-slot descriptor on a plan node: the VALUE occupying an
@@ -249,7 +249,7 @@ pub struct SlotDescriptor<L: PlanLayout> {
     /// The buffer backing the slot (same entry as `reads`/`writes`).
     pub buffer: BufferId,
     /// PROTOTYPE (Option B): the slot value's elected layout, carried
-    /// VERBATIM from the runtime's rendered table (TOTAL: every
+    /// VERBATIM from the runtime's decoded table (TOTAL: every
     /// LayoutTensor carries a layout by construction; a missing row bails
     /// at lowering, never defaults). For an operand reading through
     /// folded views this is the view's COMPOSED layout as the e-graph
@@ -1532,13 +1532,13 @@ fn validate_input_program(graph: &ExtractedGraph) -> Result<()> {
 /// [`BufferIrGraph`] whose values are buffers and whose copies are real nodes. The
 /// source `graph` is borrowed and left untouched.
 ///
-/// `layouts` is the rendered-layout table, keyed by LAYOUT e-class (each
-/// value's `LayoutTensorInfo::layout.eclass`): the runtime's renderer
+/// `layouts` is the decoded-layout table, keyed by LAYOUT e-class (each
+/// value's `LayoutTensorInfo::layout.eclass`): the runtime's decoder
 /// produced one opaque `L` per layout class it elected (see
-/// [`crate::extractor::rendered_layout_table`]). The table must cover
+/// [`crate::extractor::decoded_layout_table`]). The table must cover
 /// every value's layout class — a miss is a loud error, never a default
 /// (every LayoutTensor carries a Layout by construction, so a missing
-/// row means the renderer refused and the plan must too). Keying by
+/// row means the decoder refused and the plan must too). Keying by
 /// layout class also covers the DPS poisons for free: `dps_rewrite`
 /// clones the tied result's layout (e-class included) onto each poison
 /// destination, so the poison's `L` IS the result's.
@@ -1546,17 +1546,17 @@ pub fn bufferize<L: PlanLayout>(
     graph: &ExtractedGraph,
     layouts: &HashMap<ClassId, L>,
 ) -> Result<BufferIrGraph<L>> {
-    // `layouts` is keyed by VALUE e-class (the runtime's rendered table,
-    // [`crate::extractor::rendered_layout_table`]).
+    // `layouts` is keyed by VALUE e-class (the runtime's decoded table,
+    // [`crate::extractor::decoded_layout_table`]).
     let value_layouts = extraction_layouts(graph, layouts)?;
     let mut plan = lower(buffer_tensor_plan(graph, &value_layouts)?, &value_layouts)?;
     annotate_boundary_lits(&mut plan, graph);
     Ok(plan)
 }
 
-/// Every extraction VALUE's rendered layout, keyed by value e-class —
+/// Every extraction VALUE's decoded layout, keyed by value e-class —
 /// TOTAL: every LayoutTensor carries a Layout by construction, so a value
-/// with no rendered row is a loud refusal, never a default. This is the
+/// with no decoded row is a loud refusal, never a default. This is the
 /// ONE per-value fact the planner transports; dims, element bits, and
 /// dtype are the runtime's own extraction-side knowledge and never enter
 /// the plan (corrected contract, 2026-08-31).
@@ -1573,9 +1573,9 @@ pub(crate) fn extraction_layouts<L: PlanLayout>(
         }
         let layout = layouts.get(&value.eclass).cloned().ok_or_else(|| {
             anyhow::anyhow!(
-                "value {} (layout class {}) has no row in the rendered \
+                "value {} (layout class {}) has no row in the decoded \
                  layout table — every LayoutTensor carries a Layout by \
-                 construction, so the renderer must cover it or the plan \
+                 construction, so the decoder must cover it or the plan \
                  must refuse",
                 value.eclass,
                 value.layout.eclass,
@@ -1787,7 +1787,7 @@ impl<L: PlanLayout> Bufferizer<L> {
         let layout_of = |value: &ClassId| -> Result<L> {
             value_layouts.get(value).cloned().ok_or_else(|| {
                 anyhow::anyhow!(
-                    "value {value} has no rendered layout — every graph \
+                    "value {value} has no decoded layout — every graph \
                      value records one before assignment"
                 )
             })
@@ -2072,10 +2072,10 @@ pub(crate) fn lower<L: PlanLayout>(
 
     // Per-slot descriptor: the assignment restated per slot — (value,
     // buffer) identity from the BufferTensor pair, plus the Option-B
-    // carried layout from the rendered table.
+    // carried layout from the decoded table.
     let describe = |tensor: &BufferTensor| -> Result<SlotDescriptor<L>> {
         // PROTOTYPE (Option B): the slot's layout is TOTAL. Every
-        // EXTRACTION value has a rendered-layout row; the one legal miss
+        // EXTRACTION value has a decoded-layout row; the one legal miss
         // is a planner-SYNTHESIZED undefined value (a BufferAlloc poison
         // minted by `optimize` — never read, never returned), whose slot
         // carries its residence buffer's mint-seed layout (also total).
@@ -2088,7 +2088,7 @@ pub(crate) fn lower<L: PlanLayout>(
                 .ok_or_else(|| {
                     anyhow::anyhow!(
                         "lowering: value {} occupies a slot with neither a \
-                         rendered-layout row nor an interned buffer — a \
+                         decoded-layout row nor an interned buffer — a \
                          layoutless slot is unrepresentable (fail-closed)",
                         tensor.value
                     )
@@ -2182,7 +2182,7 @@ pub(crate) fn lower<L: PlanLayout>(
                         let parent = &operands[derives(result).expect("checked by is_view")];
                         // The fold records NO access expression (corrected
                         // contract, 2026-08-31): the view value's own
-                        // rendered layout — already composed by the
+                        // decoded layout — already composed by the
                         // e-graph at view creation — is how its readers
                         // address the parent residence's bytes. Only the
                         // fold ROOT is tracked, for the base-storage copy
@@ -2314,7 +2314,7 @@ pub(crate) fn lower<L: PlanLayout>(
                 // EVERY slot carries its elected layout uniformly: a view
                 // output is fulfilled STRUCTURALLY (its buffer is its
                 // parent's backing storage — zero-copy by construction),
-                // and the returned layout is the slot value's own rendered
+                // and the returned layout is the slot value's own decoded
                 // `L`, verbatim. Total, loud on a miss.
                 let bindings: Vec<OutputBinding<L>> = slots
                     .iter()
@@ -2323,7 +2323,7 @@ pub(crate) fn lower<L: PlanLayout>(
                         let Some(layout) = value_layouts.get(&slot.value) else {
                             anyhow::bail!(
                                 "lowering: output slot value {} has no \
-                                 rendered-layout row (fail-closed)",
+                                 decoded-layout row (fail-closed)",
                                 slot.value
                             );
                         };
@@ -3330,13 +3330,13 @@ mod tests {
     // -------------------------------------------------------------------------
     // View folds: the slot carries the view value's OWN layout (corrected
     // contract, 2026-08-31 — the hop machinery is deleted; the e-graph
-    // mints every view's composed layout, and the rendered `L` is the
+    // mints every view's composed layout, and the decoded `L` is the
     // read path).
     // -------------------------------------------------------------------------
 
     /// A folded view redirects its consumer to the parent's buffer while
     /// the slot keeps the VIEW's identity: its value, and its own
-    /// rendered layout, verbatim from the table.
+    /// decoded layout, verbatim from the table.
     #[test]
     fn folded_view_slot_carries_the_views_own_layout() {
         use crate::index_expr::IotaExpr;
@@ -3388,7 +3388,7 @@ mod tests {
         let table = crate::test_support::mock_layout_table(&graph);
         assert_eq!(
             &operand_info[0].layout, &table[&v],
-            "the slot carries the VIEW's own rendered layout, verbatim"
+            "the slot carries the VIEW's own decoded layout, verbatim"
         );
         assert_eq!(
             &result_info[0].layout, &table[&r],
@@ -3399,7 +3399,7 @@ mod tests {
 
     /// A two-hop view chain still lowers to ONE producer redirect: the
     /// consumer's slot is anchored on the ROOT parent's buffer, and the
-    /// slot's layout is the OUTER view's own rendered layout (the
+    /// slot's layout is the OUTER view's own decoded layout (the
     /// e-graph minted the composition; the planner records nothing).
     #[test]
     fn two_hop_view_chain_redirects_to_the_root_parent() {
@@ -3465,9 +3465,9 @@ mod tests {
     }
 
     /// A view op WITHOUT a numeric map still folds structurally — the
-    /// read path is the view VALUE's own rendered layout, so there is no
+    /// read path is the view VALUE's own decoded layout, so there is no
     /// per-op map to lose (fail-closure moved to RENDER time: a layout
-    /// class the renderer cannot render refuses the whole plan).
+    /// class the decoder cannot decode refuses the whole plan).
     #[test]
     fn mapless_view_fold_still_redirects_with_the_views_layout() {
         use crate::test_support::{MockView, TestGraph};
@@ -3524,7 +3524,7 @@ mod tests {
     /// the slot is backed by the input buffer itself and the declared
     /// output buffer goes unused (dropped by DCE — runtimes never allocate
     /// it). Option B's addition: the binding also CARRIES the view value's
-    /// elected layout `L`, verbatim from the rendered table, so an
+    /// elected layout `L`, verbatim from the decoded table, so an
     /// externally loaded plan can read the delivery geometry without the
     /// table a live runtime already has.
     #[test]
@@ -3579,7 +3579,7 @@ mod tests {
             "the input buffer's assignment row still names the tensor it backs"
         );
         // Option B's disclosure: the slot carries the VIEW value's own
-        // elected layout, verbatim from the rendered table.
+        // elected layout, verbatim from the decoded table.
         let table = crate::test_support::mock_layout_table(&graph);
         assert_eq!(
             &slot.layout, &table[&v],
@@ -4183,7 +4183,7 @@ mod tests {
             &mock_geometry,
         )
         .expect("construction survives the rejected tie");
-        // Lowering takes the rendered layout table directly — there is no
+        // Lowering takes the decoded layout table directly — there is no
         // second, geometry-bearing table to build, and no annotation pass
         // to run afterwards.
         let plan = lower(bt, &mock_geometry).expect("the base-storage copy lowers");

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -442,34 +442,34 @@ pub fn extract_layout_ir_with_ops_and_matchers(
     extractor.extract()
 }
 
-/// Build the rendered-layout table for one extracted graph, keyed by
+/// Build the decoded-layout table for one extracted graph, keyed by
 /// VALUE e-class: enumerate every elected value (pure enumeration — core
 /// never parses a layout spelling) and call the runtime's
-/// [`LayoutRenderer`] hook, reusing `cache` across calls. The cache key
-/// is `(layout class, dtype-of fact)` — exactly the inputs the renderer
-/// contract permits it to read (all spellings of a layout class denote
-/// one function, and the dtype fact is the one extraction-side value
-/// fact a runtime may fold into `L`), so one cache serves every genome.
-/// A renderer error is LOUD and refuses the graph: there is no default
+/// [`crate::layout_ir::LayoutDecoder`] hook, reusing `cache` across calls.
+/// The cache key is `(layout class, dtype-of fact)` — exactly the inputs
+/// the decoder contract permits it to read (all spellings of a layout
+/// class denote one function, and the dtype fact is the one extraction-side
+/// value fact a runtime may fold into `L`), so one cache serves every genome.
+/// A decoder error is LOUD and refuses the graph: there is no default
 /// layout.
 ///
 /// CALL IT ON THE GRAPH BUFFERIZE WILL SEE — the POST-DPS one. The table
 /// is VALUE-keyed now, and the DPS rewrite mints fresh poison-destination
 /// VALUES, so a pre-DPS table is not total over the post-DPS graph and
-/// `extraction_layouts` refuses it loudly. Rendering post-DPS is free:
+/// `extraction_layouts` refuses it loudly. Decoding post-DPS is free:
 /// each poison clones its tied result's layout class AND dtype fact, so
 /// it hits the `(layout class, dtype)` cache. (Historically the table was
 /// keyed by layout class, and the pre-DPS graph sufficed because
 /// the DPS rewrite's poison destinations clone their tied result's layout,
 /// e-class included, so the table covered them by construction.)
-pub fn rendered_layout_table<L: Clone>(
+pub fn decoded_layout_table<L: Clone>(
     egraph: &EGraph,
     graph: &ExtractedGraph,
-    renderer: &dyn crate::layout_ir::LayoutRenderer<L>,
+    decoder: &dyn crate::layout_ir::LayoutDecoder<L>,
     cache: &mut HashMap<(ClassId, Option<crate::dtype::PlanDtype>), L>,
 ) -> Result<HashMap<ClassId, L>> {
     let mut table: HashMap<ClassId, L> = HashMap::new();
-    let render = |value: &crate::layout_ir::LayoutTensorInfo,
+    let decode = |value: &crate::layout_ir::LayoutTensorInfo,
                   table: &mut HashMap<ClassId, L>,
                   cache: &mut HashMap<(ClassId, Option<crate::dtype::PlanDtype>), L>|
      -> Result<()> {
@@ -477,28 +477,28 @@ pub fn rendered_layout_table<L: Clone>(
             return Ok(());
         }
         let key = (value.layout.eclass.clone(), value.dtype_enum);
-        let rendered = match cache.get(&key) {
-            Some(rendered) => rendered.clone(),
+        let decoded = match cache.get(&key) {
+            Some(decoded) => decoded.clone(),
             None => {
-                let rendered = renderer.render_layout(egraph, value).with_context(|| {
+                let decoded = decoder.decode(egraph, value).with_context(|| {
                     format!(
-                        "rendering the layout of value {} (layout class {})",
+                        "decoding the layout of value {} (layout class {})",
                         value.eclass, value.layout.eclass
                     )
                 })?;
-                cache.insert(key, rendered.clone());
-                rendered
+                cache.insert(key, decoded.clone());
+                decoded
             }
         };
-        table.insert(value.eclass.clone(), rendered);
+        table.insert(value.eclass.clone(), decoded);
         Ok(())
     };
     for node in graph.dag.node_weights() {
         match node {
-            ExtractedNode::BufferInput(input) => render(&input.value, &mut table, cache)?,
+            ExtractedNode::BufferInput(input) => decode(&input.value, &mut table, cache)?,
             ExtractedNode::LayoutOp(op) => {
                 for output in &op.outputs {
-                    render(output, &mut table, cache)?;
+                    decode(output, &mut table, cache)?;
                 }
             }
             ExtractedNode::BufferOutput(_) => {}

--- a/src/implementation_search.rs
+++ b/src/implementation_search.rs
@@ -190,7 +190,7 @@ pub fn search_implementations_with_runtime<L: crate::bufferize::PlanLayout>(
     options: &ImplementationSearchOptions,
     allow_override: Option<Vec<&'static str>>,
     matchers: Vec<Box<dyn crate::layout_ir::OpMatcher>>,
-    layout_renderer: &dyn crate::layout_ir::LayoutRenderer<L>,
+    layout_decoder: &dyn crate::layout_ir::LayoutDecoder<L>,
     profiler: &mut dyn PlanProfiler<L>,
 ) -> Result<SearchOutcome<L>> {
     // Tensor-keyed at the boundary (the retired-HLIR-keyspace design);
@@ -352,8 +352,8 @@ pub fn search_implementations_with_runtime<L: crate::bufferize::PlanLayout>(
 
     // fingerprint → measured nanos (the dedup cache).
     let mut cache: FxHashMap<u64, u128> = FxHashMap::default();
-    // Rendered layouts are pure functions of (layout class, dtype fact)
-    // — the renderer cache contract — so one cache serves every genome.
+    // Decoded layouts are pure functions of (layout class, dtype fact)
+    // — the decoder cache contract — so one cache serves every genome.
     let mut layout_cache: std::collections::HashMap<
         (egraph_serialize::ClassId, Option<crate::dtype::PlanDtype>),
         L,
@@ -427,21 +427,21 @@ pub fn search_implementations_with_runtime<L: crate::bufferize::PlanLayout>(
                 }
                 None => {
                     let build_start = Instant::now();
-                    // Render the elected layouts (the runtime's hook; a
+                    // Decode the elected layouts (the runtime's hook; a
                     // refusal rejects THIS genome, loudly accounted, and
                     // the search tries others), then bufferize under the
-                    // rendered table.
+                    // decoded table.
                     // The table is VALUE-keyed (corrected contract), so it
                     // must be built over the graph bufferize sees — the
                     // POST-DPS one, whose poison destinations are fresh
                     // values. They clone their tied result's layout class
-                    // AND dtype fact, so every poison is a renderer-cache
-                    // HIT: value-keying costs no extra renderer calls.
+                    // AND dtype fact, so every poison is a decoder-cache
+                    // HIT: value-keying costs no extra decoder calls.
                     let dps = crate::dps::dps_rewrite(&graph);
-                    let built = extractor::rendered_layout_table(
+                    let built = extractor::decoded_layout_table(
                         egraph,
                         &dps,
-                        layout_renderer,
+                        layout_decoder,
                         &mut layout_cache,
                     )
                     .and_then(|table| crate::bufferize::bufferize(&dps, &table));
@@ -495,10 +495,10 @@ pub fn search_implementations_with_runtime<L: crate::bufferize::PlanLayout>(
             {
                 let build_start = Instant::now();
                 let dps = crate::dps::dps_rewrite(&graph);
-                let built = extractor::rendered_layout_table(
+                let built = extractor::decoded_layout_table(
                     egraph,
                     &dps,
-                    layout_renderer,
+                    layout_decoder,
                     &mut layout_cache,
                 )
                 .and_then(|table| crate::bufferize::bufferize(&dps, &table));
@@ -564,7 +564,7 @@ pub fn bucketed_search_implementations<L: crate::bufferize::PlanLayout>(
     options: &ImplementationSearchOptions,
     assembled_program: &str,
     matchers: impl Fn() -> Vec<Box<dyn crate::layout_ir::OpMatcher>>,
-    layout_renderer: &dyn crate::layout_ir::LayoutRenderer<L>,
+    layout_decoder: &dyn crate::layout_ir::LayoutDecoder<L>,
     profiler: &mut dyn PlanProfiler<L>,
     bindings: &dyn crate::runtime_binding::RuntimeBindingsGenerator,
 ) -> Result<Vec<BucketPlan<L>>> {
@@ -657,7 +657,7 @@ pub fn bucketed_search_implementations<L: crate::bufferize::PlanLayout>(
             options,
             None,
             matchers(),
-            layout_renderer,
+            layout_decoder,
             profiler,
         )?;
         plans.push(BucketPlan {
@@ -823,7 +823,7 @@ mod tests {
             &ImplementationSearchOptions::default(),
             luminal_reference::assembled_program(),
             luminal_reference::ops::built_in_matchers,
-            &luminal_reference::ReferenceLayoutRenderer,
+            &luminal_reference::ReferenceLayoutDecoder,
             &mut luminal_reference::ReferenceProfiler,
             &luminal_reference::ReferenceBindings,
         )

--- a/src/layout_ir/mod.rs
+++ b/src/layout_ir/mod.rs
@@ -546,33 +546,33 @@ pub trait OpMatcher: std::fmt::Debug {
     fn extract(&self, site: &ExtractionSite<'_>) -> Box<dyn LayoutIrOp>;
 }
 
-/// The runtime's LAYOUT RENDERER — the layout-side mirror of the
+/// The runtime's LAYOUT DECODER — the layout-side mirror of the
 /// [`OpMatcher`] registration seam (resident-geometry cleanup, ruling
 /// 2026-08-31). Where matchers turn elected op enodes into instances, the
-/// renderer turns each elected value's LAYOUT e-class into the runtime's
+/// decoder turns each elected value's LAYOUT e-class into the runtime's
 /// own opaque layout value `L` — the type the bufferizer transports on
 /// [`crate::bufferize::Buffer`] without ever interpreting it. Core CALLS
 /// this hook (once per distinct layout class, see
-/// [`crate::extractor::rendered_layout_table`]) and never parses a layout
+/// [`crate::extractor::decoded_layout_table`]) and never parses a layout
 /// spelling itself.
 ///
-/// RENDERING RULE for implementors: any spelling present in the class is
+/// DECODING RULE for implementors: any spelling present in the class is
 /// correct — all spellings of a layout class denote one function — and
 /// the most-structured spelling present (RightMajor > LeftMajor >
-/// Strided > ElementOffset > BitOffset) is preferred as a rendering
+/// Strided > ElementOffset > BitOffset) is preferred as a decoding
 /// preference only. No normalization, no analysis, and failure is LOUD:
 /// an error refuses the plan; there is no silent default layout.
-/// PER-VALUE RENDERING (Option B rework, 2026-08-31): the hook receives
+/// PER-VALUE DECODING (Option B rework, 2026-08-31): the hook receives
 /// the elected VALUE's [`LayoutTensorInfo`] — its layout class plus the
 /// extraction-side facts the runtime already owns (notably `dtype_enum`,
 /// the `dtype-of` row) — so a runtime may fold whatever it wants of its
 /// OWN knowledge into `L` (e.g. a typed layout). Core still never reads
-/// any of it back. CACHE CONTRACT: the rendering must be a pure function
+/// any of it back. CACHE CONTRACT: decoding must be a pure function
 /// of `(value.layout.eclass, value.dtype_enum)` — core caches on exactly
 /// that key across genomes.
-pub trait LayoutRenderer<L> {
-    /// Render one elected value's layout into `L`.
-    fn render_layout(
+pub trait LayoutDecoder<L> {
+    /// Decode one elected value's layout into `L`.
+    fn decode(
         &self,
         egraph: &egraph_serialize::EGraph,
         value: &LayoutTensorInfo,

--- a/src/layouts.rs
+++ b/src/layouts.rs
@@ -8,7 +8,7 @@
 //! this a core vocabulary: the bufferizer stays generic over an opaque
 //! layout type it only clones and transports, and nothing in the planner
 //! imports this module. It exists so runtimes can pull the five mirror
-//! structs, the [`SpanExpr`] trait, and [`render_layout`] from one place
+//! structs, the [`SpanExpr`] trait, and [`decode_layout`] from one place
 //! instead of each respelling them; a backend that wants a different
 //! layout vocabulary brings its own type and ignores this module
 //! entirely — nothing here is a closed set the planner depends on.
@@ -18,18 +18,18 @@
 //!    vocabulary the constructor fields are spelled in;
 //!  * the five mirror structs, field-for-field with the preamble's
 //!    constructors (`RightMajorContiguousElementLayoutLit(Shape, BitWidth)`
-//!    and friends), plus the [`MirrorLayout`] sum for renderers;
+//!    and friends), plus the [`MirrorLayout`] sum for decoders;
 //!  * [`SpanExpr`] — the span-as-EXPRESSION trait, implemented ONLY where
 //!    a span is honest (the packed element ladder: right-major,
 //!    left-major, strided). The offset-expression forms deliberately do
 //!    NOT implement it: an offset function alone does not disclose its
 //!    reach, and nothing here guesses. NOTHING consumes `span()` yet.
-//!  * [`render_layout`] — the spelling renderer: walk one layout e-class
+//!  * [`decode_layout`] — the spelling decoder: walk one layout e-class
 //!    of a serialized e-graph into a [`MirrorLayout`]. Any spelling
 //!    present in a class is correct (all spellings of a layout class
 //!    denote one function); the walk PREFERS the most-structured spelling
 //!    present (RightMajor > LeftMajor > Strided > ElementOffset >
-//!    BitOffset) as a rendering preference only. No normalization, no
+//!    BitOffset) as a decoding preference only. No normalization, no
 //!    analysis — a class none of whose spellings parse is a loud error,
 //!    never a guess.
 
@@ -42,7 +42,7 @@ use std::collections::HashMap;
 // =============================================================================
 
 /// An integer expression TERM — the symbolic vocabulary layout fields are
-/// rendered into. A direct transliteration of the preamble's `IntExpr`
+/// decoded into. A direct transliteration of the preamble's `IntExpr`
 /// subset that appears inside layouts; construction only, no evaluation
 /// and no rewriting.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -53,7 +53,7 @@ pub enum IntExprTerm {
     Var(String),
     /// `(CoordVar shape axis)` — a coordinate over the owning layout's
     /// domain, axis 0-based FROM THE END (the preamble's de Bruijn
-    /// convention). The owner shape is checked at render time (a foreign
+    /// convention). The owner shape is checked at decode time (a foreign
     /// shape's coordinate never silently parses); the term keeps the
     /// axis alone.
     Coord {
@@ -165,13 +165,13 @@ pub struct BitOffsetExpressionLayout {
     pub width: BitWidthTerm,
 }
 
-/// The convenience sum renderers produce — one value for "some spelling
-/// of this layout class". RENDERER CONVENIENCE ONLY: the bufferizer is
-/// generic and never sees this type; a backend may render into its own
+/// The convenience sum decoders produce — one value for "some spelling
+/// of this layout class". DECODER CONVENIENCE ONLY: the bufferizer is
+/// generic and never sees this type; a backend may decode into its own
 /// type instead. NOT a closed vocabulary — and FLAGGED for review
 /// (Austin): a sum over the five constructors may already be too
 /// enum-ish for a vocabulary that is deliberately open; kept for now as
-/// the shared renderers' return type.
+/// the shared decoders' return type.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MirrorLayout {
     RightMajor(RightMajorContiguousElementLayout),
@@ -332,19 +332,19 @@ impl MirrorLayout {
 }
 
 // =============================================================================
-// The spelling renderer
+// The spelling decoder
 // =============================================================================
 
-/// Render one layout e-class of a serialized e-graph into a
+/// Decode one layout e-class of a serialized e-graph into a
 /// [`MirrorLayout`]. Builds a class index for the walk (one pass over the
-/// e-graph), so callers rendering many classes should memoize per class
-/// (all spellings of a class denote one function, so a class renders the
+/// e-graph), so callers decoding many classes should memoize per class
+/// (all spellings of a class denote one function, so a class decodes the
 /// same every time). Errors are LOUD and name the class — never a guess.
-pub fn render_layout(egraph: &EGraph, class: &ClassId) -> Result<MirrorLayout> {
-    Reader::new(egraph).render_layout(class)
+pub fn decode_layout(egraph: &EGraph, class: &ClassId) -> Result<MirrorLayout> {
+    Reader::new(egraph).decode_layout(class)
 }
 
-/// The renderer's walk state: the e-graph plus its by-class node index.
+/// The decoder's walk state: the e-graph plus its by-class node index.
 struct Reader<'a> {
     egraph: &'a EGraph,
     class_nodes: HashMap<&'a ClassId, Vec<&'a NodeId>>,
@@ -424,8 +424,8 @@ impl<'a> Reader<'a> {
             })
     }
 
-    fn render_layout(&self, class: &ClassId) -> Result<MirrorLayout> {
-        // The rendering PREFERENCE (most-structured spelling first); any
+    fn decode_layout(&self, class: &ClassId) -> Result<MirrorLayout> {
+        // The decoding PREFERENCE (most-structured spelling first); any
         // spelling present is correct, so the first that parses wins and
         // later constructors are backtracking fallbacks only.
         let mut present = Vec::new();
@@ -433,9 +433,9 @@ impl<'a> Reader<'a> {
             present.push("RightMajorContiguousElementLayoutLit");
             let (Some(shape), Some(width)) = (
                 self.class_of_child(node, 0)
-                    .and_then(|c| self.render_shape(&c)),
+                    .and_then(|c| self.decode_shape(&c)),
                 self.class_of_child(node, 1)
-                    .and_then(|c| self.render_bit_width(&c)),
+                    .and_then(|c| self.decode_bit_width(&c)),
             ) else {
                 continue;
             };
@@ -447,9 +447,9 @@ impl<'a> Reader<'a> {
             present.push("LeftMajorContiguousElementLayoutLit");
             let (Some(shape), Some(width)) = (
                 self.class_of_child(node, 0)
-                    .and_then(|c| self.render_shape(&c)),
+                    .and_then(|c| self.decode_shape(&c)),
                 self.class_of_child(node, 1)
-                    .and_then(|c| self.render_bit_width(&c)),
+                    .and_then(|c| self.decode_bit_width(&c)),
             ) else {
                 continue;
             };
@@ -468,12 +468,12 @@ impl<'a> Reader<'a> {
                 continue;
             };
             let (Some(shape), Some(width)) = (
-                self.render_shape(&shape_class),
-                self.render_bit_width(&width_class),
+                self.decode_shape(&shape_class),
+                self.decode_bit_width(&width_class),
             ) else {
                 continue;
             };
-            let Some(chain) = self.render_affine_chain(&chain_class, &shape_class) else {
+            let Some(chain) = self.decode_affine_chain(&chain_class, &shape_class) else {
                 continue;
             };
             return Ok(MirrorLayout::Strided(StridedElementLayout {
@@ -496,8 +496,8 @@ impl<'a> Reader<'a> {
                     continue;
                 };
                 let (Some(shape), Some(width)) = (
-                    self.render_shape(&shape_class),
-                    self.render_bit_width(&width_class),
+                    self.decode_shape(&shape_class),
+                    self.decode_bit_width(&width_class),
                 ) else {
                     continue;
                 };
@@ -525,7 +525,7 @@ impl<'a> Reader<'a> {
         if present.is_empty() {
             bail!(
                 "layout class {class} has no Layout constructor spelling — \
-                 nothing to render (fail-closed, never a guess)"
+                 nothing to decode (fail-closed, never a guess)"
             );
         }
         bail!(
@@ -535,7 +535,7 @@ impl<'a> Reader<'a> {
         )
     }
 
-    fn render_bit_width(&self, class: &ClassId) -> Option<BitWidthTerm> {
+    fn decode_bit_width(&self, class: &ClassId) -> Option<BitWidthTerm> {
         for node in self.nodes_in_class_value(class, "BitWidthLit") {
             let Some(bits_class) = self.class_of_child(node, 0) else {
                 continue;
@@ -547,14 +547,14 @@ impl<'a> Reader<'a> {
         None
     }
 
-    fn render_shape(&self, class: &ClassId) -> Option<ShapeTerm> {
+    fn decode_shape(&self, class: &ClassId) -> Option<ShapeTerm> {
         for node in self.nodes_in_class_value(class, "ShapeLit") {
             let Some(head) = self.class_of_child(node, 0) else {
                 continue;
             };
             let mut memo = HashMap::new();
             if let Some(extents) =
-                self.render_expr_list(&head, "IntExprCons", "IntExprNil", 64, None, &mut memo)
+                self.decode_expr_list(&head, "IntExprCons", "IntExprNil", 64, None, &mut memo)
             {
                 return Some(ShapeTerm(extents));
             }
@@ -565,13 +565,13 @@ impl<'a> Reader<'a> {
     /// The strided chain: one summand per axis from-end. Coordinates are
     /// guarded to the layout's OWN shape (a foreign shape's coordinate is
     /// not this domain's and fails that spelling — the owner-shape guard).
-    fn render_affine_chain(
+    fn decode_affine_chain(
         &self,
         class: &ClassId,
         owner_shape: &ClassId,
     ) -> Option<Vec<IntExprTerm>> {
         let mut memo = HashMap::new();
-        self.render_expr_list(
+        self.decode_expr_list(
             class,
             "IntAffineExprCons",
             "IntAffineExprNil",
@@ -584,7 +584,7 @@ impl<'a> Reader<'a> {
     /// Cons-spine walk, existential at every level (the backtracking
     /// doctrine): a saturated list class holds several cons spellings and
     /// the first may dead-end while a sibling parses fine.
-    fn render_expr_list(
+    fn decode_expr_list(
         &self,
         class: &ClassId,
         cons_op: &str,
@@ -610,7 +610,7 @@ impl<'a> Reader<'a> {
                 continue;
             };
             if let Some(mut rest) =
-                self.render_expr_list(&tail, cons_op, nil_op, depth - 1, owner_shape, memo)
+                self.decode_expr_list(&tail, cons_op, nil_op, depth - 1, owner_shape, memo)
             {
                 rest.insert(0, expr);
                 return Some(rest);
@@ -768,10 +768,10 @@ impl<'a> Reader<'a> {
     }
 }
 
-/// Convenience for renderers that must be total: [`render_layout`] with
+/// Convenience for decoders that must be total: [`decode_layout`] with
 /// the error contextualized by who was asking.
-pub fn render_layout_for(egraph: &EGraph, class: &ClassId, who: &str) -> Result<MirrorLayout> {
-    render_layout(egraph, class).map_err(|err| anyhow!("{who}: {err}"))
+pub fn decode_layout_for(egraph: &EGraph, class: &ClassId, who: &str) -> Result<MirrorLayout> {
+    decode_layout(egraph, class).map_err(|err| anyhow!("{who}: {err}"))
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod layout_ir;
 pub mod poison;
 pub mod subst_primitive;
 // Convenience mirrors of the five egglog Layout constructors + SpanExpr +
-// render_layout, for runtimes to pull from one place. THE BUFFERIZER NEVER
+// decode_layout, for runtimes to pull from one place. THE BUFFERIZER NEVER
 // CALLS ANY OF THIS — the planner stays generic over an opaque layout type,
 // and backends may ignore this module entirely (Austin's fold-into-core
 // amendment, resident-geometry cleanup 2026-08-31).

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -146,11 +146,11 @@ use crate::layout_ir::{
 /// equality join was dropped — layout equality is enforced in the
 /// e-graph); the `PartialEq` derive here is test-assertion convenience,
 /// not a bound the planner uses. Core never constructs one outside test
-/// support; runtimes bring their own rendered types.
+/// support; runtimes bring their own decoded types.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MockLayout(pub ClassId);
 
-/// The mock rendered-layout table for a built graph, keyed by VALUE
+/// The mock decoded-layout table for a built graph, keyed by VALUE
 /// e-class (the [`crate::bufferize::bufferize`] contract): every value
 /// maps to the identity of its layout class. Works for hand-built
 /// [`TestGraph`]s and real extractions alike.
@@ -177,7 +177,7 @@ pub fn mock_layout_table(graph: &ExtractedGraph) -> HashMap<ClassId, MockLayout>
 
 /// [`crate::bufferize::bufferize`] under the mock table — the test-side
 /// one-argument convenience every suite that does not exercise a real
-/// renderer plans through.
+/// decoder plans through.
 pub fn bufferize_mock(
     graph: &ExtractedGraph,
 ) -> anyhow::Result<crate::bufferize::BufferIrGraph<MockLayout>> {
@@ -1455,7 +1455,7 @@ mod harness_tests {
     /// the bounds-row encoding), but they NO LONGER thread onto plan
     /// buffers: `PlanDtype` left the plan and bufferizer vocabulary
     /// entirely. What they thread onto is the RUNTIME'S OWN `L` — here
-    /// `RefLayout { mirror, dtype }` — which the reference renderer folds
+    /// `RefLayout { mirror, dtype }` — which the reference decoder folds
     /// at extraction time and which Option B then carries on each
     /// assignment entry.
     ///
@@ -1472,13 +1472,13 @@ mod harness_tests {
         let egraph = serialize_fixture("boundary_gather.egg");
         let graph = luminal::dps::dps_rewrite(&extract_fixture("boundary_gather.egg"));
         let mut cache = std::collections::HashMap::new();
-        let table = luminal::extractor::rendered_layout_table(
+        let table = luminal::extractor::decoded_layout_table(
             &egraph,
             &graph, // the POST-DPS graph: value-keyed tables cover poisons
-            &luminal_reference::ReferenceLayoutRenderer,
+            &luminal_reference::ReferenceLayoutDecoder,
             &mut cache,
         )
-        .expect("the reference renderer covers every elected value");
+        .expect("the reference decoder covers every elected value");
         let plan = bufferize::bufferize(&graph, &table).expect("mixed-dtype plan bufferizes");
 
         let mut by_lit: std::collections::HashMap<i64, PlanDtype> = Default::default();
@@ -1488,11 +1488,11 @@ mod harness_tests {
                 panic!("buffer {} carries no dtype fact in its L", buffer.label)
             });
             // TRANSPORT, not derivation: the row on the buffer's carried
-            // layout IS the row the renderer put on the BACKED tensor.
+            // layout IS the row the decoder put on the BACKED tensor.
             assert_eq!(
                 Some(&buffer.layout),
                 table.get(&buffer.backs),
-                "buffer {} carries its backed tensor's own rendered layout",
+                "buffer {} carries its backed tensor's own decoded layout",
                 buffer.label
             );
             if let Some(lit) = buffer.lit {
@@ -3901,7 +3901,7 @@ mod escape_execution_tests {
     //! calls `bufferize`, so the plan tells it nothing new. These plans
     //! have NO such runtime behind them: they are the surface `load_plan`
     //! accepts, built by hand, with no e-graph, no recorder and no
-    //! rendered table anywhere. Under Option B they need no companion
+    //! decoded table anywhere. Under Option B they need no companion
     //! argument, because the boundary/layout knowledge a live runtime
     //! would have had rides the plan itself: `Buffer::layout` sizes every
     //! allocation and `OutputBinding::layout` describes every delivery.

--- a/tests/test_runtime/tests/buf_attack_a2_cert_sched.rs
+++ b/tests/test_runtime/tests/buf_attack_a2_cert_sched.rs
@@ -93,7 +93,7 @@ fn report(name: &str, text: &str) {
         "[{name}] no free for the escaping buffer:\n{summary}"
     );
     // OPTION B: the layout is TOTAL on bindings; what is pinned is that
-    // the binding carries the SLOT VALUE's own rendered layout, not the
+    // the binding carries the SLOT VALUE's own decoded layout, not the
     // backing buffer's resident layout.
     assert_eq!(
         Some(&slot.layout),

--- a/tests/test_runtime/tests/cublaslt_marker_round4.rs
+++ b/tests/test_runtime/tests/cublaslt_marker_round4.rs
@@ -227,12 +227,12 @@ fn t6a_bufferize_all_four_forms() {
         );
         // THE DISCLOSURE (Option B, corrected contract): the binding
         // carries the slot VALUE's own elected layout `L`, verbatim from
-        // the rendered table — for this weld, the transpose view's
+        // the decoded table — for this weld, the transpose view's
         // composed layout. Mock plans transport `MockLayout` (the layout
         // class identity), so the pin here is IDENTITY: the returned L
         // is the value's own table row, and the ASSIGNMENT is queryable
         // (the escaping buffer backs a real tensor whose buffer is the
-        // slot's). Element-level walkability of real rendered layouts is
+        // slot's). Element-level walkability of real decoded layouts is
         // pinned in `test_runtime::test_equality`'s own tests.
         let table = luminal::test_support::mock_layout_table(&dps_graph);
         assert_eq!(

--- a/tests/test_runtime/tests/folded_operand_layout_probe.rs
+++ b/tests/test_runtime/tests/folded_operand_layout_probe.rs
@@ -5,7 +5,7 @@
 //! The reason is stated on `SlotDescriptor`: recording per-slot view-fold
 //! chains was the PLANNER composing layout knowledge, and the e-graph
 //! already mints every view value's composed layout at view creation. The
-//! runtime's rendered `L` for that value IS the read path.
+//! runtime's decoded `L` for that value IS the read path.
 //!
 //! So the plan-level fact worth pinning changed shape. It is no longer
 //! "the fold's map survived onto the descriptor"; it is:
@@ -20,8 +20,8 @@
 //!
 //! ASSERTION DISCIPLINE. These plans are built with `MockLayout`, which
 //! transports the layout e-class IDENTITY and nothing evaluable — the
-//! test runtime has no layout renderer of its own. Element-level
-//! evaluation of REAL rendered layouts is pinned where real layouts
+//! test runtime has no layout decoder of its own. Element-level
+//! evaluation of REAL decoded layouts is pinned where real layouts
 //! exist: `luminal_cuda_lite/tests/view_admission.rs` (searched plans,
 //! flat-index evaluation against hand-computed maps) and
 //! `test_runtime::test_equality` (readback through a returned
@@ -35,7 +35,7 @@ use std::collections::HashMap;
 type FoldedSlot = (String, usize, MockLayout);
 
 /// Bufferize a frontend program with views preferred; return the plan,
-/// the rendered (mock) layout table, and every operand slot READING
+/// the decoded (mock) layout table, and every operand slot READING
 /// THROUGH A FOLD.
 ///
 /// THE DISCRIMINATOR IS THE LAYOUT, not the assignment. The plan does not
@@ -139,7 +139,7 @@ fn transpose_view_consumer_carries_the_views_own_layout() {
     );
     assert!(
         table.values().any(|l| l == layout),
-        "…and it is a rendered table row, transported verbatim"
+        "…and it is a decoded table row, transported verbatim"
     );
 }
 
@@ -170,7 +170,7 @@ fn sliced_transpose_chain_arrives_as_one_layout() {
     println!("folded read on {label} operand {slot} — one layout, no chain");
     assert!(
         table.values().any(|l| l == layout),
-        "the carried layout is a rendered table row, transported verbatim"
+        "the carried layout is a decoded table row, transported verbatim"
     );
 }
 
@@ -213,7 +213,7 @@ fn r10_chained_matmuls_read_through_folded_layouts() {
     for (label, slot, layout) in &found {
         assert!(
             table.values().any(|l| l == layout),
-            "{label} operand {slot}: the carried layout must be a rendered row, \
+            "{label} operand {slot}: the carried layout must be a decoded row, \
              transported verbatim — never synthesized by the planner"
         );
     }


### PR DESCRIPTION
## Summary

- rename the `MirrorLayout` conversion helpers to `decode_layout` and `decode_layout_for`
- replace the runtime seam with `LayoutDecoder::decode`, including the reference and CUDA-lite decoder types
- rename the decoded-layout table and decoding-specific diagnostics/documentation while preserving extractor text-rendering names such as `render_layout_tensor_list`

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p luminal --lib`
- `cargo test -p luminal_reference --test mini_model_smoke mini_conv_runs`
- `cargo test -p luminal -p luminal_reference -p test_runtime -p luminal_nn`
- `cargo test -p luminal_cuda_lite --test cublaslt_bias_premise`
- `cargo clippy --workspace --exclude luminal_cuda_lite --exclude luminal_metal --exclude luminal_bench --all-targets -- -D warnings`
- `cargo clippy -p luminal_cuda_lite --all-targets -- -D warnings`

GPU-backed CUDA execution suites were not run on this machine.