### PR TITLE
Main rejoin 1/3: #384 translate_sdpa, one name-resolved SDPA body

### DIFF
--- a/crates/luminal_python/rust/src/translator/attention.rs
+++ b/crates/luminal_python/rust/src/translator/attention.rs
@@ -6,51 +6,51 @@ use crate::pt2_util::*;
 
 use super::Translator;
 
-/// Which SDPA variant we're translating. Governs argument positions and
-/// which output slots are consumed downstream.
-#[derive(Clone, Copy, Debug)]
-pub enum SdpaVariant {
-    /// `aten._scaled_dot_product_efficient_attention.default(q, k, v, attn_bias,
-    ///     compute_log_sumexp, dropout_p=0., is_causal=False, *, scale=None)
-    ///     -> (output, log_sumexp, philox_seed, philox_offset)`
-    Efficient,
-    /// `aten._scaled_dot_product_flash_attention.default(q, k, v, dropout_p=0.,
-    ///     is_causal=False, return_debug_mask=False, *, scale=None)
-    ///     -> (output, logsumexp, cum_seq_q, cum_seq_k, max_q, max_k,
-    ///         rng_state, unused, debug_attn_mask)`
-    Flash,
-    /// `aten._scaled_dot_product_flash_attention_for_cpu.default(q, k, v,
-    ///     dropout_p=0., is_causal=False, *, attn_mask=None, scale=None)
-    ///     -> (output, logsumexp)`
-    FlashForCpu,
-    /// `aten._scaled_dot_product_cudnn_attention.default(q, k, v, attn_bias,
-    ///     compute_log_sumexp, dropout_p=0., is_causal=False,
-    ///     return_debug_mask=False, *, scale=None)
-    ///     -> (output, logsumexp, cum_seq_q, cum_seq_k, max_q, max_k,
-    ///         philox_seed, philox_offset, debug_attn_mask)`
-    Cudnn,
-    /// `aten.scaled_dot_product_attention.default(q, k, v, attn_mask=None,
-    ///     dropout_p=0., is_causal=False, *, scale=None, enable_gqa=False)
-    ///     -> Tensor` (single output, no tuple).
-    Unified,
+/// Broadcast-add an additive offset (causal mask, attention bias) onto the
+/// scores. Handles dtype promotion and rank extension: a `(S_q, S_k)` offset
+/// broadcasts across any batch/head prefix dims of `scores`.
+fn add_offset(scores: GraphTensor, offset: GraphTensor) -> GraphTensor {
+    let (s, o) = ensure_same_dtype(scores, offset);
+    let (s, o) = broadcast_binary(s, o);
+    s + o
 }
 
 impl<'a> Translator<'a> {
-    /// Translate any SDPA op variant into `softmax((Q@K^T)*scale + causal_mask +
-    /// attn_bias) @ V`. Stores the primary `output` by the node's first output
-    /// name. Other tuple outputs (logsumexp, philox_seed, etc.) are unused in
-    /// inference — left unbound; the downstream `getitem(node, 0)` resolves
-    /// to `output` via the tuple-output name list.
-    pub(crate) fn translate_sdpa(&mut self, node: &Node, variant: SdpaVariant) -> Result<()> {
+    /// Translate all `scaled_dot_product_attention` ATen variants (unified,
+    /// efficient, flash, flash_for_cpu, cudnn) into
+    /// `softmax((Q@K^T)*scale + causal_mask + attn_bias) @ V`. Args resolve
+    /// by name so one body serves every variant; only tuple slot 0 (the
+    /// attention output) is bound — logsumexp and later slots are
+    /// inference-time dead ends, left unbound by design.
+    ///
+    /// Torch-kernel parity notes: bf16/f16 run the score chain in F32, probs
+    /// return to the value dtype for PV — mirroring torch's kernels, which
+    /// compute in `opmath_type<scalar_t>` (= f32 for bf16/f16; see pytorch
+    /// `aten/src/ATen/native/cpu/FlashAttentionKernel.cpp`, `accum_t`, and
+    /// the FlashAttention-2 paper, arXiv:2307.08691 §3); `is_causal` is a
+    /// top-left iota mask
+    /// (symbolic-seq safe); bool masks are keep-masks and fully-masked query
+    /// rows output zeros; grouped K/V heads are repeat-interleaved (GQA);
+    /// Q/K head_dim and K/V seq SymInts are unified per the op contract.
+    pub(crate) fn translate_sdpa(&mut self, node: &Node) -> Result<()> {
         let query = self.get_input_tensor(node, 0)?;
-        let key = self.get_input_tensor(node, 1)?;
-        let value = self.get_input_tensor(node, 2)?;
+        let mut key = self.get_input_tensor(node, 1)?;
+        let mut value = self.get_input_tensor(node, 2)?;
 
-        // Resolve args by NAME rather than positional index. PT2 serializes
-        // kwargs inline in `node.inputs` with `kind=2`, so any arg that wasn't
-        // passed positionally by the caller shifts the indices of subsequent
-        // positional args. Name-based lookup is unambiguous across variants
-        // and across caller argument-passing styles.
+        let q_ndim = query.legacy_tracker_ref().len();
+        anyhow::ensure!(
+            q_ndim >= 2,
+            "SDPA: query must have at least 2 dims (got {q_ndim})"
+        );
+
+        // Q/K share head_dim and K/V share seq by op contract, but dynamo
+        // gives each placeholder its own SymInt — unify so matmul
+        // dim-equality checks hold.
+        if key.legacy_tracker_ref().len() == q_ndim && value.legacy_tracker_ref().len() == q_ndim {
+            key.legacy_tracker_mut().dims[q_ndim - 1] = query.legacy_tracker_ref().dims[q_ndim - 1];
+            value.legacy_tracker_mut().dims[q_ndim - 2] = key.legacy_tracker_ref().dims[q_ndim - 2];
+        }
+
         let arg_by_name =
             |name: &str| -> Option<&NodeInput> { node.inputs.iter().find(|i| i.name == name) };
         let tensor_arg = |name: &str| -> Option<GraphTensor> {
@@ -65,143 +65,148 @@ impl<'a> Translator<'a> {
 
         // attn_bias (Efficient/Cudnn/Unified) or attn_mask (FlashForCpu/Unified).
         let additive = tensor_arg("attn_bias").or_else(|| tensor_arg("attn_mask"));
+        let is_causal = bool_arg("is_causal").unwrap_or(false);
 
         let dropout_p = float_arg("dropout_p").unwrap_or(0.0) as f32;
         anyhow::ensure!(
             dropout_p == 0.0,
             "SDPA: dropout_p={dropout_p} unsupported (inference only)"
         );
-        let is_causal = bool_arg("is_causal").unwrap_or(false);
-        // Silence compiler warnings — variant arg remains for branch-specific
-        // logic (output tuple-name resolution below) and for future divergence.
-        let _ = variant;
 
-        // `scale` kwarg, default 1/sqrt(head_dim).
-        let head_dim = query
-            .legacy_tracker_ref()
-            .dims
-            .last()
-            .and_then(|d| d.to_usize())
-            .context("SDPA: query head_dim must be concrete")?;
-        let default_scale = 1.0_f32 / (head_dim as f32).sqrt();
-        let scale = float_arg("scale")
-            .map(|v| v as f32)
-            .unwrap_or(default_scale);
+        // Default scale 1/sqrt(head_dim) needs a concrete head_dim;
+        // symbolic-shape HF graphs always pass `scale` explicitly.
+        let scale = match float_arg("scale") {
+            Some(v) => v as f32,
+            None => {
+                let head_dim = query
+                    .legacy_tracker_ref()
+                    .dims
+                    .last()
+                    .and_then(|d| d.to_usize())
+                    .context(
+                        "SDPA: query head_dim must be concrete to derive the default \
+                         scale (pass `scale` explicitly for symbolic head dims)",
+                    )?;
+                1.0_f32 / (head_dim as f32).sqrt()
+            }
+        };
 
-        // Math form: scores = (Q @ K^T) * scale; + causal_mask; + attn_bias;
-        // attn = softmax(scores, dim=-1); out = attn @ V.
-        let q_ndim = query.legacy_tracker_ref().len();
-        anyhow::ensure!(
-            q_ndim >= 2,
-            "SDPA: query must have at least 2 dims (got {q_ndim})"
-        );
-        // Transpose last two dims of key.
+        // GQA: repeat-interleave K/V heads up to Q's count, gated on
+        // `enable_gqa` — only the unified op carries the flag, and the
+        // pipeline emits only the unified op (sdpa decomps are stripped).
+        // Flagless graphs with mismatched heads fail the ensure below.
+        let enable_gqa = bool_arg("enable_gqa").unwrap_or(false);
+        if enable_gqa
+            && q_ndim >= 3
+            && query.legacy_tracker_ref().dims[q_ndim - 3]
+                != key.legacy_tracker_ref().dims[q_ndim - 3]
+        {
+            let h_axis = q_ndim - 3;
+            let h_q = query.legacy_tracker_ref().dims[h_axis]
+                .to_usize()
+                .context("SDPA GQA: query head count must be concrete")?;
+            let h_kv = key.legacy_tracker_ref().dims[h_axis]
+                .to_usize()
+                .context("SDPA GQA: kv head count must be concrete")?;
+            anyhow::ensure!(
+                h_kv > 0 && h_q % h_kv == 0,
+                "SDPA GQA: query heads ({h_q}) must be a positive multiple of kv heads ({h_kv})"
+            );
+            let group = IntExpr::from(h_q / h_kv);
+            key = key
+                .expand_dim(h_axis + 1, group)
+                .merge_dims(h_axis, h_axis + 1);
+            value = value
+                .expand_dim(h_axis + 1, group)
+                .merge_dims(h_axis, h_axis + 1);
+        } else if q_ndim >= 3 {
+            anyhow::ensure!(
+                query.legacy_tracker_ref().dims[q_ndim - 3]
+                    == key.legacy_tracker_ref().dims[q_ndim - 3],
+                "SDPA: query/key head counts differ ({:?} vs {:?}) without enable_gqa",
+                query.legacy_tracker_ref().dims[q_ndim - 3],
+                key.legacy_tracker_ref().dims[q_ndim - 3]
+            );
+        }
+
+        // scores = (Q @ K^T) * scale.
         let mut perm: Vec<usize> = (0..q_ndim).collect();
         perm.swap(q_ndim - 2, q_ndim - 1);
-        let key_t = key.permute(perm);
-        let (q_for_mm, k_for_mm) = ensure_same_dtype(query, key_t);
-        let scores = q_for_mm.matmul(k_for_mm);
-        let scale_t = self
-            .graph
-            .constant_float(scale)
-            .cast(scores.dtype)
-            .expand_rhs(scores.dims());
-        let mut scores = scores * scale_t;
+        let (q_for_mm, k_for_mm) = ensure_same_dtype(query, key.permute(perm));
+        // torch parity: fused kernels accumulate QK^T in fp32 and never
+        // materialize low-precision scores (CPU: opmath_type = f32, see
+        // pytorch's FlashAttentionKernel.cpp; CUDA likewise via tensor-core
+        // fp32 accumulators — FA2 paper, arXiv:2307.08691 §3). Cast Q/K
+        // before the matmul; scale, masks, and softmax inherit F32 from here.
+        let low_precision = matches!(q_for_mm.dtype, DType::Bf16 | DType::F16);
+        let (q_for_mm, k_for_mm) = if low_precision {
+            (q_for_mm.cast(DType::F32), k_for_mm.cast(DType::F32))
+        } else {
+            (q_for_mm, k_for_mm)
+        };
+        let mut scores = self.apply_scalar_op(q_for_mm.matmul(k_for_mm), scale, BinaryOp::Mul);
 
         if is_causal {
-            let s_q = scores
-                .legacy_tracker_ref()
-                .dims
-                .get(q_ndim - 2)
-                .and_then(|d| d.to_usize())
-                .context("SDPA is_causal: S_q must be concrete")?;
-            let s_k = scores
-                .legacy_tracker_ref()
-                .dims
-                .get(q_ndim - 1)
-                .and_then(|d| d.to_usize())
-                .context("SDPA is_causal: S_k must be concrete")?;
-            let size = s_q.max(s_k);
-            // triu with diagonal=1 = 1 strictly above diagonal, 0 elsewhere.
-            let mut mask = self.graph.triu(size, 1).cast(DType::F32);
-            if s_q != size || s_k != size {
-                mask = mask.slice_along(0..s_q, 0).slice_along(0..s_k, 1);
-            }
-            // -1e9 * mask ≈ -inf where masked, 0 otherwise. Broadcast across
-            // batch/head prefix dims of `scores`.
-            let neg_large = mask * (-1e9_f32);
-            let mut neg_large = neg_large.cast(scores.dtype);
-            for _ in 0..(q_ndim - 2) {
-                neg_large = neg_large.expand_dim(0, IntExpr::from(1usize));
-            }
-            let (scores_b, mask_b) = broadcast_binary(scores, neg_large);
-            scores = scores_b + mask_b;
+            let s_q = scores.legacy_tracker_ref().dims[q_ndim - 2];
+            let s_k = scores.legacy_tracker_ref().dims[q_ndim - 1];
+            let row = self.graph.arange(s_q).cast(DType::F32).expand_dim(1, s_k);
+            let col = self.graph.arange(s_k).cast(DType::F32).expand_dim(0, s_q);
+            // 1.0 strictly above the diagonal (j > i = masked); -1e9 ≈ -inf.
+            let masked = col.gt(row).cast(DType::F32);
+            scores = add_offset(scores, masked * (-1e9_f32));
         }
+
+        // Bool masks: track per-row any-keep to zero fully-masked rows
+        // after softmax (see doc comment).
+        let mut row_any_keep: Option<GraphTensor> = None;
         if let Some(mask) = additive {
-            // torch.nn.functional.scaled_dot_product_attention's attn_mask
-            // contract: "A boolean mask where a value of True indicates that
-            // the element should take part in attention. A float mask ...
-            // that is added to the attention score." Convert the bool
-            // keep-mask to an additive offset (-1e9 where false) before adding.
-            let mask_offset = if mask.dtype == DType::Bool {
+            let offset = if mask.dtype == DType::Bool {
                 let keep = mask.cast(DType::F32);
+                let key_axis = keep.legacy_tracker_ref().len() - 1;
+                row_any_keep = Some(
+                    keep.max(key_axis)
+                        .expand_to_shape_on_axes(keep.dims(), key_axis),
+                );
                 let one = keep.graph().constant_float(1.0).expand_rhs(keep.dims());
                 (one - keep) * -1e9_f32
             } else {
                 mask
             };
-            let (scores_b, offset_b) = ensure_same_dtype(scores, mask_offset);
-            let (scores_b, offset_b) = broadcast_binary(scores_b, offset_b);
-            scores = scores_b + offset_b;
+            scores = add_offset(scores, offset);
         }
 
-        let attn = scores.softmax(q_ndim - 1);
-        let (attn, value) = ensure_same_dtype(attn, value);
-        let out = attn.matmul(value);
+        // Tuple outputs serialize as one `as_tensors` list or one entry per
+        // element — flatten to slot order; slot 0 is the attention output.
+        let output_names: Vec<String> = node
+            .outputs
+            .iter()
+            .flat_map(|o| {
+                if let Some(t) = o.as_tensor.as_ref() {
+                    vec![t.name.clone()]
+                } else if let Some(ts) = o.as_tensors.as_ref() {
+                    ts.iter().map(|t| t.name.clone()).collect()
+                } else {
+                    vec![]
+                }
+            })
+            .collect();
 
-        // Store the primary output by name. The other tuple outputs are
-        // inference-time dead ends — downstream getitem(node, 0) resolves to
-        // the same tensor name we bind here, because pt2 serializes the
-        // multi-output name list with output[0] as the primary slot.
-        let out_name = if let Some(ts) = node.outputs.first().and_then(|o| o.as_tensors.as_ref()) {
-            ts.first().map(|t| t.name.clone())
-        } else if variant == SdpaVariant::Unified {
-            node.outputs
-                .first()
-                .and_then(|o| o.as_tensor.as_ref().map(|t| t.name.clone()))
-        } else {
-            node.outputs
-                .first()
-                .and_then(|o| o.as_tensor.as_ref().map(|t| t.name.clone()))
-                .or_else(|| {
-                    node.outputs
-                        .first()
-                        .and_then(|o| o.as_tensors.as_ref())
-                        .and_then(|ts| ts.first().map(|t| t.name.clone()))
-                })
-        };
-
-        if let Some(name) = out_name
-            && !name.is_empty()
-        {
-            self.tensors.insert(name, out);
-        } else {
-            anyhow::bail!("SDPA: no output tensor name found on node {}", node.target);
+        let mut attn = scores.softmax(q_ndim - 1);
+        if let Some(indicator) = row_any_keep {
+            let (a, i) = ensure_same_dtype(attn, indicator);
+            let (a, i) = broadcast_binary(a, i);
+            attn = a * i;
         }
+        // torch parity, part two: probs round back to the input dtype for
+        // the P@V GEMM (keeps V out of an fp32 matmul). No-op on fp32.
+        let out = attn.cast(value.dtype).matmul(value);
 
-        Ok(())
-    }
-}
-
-impl PartialEq for SdpaVariant {
-    fn eq(&self, other: &Self) -> bool {
-        matches!(
-            (self, other),
-            (SdpaVariant::Efficient, SdpaVariant::Efficient)
-                | (SdpaVariant::Flash, SdpaVariant::Flash)
-                | (SdpaVariant::FlashForCpu, SdpaVariant::FlashForCpu)
-                | (SdpaVariant::Cudnn, SdpaVariant::Cudnn)
-                | (SdpaVariant::Unified, SdpaVariant::Unified)
-        )
+        match output_names.first().filter(|n| !n.is_empty()) {
+            Some(name) => {
+                self.tensors.insert(name.clone(), out);
+                Ok(())
+            }
+            None => anyhow::bail!("SDPA: no output tensor name found on node {}", node.target),
+        }
     }
 }

--- a/crates/luminal_python/rust/src/translator/dispatch.rs
+++ b/crates/luminal_python/rust/src/translator/dispatch.rs
@@ -5,7 +5,6 @@ use crate::pt2_schema::*;
 use crate::pt2_util::*;
 
 use super::Translator;
-use super::attention::SdpaVariant;
 use super::reduction::ArgExtremum;
 
 impl<'a> Translator<'a> {
@@ -462,26 +461,14 @@ impl<'a> Translator<'a> {
                 return Ok(());
             }
 
-            // Scaled dot-product attention — each variant binds args slightly
-            // differently but all lower to matmul+softmax via translate_sdpa.
-            "torch.ops.aten._scaled_dot_product_efficient_attention.default" => {
-                self.translate_sdpa(node, SdpaVariant::Efficient)?;
-                return Ok(());
-            }
-            "torch.ops.aten._scaled_dot_product_flash_attention.default" => {
-                self.translate_sdpa(node, SdpaVariant::Flash)?;
-                return Ok(());
-            }
-            "torch.ops.aten._scaled_dot_product_flash_attention_for_cpu.default" => {
-                self.translate_sdpa(node, SdpaVariant::FlashForCpu)?;
-                return Ok(());
-            }
-            "torch.ops.aten._scaled_dot_product_cudnn_attention.default" => {
-                self.translate_sdpa(node, SdpaVariant::Cudnn)?;
-                return Ok(());
-            }
-            "torch.ops.aten.scaled_dot_product_attention.default" => {
-                self.translate_sdpa(node, SdpaVariant::Unified)?;
+            // Scaled dot-product attention — args are resolved by name in
+            // translate_sdpa, so every ATen variant shares one lowering.
+            "torch.ops.aten.scaled_dot_product_attention.default"
+            | "torch.ops.aten._scaled_dot_product_efficient_attention.default"
+            | "torch.ops.aten._scaled_dot_product_flash_attention.default"
+            | "torch.ops.aten._scaled_dot_product_flash_attention_for_cpu.default"
+            | "torch.ops.aten._scaled_dot_product_cudnn_attention.default" => {
+                self.translate_sdpa(node)?;
                 return Ok(());
             }
 

--- a/crates/luminal_python/tests/test_hlir_ops.py
+++ b/crates/luminal_python/tests/test_hlir_ops.py
@@ -1979,6 +1979,189 @@ def test_sdpa_with_attn_bias(device: torch.device):
     assert torch.allclose(actual, expected, atol=1e-5)
 
 
+# ---- SDPA low-precision softmax parity -------------------------------------
+#
+# torch's fused kernels run QK^T accumulation and softmax in fp32 even for
+# bf16/f16; translate_sdpa mirrors this. Parity bound: luminal's error vs an
+# fp64 reference stays within a small factor of torch's own kernel error —
+# an all-bf16 chain fails by ~7-10x on wide scores (the Qwen2.5-style
+# outlier-activation divergence).
+
+
+def _sdpa_wide_qkv(device: torch.device, dtype: torch.dtype):
+    """Q/K with a wide score distribution — the softmax-precision stress case."""
+    torch.manual_seed(0)
+    b, h, s, d = 1, 4, 64, 64
+    q = (torch.randn(b, h, s, d) * 4.0).to(dtype).to(device)
+    k = (torch.randn(b, h, s, d) * 4.0).to(dtype).to(device)
+    v = torch.randn(b, h, s, d).to(dtype).to(device)
+    return q, k, v
+
+
+def _assert_sdpa_parity(model, inputs, factor: float = 3.0, select=None):
+    """luminal error vs fp64 reference <= `factor` x torch's own kernel error.
+
+    `select` restricts the compared region (e.g. to rows where the reference
+    is well-defined). Returns the compiled output for further assertions."""
+    with torch.no_grad():
+        ref64 = model(
+            *(t.double() if t.is_floating_point() else t for t in inputs)
+        ).double()
+        eager = model(*inputs)
+        compiled = torch.compile(model, backend=luminal_backend)
+        actual = compiled(*inputs)
+    ref_c, eager_c, actual_c = ref64, eager, actual
+    if select is not None:
+        ref_c, eager_c, actual_c = select(ref64), select(eager), select(actual)
+    err_eager = (eager_c.double() - ref_c).abs().max().item()
+    err_luminal = (actual_c.double() - ref_c).abs().max().item()
+    assert err_luminal <= factor * err_eager + 1e-6, (
+        f"luminal SDPA error {err_luminal:.5f} vs fp64 reference exceeds "
+        f"{factor}x torch's fused-kernel error {err_eager:.5f} — "
+        "score chain is likely not running in fp32"
+    )
+    return actual
+
+
+def test_sdpa_bf16_softmax_parity(device: torch.device):
+    """bf16 SDPA, no mask: fp32 score-chain parity with torch's fused kernel."""
+    from test_models import SdpaBasicModel
+
+    model: torch.nn.Module = SdpaBasicModel().to(device)
+    _assert_sdpa_parity(model, _sdpa_wide_qkv(device, torch.bfloat16))
+
+
+def test_sdpa_f16_softmax_parity(device: torch.device):
+    """f16 SDPA, no mask: fp32 score-chain parity with torch's fused kernel."""
+    from test_models import SdpaBasicModel
+
+    model: torch.nn.Module = SdpaBasicModel().to(device)
+    _assert_sdpa_parity(model, _sdpa_wide_qkv(device, torch.float16))
+
+
+def test_sdpa_bf16_causal_softmax_parity(device: torch.device):
+    """bf16 SDPA with is_causal=True: the causal mask rides the fp32 chain."""
+    from test_models import SdpaCausalModel
+
+    model: torch.nn.Module = SdpaCausalModel().to(device)
+    _assert_sdpa_parity(model, _sdpa_wide_qkv(device, torch.bfloat16))
+
+
+def test_sdpa_bf16_bool_mask_softmax_parity(device: torch.device):
+    """bf16 SDPA with a boolean keep-mask: mask conversion joins the fp32 chain."""
+    from test_models import SdpaWithBiasModel
+
+    model: torch.nn.Module = SdpaWithBiasModel().to(device)
+    q, k, v = _sdpa_wide_qkv(device, torch.bfloat16)
+    keep = ~torch.triu(
+        torch.ones(q.shape[-2], k.shape[-2], dtype=torch.bool, device=q.device),
+        diagonal=1,
+    )
+    _assert_sdpa_parity(model, (q, k, v, keep))
+
+
+def test_sdpa_bf16_float_bias_softmax_parity(device: torch.device):
+    """bf16 SDPA with a bf16 additive bias: bias is promoted into the fp32 chain."""
+    from test_models import SdpaWithBiasModel
+
+    model: torch.nn.Module = SdpaWithBiasModel().to(device)
+    q, k, v = _sdpa_wide_qkv(device, torch.bfloat16)
+    torch.manual_seed(1)
+    bias = (torch.randn(1, 1, q.shape[-2], k.shape[-2]) * 2.0).to(q.dtype).to(q.device)
+    _assert_sdpa_parity(model, (q, k, v, bias))
+
+
+def test_sdpa_bool_mask_fully_masked_row(device: torch.device):
+    """Fully-masked query rows must be exactly zero (torch CPU-kernel
+    semantics); a plain -1e9 conversion averages V instead — silently wrong
+    for left-padded batches."""
+    from test_models import SdpaWithBiasModel
+
+    model: torch.nn.Module = SdpaWithBiasModel().to(device)
+    compiled: Callable = torch.compile(model, backend=luminal_backend)
+    q, k, v = _sdpa_qkv(device)
+    s_q, s_k = q.shape[-2], k.shape[-2]
+    keep = torch.ones(s_q, s_k, dtype=torch.bool, device=device)
+    keep[0, :] = False  # query row 0 attends to nothing
+    expected: torch.Tensor = model(q, k, v, keep)
+    actual: torch.Tensor = compiled(q, k, v, keep)
+    assert torch.all(actual[..., 0, :] == 0.0), (
+        f"fully-masked row must be zeros, got absmax "
+        f"{actual[..., 0, :].abs().max().item():.4f}"
+    )
+    # torch is backend-inconsistent here (CPU zeros, CUDA efficient-attn
+    # unspecified) — compare eager on defined rows only; zeros asserted above.
+    assert torch.allclose(actual[..., 1:, :], expected[..., 1:, :], atol=1e-5)
+
+
+def test_sdpa_bool_mask_fully_masked_row_bf16_4d(device: torch.device):
+    """Same contract on the bf16 fp32-upcast chain with a 4D broadcast mask."""
+    from test_models import SdpaWithBiasModel
+
+    model: torch.nn.Module = SdpaWithBiasModel().to(device)
+    q, k, v = _sdpa_wide_qkv(device, torch.bfloat16)
+    s_q, s_k = q.shape[-2], k.shape[-2]
+    keep = torch.ones(1, 1, s_q, s_k, dtype=torch.bool, device=device)
+    keep[..., -1, :] = False  # last query row attends to nothing
+    # Parity-bounded on defined rows only: the fp64 reference (and CUDA
+    # eager) is undefined for the fully-masked row — see the 2D test note.
+    actual = _assert_sdpa_parity(
+        model, (q, k, v, keep), select=lambda t: t[..., :-1, :]
+    )
+    assert torch.all(actual[..., -1, :] == 0.0), (
+        f"fully-masked row must be zeros, got absmax "
+        f"{actual[..., -1, :].abs().max().item():.4f}"
+    )
+
+
+def _gqa_qkv(device: torch.device, dtype: torch.dtype = torch.float32):
+    """Q with 4 heads, K/V with 2 — the grouped-query head layout."""
+    torch.manual_seed(0)
+    b, s, d = 1, 8, 16
+    q = torch.randn(b, 4, s, d, dtype=dtype, device=device)
+    k = torch.randn(b, 2, s, d, dtype=dtype, device=device)
+    v = torch.randn(b, 2, s, d, dtype=dtype, device=device)
+    return q, k, v
+
+
+def test_sdpa_gqa_fp32(device: torch.device):
+    """`enable_gqa=True` with H_q=4, H_kv=2: K/V head-broadcast, exact match."""
+    from test_models import SdpaGqaModel
+
+    model: torch.nn.Module = SdpaGqaModel().to(device)
+    compiled: Callable = torch.compile(model, backend=luminal_backend)
+    q, k, v = _gqa_qkv(device)
+    expected: torch.Tensor = model(q, k, v)
+    actual: torch.Tensor = compiled(q, k, v)
+    assert torch.allclose(actual, expected, atol=1e-5), (
+        f"max_diff={torch.max(torch.abs(actual - expected)).item():.2e}"
+    )
+
+
+def test_sdpa_gqa_causal_bf16_parity(device: torch.device):
+    """GQA + is_causal on the bf16 fp32-upcast chain, parity-bounded."""
+    from test_models import SdpaGqaModel
+
+    model: torch.nn.Module = SdpaGqaModel(is_causal=True).to(device)
+    _assert_sdpa_parity(model, _gqa_qkv(device, torch.bfloat16))
+
+
+def test_sdpa_f32_unaffected_by_upcast(device: torch.device):
+    """fp32 SDPA still matches eager tightly — the upcast is low-precision-only."""
+    from test_models import SdpaBasicModel
+
+    model: torch.nn.Module = SdpaBasicModel().to(device)
+    compiled: Callable = torch.compile(model, backend=luminal_backend)
+    q, k, v = _sdpa_wide_qkv(device, torch.float32)
+    expected: torch.Tensor = model(q, k, v)
+    actual: torch.Tensor = compiled(q, k, v)
+    # 1e-4, not 1e-5: wide scores expose fp32 accumulation order — measured
+    # ~1.4-1.7e-5 vs eager (cpu/cuda); reduction ordering, not a bug.
+    assert torch.allclose(actual, expected, atol=1e-4), (
+        f"max_diff={torch.max(torch.abs(actual - expected)).item():.2e}"
+    )
+
+
 def test_mlp_block(device: torch.device):
     """Test two-layer MLP: Linear(8,16) -> ReLU -> Linear(16,4) on input (2,8)."""
     model: torch.nn.Module = MLPBlockModel().to(device)

--- a/crates/luminal_python/tests/test_models.py
+++ b/crates/luminal_python/tests/test_models.py
@@ -2480,6 +2480,23 @@ class SdpaWithBiasModel(torch.nn.Module):
         return torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=bias)
 
 
+class SdpaGqaModel(torch.nn.Module):
+    """`enable_gqa=True`: K/V carry fewer heads and the kernel
+    head-broadcasts. Newer transformers pass this instead of materializing
+    `repeat_kv`."""
+
+    def __init__(self, is_causal: bool = False) -> None:
+        super().__init__()
+        self.is_causal = is_causal
+
+    def forward(
+        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+    ) -> torch.Tensor:
+        return torch.nn.functional.scaled_dot_product_attention(
+            q, k, v, is_causal=self.is_causal, enable_gqa=True
+        )
+
+
 class RepeatModel(torch.nn.Module):
     """`Tensor.repeat(*repeats)` — tiles `repeats[d]` copies along each dim;
     when `len(repeats) > ndim`, size-1 leading dims are prepended first."""


### PR DESCRIPTION
Main rejoin, batch 1, first of three stacked PRs (merge base 325e2e3c; main commit cd0aa58f, cherry-picked with -x).

## Summary
One name-resolved SDPA body serves all five ATen SDPA variants; the SdpaVariant enum and its dispatch arms are gone. Torch-kernel precision parity (bf16/f16 Q/K upcast to F32 for the score chain, probs cast back before P@V), a symbolic-shape-safe causal mask, bool keep-mask handling that zeroes fully-masked rows, GQA repeat-interleave of K/V heads, SymInt unification of head_dim and seq, a scale fallback, and a flattened tuple-output list. +183 lines of parity tests and an SdpaGqaModel fixture.

## What was re-expressed and why
attention.rs: main's new body taken wholesale, then the branch's two mechanical renames re-applied at 12 shape touchpoints: the A2 quarantine (.shape reads to legacy_tracker_ref(), the two SymInt shape writes to legacy_tracker_mut(), a tracker passed as an argument to dims()) and IntegerExpression to IntExpr. Machine-checked: main's post-image with the rename map applied and formatted is byte-identical to the committed file. dispatch.rs and both .py files are byte-identical to main.

## Audit
Per-commit diff-of-diffs against the main commit: zero dropped hunks; the only deltas are the branch renames listed above. Only crates/luminal_python paths change. Reviewer verdict: READY (source-level review).

## Not verified
crates/luminal_python is parked: it is not a workspace member on this branch and the A2 quarantine accessors (legacy_tracker_ref / legacy_tracker_mut) have no definition yet, so nothing here was compiled or tested. rustfmt (edition 2024) is clean on the rewritten files; the remaining --check diffs are pre-existing drift on the branch base. py_compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
