### PR TITLE
Genome sampling by candidate-graph component; input terminals are leaves; cyclic extracted graphs are a named invariant

### DIFF
--- a/crates/luminal_cuda_lite/tests/scc_sampler_marker.rs
+++ b/crates/luminal_cuda_lite/tests/scc_sampler_marker.rs
@@ -1,0 +1,83 @@
+//! THE MARKER 2-CYCLE, at the HARNESS budget (sampler ruling 2026-09-02).
+//!
+//! The cuBLASLt double-transpose collapse (`(union ?w ?x)` in
+//! `cublaslt_marker_canonicalize.egg`) makes two DIFFERENT logical
+//! values re-describe each other: class X gains
+//! `LogicalIndexMapApply(V, transpose)` while class V holds
+//! `LogicalIndexMapApply(X, transpose)`. The 2026-08-07 sampler grouped
+//! re-description candidates by SHARED LOGICAL VALUE, so it saw both
+//! spellings as "progressing", sampled both, and the extractor refused
+//! the genome as a choice cycle — at the 2x4 harness budget every
+//! genome could be eaten that way and the search died with "no
+//! candidate genome produced an executable plan".
+//!
+//! Components of the candidate graph do not care whose logical value a
+//! class instantiates, so the 2-cycle is a component and the forest
+//! sampler cannot elect both arms. ACCEPTANCE: the search completes at
+//! the harness budget, and its choice-cycle refusal count is ZERO.
+//! Election at 2x4 is REPORTED, not asserted (the 12x16 pin in
+//! `cublaslt_election.rs` owns that claim).
+
+use luminal::buffer_tensor_ir::TypedBuffer;
+use luminal::bufferize::BufferNode;
+use luminal::graph::Graph;
+use luminal::prelude::{FxHashMap, NodeIndex};
+use luminal_cuda_lite::CudaRuntime;
+
+fn weights(n: usize, seed: usize) -> Vec<f32> {
+    (0..n)
+        .map(|i| (((i * 37 + seed * 101 + 13) % 121) as f32 / 100.0) - 0.6)
+        .collect()
+}
+
+#[test]
+fn canonical_2d_matmul_searches_green_at_the_harness_budget() {
+    let mut cx = Graph::new();
+    let a = cx.tensor((4usize, 8usize));
+    let b = cx.tensor((8usize, 3usize));
+    let _out = a.matmul(b).output();
+
+    let mut rt = CudaRuntime::load_with_cublaslt(&cx).expect("load");
+    let data: FxHashMap<NodeIndex, TypedBuffer> =
+        [(a.id, weights(32, 1).into()), (b.id, weights(24, 2).into())]
+            .into_iter()
+            .collect();
+
+    let options = luminal::test_support::harness_search_options();
+    let outcome = rt
+        .search(&data, &options)
+        .unwrap_or_else(|e| panic!("the marker 2-cycle must not exhaust the 2x4 budget: {e:#}"));
+
+    let breakdown = &outcome.refusal_breakdown;
+    let plan = rt.plan().expect("plan");
+    let mut elected = 0usize;
+    let mut computes = 0usize;
+    for node in plan.dag.node_weights() {
+        if let BufferNode::Compute { op, .. } = node {
+            let label = op.label();
+            if label == "BufferAlloc" || label == "BufferFree" {
+                continue;
+            }
+            computes += 1;
+            if label.starts_with("CublasLt") {
+                elected += 1;
+            }
+        }
+    }
+    println!(
+        "SCC-SAMPLER 2x4 matmul_2d(4x8 . 8x3): cublaslt_elected={elected} computes={computes} \
+         plans={} refusals=[{}]",
+        outcome.plans_profiled,
+        breakdown.summary()
+    );
+    for exemplar in &breakdown.exemplars {
+        println!("SCC-SAMPLER 2x4 exemplar: {exemplar}");
+    }
+    assert_eq!(
+        breakdown.with_choice_cycles,
+        0,
+        "the forest sampler cannot elect both arms of the collapse's 2-cycle: {}",
+        breakdown.summary()
+    );
+    assert!(outcome.plans_profiled > 0, "a plan must be profiled");
+}

--- a/src/bufferize.rs
+++ b/src/bufferize.rs
@@ -1638,6 +1638,48 @@ fn annotate_boundary_lits<L: PlanLayout>(plan: &mut BufferIrGraph<L>, graph: &Ex
     }
 }
 
+/// The stable marker of the cyclic-extracted-graph refusal — matched by
+/// the implementation search's sampler tripwire, which treats a cycle
+/// reaching bufferize as a SAMPLER BUG (the genome's chosen edges were
+/// supposed to be acyclic) rather than as an ordinary refusal.
+pub const EXTRACTED_GRAPH_CYCLE: &str = "extracted graph has a cycle";
+
+/// NAME THE CYCLE (2026-09-02). `toposort` hands back one node it could
+/// not order; the cycle is inside that node's strongly connected
+/// component, so report the whole component's nodes — a plan whose input
+/// is computed from something that reads it back says so by name instead
+/// of by "there is a cycle somewhere".
+fn describe_cycle(graph: &ExtractedGraph, seed: petgraph::graph::NodeIndex) -> String {
+    let label = |index: petgraph::graph::NodeIndex| -> String {
+        match &graph.dag[index] {
+            ExtractedNode::BufferInput(input) => {
+                format!("input {}", input.value.label)
+            }
+            ExtractedNode::LayoutOp(op) => {
+                let outputs: Vec<&str> = op
+                    .outputs
+                    .iter()
+                    .map(|output| output.label.as_str())
+                    .collect();
+                format!("{} -> {}", op.op.label(), outputs.join(", "))
+            }
+            ExtractedNode::BufferOutput(output) => format!("output {}", output.label),
+        }
+    };
+    let members: Vec<String> = petgraph::algo::tarjan_scc(&graph.dag)
+        .into_iter()
+        .find(|scc| scc.contains(&seed))
+        .unwrap_or_else(|| vec![seed])
+        .into_iter()
+        .map(label)
+        .collect();
+    format!(
+        "the cycle runs through {} node(s): [{}]",
+        members.len(),
+        members.join(" | ")
+    )
+}
+
 /// The PLANNING half of [`bufferize`]: validate the input program, analyze,
 /// assign, build the BufferTensor graph, install anti-dependence ordering,
 /// certify, and run the storage-level rewrites — everything semantic. The
@@ -1649,8 +1691,12 @@ pub(crate) fn buffer_tensor_plan<L: PlanLayout>(
     value_layouts: &HashMap<ClassId, L>,
 ) -> Result<crate::buffer_tensor_ir::BufferTensorIrGraph<L>> {
     validate_input_program(graph)?;
-    let order = toposort(&graph.dag, None)
-        .map_err(|_| anyhow::anyhow!("extracted graph has a cycle; cannot bufferize"))?;
+    let order = toposort(&graph.dag, None).map_err(|cycle| {
+        anyhow::anyhow!(
+            "{EXTRACTED_GRAPH_CYCLE}; cannot bufferize: {}",
+            describe_cycle(graph, cycle.node_id())
+        )
+    })?;
 
     // Collect the ops (in topo order, one dense position each) and the boundary
     // facts the analyzer needs.
@@ -2520,6 +2566,73 @@ mod tests {
 
     fn cid(s: &str) -> ClassId {
         ClassId::from(s)
+    }
+
+    /// THE CYCLE IS NAMED (2026-09-02). `toposort` only says "there is a
+    /// cycle"; the refusal now walks the strongly connected component the
+    /// unorderable node sits in and prints its members, so the plan that
+    /// computes a value from something that reads it back says WHICH ops
+    /// those are. (Since input terminals became leaves the extractor no
+    /// longer emits such a graph — this board builds one by hand, which is
+    /// also what the implementation search's tripwire watches for.)
+    #[test]
+    fn a_cyclic_extracted_graph_names_the_cycle_members() {
+        use crate::layout_ir::ExtractedEdge;
+        use crate::test_support::TestGraph;
+
+        let mut g = TestGraph::new();
+        let x = g.input("x", "A", Access::ReadOnly, "rm");
+        let y = g.op(
+            Box::new(MockOp {
+                reads: vec![true],
+                ..Default::default()
+            }),
+            &[&x],
+            &[("y", "rm")],
+        )[0]
+        .clone();
+        let z = g.op(
+            Box::new(MockOp {
+                reads: vec![true],
+                ..Default::default()
+            }),
+            &[&y],
+            &[("z", "rm")],
+        )[0]
+        .clone();
+        g.output(&z, "D");
+        let mut graph = g.build();
+
+        let node_of = |graph: &ExtractedGraph, label: &str| {
+            graph
+                .dag
+                .node_indices()
+                .find(|index| match &graph.dag[*index] {
+                    ExtractedNode::LayoutOp(op) => op.outputs.iter().any(|out| out.label == label),
+                    _ => false,
+                })
+                .expect("the board built this op")
+        };
+        let (writes_y, writes_z) = (node_of(&graph, "y"), node_of(&graph, "z"));
+        graph.dag.add_edge(
+            writes_z,
+            writes_y,
+            ExtractedEdge {
+                value: z.clone(),
+                port: "in0".to_string(),
+            },
+        );
+
+        let err = crate::test_support::bufferize_mock(&graph).unwrap_err();
+        let text = format!("{err:#}");
+        assert!(
+            text.contains(EXTRACTED_GRAPH_CYCLE),
+            "the refusal keeps its stable marker: {text}"
+        );
+        assert!(
+            text.contains("-> y") && text.contains("-> z"),
+            "the refusal names both ops in the cycle: {text}"
+        );
     }
 
     /// A write-only destination whose operand value has no other reader: the old

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -206,6 +206,14 @@ impl<'a> ExtractionSession<'a> {
     /// candidate graph's strongly connected components, built from the
     /// extractor's OWN per-candidate input enumeration (so the sampler
     /// and the planner agree on what an input is, by construction).
+    ///
+    /// ONE LEAF NOTION: a class with no genome row. Input terminals are
+    /// leaves because they hold no row (they are produced by nothing —
+    /// see `Extractor::candidates_for_class`), not by a special case
+    /// here; every other row-less class is CONTRACTED rather than
+    /// dropped, so the dependency `C -> D(no row) -> E(row)` shows up as
+    /// the edge `C -> E` it really is and a cycle closing through `D`
+    /// cannot hide from the component analysis.
     pub fn sampling_space(
         &self,
         index: &std::collections::BTreeMap<ClassId, Vec<(String, ProducerChoice)>>,
@@ -213,39 +221,14 @@ impl<'a> ExtractionSession<'a> {
         let candidate_inputs = index
             .iter()
             .map(|(class, entries)| {
-                // AN INPUT-TERMINAL CLASS IS A LEAF, whatever its genome
-                // row says. `relax_to_fixpoint` seeds every such class's
-                // plan from the boundary input on the FIRST pass, at
-                // cost 0 and with no children — it is planned before any
-                // candidate is considered, so it never enters `blocked`
-                // and no edge out of it can join a blocking cycle (a
-                // choice cycle IS an SCC among blocked classes; see
-                // `ExtractionSession::failure_breakdown`). Drawing those
-                // edges would invent components the planner does not
-                // have, and the forest rule would then eliminate
-                // genomes that extract perfectly well.
-                //
-                // MEASURED BOTH WAYS 2026-09-02 (the boards in
-                // `tests/test_runtime/tests/scc_sampler.rs`). With the
-                // edges drawn: `basic_program.egg` grows a THIRD
-                // component of 1 combination and 0 acyclic, so the
-                // documented fallback fires on 2000/2000 samples and
-                // the free sampler reads 0/500 acyclic; the `b = y`
-                // union board grows a 36-combination component with 0
-                // acyclic (2000/2000 fallbacks); and the cuBLASLt
-                // matmul's operand weld grows from 3 members to 4, one
-                // of which has no progressing candidate at all. With
-                // them omitted, every component on both boards offers
-                // acyclic combinations and no sample falls back.
-                if self.extractor.is_input_terminal(class) {
-                    return (class.clone(), vec![Vec::new(); entries.len()]);
-                }
                 let per_candidate = entries
                     .iter()
                     .map(|(_, choice)| {
-                        let mut inputs = self.extractor.choice_input_classes(class, choice);
-                        inputs.retain(|input| index.contains_key(input));
-                        inputs
+                        contract_candidate_inputs(
+                            &self.extractor.choice_input_classes(class, choice),
+                            &|input| index.contains_key(input),
+                            &|input| self.extractor.demanded_input_classes(input),
+                        )
                     })
                     .collect();
                 (class.clone(), per_candidate)
@@ -656,13 +639,16 @@ fn producer_index_from(
 /// edge `C -> D` for every candidate of `C` whose extractor-demanded
 /// inputs include `D` (see [`Extractor::choice_input_classes`] — the
 /// SAME `OpSpec::inputs` enumeration `producer_candidates_for_output`
-/// hands the planner, never a second notion of "input"). LEAVES, with
-/// no outgoing edges at all, are the classes the planner can always
-/// plan without waiting: inputs with no genome row, and — the same
-/// thing one step further in — INPUT-TERMINAL classes, which
-/// `relax_to_fixpoint` plans from the boundary on its first pass
-/// whatever their genome row says. Neither can ever block, so neither
-/// can be part of a blocking cycle.
+/// hands the planner, never a second notion of "input"). A class the
+/// genome index has no row for is not a node; it is CONTRACTED, not
+/// dropped — the candidate reading it inherits its demands (see
+/// [`contract_candidate_inputs`]), so `C -> D(no row) -> E(row)` draws
+/// the edge `C -> E`. THE ONLY LEAVES are therefore the classes that
+/// demand nothing, which after contraction means the INPUT TERMINALS:
+/// produced by nothing, planned from the boundary on
+/// `relax_to_fixpoint`'s first pass, never blocked, and so never part
+/// of a blocking cycle. They hold no genome row either (the producer
+/// index drops them), which is the same fact, not a second rule.
 ///
 /// THE COMPONENT CRITERION. A choice cycle is possible only where the
 /// candidate graph has a cycle, so the re-description groups are
@@ -809,6 +795,78 @@ impl SamplingSpace {
             })
             .collect()
     }
+
+    /// The genome's chosen INTRA-COMPONENT edges: component members
+    /// only, each mapped to the intra-component sources of the one
+    /// candidate the genome elected. This is the sub-graph the forest
+    /// sampler and the mutation check actually keep acyclic, so it is
+    /// what a tripwire prints when a genome reaches the planner with a
+    /// cycle anyway.
+    pub fn chosen_intra_edges(
+        &self,
+        index: &std::collections::BTreeMap<ClassId, Vec<(String, ProducerChoice)>>,
+        genome: &Genome,
+    ) -> std::collections::BTreeMap<ClassId, Vec<ClassId>> {
+        self.component_of
+            .keys()
+            .map(|class| {
+                let sources = self
+                    .chosen_position(index, genome, class)
+                    .and_then(|position| {
+                        self.intra_sources
+                            .get(class)
+                            .and_then(|per_candidate| per_candidate.get(position))
+                    })
+                    .cloned()
+                    .unwrap_or_default();
+                (class.clone(), sources)
+            })
+            .collect()
+    }
+}
+
+/// CONTRACT THE ROW-LESS CLASSES out of one candidate's input list.
+///
+/// The candidate graph has a node per class holding a genome row, so an
+/// input that holds no row is not a node — but it is not necessarily a
+/// LEAF either. A row-less class is planned WITHOUT a choice (there is
+/// nothing to choose), yet whatever it demands, the candidate reading it
+/// demands transitively: `C -> D(no row) -> E(row)` IS the edge
+/// `C -> E`, and a cycle closing through `D` would otherwise be
+/// invisible to the component analysis and survive sampling.
+///
+/// So each row-less input is replaced by what it demands (`demanded`),
+/// transitively — a row-less class may lead to further row-less classes
+/// — with a visited set so a re-description ring among row-less classes
+/// terminates. Input terminals demand NOTHING (they are produced by
+/// nothing), which is what makes them leaves; no leaf case is written
+/// here.
+///
+/// `has_row`: does this class hold a genome row (is it a node)?
+/// `demanded`: what does this row-less class demand? Both are supplied
+/// by the caller so the rule is testable without an e-graph.
+pub fn contract_candidate_inputs(
+    inputs: &[ClassId],
+    has_row: &dyn Fn(&ClassId) -> bool,
+    demanded: &dyn Fn(&ClassId) -> Vec<ClassId>,
+) -> Vec<ClassId> {
+    let mut out: Vec<ClassId> = Vec::new();
+    let mut stack: Vec<ClassId> = inputs.to_vec();
+    let mut expanded: HashSet<ClassId> = HashSet::new();
+    while let Some(input) = stack.pop() {
+        if has_row(&input) {
+            if !out.contains(&input) {
+                out.push(input);
+            }
+            continue;
+        }
+        if !expanded.insert(input.clone()) {
+            continue;
+        }
+        stack.extend(demanded(&input));
+    }
+    out.sort();
+    out
 }
 
 /// Does a chosen-edge graph close a cycle? (Iterative three-colour DFS;
@@ -921,11 +979,23 @@ impl<'a> Extractor<'a> {
             .collect();
         let class_nodes = class_nodes(egraph);
         let render = Rc::new(RenderCtx::new(egraph));
-        let (op_specs, producer_index) = collect_op_specs(egraph, &render.class_nodes);
+        let (op_specs, mut producer_index) = collect_op_specs(egraph, &render.class_nodes);
         let output_buffer_classes = collect_output_buffer_classes(egraph, &class_nodes);
         let input_buffer_classes = collect_input_buffer_classes(egraph, &class_nodes);
         let input_terminals =
             collect_input_terminals(&render, &output_buffer_classes, &input_buffer_classes);
+        // AN INPUT TERMINAL HAS NO PRODUCERS (2026-09-02). Its value
+        // exists at launch: `relax_to_fixpoint` plans it from the
+        // boundary, and `candidates_for_class` offers it no candidate at
+        // all (see the leaf note there). Keeping producer rows for such
+        // a class would leave DEAD WEIGHT in every genome — rows the
+        // extractor must never honour — and the genome index built from
+        // this map is exactly what the sampler's candidate graph has
+        // nodes for, so dropping them here gives the component analysis
+        // ONE leaf notion: a class with no genome row. Producers of
+        // OTHER classes that READ a terminal are untouched — that is how
+        // copy-from-a-boundary-input plans exist.
+        producer_index.retain(|class, _| !input_terminals.contains_key(class));
 
         Self {
             egraph,
@@ -1093,6 +1163,21 @@ impl<'a> Extractor<'a> {
     /// construction (2026-08-06): candidates are built for the chosen
     /// enode only, never built-then-discarded per spelling.
     fn candidates_for_class(&self, class: &ClassId) -> Vec<Candidate> {
+        // AN INPUT TERMINAL IS A LEAF BY DEFINITION (2026-09-02): its
+        // value exists at launch, so it is PRODUCED BY NOTHING.
+        // `relax_to_fixpoint` seeds its plan from the boundary on pass
+        // one at cost 0 with no children; offering candidates here let a
+        // zero-cost producer (a VIEW moves no bytes, so it ties the
+        // input plan at 0 and wins the `plan_label` tie-break —
+        // "IndexMapApplyViewGeneric" sorts before "Input:…") take the
+        // class over and EMIT a plan in which a program input is
+        // computed from something that reads it back: a cyclic extracted
+        // graph only bufferize rejects. Producers of OTHER classes that
+        // read this one stay available — copies and views out of a
+        // boundary input are exactly how such plans are written.
+        if self.is_input_terminal(class) {
+            return Vec::new();
+        }
         let genome_choice = self.genome.as_ref().and_then(|genome| {
             self.producer_index
                 .contains_key(class)
@@ -1380,6 +1465,36 @@ impl<'a> Extractor<'a> {
             {
                 continue;
             }
+            let Some(spec) = self
+                .op_specs
+                .get(&producer.op_class)
+                .and_then(|specs| specs.get(producer.spec_index))
+            else {
+                continue;
+            };
+            inputs.extend(spec.inputs.iter().cloned());
+        }
+        inputs.sort();
+        inputs.dedup();
+        inputs
+    }
+
+    /// What a class the genome index has NO row for demands, for the
+    /// candidate-graph contraction (see [`contract_candidate_inputs`]).
+    ///
+    /// Such a class is planned without a choice, so every route the
+    /// planner might take through it counts: the union of `OpSpec::inputs`
+    /// over all its producers — the same enumeration
+    /// [`Extractor::choice_input_classes`] restricts to one chosen enode.
+    /// An INPUT TERMINAL demands nothing, for the one reason it has no
+    /// row either: it is produced by nothing (see
+    /// [`Extractor::candidates_for_class`]).
+    fn demanded_input_classes(&self, class: &ClassId) -> Vec<ClassId> {
+        if self.is_input_terminal(class) {
+            return Vec::new();
+        }
+        let mut inputs: Vec<ClassId> = Vec::new();
+        for producer in self.producer_index.get(class).into_iter().flatten() {
             let Some(spec) = self
                 .op_specs
                 .get(&producer.op_class)

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -202,6 +202,58 @@ impl<'a> ExtractionSession<'a> {
         producer_index_from(&self.extractor)
     }
 
+    /// The [`SamplingSpace`] over this session's producer index — the
+    /// candidate graph's strongly connected components, built from the
+    /// extractor's OWN per-candidate input enumeration (so the sampler
+    /// and the planner agree on what an input is, by construction).
+    pub fn sampling_space(
+        &self,
+        index: &std::collections::BTreeMap<ClassId, Vec<(String, ProducerChoice)>>,
+    ) -> SamplingSpace {
+        let candidate_inputs = index
+            .iter()
+            .map(|(class, entries)| {
+                // AN INPUT-TERMINAL CLASS IS A LEAF, whatever its genome
+                // row says. `relax_to_fixpoint` seeds every such class's
+                // plan from the boundary input on the FIRST pass, at
+                // cost 0 and with no children — it is planned before any
+                // candidate is considered, so it never enters `blocked`
+                // and no edge out of it can join a blocking cycle (a
+                // choice cycle IS an SCC among blocked classes; see
+                // `ExtractionSession::failure_breakdown`). Drawing those
+                // edges would invent components the planner does not
+                // have, and the forest rule would then eliminate
+                // genomes that extract perfectly well.
+                //
+                // MEASURED BOTH WAYS 2026-09-02 (the boards in
+                // `tests/test_runtime/tests/scc_sampler.rs`). With the
+                // edges drawn: `basic_program.egg` grows a THIRD
+                // component of 1 combination and 0 acyclic, so the
+                // documented fallback fires on 2000/2000 samples and
+                // the free sampler reads 0/500 acyclic; the `b = y`
+                // union board grows a 36-combination component with 0
+                // acyclic (2000/2000 fallbacks); and the cuBLASLt
+                // matmul's operand weld grows from 3 members to 4, one
+                // of which has no progressing candidate at all. With
+                // them omitted, every component on both boards offers
+                // acyclic combinations and no sample falls back.
+                if self.extractor.is_input_terminal(class) {
+                    return (class.clone(), vec![Vec::new(); entries.len()]);
+                }
+                let per_candidate = entries
+                    .iter()
+                    .map(|(_, choice)| {
+                        let mut inputs = self.extractor.choice_input_classes(class, choice);
+                        inputs.retain(|input| index.contains_key(input));
+                        inputs
+                    })
+                    .collect();
+                (class.clone(), per_candidate)
+            })
+            .collect();
+        SamplingSpace::from_candidate_inputs(candidate_inputs)
+    }
+
     /// Classify the last failed extraction's blockage (diagnosis ruling
     /// 2026-08-07: understand refusals, never auto-repair). Returns
     /// (has_choice_cycle, has_dead_end, summary): choice-cycles are
@@ -595,89 +647,206 @@ fn producer_index_from(
     index
 }
 
-/// The sibling anatomy of a producer index — what two-phase sampling
-/// ("select the logical progressing ops first, insert copies as
-/// plumbing", ruling 2026-08-07) consumes. A candidate's SIBLING
-/// SOURCES are its input classes that instantiate the SAME logical
-/// value as the candidate's own class and hold genome rows themselves —
-/// exactly what a layout copy reads. A candidate with no sibling
-/// sources PROGRESSES the computation: its inputs are other logical
-/// values, and since the logical graph is a DAG, per-class choices over
-/// progressing candidates can never close a choice cycle. Every
-/// measured extraction deadlock was a Copy⟷Copy weld between two
-/// layout siblings of one logical value (dossier 2026-08-07); keeping
-/// sibling-sourced candidates subordinate to a progressing producer
-/// removes that whole failure class by construction. Same-logical
-/// inputs WITHOUT genome rows (boundary inputs) are deliberately not
-/// sibling sources: they are leaves, always available, and copying
-/// them can never cycle.
-#[allow(dead_code)] // selection-adapter API: test harness here; lib export in the luminal graft
+/// The RE-DESCRIPTION anatomy of a producer index — what two-phase
+/// sampling ("elect the progressing producers first, insert the
+/// re-describing ones as plumbing", ruling 2026-08-07, generalized
+/// 2026-09-02) consumes.
+///
+/// THE CANDIDATE GRAPH. One node per class holding a genome row; one
+/// edge `C -> D` for every candidate of `C` whose extractor-demanded
+/// inputs include `D` (see [`Extractor::choice_input_classes`] — the
+/// SAME `OpSpec::inputs` enumeration `producer_candidates_for_output`
+/// hands the planner, never a second notion of "input"). LEAVES, with
+/// no outgoing edges at all, are the classes the planner can always
+/// plan without waiting: inputs with no genome row, and — the same
+/// thing one step further in — INPUT-TERMINAL classes, which
+/// `relax_to_fixpoint` plans from the boundary on its first pass
+/// whatever their genome row says. Neither can ever block, so neither
+/// can be part of a blocking cycle.
+///
+/// THE COMPONENT CRITERION. A choice cycle is possible only where the
+/// candidate graph has a cycle, so the re-description groups are
+/// exactly its NON-TRIVIAL strongly connected components (size >= 2,
+/// or a single class with a self-loop). A candidate's INTRA-COMPONENT
+/// SOURCES are its inputs inside its own component; a candidate with
+/// none PROGRESSES — every route it takes leaves the component, and
+/// the condensation of an SCC decomposition is a DAG, so progressing
+/// choices can never close a cycle no matter how they combine.
+///
+/// WHAT THIS SUBSUMES. The 2026-08-07 form grouped classes by SHARED
+/// LOGICAL VALUE, on the (then true) premise that the logical graph is
+/// a DAG so only layout siblings of one value could re-describe each
+/// other — the measured Copy⟷Copy welds. The cuBLASLt double-transpose
+/// collapse `(union ?w ?x)` broke that premise: two DIFFERENT logical
+/// values re-describe each other through `LogicalIndexMapApply`
+/// transposes, and both spellings looked "progressing" to the
+/// logical-value grouping. Components are the mechanism itself — no op
+/// name list, no logical-value heuristic — and same-logical sibling
+/// groups fall out of them automatically wherever the welds are real.
 pub struct SamplingSpace {
-    /// class → per-candidate sibling-source classes, parallel to the
-    /// class's producer-index entry. An empty inner vec marks a
-    /// progressing candidate.
-    pub sibling_sources: std::collections::BTreeMap<ClassId, Vec<Vec<ClassId>>>,
-    /// Sibling groups: index classes sharing one logical value (only
-    /// groups of two or more), members sorted, groups ordered by their
-    /// logical class — deterministic election order for the sampler.
-    pub groups: Vec<Vec<ClassId>>,
+    /// class → per-candidate input classes that hold genome rows,
+    /// parallel to the class's producer-index entry. These are the
+    /// candidate-graph edges out of each candidate.
+    pub candidate_inputs: std::collections::BTreeMap<ClassId, Vec<Vec<ClassId>>>,
+    /// class → per-candidate INTRA-COMPONENT source classes, parallel
+    /// to the class's producer-index entry. An empty inner vec marks a
+    /// PROGRESSING candidate. Always a subset of `candidate_inputs`;
+    /// identical to it only inside a component, empty everywhere else.
+    pub intra_sources: std::collections::BTreeMap<ClassId, Vec<Vec<ClassId>>>,
+    /// The non-trivial components: members sorted, components ordered —
+    /// a deterministic processing order for the sampler.
+    pub components: Vec<Vec<ClassId>>,
+    /// class → its index in [`SamplingSpace::components`], for the
+    /// classes that belong to a non-trivial one.
+    pub component_of: std::collections::BTreeMap<ClassId, usize>,
 }
 
-/// Compute the [`SamplingSpace`] for a producer index over its e-graph.
-#[allow(dead_code)] // selection-adapter API: test harness here; lib export in the luminal graft
-pub fn sampling_space(
-    egraph: &EGraph,
-    index: &std::collections::BTreeMap<ClassId, Vec<(String, ProducerChoice)>>,
-) -> SamplingSpace {
-    let class_nodes = class_nodes(egraph);
-    let logical_of = |class: &ClassId| -> Option<ClassId> {
-        class_nodes.get(class)?.iter().find_map(|node_id| {
-            let node = egraph.nodes.get(node_id)?;
-            if node.op != "LayoutTensorLit" {
-                return None;
+impl SamplingSpace {
+    /// The component decomposition of a candidate graph given directly
+    /// as class → per-candidate input classes (already restricted to
+    /// classes holding genome rows). Deterministic: nodes in sorted
+    /// class order, edges in candidate order, components sorted.
+    pub fn from_candidate_inputs(
+        candidate_inputs: std::collections::BTreeMap<ClassId, Vec<Vec<ClassId>>>,
+    ) -> Self {
+        let mut graph = DiGraph::<ClassId, ()>::new();
+        let mut node_of: std::collections::BTreeMap<ClassId, NodeIndex> =
+            std::collections::BTreeMap::new();
+        for class in candidate_inputs.keys() {
+            node_of.insert(class.clone(), graph.add_node(class.clone()));
+        }
+        for (class, per_candidate) in &candidate_inputs {
+            let from = node_of[class];
+            let mut added: std::collections::BTreeSet<ClassId> = std::collections::BTreeSet::new();
+            for inputs in per_candidate {
+                for input in inputs {
+                    let Some(&to) = node_of.get(input) else {
+                        continue; // boundary input: a leaf, never an edge
+                    };
+                    if added.insert(input.clone()) {
+                        graph.add_edge(from, to, ());
+                    }
+                }
             }
-            Some(egraph.nodes.get(node.children.first()?)?.eclass.clone())
-        })
-    };
-    let mut sibling_sources = std::collections::BTreeMap::new();
-    let mut groups_by_logical: std::collections::BTreeMap<ClassId, Vec<ClassId>> =
-        std::collections::BTreeMap::new();
-    for (class, entries) in index {
-        let logical = logical_of(class);
-        let per_candidate: Vec<Vec<ClassId>> = entries
-            .iter()
-            .map(|(_, choice)| {
-                let (Some(node), Some(logical)) = (egraph.nodes.get(&choice.enode), &logical)
-                else {
-                    return Vec::new();
-                };
-                node.children
-                    .iter()
-                    .filter_map(|child| {
-                        let input_class = egraph.nodes.get(child)?.eclass.clone();
-                        (index.contains_key(&input_class)
-                            && logical_of(&input_class).as_ref() == Some(logical))
-                        .then_some(input_class)
-                    })
-                    .collect()
+        }
+        let mut components: Vec<Vec<ClassId>> = petgraph::algo::tarjan_scc(&graph)
+            .into_iter()
+            .filter(|scc| scc.len() > 1 || graph.contains_edge(scc[0], scc[0]))
+            .map(|scc| {
+                let mut members: Vec<ClassId> =
+                    scc.iter().map(|index| graph[*index].clone()).collect();
+                members.sort();
+                members
             })
             .collect();
-        sibling_sources.insert(class.clone(), per_candidate);
-        if let Some(logical) = logical {
-            groups_by_logical
-                .entry(logical)
-                .or_default()
-                .push(class.clone());
+        components.sort();
+        let mut component_of: std::collections::BTreeMap<ClassId, usize> =
+            std::collections::BTreeMap::new();
+        for (component, members) in components.iter().enumerate() {
+            for member in members {
+                component_of.insert(member.clone(), component);
+            }
+        }
+        let intra_sources = candidate_inputs
+            .iter()
+            .map(|(class, per_candidate)| {
+                let component = component_of.get(class).copied();
+                let per_candidate = per_candidate
+                    .iter()
+                    .map(|inputs| match component {
+                        None => Vec::new(),
+                        Some(component) => inputs
+                            .iter()
+                            .filter(|input| component_of.get(*input) == Some(&component))
+                            .cloned()
+                            .collect(),
+                    })
+                    .collect();
+                (class.clone(), per_candidate)
+            })
+            .collect();
+        Self {
+            candidate_inputs,
+            intra_sources,
+            components,
+            component_of,
         }
     }
-    let groups = groups_by_logical
-        .into_values()
-        .filter(|members| members.len() >= 2)
-        .collect();
-    SamplingSpace {
-        sibling_sources,
-        groups,
+
+    /// The candidate position a genome selected for `class`, if the
+    /// genome names one of the class's index entries.
+    pub fn chosen_position(
+        &self,
+        index: &std::collections::BTreeMap<ClassId, Vec<(String, ProducerChoice)>>,
+        genome: &Genome,
+        class: &ClassId,
+    ) -> Option<usize> {
+        let choice = genome.choices.get(class)?;
+        index
+            .get(class)?
+            .iter()
+            .position(|(_, candidate)| candidate == choice)
     }
+
+    /// The genome's CHOSEN-EDGE graph: class → the genome-row input
+    /// classes of the one candidate the genome elected for it. This is
+    /// the graph the sampler keeps acyclic, and the graph the
+    /// extractor's blocking follows.
+    pub fn chosen_edges(
+        &self,
+        index: &std::collections::BTreeMap<ClassId, Vec<(String, ProducerChoice)>>,
+        genome: &Genome,
+    ) -> std::collections::BTreeMap<ClassId, Vec<ClassId>> {
+        self.candidate_inputs
+            .iter()
+            .map(|(class, per_candidate)| {
+                let edges = self
+                    .chosen_position(index, genome, class)
+                    .and_then(|position| per_candidate.get(position))
+                    .cloned()
+                    .unwrap_or_default();
+                (class.clone(), edges)
+            })
+            .collect()
+    }
+}
+
+/// Does a chosen-edge graph close a cycle? (Iterative three-colour DFS;
+/// the graphs are the sampler's own component-local edges.)
+pub fn edges_have_cycle(edges: &std::collections::BTreeMap<ClassId, Vec<ClassId>>) -> bool {
+    #[derive(Clone, Copy, PartialEq)]
+    enum Colour {
+        Open,
+        Done,
+    }
+    let mut colour: HashMap<&ClassId, Colour> = HashMap::new();
+    for root in edges.keys() {
+        if colour.contains_key(root) {
+            continue;
+        }
+        // (class, next child index) frames — no recursion, the graphs
+        // can be as deep as the program.
+        let mut stack: Vec<(&ClassId, usize)> = vec![(root, 0)];
+        colour.insert(root, Colour::Open);
+        while let Some((class, cursor)) = stack.pop() {
+            let children = edges.get(class).map_or(&[][..], Vec::as_slice);
+            if cursor >= children.len() {
+                colour.insert(class, Colour::Done);
+                continue;
+            }
+            stack.push((class, cursor + 1));
+            let child = &children[cursor];
+            match colour.get(child) {
+                Some(Colour::Open) => return true,
+                Some(Colour::Done) => {}
+                None => {
+                    colour.insert(child, Colour::Open);
+                    stack.push((child, 0));
+                }
+            }
+        }
+    }
+    false
 }
 
 /// A stable fingerprint of a plan's SHAPE: the chosen instances (enode +
@@ -1165,6 +1334,64 @@ impl<'a> Extractor<'a> {
             }
             _ => None,
         }
+    }
+
+    /// Is this class planned straight from a boundary input? Such a
+    /// class is plannable unconditionally (see the leaf note in
+    /// `ExtractionSession::sampling_space`).
+    fn is_input_terminal(&self, class: &ClassId) -> bool {
+        self.input_terminals.contains_key(class)
+    }
+
+    /// The input classes the extractor would DEMAND for one genome
+    /// choice on `class`: the union of `OpSpec::inputs` over every
+    /// producer entry the choice resolves to — literally what
+    /// [`Extractor::producer_candidates_for_output`] turns into a
+    /// candidate's `children` (via `op_children`) and what
+    /// `relax_to_fixpoint` blocks on. The sampler's candidate graph is
+    /// built from THIS, so "input" means one thing in both places.
+    ///
+    /// A union rather than a per-spec list because a `ProducerChoice`
+    /// names (enode, output slot) only: when one op class carries
+    /// several distinct input lists at that slot, the planner enables
+    /// the class as soon as SOME of them plans, so taking the union is
+    /// the conservative reading — every edge the planner might follow
+    /// is present, and a union-acyclic genome is acyclic under each
+    /// spec individually.
+    fn choice_input_classes(&self, class: &ClassId, choice: &ProducerChoice) -> Vec<ClassId> {
+        let mut inputs: Vec<ClassId> = Vec::new();
+        let Some(producers) = self.producer_index.get(class) else {
+            return inputs;
+        };
+        let Some(node) = self.egraph.nodes.get(&choice.enode) else {
+            return inputs;
+        };
+        if node.subsumed || node.op == "[...]" || !self.matchers.contains_key(node.op.as_str()) {
+            return inputs;
+        }
+        for producer in producers {
+            if producer.output_index != choice.output_index {
+                continue;
+            }
+            if !self
+                .class_nodes
+                .get(&producer.op_class)
+                .is_some_and(|nodes| nodes.contains(&choice.enode))
+            {
+                continue;
+            }
+            let Some(spec) = self
+                .op_specs
+                .get(&producer.op_class)
+                .and_then(|specs| specs.get(producer.spec_index))
+            else {
+                continue;
+            };
+            inputs.extend(spec.inputs.iter().cloned());
+        }
+        inputs.sort();
+        inputs.dedup();
+        inputs
     }
 
     fn producer_candidates_for_output(&self, output_class: &ClassId) -> Vec<Candidate> {

--- a/src/implementation_search.rs
+++ b/src/implementation_search.rs
@@ -450,6 +450,42 @@ pub fn mutate_genome_with_seed(
     )
 }
 
+/// THE BUFFERIZE TRIPWIRE (2026-09-02), the second half of the sampler
+/// invariant. Sampling and mutation keep a genome's chosen intra-component
+/// edges acyclic, and the extractor plans an input terminal from the
+/// boundary rather than from any producer, so no sampled or mutated genome
+/// can extract a graph with a cycle in it. If one reaches bufferize anyway,
+/// the sampler's candidate graph has drifted from the plan the extractor
+/// actually emits: the search STOPS and names the genome's own chosen
+/// intra-component edges alongside the cycle bufferize found, instead of
+/// quietly losing that genome as an ordinary refusal. Every other
+/// bufferize refusal (dead ends, unsupported ownership, unschedulable
+/// anti-edges) passes through untouched.
+fn bufferize_cycle_tripwire(
+    err: &anyhow::Error,
+    index: &ProducerIndex,
+    space: &SamplingSpace,
+    genome: &Genome,
+) -> Result<()> {
+    let text = format!("{err:#}");
+    if !text.contains(crate::bufferize::EXTRACTED_GRAPH_CYCLE) {
+        return Ok(());
+    }
+    let intra = space.chosen_intra_edges(index, genome);
+    let intra: Vec<String> = intra
+        .iter()
+        .map(|(class, sources)| format!("{class} <- {sources:?}"))
+        .collect();
+    Err(anyhow!(
+        "sampler invariant violated: a sampled genome extracted a CYCLIC graph \
+         (bufferize refused it). Sampling and mutation keep the chosen \
+         intra-component edges acyclic and input terminals are planned from the \
+         boundary, so this means the sampler's candidate graph disagrees with the \
+         plan the extractor emitted. Chosen intra-component edges: [{}]. {text}",
+        intra.join("; ")
+    ))
+}
+
 /// The runtime-owned search entry (ruling 2026-08-17): the caller
 /// supplies its OWN matcher set (None = the in-core reference
 /// registry, which Step B moves out) and its OWN profiler.
@@ -634,6 +670,10 @@ pub fn search_implementations_with_runtime<L: crate::bufferize::PlanLayout>(
                     let plan = match built {
                         Ok(plan) => plan,
                         Err(err) => {
+                            // THE BUFFERIZE TRIPWIRE (2026-09-02): a
+                            // cyclic extracted graph from a SAMPLED
+                            // genome is a sampler bug, not a refusal.
+                            bufferize_cycle_tripwire(&err, &index, &space, &genome)?;
                             breakdown.plan_build_refusals += 1;
                             if refusals.len() < 8 {
                                 refusals.push(format!("bufferize: {err:#}"));
@@ -688,8 +728,12 @@ pub fn search_implementations_with_runtime<L: crate::bufferize::PlanLayout>(
                 )
                 .and_then(|table| crate::bufferize::bufferize(&dps, &table));
                 timings.plan_build_nanos += build_start.elapsed().as_nanos();
-                let Ok(plan) = built else {
-                    continue;
+                let plan = match built {
+                    Ok(plan) => plan,
+                    Err(err) => {
+                        bufferize_cycle_tripwire(&err, &index, &space, &genome)?;
+                        continue;
+                    }
                 };
                 best = Some((nanos, genome.clone(), plan));
             }
@@ -1082,9 +1126,11 @@ mod sampler_tests {
     use rand::SeedableRng;
     use rand::rngs::StdRng;
 
-    use crate::extractor::{Genome, ProducerChoice, SamplingSpace, edges_have_cycle};
+    use crate::extractor::{
+        Genome, ProducerChoice, SamplingSpace, contract_candidate_inputs, edges_have_cycle,
+    };
 
-    use super::{ProducerIndex, mutate_genome, sample_genome};
+    use super::{ProducerIndex, bufferize_cycle_tripwire, mutate_genome, sample_genome};
 
     fn class(name: &str) -> ClassId {
         ClassId::from(name)
@@ -1128,6 +1174,65 @@ mod sampler_tests {
         }
         let space = SamplingSpace::from_candidate_inputs(inputs);
         (index, space)
+    }
+
+    /// [`build`] with ROW-LESS classes in the picture: `rows` is the
+    /// board's producer index as above, and `row_less` names classes the
+    /// index has NO row for together with what each DEMANDS. Candidate
+    /// inputs are contracted exactly as `ExtractionSession::sampling_space`
+    /// contracts them, so the edges under test are the ones the real
+    /// analysis draws.
+    fn build_with_row_less(
+        rows: &[BoardRow<'_>],
+        row_less: &[(&str, &[&str])],
+    ) -> (ProducerIndex, SamplingSpace) {
+        let (index, _) = build(rows);
+        let demands: BTreeMap<ClassId, Vec<ClassId>> = row_less
+            .iter()
+            .map(|(owner, demanded)| {
+                (
+                    class(owner),
+                    demanded.iter().map(|name| class(name)).collect(),
+                )
+            })
+            .collect();
+        let inputs: BTreeMap<ClassId, Vec<Vec<ClassId>>> = rows
+            .iter()
+            .map(|(owner, candidates)| {
+                (
+                    class(owner),
+                    candidates
+                        .iter()
+                        .map(|(_, sources)| {
+                            let raw: Vec<ClassId> =
+                                sources.iter().map(|name| class(name)).collect();
+                            contract_candidate_inputs(
+                                &raw,
+                                &|input| index.contains_key(input),
+                                &|input| demands.get(input).cloned().unwrap_or_default(),
+                            )
+                        })
+                        .collect(),
+                )
+            })
+            .collect();
+        let space = SamplingSpace::from_candidate_inputs(inputs);
+        (index, space)
+    }
+
+    /// The genome electing the named candidate per class — the hand-built
+    /// genome a FREE sampler (uniform over every candidate, no invariant)
+    /// is free to draw.
+    fn genome_electing(index: &ProducerIndex, picks: &[(&str, &str)]) -> Genome {
+        let mut genome = Genome::default();
+        for (owner, name) in picks {
+            let (_, choice) = index[&class(owner)]
+                .iter()
+                .find(|(candidate, _)| candidate == name)
+                .expect("the board names this candidate");
+            genome.choices.insert(class(owner), choice.clone());
+        }
+        genome
     }
 
     /// The candidate NAME the genome elected per class, sorted by class
@@ -1307,6 +1412,151 @@ mod sampler_tests {
             let child = mutate_genome(&genome, &index, &space, &classes, &mut rng, 3);
             assert_eq!(spelling(&index, &child), vec!["a=prog".to_string()]);
         }
+    }
+
+    /// (vi) A CYCLE THAT CLOSES THROUGH A ROW-LESS CLASS. `a` reads `d`,
+    /// which the genome index has no row for; `d` demands `b`; `b` reads
+    /// `a`. Nothing chooses anything at `d` — it is planned whichever way
+    /// the two ends go — so `a -> d -> b` IS the edge `a -> b` and the
+    /// only cycle in the board runs a -> b -> a. Contracting `d` is what
+    /// makes the component visible; leaving `d` out (round 1) left `a`
+    /// with no edges at all, no component, and the cyclic pair reachable.
+    #[test]
+    fn a_cycle_through_a_row_less_class_is_one_component() {
+        let (index, space) = build_with_row_less(
+            &[
+                ("a", &[("prog", &[]), ("reads_d", &["d"])]),
+                ("b", &[("prog", &[]), ("reads_a", &["a"])]),
+            ],
+            &[("d", &["b"])],
+        );
+        assert_eq!(
+            space.candidate_inputs[&class("a")],
+            vec![vec![], vec![class("b")]],
+            "`d` holds no row, so `a`'s second candidate depends on what `d` demands"
+        );
+        assert_eq!(
+            space.components,
+            vec![vec![class("a"), class("b")]],
+            "the cycle closes through a row-less class, and the component must contain \
+             both classes that DO hold rows"
+        );
+
+        // THE FREE SAMPLER REACHES IT: uniform over every candidate, the
+        // cyclic pair is one of the four combinations, and it is cyclic.
+        let free = genome_electing(&index, &[("a", "reads_d"), ("b", "reads_a")]);
+        assert!(
+            cyclic(&index, &space, &free),
+            "the (reads_d, reads_a) pair is the cycle this board is made of"
+        );
+
+        // THE FOREST SAMPLER NEVER DOES, and still reaches everything else.
+        let mut seen: std::collections::BTreeSet<Vec<String>> = std::collections::BTreeSet::new();
+        for seed in 0..200u64 {
+            let genome = sample_genome(&index, &space, &mut StdRng::seed_from_u64(seed));
+            assert!(
+                !cyclic(&index, &space, &genome),
+                "seed {seed} sampled the cycle through the row-less class: {:?}",
+                spelling(&index, &genome)
+            );
+            seen.insert(spelling(&index, &genome));
+        }
+        let expected: std::collections::BTreeSet<Vec<String>> = [
+            vec!["a=prog".to_string(), "b=prog".to_string()],
+            vec!["a=prog".to_string(), "b=reads_a".to_string()],
+            vec!["a=reads_d".to_string(), "b=prog".to_string()],
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            seen, expected,
+            "exactly the three acyclic genomes stay reachable"
+        );
+    }
+
+    /// CONTRACTION IS TRANSITIVE AND TERMINATES: `a` reads `d`, `d`
+    /// demands `e`, `e` demands `b` AND `d` (a ring among the row-less
+    /// classes). The contraction must walk through both and stop, and
+    /// the edge that comes out is `a -> b`.
+    #[test]
+    fn contraction_walks_chains_of_row_less_classes_and_terminates() {
+        let (_index, space) = build_with_row_less(
+            &[
+                ("a", &[("prog", &[]), ("reads_d", &["d"])]),
+                ("b", &[("prog", &[]), ("reads_a", &["a"])]),
+            ],
+            &[("d", &["e"]), ("e", &["b", "d"])],
+        );
+        assert_eq!(
+            space.candidate_inputs[&class("a")],
+            vec![vec![], vec![class("b")]],
+            "a -> d -> e -> b contracts to a -> b, and the d/e ring does not hang"
+        );
+        assert_eq!(space.components, vec![vec![class("a"), class("b")]]);
+    }
+
+    /// A ROW-LESS CLASS THAT DEMANDS NOTHING IS A LEAF — the input
+    /// terminal's shape (produced by nothing, planned from the boundary).
+    /// Its readers keep no edge at all, so no component forms.
+    #[test]
+    fn a_row_less_class_that_demands_nothing_is_a_leaf() {
+        let (index, space) = build_with_row_less(
+            &[
+                ("a", &[("prog", &[]), ("reads_t", &["t"])]),
+                ("b", &[("prog", &[]), ("reads_a", &["a"])]),
+            ],
+            &[("t", &[])],
+        );
+        assert_eq!(
+            space.candidate_inputs[&class("a")],
+            vec![vec![], vec![]],
+            "a terminal demands nothing, so reading one draws no edge"
+        );
+        assert!(space.components.is_empty());
+        let mut seen: std::collections::BTreeSet<Vec<String>> = std::collections::BTreeSet::new();
+        for seed in 0..200u64 {
+            seen.insert(spelling(
+                &index,
+                &sample_genome(&index, &space, &mut StdRng::seed_from_u64(seed)),
+            ));
+        }
+        assert_eq!(seen.len(), 4, "all four combinations stay reachable");
+    }
+
+    /// THE BUFFERIZE TRIPWIRE fires on the cyclic-graph refusal and on
+    /// nothing else, and it prints the genome's own chosen
+    /// intra-component edges — the evidence for "the sampler's candidate
+    /// graph disagrees with the plan the extractor emitted".
+    #[test]
+    fn the_bufferize_tripwire_fires_only_on_the_cycle_refusal() {
+        let (index, space) = build(&[
+            ("a", &[("prog", &[]), ("reads_b", &["b"])]),
+            ("b", &[("prog", &[]), ("reads_a", &["a"])]),
+        ]);
+        let genome = genome_electing(&index, &[("a", "reads_b"), ("b", "prog")]);
+
+        let ordinary = anyhow::anyhow!("op declares result 0 as internally allocated");
+        assert!(
+            bufferize_cycle_tripwire(&ordinary, &index, &space, &genome).is_ok(),
+            "every other bufferize refusal stays an ordinary refusal"
+        );
+
+        let cyclic = anyhow::anyhow!(
+            "{}; cannot bufferize: the cycle runs through 2 node(s): [Copy -> a | Copy -> b]",
+            crate::bufferize::EXTRACTED_GRAPH_CYCLE
+        );
+        let err = bufferize_cycle_tripwire(&cyclic, &index, &space, &genome)
+            .expect_err("a cyclic extracted graph from a sampled genome stops the search");
+        let text = format!("{err:#}");
+        assert!(text.contains("sampler invariant violated"), "{text}");
+        assert!(
+            text.contains("a <- [ClassId(\"b\")]") && text.contains("b <- []"),
+            "the bail names the genome's chosen intra-component edges: {text}"
+        );
+        assert!(
+            text.contains("the cycle runs through 2 node(s)"),
+            "and carries bufferize's cycle members: {text}"
+        );
     }
 
     /// Classes OUTSIDE every component are free: a plain DAG of

--- a/src/implementation_search.rs
+++ b/src/implementation_search.rs
@@ -17,13 +17,14 @@
 use std::time::Instant;
 
 use anyhow::{Result, anyhow, ensure};
+use egraph_serialize::ClassId;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::BTreeMap;
 
 use crate::bufferize::BufferIrGraph;
-use crate::extractor::{self, Genome};
+use crate::extractor::{self, Genome, ProducerChoice, SamplingSpace};
 use crate::graph::LogicalProgram;
 
 #[derive(Debug, Clone)]
@@ -75,6 +76,15 @@ pub struct RefusalBreakdown {
     pub extract_refusals: usize,
     /// ...of those, how many involved a CHOICE-CYCLE (the genome's
     /// chosen producers block on each other).
+    ///
+    /// INVARIANT (2026-09-02): sampling and mutation both keep a
+    /// genome's chosen-edge graph acyclic, so for a SAMPLED genome this
+    /// can only be nonzero through the sampler's documented full-list
+    /// fallback — a component position with no acyclic option at all.
+    /// A choice cycle on an acyclic chosen-edge graph is a sampler bug
+    /// and stops the search (see `search_implementations_with_runtime`).
+    /// Genomes assembled by hand (the election boards) are of course
+    /// still free to name cycles, and are still counted here.
     pub with_choice_cycles: usize,
     /// ...and how many involved a DEAD-END (an unplanned class with no
     /// candidate at all).
@@ -176,6 +186,270 @@ impl<L: crate::bufferize::PlanLayout> PlanProfiler<L> for StaticProfiler {
     }
 }
 
+/// Producer index shorthand: class -> its candidate `(constructor
+/// name, choice)` entries, in the index's own deterministic order.
+pub type ProducerIndex = BTreeMap<ClassId, Vec<(String, ProducerChoice)>>;
+
+/// Pick a position: uniformly among `allowed`, or — when nothing is
+/// admissible — uniformly over the FULL candidate list.
+///
+/// THE FALLBACK is deliberate and unchanged from the 2026-08-07
+/// sampler: a class every one of whose candidates sources from a member
+/// of its own component that is not yet assigned has no acyclic option
+/// at this position, which means its component holds no acyclic genome
+/// at all through this class. Refusing to choose would silently shrink
+/// the space; choosing anyway keeps the refusal accounting (and the
+/// blockage anatomy) as the loud diagnosis for that corner.
+fn choose_position(rng: &mut StdRng, allowed: &[usize], total: usize) -> usize {
+    if allowed.is_empty() {
+        rng.random_range(0..total)
+    } else {
+        allowed[rng.random_range(0..allowed.len())]
+    }
+}
+
+/// GENERATION-0 SAMPLING: a FOREST inside every component.
+///
+/// Each component's members are assigned in a random order built one
+/// step at a time. A member may elect a candidate with
+/// intra-component sources only when ALL of them are already assigned,
+/// so every chosen intra-component edge points BACKWARD along the
+/// order — acyclic by construction.
+///
+/// THE ORDER IS DRAWN FROM THE ADMISSIBLE ONES: at each step the next
+/// member is picked uniformly among those that still HAVE an
+/// admissible candidate, so the first member always progresses and no
+/// member is forced into the fallback by an unlucky shuffle. (A
+/// uniformly random order over all members would sometimes lead with a
+/// member that cannot progress — e.g. a layout copy whose only sources
+/// are its own component — and then the fallback could weld a cycle
+/// the 2026-08-07 sampler would have refused. Restricting to
+/// admissible orders removes no genome: see COVERAGE.)
+///
+/// COVERAGE. This admits chains and forests, not just the 2026-08-07
+/// star (one elected primary, everyone else copying it): for any
+/// acyclic assignment of intra-component candidates there is a
+/// topological order of the chosen edges, at every prefix of which the
+/// next member's own chosen candidate is admissible — so that member
+/// is in the pool, and the assignment is reachable. The only genomes
+/// excluded are the cyclic ones. Classes outside every component are
+/// sampled freely: their candidates' edges all leave the component,
+/// and the condensation of the SCC decomposition is a DAG.
+pub fn sample_genome(index: &ProducerIndex, space: &SamplingSpace, rng: &mut StdRng) -> Genome {
+    sample_genome_reporting(index, space, rng).0
+}
+
+/// [`sample_genome`] plus the classes that had to take the full-list
+/// fallback, in the order they took it — the sampler's own account of
+/// where its acyclicity invariant was unenforceable. An EMPTY list is
+/// the guarantee: the genome's chosen-edge graph is acyclic.
+pub fn sample_genome_reporting(
+    index: &ProducerIndex,
+    space: &SamplingSpace,
+    rng: &mut StdRng,
+) -> (Genome, Vec<ClassId>) {
+    let mut genome = Genome::default();
+    let mut fallbacks: Vec<ClassId> = Vec::new();
+    for members in &space.components {
+        // Per member, per candidate: how many of its intra-component
+        // sources are still unassigned. Zero = admissible now. (Sources
+        // are deduplicated, so one decrement each.)
+        let mut pending: Vec<Vec<usize>> = members
+            .iter()
+            .map(|class| {
+                space.intra_sources[class]
+                    .iter()
+                    .map(Vec::len)
+                    .collect::<Vec<usize>>()
+            })
+            .collect();
+        // How many admissible candidates each member currently has.
+        let mut admissible: Vec<usize> = pending
+            .iter()
+            .map(|per_candidate| per_candidate.iter().filter(|left| **left == 0).count())
+            .collect();
+        // source class -> the (member, candidate) counters it releases.
+        let mut dependents: std::collections::BTreeMap<&ClassId, Vec<(usize, usize)>> =
+            std::collections::BTreeMap::new();
+        for (member, class) in members.iter().enumerate() {
+            for (candidate, sources) in space.intra_sources[class].iter().enumerate() {
+                for source in sources {
+                    dependents
+                        .entry(source)
+                        .or_default()
+                        .push((member, candidate));
+                }
+            }
+        }
+
+        let mut assigned = vec![false; members.len()];
+        for _ in 0..members.len() {
+            // The next member: uniform over those that can still choose
+            // admissibly, or — when none can — over whoever is left,
+            // which is the full-list fallback.
+            let mut pool: Vec<usize> = (0..members.len())
+                .filter(|member| !assigned[*member] && admissible[*member] > 0)
+                .collect();
+            let forced = pool.is_empty();
+            if forced {
+                pool = (0..members.len())
+                    .filter(|member| !assigned[*member])
+                    .collect();
+            }
+            let member = pool[rng.random_range(0..pool.len())];
+            let class = &members[member];
+            let candidates = &index[class];
+            let allowed: Vec<usize> = (0..candidates.len())
+                .filter(|position| pending[member][*position] == 0)
+                .collect();
+            debug_assert_eq!(allowed.is_empty(), forced);
+            if forced {
+                fallbacks.push(class.clone());
+            }
+            let position = choose_position(rng, &allowed, candidates.len());
+            genome
+                .choices
+                .insert(class.clone(), candidates[position].1.clone());
+            assigned[member] = true;
+            for (other, candidate) in dependents.get(class).into_iter().flatten() {
+                pending[*other][*candidate] -= 1;
+                if pending[*other][*candidate] == 0 {
+                    admissible[*other] += 1;
+                }
+            }
+        }
+    }
+    for (class, candidates) in index {
+        if genome.choices.contains_key(class) {
+            continue;
+        }
+        let position = rng.random_range(0..candidates.len());
+        genome
+            .choices
+            .insert(class.clone(), candidates[position].1.clone());
+    }
+    (genome, fallbacks)
+}
+
+/// Would routing `class` through `sources` close a cycle in the genome's
+/// chosen intra-component edge graph? A DFS from each source over the
+/// OTHER members' current choices; reaching `class` again — or a source
+/// that IS `class` — is the cycle. Intra-component edges never leave the
+/// component, so the walk is component-local and small.
+fn flip_closes_cycle(
+    index: &ProducerIndex,
+    space: &SamplingSpace,
+    genome: &Genome,
+    class: &ClassId,
+    sources: &[ClassId],
+) -> bool {
+    let mut stack: Vec<ClassId> = sources.to_vec();
+    let mut seen: FxHashSet<ClassId> = FxHashSet::default();
+    while let Some(node) = stack.pop() {
+        if &node == class {
+            return true;
+        }
+        if !seen.insert(node.clone()) {
+            continue;
+        }
+        let Some(position) = space.chosen_position(index, genome, &node) else {
+            continue;
+        };
+        if let Some(next) = space
+            .intra_sources
+            .get(&node)
+            .and_then(|per_candidate| per_candidate.get(position))
+        {
+            stack.extend(next.iter().cloned());
+        }
+    }
+    false
+}
+
+/// POINT MUTATION under the same invariant: a flip of one class to one
+/// candidate is admissible exactly when the resulting chosen-edge graph
+/// closes no cycle through that class (see [`flip_closes_cycle`]).
+/// Progressing candidates have no intra-component sources and so are
+/// always admissible; a candidate sourcing from its own class never is.
+/// Mutations hit ANY producer class, dead rows included (deliberately —
+/// a dead-row mutation is free now and pre-stages the choice a later
+/// route flip lands on).
+pub fn mutate_genome(
+    parent: &Genome,
+    index: &ProducerIndex,
+    space: &SamplingSpace,
+    classes: &[ClassId],
+    rng: &mut StdRng,
+    count: usize,
+) -> Genome {
+    mutate_genome_reporting(parent, index, space, classes, rng, count).0
+}
+
+/// [`mutate_genome`] plus the classes whose flip found NO admissible
+/// candidate and took the full-list fallback (see
+/// [`sample_genome_reporting`]).
+pub fn mutate_genome_reporting(
+    parent: &Genome,
+    index: &ProducerIndex,
+    space: &SamplingSpace,
+    classes: &[ClassId],
+    rng: &mut StdRng,
+    count: usize,
+) -> (Genome, Vec<ClassId>) {
+    let mut child = parent.clone();
+    let mut fallbacks: Vec<ClassId> = Vec::new();
+    if classes.is_empty() {
+        return (child, fallbacks); // one-point genome space: nothing to mutate
+    }
+    for _ in 0..count {
+        let class = &classes[rng.random_range(0..classes.len())];
+        let candidates = &index[class];
+        let sources = &space.intra_sources[class];
+        let allowed: Vec<usize> = (0..candidates.len())
+            .filter(|&position| !flip_closes_cycle(index, space, &child, class, &sources[position]))
+            .collect();
+        if allowed.is_empty() {
+            fallbacks.push(class.clone());
+        }
+        let position = choose_position(rng, &allowed, candidates.len());
+        child
+            .choices
+            .insert(class.clone(), candidates[position].1.clone());
+    }
+    (child, fallbacks)
+}
+
+/// [`sample_genome_reporting`] from a seed — the entry the
+/// sampler-invariant boards use, so a test crate needs no `rand` of its
+/// own. Returns the genome and its fallback classes.
+pub fn sample_genome_with_seed(
+    index: &ProducerIndex,
+    space: &SamplingSpace,
+    seed: u64,
+) -> (Genome, Vec<ClassId>) {
+    sample_genome_reporting(index, space, &mut StdRng::seed_from_u64(seed))
+}
+
+/// [`mutate_genome_reporting`] from a seed (see
+/// [`sample_genome_with_seed`]).
+pub fn mutate_genome_with_seed(
+    parent: &Genome,
+    index: &ProducerIndex,
+    space: &SamplingSpace,
+    count: usize,
+    seed: u64,
+) -> (Genome, Vec<ClassId>) {
+    let classes: Vec<ClassId> = index.keys().cloned().collect();
+    mutate_genome_reporting(
+        parent,
+        index,
+        space,
+        &classes,
+        &mut StdRng::seed_from_u64(seed),
+        count,
+    )
+}
+
 /// The runtime-owned search entry (ruling 2026-08-17): the caller
 /// supplies its OWN matcher set (None = the in-core reference
 /// registry, which Step B moves out) and its OWN profiler.
@@ -223,131 +497,23 @@ pub fn search_implementations_with_runtime<L: crate::bufferize::PlanLayout>(
     let classes: Vec<_> = index.keys().cloned().collect();
     let mut rng = StdRng::seed_from_u64(options.seed);
 
-    // TWO-PHASE SAMPLING (ruling 2026-08-07): the genome searches
-    // PROGRESSING candidates — ops whose inputs are other logical
-    // values — freely; sibling-sourced candidates (layout copies within
-    // one logical value) are subordinate plumbing. Generation 0 elects
-    // one progressing PRIMARY per sibling group; the other members
-    // choose uniformly between their progressing candidates and copies
-    // sourced from the primary. Mutation preserves the same invariant
-    // locally: a sibling-sourced choice needs its source to currently
-    // progress, and a member some sibling currently copies must keep
-    // progressing. Copy⟷Copy welds and copy chains are therefore
-    // unconstructible, while recompute-at-every-layout and
-    // copy-from-boundary-input plans stay in the space. A class whose
-    // allowed set comes up empty falls back to its full candidate list
-    // (same space as the old free sampler); the refusal accounting
-    // stays the loud diagnosis for that corner.
-    let space = extractor::sampling_space(egraph, &index);
-    let group_of: FxHashMap<_, usize> = space
-        .groups
-        .iter()
-        .enumerate()
-        .flat_map(|(group, members)| members.iter().map(move |member| (member.clone(), group)))
-        .collect();
+    // TWO-PHASE SAMPLING over the candidate graph's COMPONENTS
+    // (ruling 2026-08-07, generalized 2026-09-02). See
+    // [`extractor::SamplingSpace`] for the criterion: a choice cycle
+    // can only close inside a strongly connected component of the
+    // candidate graph, so components ARE the re-description groups —
+    // Copy⟷Copy layout welds and the cuBLASLt collapse's
+    // `x ≡ Tᵀ(x)` two-logical-value 2-cycle alike, with no op-name
+    // pattern list anywhere. Generation 0 samples a FOREST inside each
+    // component (see [`sample_genome`]); mutation admits a flip only
+    // when it closes no cycle (see [`mutate_genome`]). Everything
+    // outside a component is sampled freely: its edges leave the
+    // component and the condensation is a DAG.
+    let space = session.sampling_space(&index);
 
-    let random_genome = |rng: &mut StdRng| {
-        let mut genome = Genome::default();
-        let mut primary_of: FxHashMap<_, _> = FxHashMap::default();
-        for members in &space.groups {
-            let eligible: Vec<_> = members
-                .iter()
-                .filter(|member| {
-                    space.sibling_sources[*member]
-                        .iter()
-                        .any(|sources| sources.is_empty())
-                })
-                .cloned()
-                .collect();
-            if eligible.is_empty() {
-                continue; // copy-only group: full-list fallback below
-            }
-            let primary = eligible[rng.random_range(0..eligible.len())].clone();
-            for member in members {
-                primary_of.insert(member.clone(), primary.clone());
-            }
-        }
-        for (class, candidates) in &index {
-            let sources_per_candidate = &space.sibling_sources[class];
-            let allowed: Vec<usize> = match primary_of.get(class) {
-                Some(primary) if class == primary => (0..candidates.len())
-                    .filter(|&position| sources_per_candidate[position].is_empty())
-                    .collect(),
-                Some(primary) => (0..candidates.len())
-                    .filter(|&position| {
-                        sources_per_candidate[position]
-                            .iter()
-                            .all(|source| source == primary)
-                    })
-                    .collect(),
-                None => (0..candidates.len()).collect(),
-            };
-            let position = if allowed.is_empty() {
-                rng.random_range(0..candidates.len())
-            } else {
-                allowed[rng.random_range(0..allowed.len())]
-            };
-            genome
-                .choices
-                .insert(class.clone(), candidates[position].1.clone());
-        }
-        genome
-    };
-    // Whether a class's CURRENT choice progresses (boundary classes
-    // without genome rows are leaves — they trivially progress).
-    let progresses = |child: &Genome, class: &egraph_serialize::ClassId| -> bool {
-        let (Some(choice), Some(candidates)) = (child.choices.get(class), index.get(class)) else {
-            return true;
-        };
-        candidates
-            .iter()
-            .position(|(_, candidate)| candidate == choice)
-            .is_none_or(|position| space.sibling_sources[class][position].is_empty())
-    };
+    let random_genome = |rng: &mut StdRng| sample_genome(&index, &space, rng);
     let mutate = |parent: &Genome, rng: &mut StdRng, count: usize| {
-        let mut child = parent.clone();
-        if classes.is_empty() {
-            return child; // one-point genome space: nothing to mutate
-        }
-        for _ in 0..count {
-            let class = &classes[rng.random_range(0..classes.len())];
-            let candidates = &index[class];
-            let sources_per_candidate = &space.sibling_sources[class];
-            let copied_by_sibling = group_of.get(class).is_some_and(|group| {
-                space.groups[*group].iter().any(|member| {
-                    member != class
-                        && child.choices.get(member).is_some_and(|choice| {
-                            index[member]
-                                .iter()
-                                .position(|(_, candidate)| candidate == choice)
-                                .is_some_and(|position| {
-                                    space.sibling_sources[member][position]
-                                        .iter()
-                                        .any(|source| source == class)
-                                })
-                        })
-                })
-            });
-            let allowed: Vec<usize> = (0..candidates.len())
-                .filter(|&position| {
-                    let sources = &sources_per_candidate[position];
-                    sources.is_empty()
-                        || (!copied_by_sibling
-                            && sources
-                                .iter()
-                                .all(|source| source != class && progresses(&child, source)))
-                })
-                .collect();
-            let position = if allowed.is_empty() {
-                rng.random_range(0..candidates.len())
-            } else {
-                allowed[rng.random_range(0..allowed.len())]
-            };
-            child
-                .choices
-                .insert(class.clone(), candidates[position].1.clone());
-        }
-        child
+        mutate_genome(parent, &index, &space, &classes, rng, count)
     };
 
     // fingerprint → measured nanos (the dedup cache).
@@ -403,6 +569,25 @@ pub fn search_implementations_with_runtime<L: crate::bufferize::PlanLayout>(
                     let (cycle, dead_end, summary) = session.failure_breakdown();
                     if cycle {
                         breakdown.with_choice_cycles += 1;
+                        // THE SAMPLER INVARIANT (2026-09-02). Sampling
+                        // and mutation both keep the genome's
+                        // chosen-edge graph acyclic, so the ONLY way a
+                        // sampled genome can reach the extractor with a
+                        // choice cycle is the documented full-list
+                        // fallback (a component position with no
+                        // acyclic option at all — its own diagnosis).
+                        // A choice cycle on an ACYCLIC chosen-edge
+                        // graph means the sampler's notion of a
+                        // candidate's inputs has drifted from the
+                        // planner's: a bug, and it stops the search
+                        // instead of quietly costing genomes.
+                        let edges = space.chosen_edges(&index, &genome);
+                        ensure!(
+                            extractor::edges_have_cycle(&edges),
+                            "sampler invariant violated: choice cycle in a sampled genome \
+                             whose chosen-edge graph is acyclic — the sampler's candidate \
+                             inputs disagree with the extractor's; {summary}"
+                        );
                     }
                     if dead_end {
                         breakdown.with_dead_ends += 1;
@@ -877,5 +1062,275 @@ mod tests {
                 );
             }
         }
+    }
+}
+
+/// THE SAMPLER-INVARIANT UNIT BOARD (2026-09-02): components, forest
+/// sampling and the mutation cycle check on hand-built candidate
+/// graphs — no e-graph, no runtime, so the rule itself is under test
+/// rather than a graph that happens to exercise it.
+///
+/// CRATE-LOCAL types only (`crate::`, never `luminal::`): the sibling
+/// `mod tests` above is a DEP-WORLD suite driving the reference runtime
+/// through the cyclic dev-dependency, which compiles this library twice
+/// and does not unify the two builds' types. These tests touch neither.
+#[cfg(test)]
+mod sampler_tests {
+    use std::collections::BTreeMap;
+
+    use egraph_serialize::{ClassId, NodeId};
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    use crate::extractor::{Genome, ProducerChoice, SamplingSpace, edges_have_cycle};
+
+    use super::{ProducerIndex, mutate_genome, sample_genome};
+
+    fn class(name: &str) -> ClassId {
+        ClassId::from(name)
+    }
+
+    /// One candidate of one class: `(candidate name, input classes)`.
+    type CandidateRow<'a> = (&'a str, &'a [&'a str]);
+    /// One class of a hand-built board: `(class, its candidates)`.
+    type BoardRow<'a> = (&'a str, &'a [CandidateRow<'a>]);
+
+    /// A producer index and its candidate graph from one table:
+    /// `(class, [(candidate name, [input classes])])`. Candidate
+    /// positions line up between the two by construction — the same
+    /// parallelism `SamplingSpace` assumes of the real index.
+    fn build(table: &[BoardRow<'_>]) -> (ProducerIndex, SamplingSpace) {
+        let mut index: ProducerIndex = BTreeMap::new();
+        let mut inputs: BTreeMap<ClassId, Vec<Vec<ClassId>>> = BTreeMap::new();
+        for (owner, candidates) in table {
+            index.insert(
+                class(owner),
+                candidates
+                    .iter()
+                    .map(|(name, _)| {
+                        (
+                            (*name).to_string(),
+                            ProducerChoice {
+                                enode: NodeId::from(format!("{owner}::{name}")),
+                                output_index: 0,
+                            },
+                        )
+                    })
+                    .collect(),
+            );
+            inputs.insert(
+                class(owner),
+                candidates
+                    .iter()
+                    .map(|(_, sources)| sources.iter().map(|s| class(s)).collect())
+                    .collect(),
+            );
+        }
+        let space = SamplingSpace::from_candidate_inputs(inputs);
+        (index, space)
+    }
+
+    /// The candidate NAME the genome elected per class, sorted by class
+    /// — a readable genome identity for coverage assertions.
+    fn spelling(index: &ProducerIndex, genome: &Genome) -> Vec<String> {
+        index
+            .iter()
+            .map(|(owner, candidates)| {
+                let choice = &genome.choices[owner];
+                let (name, _) = candidates
+                    .iter()
+                    .find(|(_, candidate)| candidate == choice)
+                    .expect("the genome names an index entry");
+                format!("{owner}={name}")
+            })
+            .collect()
+    }
+
+    fn cyclic(index: &ProducerIndex, space: &SamplingSpace, genome: &Genome) -> bool {
+        edges_have_cycle(&space.chosen_edges(index, genome))
+    }
+
+    /// (i) TWO CLASSES RE-DESCRIBING EACH OTHER — the cuBLASLt
+    /// collapse's shape in miniature. One component of size 2; over 200
+    /// seeds the (intra, intra) pair never appears and all three acyclic
+    /// combinations do.
+    #[test]
+    fn mutual_re_description_is_one_component_and_only_the_cycle_is_excluded() {
+        let (index, space) = build(&[
+            ("a", &[("prog", &[]), ("reads_b", &["b"])]),
+            ("b", &[("prog", &[]), ("reads_a", &["a"])]),
+        ]);
+        assert_eq!(
+            space.components,
+            vec![vec![class("a"), class("b")]],
+            "two classes reading each other are one non-trivial component"
+        );
+
+        let mut seen: std::collections::BTreeSet<Vec<String>> = std::collections::BTreeSet::new();
+        for seed in 0..200u64 {
+            let genome = sample_genome(&index, &space, &mut StdRng::seed_from_u64(seed));
+            assert!(
+                !cyclic(&index, &space, &genome),
+                "seed {seed} sampled a cyclic genome: {:?}",
+                spelling(&index, &genome)
+            );
+            seen.insert(spelling(&index, &genome));
+        }
+        let expected: std::collections::BTreeSet<Vec<String>> = [
+            vec!["a=prog".to_string(), "b=prog".to_string()],
+            vec!["a=prog".to_string(), "b=reads_a".to_string()],
+            vec!["a=reads_b".to_string(), "b=prog".to_string()],
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            seen, expected,
+            "exactly the three acyclic genomes are reachable"
+        );
+    }
+
+    /// (ii) COVERAGE OF CHAINS: a 3-cycle of re-descriptions
+    /// (a<-c, b<-a, c<-b) with a progressing option each. The CHAIN
+    /// genome — a progresses, b reads a, c reads b — is a forest, not
+    /// a star, and the 2026-08-07 sampler could not build it. It must
+    /// be reachable; the all-intra 3-cycle must not be.
+    #[test]
+    fn chains_inside_a_component_are_reachable() {
+        let (index, space) = build(&[
+            ("a", &[("prog", &[]), ("reads_c", &["c"])]),
+            ("b", &[("prog", &[]), ("reads_a", &["a"])]),
+            ("c", &[("prog", &[]), ("reads_b", &["b"])]),
+        ]);
+        assert_eq!(
+            space.components,
+            vec![vec![class("a"), class("b"), class("c")]],
+            "the 3-cycle is one component"
+        );
+
+        let chain = vec![
+            "a=prog".to_string(),
+            "b=reads_a".to_string(),
+            "c=reads_b".to_string(),
+        ];
+        let mut chain_seen = false;
+        for seed in 0..200u64 {
+            let genome = sample_genome(&index, &space, &mut StdRng::seed_from_u64(seed));
+            assert!(
+                !cyclic(&index, &space, &genome),
+                "seed {seed} sampled a cyclic genome: {:?}",
+                spelling(&index, &genome)
+            );
+            chain_seen |= spelling(&index, &genome) == chain;
+        }
+        assert!(
+            chain_seen,
+            "the chain genome (a progresses, b reads a, c reads b) must be sampled"
+        );
+    }
+
+    /// (iii) A COMPONENT WITH NO PROGRESSING MEMBER: every candidate of
+    /// every member is intra-component, so the first member processed
+    /// has no admissible candidate and takes the documented full-list
+    /// fallback. The sampler must produce a total genome and not panic;
+    /// the resulting cycle is the refusal accounting's business.
+    #[test]
+    fn a_component_with_no_progressing_member_falls_back() {
+        let (index, space) = build(&[("a", &[("reads_b", &["b"])]), ("b", &[("reads_a", &["a"])])]);
+        assert_eq!(space.components, vec![vec![class("a"), class("b")]]);
+        for seed in 0..32u64 {
+            let genome = sample_genome(&index, &space, &mut StdRng::seed_from_u64(seed));
+            assert_eq!(genome.choices.len(), 2, "the genome stays total");
+            assert!(
+                cyclic(&index, &space, &genome),
+                "the fallback is the ONLY route to a cyclic sample, and here it is forced"
+            );
+        }
+    }
+
+    /// MUTATION keeps the invariant: from every acyclic parent, 500
+    /// mutated children over the two-class and three-class boards are
+    /// acyclic — and the flip check is not merely refusing everything,
+    /// since the children do move.
+    #[test]
+    fn mutation_never_closes_a_cycle() {
+        for table in [
+            &[
+                (
+                    "a",
+                    &[("prog", &[] as &[&str]), ("reads_b", &["b"] as &[&str])]
+                        as &[(&str, &[&str])],
+                ),
+                ("b", &[("prog", &[]), ("reads_a", &["a"])]),
+            ] as &[(&str, &[(&str, &[&str])])],
+            &[
+                ("a", &[("prog", &[]), ("reads_c", &["c"])]),
+                ("b", &[("prog", &[]), ("reads_a", &["a"])]),
+                ("c", &[("prog", &[]), ("reads_b", &["b"])]),
+            ],
+        ] {
+            let (index, space) = build(table);
+            let classes: Vec<ClassId> = index.keys().cloned().collect();
+            let mut moved = 0usize;
+            for seed in 0..500u64 {
+                let mut rng = StdRng::seed_from_u64(seed);
+                let parent = sample_genome(&index, &space, &mut rng);
+                let child = mutate_genome(&parent, &index, &space, &classes, &mut rng, 2);
+                assert!(
+                    !cyclic(&index, &space, &child),
+                    "seed {seed}: mutation closed a cycle: {:?} -> {:?}",
+                    spelling(&index, &parent),
+                    spelling(&index, &child)
+                );
+                if spelling(&index, &child) != spelling(&index, &parent) {
+                    moved += 1;
+                }
+            }
+            assert!(moved > 0, "mutation must actually move the genome");
+        }
+    }
+
+    /// A class whose candidate sources from ITSELF is a self-loop: a
+    /// one-member component, and the sampler must never elect it.
+    #[test]
+    fn a_self_sourcing_candidate_is_never_elected() {
+        let (index, space) = build(&[("a", &[("prog", &[]), ("reads_self", &["a"])])]);
+        assert_eq!(
+            space.components,
+            vec![vec![class("a")]],
+            "a self-loop is a non-trivial component of one"
+        );
+        let classes: Vec<ClassId> = index.keys().cloned().collect();
+        for seed in 0..200u64 {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let genome = sample_genome(&index, &space, &mut rng);
+            assert_eq!(spelling(&index, &genome), vec!["a=prog".to_string()]);
+            let child = mutate_genome(&genome, &index, &space, &classes, &mut rng, 3);
+            assert_eq!(spelling(&index, &child), vec!["a=prog".to_string()]);
+        }
+    }
+
+    /// Classes OUTSIDE every component are free: a plain DAG of
+    /// candidates yields no components and full-list sampling.
+    #[test]
+    fn an_acyclic_candidate_graph_has_no_components() {
+        let (index, space) = build(&[
+            ("a", &[("prog", &[])]),
+            ("b", &[("prog", &[]), ("reads_a", &["a"])]),
+            ("c", &[("reads_a", &["a"]), ("reads_b", &["b"])]),
+        ]);
+        assert!(space.components.is_empty());
+        for per_candidate in space.intra_sources.values() {
+            for sources in per_candidate {
+                assert!(sources.is_empty(), "no component, no intra sources");
+            }
+        }
+        let mut seen: std::collections::BTreeSet<Vec<String>> = std::collections::BTreeSet::new();
+        for seed in 0..200u64 {
+            seen.insert(spelling(
+                &index,
+                &sample_genome(&index, &space, &mut StdRng::seed_from_u64(seed)),
+            ));
+        }
+        assert_eq!(seen.len(), 4, "all 1x2x2 combinations stay reachable");
     }
 }

--- a/tests/test_runtime/tests/scc_sampler.rs
+++ b/tests/test_runtime/tests/scc_sampler.rs
@@ -29,6 +29,15 @@
 //!    is recorded there: because b = y is a BOUND INPUT, and an
 //!    input-terminal class is planned unconditionally, the weld is not
 //!    a cycle at all and the sampler is free.
+//!
+//!  * `an_input_terminal_*` — the leaf rule itself (2026-09-02). The
+//!    double-transpose collapse gives the marker's BOUND INPUTS
+//!    producers of their own, and a zero-byte view used to win the
+//!    input class on the `plan_label` tie-break — 11 of 64 sampled
+//!    genomes then extracted a plan that computed an input from a value
+//!    reading it back, which only bufferize's toposort caught. An input
+//!    terminal is a leaf: no genome row, no candidate, and every sample
+//!    reads it as a `BufferInput`.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -461,12 +470,13 @@ fn re_description_program() -> String {
 ///
 /// The weld is real — class(a) reads class(b = y) and class(b = y)'s
 /// `a + (-1) * x` producer reads class(a) — but `b = y`'s class is a
-/// BOUND INPUT, and `relax_to_fixpoint` seeds every input-terminal
-/// class's plan from the boundary on the first pass, at cost 0 and with
-/// no children. Such a class can never block, so no edge out of it can
-/// join a blocking cycle, and the candidate graph draws none. The
-/// cross-logical re-description that DOES make a component is on the
-/// `marker_*` board, where neither member is a boundary value.
+/// BOUND INPUT: it is produced by nothing, so it holds no genome row,
+/// offers no candidate, and is planned from the boundary on
+/// `relax_to_fixpoint`'s first pass. It is not a node of the candidate
+/// graph at all, and a class that demands nothing contracts to nothing
+/// for its readers either, so no edge and no cycle. The cross-logical
+/// re-description that DOES make a component is on the `marker_*`
+/// board, where neither member is a boundary value.
 #[test]
 fn union_of_b_and_y_is_a_leaf_weld_not_a_cycle() {
     let egraph = test_runtime::serialize_fixture(&re_description_program());
@@ -511,11 +521,12 @@ fn union_of_b_and_y_is_a_leaf_weld_not_a_cycle() {
 ///
 /// ROUTES, honestly: only ONE of the two routes for `c` is electable,
 /// and the reason is not the sampler. `b = y`'s class is a bound INPUT,
-/// and `relax_to_fixpoint` seeds every input-terminal class's plan
-/// from the input at `heuristic_cost` 0 REGARDLESS of the genome, so
-/// `is_better` can never prefer the recomputed `a - x`. Every plan here
-/// is therefore two adds — `a` from x and y, and `c` from z and the
-/// same class — with `b`'s -1 constant/mul chain never planned.
+/// so it is a LEAF — no genome row, no candidate, planned from the
+/// boundary at `heuristic_cost` 0 whatever the genome says. The
+/// recomputed `a - x` is not something `is_better` could prefer; it is
+/// not offered at all. Every plan here is therefore two adds — `a` from
+/// x and y, and `c` from z and the same class — with `b`'s -1
+/// constant/mul chain never planned.
 #[test]
 fn union_extraction_never_cycles() {
     let egraph = test_runtime::serialize_fixture(&re_description_program());
@@ -580,5 +591,196 @@ fn union_extraction_never_cycles() {
                 "both ops are adds (b's -1 constant/mul chain is never planned): {labels:?}"
             );
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// D. AN INPUT TERMINAL IS A LEAF: no genome row, no producer, no cycle.
+// ---------------------------------------------------------------------------
+
+/// The extractor's own input-terminal rule replicated on the raw
+/// e-graph (`collect_input_terminals`): the LayoutTensor child of every
+/// `BufferTensorLit` whose BufferTensor class is one of the program's
+/// bound inputs.
+fn input_terminal_classes(egraph: &EGraph) -> BTreeSet<ClassId> {
+    let buffer_list = |root_op: &str| -> BTreeSet<ClassId> {
+        let mut out = BTreeSet::new();
+        for node in egraph.nodes.values().filter(|node| node.op == root_op) {
+            let mut cursor = node
+                .children
+                .first()
+                .and_then(|id| egraph.nodes.get(id))
+                .map(|child| child.eclass.clone());
+            while let Some(list) = cursor {
+                let Some(cons) = egraph
+                    .nodes
+                    .values()
+                    .find(|node| node.eclass == list && node.op == "BufferTensorCons")
+                else {
+                    break;
+                };
+                if let Some(head) = cons.children.first().and_then(|id| egraph.nodes.get(id)) {
+                    out.insert(head.eclass.clone());
+                }
+                cursor = cons
+                    .children
+                    .get(1)
+                    .and_then(|id| egraph.nodes.get(id))
+                    .map(|child| child.eclass.clone());
+            }
+        }
+        out
+    };
+    let inputs = buffer_list("BufferInputLit");
+    let outputs = buffer_list("BufferOutputLit");
+    let mut terminals = BTreeSet::new();
+    for node in egraph
+        .nodes
+        .values()
+        .filter(|node| !node.subsumed && node.op == "BufferTensorLit")
+    {
+        if if inputs.is_empty() {
+            outputs.contains(&node.eclass)
+        } else {
+            !inputs.contains(&node.eclass)
+        } {
+            continue;
+        }
+        if let Some(tensor) = node.children.first().and_then(|id| egraph.nodes.get(id)) {
+            terminals.insert(tensor.eclass.clone());
+        }
+    }
+    terminals
+}
+
+/// The implementation op names that PRODUCE `class` in the e-graph: for
+/// every `LayoutTensorOpLit` spec whose output list contains it, the
+/// `LayoutTensorOp*` spellings of the op class it belongs to. This is
+/// the board's non-vacuity witness — the rows the producer index used
+/// to carry for an input terminal.
+fn producer_op_names(egraph: &EGraph, class: &ClassId) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    for node in egraph
+        .nodes
+        .values()
+        .filter(|node| node.op == "LayoutTensorOpLit")
+    {
+        let Some(outputs) = node.children.get(1).and_then(|id| egraph.nodes.get(id)) else {
+            continue;
+        };
+        let mut cursor = Some(outputs.eclass.clone());
+        let mut produces = false;
+        while let Some(list) = cursor {
+            let Some(cons) = egraph
+                .nodes
+                .values()
+                .find(|node| node.eclass == list && node.op == "LayoutTensorCons")
+            else {
+                break;
+            };
+            if let Some(head) = cons.children.first().and_then(|id| egraph.nodes.get(id)) {
+                produces |= &head.eclass == class;
+            }
+            cursor = cons
+                .children
+                .get(1)
+                .and_then(|id| egraph.nodes.get(id))
+                .map(|child| child.eclass.clone());
+        }
+        if !produces {
+            continue;
+        }
+        for sibling in egraph
+            .nodes
+            .values()
+            .filter(|sibling| sibling.eclass == node.eclass && !sibling.subsumed)
+        {
+            if sibling.op.starts_with("LayoutTensorOp") && sibling.op != "LayoutTensorOpLit" {
+                names.insert(sibling.op.clone());
+            }
+        }
+    }
+    names
+}
+
+/// THE GAP-A BOARD (2026-09-02). The double-transpose collapse gives
+/// the marker matmul's bound INPUTS producers of their own — `x` is in
+/// the class of `Tᵀ(T(x))`, whose producer is a view. A view moves no
+/// bytes, so its plan ties the input plan at `heuristic_cost` 0 and the
+/// `plan_label` tie-break ("IndexMapApplyViewGeneric" sorts before
+/// "Input:…") HANDED THE INPUT CLASS TO THE VIEW: the extractor emitted
+/// a plan in which a program input is computed from a value that reads
+/// it back, and only bufferize's toposort noticed.
+///
+/// An input terminal is a leaf by definition — its value exists at
+/// launch. So: no genome row for it (the producer index drops them), no
+/// candidate for it (`candidates_for_class` returns none), and every
+/// sampled genome extracts a graph that reads it as a `BufferInput` and
+/// bufferizes.
+#[test]
+fn an_input_terminal_keeps_its_buffer_input_and_never_a_producer() {
+    let egraph = test_runtime::serialize_fixture(&marker_matmul_program());
+    let terminals = input_terminal_classes(&egraph);
+    assert_eq!(
+        terminals.len(),
+        2,
+        "the 2D matmul binds two inputs: {terminals:?}"
+    );
+
+    // NON-VACUITY: the collapse really does offer these classes producers.
+    let mut with_producers = 0usize;
+    for terminal in &terminals {
+        let names = producer_op_names(&egraph, terminal);
+        println!("SCC-TERMINAL {terminal} producers {names:?}");
+        with_producers += usize::from(!names.is_empty());
+    }
+    assert!(
+        with_producers > 0,
+        "the board is vacuous unless some input terminal has a producer spelling"
+    );
+
+    let mut session =
+        ExtractionSession::new_with_matcher_set(&egraph, None, test_runtime::matchers());
+    let index = session.producer_index();
+    for terminal in &terminals {
+        assert!(
+            !index.contains_key(terminal),
+            "{terminal} is an input terminal: the producer index must carry NO genome \
+             row for it (a row is dead weight the extractor must never honour)"
+        );
+    }
+    let space = session.sampling_space(&index);
+
+    for seed in 0..64u64 {
+        let (genome, _fallbacks) = sample_genome_with_seed(&index, &space, seed);
+        let graph = match session.extract_with_genome(&genome) {
+            Ok(Some(graph)) => graph,
+            Ok(None) => panic!("seed {seed}: extraction reached no boundary"),
+            Err(err) => {
+                let (cycle, dead_end, summary) = session.failure_breakdown();
+                panic!(
+                    "seed {seed}: extraction refused (choice-cycle {cycle}, dead-end \
+                     {dead_end}; {summary}): {err:#}"
+                );
+            }
+        };
+        let read_as_inputs: BTreeSet<ClassId> = graph
+            .dag
+            .node_weights()
+            .filter_map(|node| match node {
+                ExtractedNode::BufferInput(input) => Some(input.value.eclass.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            read_as_inputs, terminals,
+            "seed {seed}: every bound input must reach the plan as a BufferInput, never \
+             as the result of a producer"
+        );
+        // AND THE PLAN IS ACYCLIC: the cycle this bug produced was only
+        // ever caught here, by bufferize's toposort.
+        let dps = luminal::dps::dps_rewrite(&graph);
+        luminal::test_support::bufferize_mock(&dps)
+            .unwrap_or_else(|err| panic!("seed {seed}: bufferize refused the plan: {err:#}"));
     }
 }

--- a/tests/test_runtime/tests/scc_sampler.rs
+++ b/tests/test_runtime/tests/scc_sampler.rs
@@ -1,0 +1,584 @@
+//! THE SAMPLER-INVARIANT BOARDS on real e-graphs (ruling 2026-09-02).
+//!
+//! Genome sampling used to keep re-description candidates subordinate
+//! by grouping index classes that instantiate the SAME LOGICAL VALUE
+//! (the 2026-08-07 two-phase form, built for Copy⟷Copy layout welds).
+//! It now groups them by STRONGLY CONNECTED COMPONENT of the candidate
+//! graph, which is the mechanism itself: a choice cycle can only close
+//! inside a component, whoever's logical value the members carry.
+//!
+//! Three boards here:
+//!
+//!  * `coverage_*` — the cross-check, in two halves. A FREE sampler
+//!    (uniform over every candidate — the pre-2026-08-07 space) is run
+//!    500 times and "the forest rule admits this genome" must agree
+//!    EXACTLY with "its chosen-edge graph is acyclic"; then every
+//!    component's candidate combinations are ENUMERATED and the set the
+//!    forest sampler reaches is compared with the acyclic set. Equality
+//!    is the two-sided claim: nothing cyclic survives, and nothing
+//!    acyclic is eliminated.
+//!
+//!  * `marker_*` — the cuBLASLt double-transpose collapse on a 2D
+//!    matmul, CPU-side. Its components hold members of DIFFERENT
+//!    logical values, which is exactly what the same-logical-value
+//!    grouping could not see.
+//!
+//!  * `union_*` — Austin's worked example. Inputs x, y, z; a = x + y;
+//!    b = a - x; c = z + b; outputs (a, c) — then the recorded script
+//!    is told what is true of it, `(union v7 v1)`: b IS y. The FINDING
+//!    is recorded there: because b = y is a BOUND INPUT, and an
+//!    input-terminal class is planned unconditionally, the weld is not
+//!    a cycle at all and the sampler is free.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use luminal::extractor::{edges_have_cycle, ExtractionSession, Genome, SamplingSpace};
+use luminal::graph::Graph;
+use luminal::implementation_search::{
+    mutate_genome_with_seed, sample_genome_with_seed, ProducerIndex,
+};
+use luminal::layout_ir::ExtractedNode;
+use luminal::prelude::egraph_serialize::{ClassId, EGraph};
+
+// ---------------------------------------------------------------------------
+// Shared machinery.
+// ---------------------------------------------------------------------------
+
+/// SplitMix64 — a self-contained deterministic stream, so these boards
+/// need no `rand` of their own and the free sampler is reproducible.
+struct Stream(u64);
+
+impl Stream {
+    fn next(&mut self, bound: usize) -> usize {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        ((z ^ (z >> 31)) % bound as u64) as usize
+    }
+}
+
+/// THE FREE SAMPLER: uniform over every candidate of every class, with
+/// no invariant at all — the space the forest rule carves out of.
+fn free_genome(index: &ProducerIndex, stream: &mut Stream) -> Genome {
+    let mut genome = Genome::default();
+    for (class, candidates) in index {
+        let position = stream.next(candidates.len());
+        genome
+            .choices
+            .insert(class.clone(), candidates[position].1.clone());
+    }
+    genome
+}
+
+/// Is there an order of each component's members that makes every one
+/// of this genome's chosen candidates admissible under the forest rule
+/// (all its intra-component sources already assigned)? Greedy answers
+/// it exactly: admissibility only ever grows as members are assigned,
+/// so a member that is ever admissible stays admissible.
+fn forest_admits(index: &ProducerIndex, space: &SamplingSpace, genome: &Genome) -> bool {
+    for members in &space.components {
+        let mut assigned: BTreeSet<ClassId> = BTreeSet::new();
+        let mut remaining: Vec<ClassId> = members.clone();
+        while let Some(at) = remaining.iter().position(|class| {
+            let position = space
+                .chosen_position(index, genome, class)
+                .expect("the genome names an index entry for every component member");
+            space.intra_sources[class][position]
+                .iter()
+                .all(|source| assigned.contains(source))
+        }) {
+            assigned.insert(remaining.remove(at));
+        }
+        if !remaining.is_empty() {
+            return false;
+        }
+    }
+    true
+}
+
+fn cyclic(index: &ProducerIndex, space: &SamplingSpace, genome: &Genome) -> bool {
+    edges_have_cycle(&space.chosen_edges(index, genome))
+}
+
+/// Every combination of candidate positions for one component's
+/// members, as a `Vec<usize>` parallel to `members` — small by
+/// construction (re-description groups are pairs and triples), capped
+/// so a pathological component cannot blow the board up.
+fn component_combinations(index: &ProducerIndex, members: &[ClassId]) -> Option<Vec<Vec<usize>>> {
+    let widths: Vec<usize> = members.iter().map(|class| index[class].len()).collect();
+    let total: usize = widths
+        .iter()
+        .try_fold(1usize, |acc, w| acc.checked_mul(*w))?;
+    if total > 4096 {
+        return None;
+    }
+    let mut combos = vec![Vec::new()];
+    for width in &widths {
+        combos = combos
+            .into_iter()
+            .flat_map(|prefix| {
+                (0..*width).map(move |position| {
+                    let mut next = prefix.clone();
+                    next.push(position);
+                    next
+                })
+            })
+            .collect();
+    }
+    Some(combos)
+}
+
+/// Is one component-local combination acyclic over the chosen INTRA
+/// edges? (A cycle in a genome's chosen-edge graph always lies inside
+/// one component: inter-component edges follow the condensation, which
+/// is a DAG.)
+fn combination_is_acyclic(
+    space: &SamplingSpace,
+    members: &[ClassId],
+    combination: &[usize],
+) -> bool {
+    let edges: BTreeMap<ClassId, Vec<ClassId>> = members
+        .iter()
+        .zip(combination)
+        .map(|(class, position)| (class.clone(), space.intra_sources[class][*position].clone()))
+        .collect();
+    !edges_have_cycle(&edges)
+}
+
+/// The component-local combination a genome elected.
+fn combination_of(
+    index: &ProducerIndex,
+    space: &SamplingSpace,
+    genome: &Genome,
+    members: &[ClassId],
+) -> Vec<usize> {
+    members
+        .iter()
+        .map(|class| {
+            space
+                .chosen_position(index, genome, class)
+                .expect("the genome names an index entry for every component member")
+        })
+        .collect()
+}
+
+/// The two-sided coverage claim on one e-graph — see the module note.
+/// Returns `(components, exactness-checked components)`.
+///
+/// MEASURED 2026-09-02 on the fixtures below: every component admits
+/// acyclic combinations and NO sample takes the fallback (0/2000 on
+/// each board). Where a component admits no acyclic combination at
+/// all, the documented full-list fallback is what runs and the
+/// assertion is only that it still produces a total genome — the same
+/// corner, and the same behaviour, as the 2026-08-07 sampler's
+/// copy-only groups.
+fn cross_check(name: &str, egraph: &EGraph) -> (usize, usize) {
+    let session = ExtractionSession::new_with_matcher_set(egraph, None, test_runtime::matchers());
+    let index = session.producer_index();
+    let space = session.sampling_space(&index);
+    assert!(!index.is_empty(), "{name}: nothing to sample");
+
+    let mut stream = Stream(0xC0FF_EE00);
+    let (mut free_acyclic, mut free_cyclic) = (0usize, 0usize);
+    for sample in 0..500 {
+        let genome = free_genome(&index, &mut stream);
+        let closes = cyclic(&index, &space, &genome);
+        assert_eq!(
+            forest_admits(&index, &space, &genome),
+            !closes,
+            "{name} free sample {sample}: the forest rule must admit EXACTLY the acyclic \
+             genomes, and this one is {}",
+            if closes { "cyclic" } else { "acyclic" }
+        );
+        if closes {
+            free_cyclic += 1;
+        } else {
+            free_acyclic += 1;
+        }
+    }
+
+    let mut fell_back = 0usize;
+    let mut mutated = 0usize;
+    let mut sampled: Vec<BTreeSet<Vec<usize>>> = vec![BTreeSet::new(); space.components.len()];
+    // THE E[copies] MEASUREMENT (not re-tuned here, ruling 2026-09-02 —
+    // just measured): across every component member of every sample,
+    // how often does the sampler elect a RE-DESCRIBING candidate (one
+    // with intra-component sources) rather than a progressing one? The
+    // 2026-08-07 star fixed this at one primary per group; the forest
+    // lets it float, so it is reported, never asserted.
+    let (mut member_choices, mut intra_choices) = (0usize, 0usize);
+    for seed in 0..2000u64 {
+        let (genome, fallbacks) = sample_genome_with_seed(&index, &space, seed);
+        assert_eq!(
+            genome.choices.len(),
+            index.len(),
+            "{name} seed {seed}: the genome must stay total"
+        );
+        if fallbacks.is_empty() {
+            assert!(
+                !cyclic(&index, &space, &genome),
+                "{name} seed {seed}: a fallback-free sample closed a cycle"
+            );
+        } else {
+            fell_back += 1;
+        }
+        for (component, members) in space.components.iter().enumerate() {
+            let combination = combination_of(&index, &space, &genome, members);
+            for (class, position) in members.iter().zip(&combination) {
+                member_choices += 1;
+                intra_choices += usize::from(!space.intra_sources[class][*position].is_empty());
+            }
+            sampled[component].insert(combination);
+        }
+        // MUTATION under the same invariant: two point mutations off
+        // this genome, and the child may not close a cycle either
+        // (unless the flip itself had to fall back).
+        let (child, mutation_fallbacks) =
+            mutate_genome_with_seed(&genome, &index, &space, 2, seed ^ 0x5EED);
+        if fallbacks.is_empty() && mutation_fallbacks.is_empty() {
+            assert!(
+                !cyclic(&index, &space, &child),
+                "{name} seed {seed}: a fallback-free mutation closed a cycle"
+            );
+        }
+        mutated += usize::from(child.choices != genome.choices);
+    }
+    assert!(
+        mutated > 0,
+        "{name}: mutation must actually move the genome somewhere"
+    );
+
+    let mut enumerated = 0usize;
+    let mut checked_exactly = 0usize;
+    for (component, members) in space.components.iter().enumerate() {
+        let Some(combos) = component_combinations(&index, members) else {
+            println!("SCC-COVERAGE {name}: component {component} too wide to enumerate");
+            continue;
+        };
+        enumerated += 1;
+        let acyclic: BTreeSet<Vec<usize>> = combos
+            .iter()
+            .filter(|combination| combination_is_acyclic(&space, members, combination))
+            .cloned()
+            .collect();
+        println!(
+            "SCC-COVERAGE {name}: component {component} {members:?} — {} combinations, \
+             {} acyclic, {} sampled",
+            combos.len(),
+            acyclic.len(),
+            sampled[component].len()
+        );
+        if acyclic.is_empty() {
+            assert!(
+                !sampled[component].is_empty(),
+                "{name} component {component}: no acyclic combination exists, so the \
+                 documented fallback must still produce one"
+            );
+            continue;
+        }
+        // SOUNDNESS, always: nothing the sampler reaches may be cyclic.
+        assert!(
+            sampled[component].is_subset(&acyclic),
+            "{name} component {component}: the forest sampler reached a CYCLIC \
+             combination"
+        );
+        // COMPLETENESS, where 2000 seeds can plausibly cover the space:
+        // nothing acyclic may be unreachable. A component with more
+        // acyclic combinations than that gets the soundness half only —
+        // its coverage is the enumerated small components' business.
+        if acyclic.len() <= 128 {
+            checked_exactly += 1;
+            assert_eq!(
+                sampled[component], acyclic,
+                "{name} component {component}: the forest sampler must reach EXACTLY \
+                 the acyclic combinations — no acyclic shape may be unreachable"
+            );
+        }
+    }
+
+    println!(
+        "SCC-COVERAGE {name}: {} genome classes, {} components ({enumerated} enumerated, \
+         {checked_exactly} exactness-checked), free samples {free_acyclic} acyclic / \
+         {free_cyclic} cyclic, forest samples with a fallback {fell_back}/2000, \
+         mutations that moved {mutated}/2000, re-describing choices \
+         {intra_choices}/{member_choices}",
+        index.len(),
+        space.components.len()
+    );
+    (space.components.len(), checked_exactly)
+}
+
+// ---------------------------------------------------------------------------
+// B. Coverage cross-check on real fixture e-graphs.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn coverage_on_the_basic_program_fixture() {
+    let source = std::fs::read_to_string(test_runtime::fixture_path("basic_program.egg"))
+        .expect("fixture readable");
+    let egraph = test_runtime::serialize_fixture(&source);
+    let (components, checked_exactly) = cross_check("basic_program", &egraph);
+    assert_eq!(
+        components, 2,
+        "the fixture's layout copies weld into two components — the 2026-08-07 \
+         Copy⟷Copy shape, found now by the component criterion rather than by \
+         same-logical-value grouping"
+    );
+    assert_eq!(
+        checked_exactly, 2,
+        "both components must be small enough to enumerate AND offer acyclic \
+         combinations, or the exactness half of the cross-check is vacuous here"
+    );
+}
+
+#[test]
+fn coverage_on_the_re_description_program() {
+    let egraph = test_runtime::serialize_fixture(&re_description_program());
+    let (components, _) = cross_check("b_is_y_union", &egraph);
+    assert_eq!(
+        components, 0,
+        "b = y welds through a BOUND INPUT, which is a leaf — see \
+         `union_of_b_and_y_is_a_leaf_weld_not_a_cycle`"
+    );
+}
+
+/// THE CROSS-LOGICAL CASE, CPU-side: the cuBLASLt marker estate's
+/// double-transpose collapse on the 2D canonical matmul. Its components
+/// hold members instantiating DIFFERENT logical values — invisible to
+/// the 2026-08-07 same-logical-value grouping, which saw both arms of
+/// each weld as "progressing" and let genomes elect them together.
+#[test]
+fn marker_matmul_components_span_different_logical_values() {
+    let egraph = test_runtime::serialize_fixture(&marker_matmul_program());
+    let session = ExtractionSession::new_with_matcher_set(&egraph, None, test_runtime::matchers());
+    let index = session.producer_index();
+    let space = session.sampling_space(&index);
+    assert!(
+        !space.components.is_empty(),
+        "the collapse must weld re-description components"
+    );
+
+    let logical_of = |class: &ClassId| -> BTreeSet<String> {
+        egraph
+            .nodes
+            .values()
+            .filter(|node| &node.eclass == class && node.op == "LayoutTensorLit")
+            .map(|node| egraph.nodes[&node.children[0]].eclass.to_string())
+            .collect()
+    };
+    let mut cross_logical = 0usize;
+    for members in &space.components {
+        let logicals: Vec<BTreeSet<String>> = members.iter().map(&logical_of).collect();
+        println!("SCC-MARKER component {members:?} logical values {logicals:?}");
+        let spans = logicals
+            .iter()
+            .enumerate()
+            .any(|(i, a)| logicals[i + 1..].iter().any(|b| a.is_disjoint(b)));
+        cross_logical += usize::from(spans);
+        // Every member must have somewhere to go, or the sampler is
+        // forced into the fallback on a graph that has a way out.
+        for member in members {
+            assert!(
+                space.intra_sources[member]
+                    .iter()
+                    .any(|sources| sources.is_empty()),
+                "{member} has no progressing candidate in its own component"
+            );
+        }
+    }
+    assert!(
+        cross_logical > 0,
+        "at least one component must span two DIFFERENT logical values — that is \
+         the case the same-logical-value grouping could not group"
+    );
+    cross_check("marker_matmul_2d", &egraph);
+}
+
+/// The 2D canonical matmul the round-11 marker matches: A[4,8] . B[8,3].
+fn marker_matmul_program() -> String {
+    let mut cx = Graph::new();
+    let a = cx.tensor((4usize, 8usize));
+    let b = cx.tensor((8usize, 3usize));
+    let _out = a.matmul(b).output();
+    cx.logical
+        .bound_program(&test_runtime::TestRuntimeBindings)
+        .expect("recorder clean")
+        .text
+}
+
+// ---------------------------------------------------------------------------
+// C. Austin's example: b = y, told to the e-graph as a union.
+// ---------------------------------------------------------------------------
+
+/// x, y, z inputs; a = x + y; b = a - x; c = z + b; outputs (a, c) —
+/// recorded through the TestRuntime bindings, then handed the fact the
+/// recorder cannot know: `b` and `y` are the same value.
+///
+/// The recorder's SSA names are read off the emitted text the way
+/// `cublaslt_bias_leftmajor_premise.rs` reads `natout{key}`: the
+/// recorder names every value `v{node index}`, so `y` is `v1` and `b`
+/// is `v7` = `(LogicalAdd v3 v6)`, a + (-1) * x. The union goes in
+/// BEFORE the schedule so saturation sees it.
+fn re_description_program() -> String {
+    let mut cx = Graph::new();
+    let x = cx.tensor(4usize);
+    let y = cx.tensor(4usize);
+    let z = cx.tensor(4usize);
+    let a = x + y;
+    let b = a - x;
+    let c = z + b;
+    let _ = a.output();
+    let _ = c.output();
+    let text = cx
+        .logical
+        .bound_program(&test_runtime::TestRuntimeBindings)
+        .expect("recorder clean")
+        .text;
+    let b_name = format!("v{}", b.id.index());
+    let y_name = format!("v{}", y.id.index());
+    assert!(
+        text.contains(&format!("(let {b_name} (LogicalAdd ")),
+        "b is the recorder's {b_name}: {text}"
+    );
+    assert!(
+        text.contains(&format!("(let {y_name} (LogicalTensorInputLit ")),
+        "y is the recorder's {y_name}: {text}"
+    );
+    let at = text
+        .find("(run-schedule")
+        .expect("the recorder emits a schedule");
+    format!(
+        "{}\n; b IS y — the fact the recorder cannot know.\n(union {b_name} {y_name})\n\n{}",
+        &text[..at],
+        &text[at..]
+    )
+}
+
+/// THE FINDING, recorded rather than wished away: after the union the
+/// candidate graph has NO cycle at all, so there is no component and
+/// the sampler is unconstrained here.
+///
+/// The weld is real — class(a) reads class(b = y) and class(b = y)'s
+/// `a + (-1) * x` producer reads class(a) — but `b = y`'s class is a
+/// BOUND INPUT, and `relax_to_fixpoint` seeds every input-terminal
+/// class's plan from the boundary on the first pass, at cost 0 and with
+/// no children. Such a class can never block, so no edge out of it can
+/// join a blocking cycle, and the candidate graph draws none. The
+/// cross-logical re-description that DOES make a component is on the
+/// `marker_*` board, where neither member is a boundary value.
+#[test]
+fn union_of_b_and_y_is_a_leaf_weld_not_a_cycle() {
+    let egraph = test_runtime::serialize_fixture(&re_description_program());
+    let session = ExtractionSession::new_with_matcher_set(&egraph, None, test_runtime::matchers());
+    let index = session.producer_index();
+    let space = session.sampling_space(&index);
+
+    assert!(
+        space.components.is_empty(),
+        "the weld runs through a bound input, which is a leaf: {:?}",
+        space.components
+    );
+    for per_candidate in space.intra_sources.values() {
+        for sources in per_candidate {
+            assert!(
+                sources.is_empty(),
+                "no component, no intra-component sources"
+            );
+        }
+    }
+    // The union itself must still be there, or this board proves
+    // nothing: some LOGICAL class holds both the boundary input `y` and
+    // the computed `b`, which is what `(union v7 v1)` asserts.
+    let mut welded: BTreeMap<String, BTreeSet<&str>> = BTreeMap::new();
+    for node in egraph.nodes.values() {
+        welded
+            .entry(node.eclass.to_string())
+            .or_default()
+            .insert(node.op.as_str());
+    }
+    assert!(
+        welded
+            .values()
+            .any(|ops| ops.contains("LogicalTensorInputLit") && ops.contains("LogicalAdd")),
+        "b = y must put the input and the `a + (-1) * x` add in ONE logical class — \
+         otherwise the union never reached the e-graph"
+    );
+}
+
+/// THE ACCEPTANCE: sampling this program 200 ways never produces a
+/// choice cycle, and `a` is always computed from x and y.
+///
+/// ROUTES, honestly: only ONE of the two routes for `c` is electable,
+/// and the reason is not the sampler. `b = y`'s class is a bound INPUT,
+/// and `relax_to_fixpoint` seeds every input-terminal class's plan
+/// from the input at `heuristic_cost` 0 REGARDLESS of the genome, so
+/// `is_better` can never prefer the recomputed `a - x`. Every plan here
+/// is therefore two adds — `a` from x and y, and `c` from z and the
+/// same class — with `b`'s -1 constant/mul chain never planned.
+#[test]
+fn union_extraction_never_cycles() {
+    let egraph = test_runtime::serialize_fixture(&re_description_program());
+    let mut session =
+        ExtractionSession::new_with_matcher_set(&egraph, None, test_runtime::matchers());
+    let index = session.producer_index();
+    let space = session.sampling_space(&index);
+
+    let mut shapes: BTreeMap<Vec<String>, usize> = BTreeMap::new();
+    for seed in 0..200u64 {
+        let (genome, _fallbacks) = sample_genome_with_seed(&index, &space, seed);
+        match session.extract_with_genome(&genome) {
+            Ok(Some(graph)) => {
+                let mut labels: Vec<String> = graph
+                    .dag
+                    .node_weights()
+                    .filter_map(|node| match node {
+                        ExtractedNode::LayoutOp(op) => Some(op.op.label().to_string()),
+                        _ => None,
+                    })
+                    .collect();
+                labels.sort();
+                // `a` IS computed from x and y: all three bound inputs
+                // are read, so neither add reads a recomputed `b`
+                // (which would need the -1 constant/mul chain, and
+                // more ops than the label check below allows).
+                let inputs = graph
+                    .dag
+                    .node_weights()
+                    .filter(|node| matches!(node, ExtractedNode::BufferInput(_)))
+                    .count();
+                assert_eq!(
+                    inputs, 3,
+                    "seed {seed}: every plan reads x, y and z — got {inputs} inputs \
+                     alongside {labels:?}"
+                );
+                *shapes.entry(labels).or_default() += 1;
+            }
+            Ok(None) => panic!("seed {seed}: extraction reached no boundary"),
+            Err(err) => {
+                let (cycle, dead_end, summary) = session.failure_breakdown();
+                panic!(
+                    "seed {seed}: extraction refused (choice-cycle {cycle}, dead-end \
+                     {dead_end}; {summary}): {err:#}"
+                );
+            }
+        }
+    }
+    for (labels, count) in &shapes {
+        println!("SCC-UNION plan x{count}: {labels:?}");
+    }
+    assert!(shapes.len() > 1, "the sampler explores more than one plan");
+    for labels in shapes.keys() {
+        assert_eq!(
+            labels.len(),
+            2,
+            "a = x + y and c = z + (b = y): two adds, no recompute of b — got {labels:?}"
+        );
+        for label in labels {
+            assert!(
+                label.starts_with("Add"),
+                "both ops are adds (b's -1 constant/mul chain is never planned): {labels:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## What

Two commits. Together they make the search return a plan for every genome it draws at the harness budget, with the cuBLASLt marker vocabulary on.

**1. Sampling groups by candidate-graph COMPONENT, not shared logical value.** The two-phase sampler assumed "the logical graph is a DAG, so progressing candidates can never close a choice cycle". The marker's double-transpose collapse `x ≡ xᵀᵀ` breaks that: two different logical values re-describe each other, both count as progressing, and 83% of freely sampled genomes on the 2D marker graph were cyclic. Generalization: build the candidate graph over genome classes, take strongly connected components (Tarjan, deterministic), and sample within a component so chosen intra-component edges always point backward (forest rule; every acyclic genome reachable, only cyclic ones excluded — proven by free-sampler agreement and full enumeration). Mutation admits a flip only if a DFS over the component's chosen edges finds no cycle. Same-logical-value sibling groups fall out as components, so the Copy⟷Copy case is subsumed with no op-name list anywhere. Tripwire: a choice-cycle refusal whose chosen-edge graph is acyclic is a hard error.

**2. An input terminal is a leaf.** Root cause of the remaining failures: the collapse puts `apply(apply(x,t),t)` into a boundary input's class; a zero-byte View producer then ties the cost-0 input seed and wins the label tie-break, the BufferInput vanishes, and the extracted graph is cyclic (caught only by bufferize's toposort). Fix: `candidates_for_class` returns nothing for an input terminal and input terminals carry no genome rows, leaving ONE leaf notion; component edges contract through row-less classes (proven a no-op on today's e-graphs, kept as a structural guard); a cyclic extracted graph at bufferize is a named invariant failure listing the cycle members and the genome's chosen edges.

## Measured (marker on, 2×4 harness budget, static-profiler elections; 8 genomes each)

| mini | profiled | duplicate | refused | before |
|---|---|---|---|---|
| conv | 4 | 4 | 0 | 0 refused |
| llama3 | 4 | 4 | 0 | 3 refused |
| qwen3 | 5 | 3 | 0 | search died (8/8) |
| whisper | 5 | 3 | 0 | 3 refused |
| qwen3_moe | 5 | 3 | 0 | 3 refused |
| gemma4_moe | 6 | 2 | 0 | 7 refused |
| gemma3 | 6 | 2 | 0 | search died (8/8) |

Every refusal counter zero on every row (extract, bufferize, execute). 2D marker matmul elects cuBLASLt at 2×4 with zero refusals; the 12×16 pin still elects. Marker off unchanged (conv 6+2, llama3 8+0, qwen3 6+2; zero refusals).

## Review
Two Fable reviews (round 1 and round 2): LANDABLE, no must-fix. Round-1 review found the input-terminal flaw and measured it (50/50 weld genomes cyclic; 9/32 lost in a 1×32 search); round 2 closes it.

## Gates (rebased onto #443 / 1424a869, clean)
luminal --lib 243 passed / 0 failed; test_runtime 212 / 0; luminal_reference all green; luminal_cuda_lite 65 / 0; clippy clean (luminal and cuda_lite); fmt clean. Six tests added, none weakened; no pre-existing expectation changed.

## Decisions for review (non-blocking)
1. `contract_candidate_inputs` / `demanded_input_classes` are provably a no-op in production (genome-index keys == producer-index keys after the viability filter). Keep as a structural guard with an honest doc line, add a debug assertion, or delete under the minimal-repo rule?
2. `crates/luminal_cuda_lite/src/ops/cublaslt/election.rs:118-128` still carries a hand-written "no genome row for input terminals" skip, now redundant. Delete in a follow-up?

## Follows
An estate-level cleanup stratum (subsume/mark producer spellings in an input's class, before the fixpoint invariants) is in preparation and stacks on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)