### PR TITLE
Main rejoin 2/3: #385 in-place mutation contract (write-back outputs)

### DIFF
--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -98,6 +98,9 @@ pub struct GraphTranslation {
     pub output_dtypes: Vec<u32>,
     pub input_shape_exprs: Vec<Vec<IntExpr>>,
     pub dim_param_map: DimParamMap,
+    /// (output position, user-input name) for outputs that write back into a
+    /// user input's buffer (in-place state updates like HF StaticCache k/v).
+    pub writeback_outputs: Vec<(usize, String)>,
 }
 
 /// Pre-loaded weight data from any model format (dtype-aware).
@@ -126,6 +129,8 @@ pub struct CompiledGraph {
     pub output_dtypes: Vec<u32>,
     pub input_shape_exprs: Vec<Vec<IntExpr>>,
     pub dim_param_map: DimParamMap,
+    /// See [`GraphTranslation::writeback_outputs`].
+    pub writeback_outputs: Vec<(usize, String)>,
 }
 
 impl CompiledGraph {
@@ -149,6 +154,7 @@ impl CompiledGraph {
             output_dtypes,
             input_shape_exprs,
             dim_param_map,
+            writeback_outputs,
         } = translation;
         let WeightData {
             weights,
@@ -191,6 +197,7 @@ impl CompiledGraph {
             output_dtypes,
             input_shape_exprs,
             dim_param_map,
+            writeback_outputs,
         })
     }
 }
@@ -237,6 +244,13 @@ impl CompiledGraph {
     #[getter]
     fn tensor_names(&self) -> Vec<String> {
         self.tensor_ids.keys().cloned().collect()
+    }
+
+    /// (output position, input name) pairs for outputs that write back into a
+    /// user input's buffer (in-place state updates like HF StaticCache k/v).
+    #[getter]
+    fn writeback_outputs(&self) -> Vec<(usize, String)> {
+        self.writeback_outputs.clone()
     }
 
     /// Get the name of the active backend.

--- a/crates/luminal_python/rust/src/pt2_compiled_model.rs
+++ b/crates/luminal_python/rust/src/pt2_compiled_model.rs
@@ -261,6 +261,7 @@ pub fn translate_pt2(
         output_shape_exprs,
         input_shape_exprs,
         dim_param_map,
+        writeback_outputs: parsed.writeback_outputs(),
     };
 
     let weight_data = WeightData {

--- a/crates/luminal_python/rust/src/pt2_parser.rs
+++ b/crates/luminal_python/rust/src/pt2_parser.rs
@@ -96,6 +96,37 @@ impl ParsedPT2 {
             .collect()
     }
 
+    /// (output position, mutated user-input name) for every output the export
+    /// signature declares as an in-place input mutation — the extra outputs
+    /// functionalization appends for `index_put_`/`copy_`/`add_` on graph
+    /// inputs (e.g. HF StaticCache updates). Keyed by position, not name: a
+    /// model that mutates an input *and* returns it yields two outputs with
+    /// the same tensor name.
+    ///
+    /// Positions index the same tensor-only output list `output_names()`
+    /// returns: output_specs is parallel to graph.outputs, but non-tensor
+    /// user outputs (e.g. a returned `None` serializes as `as_none`) are
+    /// filtered out of `output_names()`, so counting raw spec positions
+    /// would skew everything after one.
+    pub fn writeback_outputs(&self) -> Vec<(usize, String)> {
+        let outputs = &self.program.graph_module.graph.outputs;
+        self.program
+            .graph_module
+            .signature
+            .output_specs
+            .iter()
+            .zip(outputs)
+            .filter(|(_, output)| output.as_tensor.is_some())
+            .enumerate()
+            .filter_map(|(position, (spec, _))| match spec {
+                OutputSpec::UserInputMutation {
+                    user_input_mutation,
+                } => Some((position, user_input_mutation.user_input_name.clone())),
+                _ => None,
+            })
+            .collect()
+    }
+
     /// Get tensor metadata by name.
     pub fn tensor_meta(&self, name: &str) -> Option<&TensorMeta> {
         self.program.graph_module.graph.tensor_values.get(name)

--- a/crates/luminal_python/rust/src/pt2_schema.rs
+++ b/crates/luminal_python/rust/src/pt2_schema.rs
@@ -324,6 +324,29 @@ impl DimSize {
 #[derive(Debug, Deserialize)]
 pub struct Signature {
     pub input_specs: Vec<InputSpec>,
+    /// Output specs — distinguish real user outputs from the extra outputs
+    /// torch.export's functionalization appends for in-place input mutations
+    /// (e.g. HF StaticCache k/v updates, cumulative_length counters).
+    #[serde(default)]
+    pub output_specs: Vec<OutputSpec>,
+}
+
+/// An output spec — tagged enum via JSON key. Only mutations are modeled;
+/// user outputs (and anything else) fall through to `Other`.
+/// `{"user_input_mutation": {"arg": {...}, "user_input_name": "cache"}}`
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum OutputSpec {
+    UserInputMutation {
+        user_input_mutation: UserInputMutation,
+    },
+    #[allow(dead_code)] // Serde catch-all for untagged enum
+    Other(serde_json::Value),
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UserInputMutation {
+    pub user_input_name: String,
 }
 
 /// An input spec — tagged enum via JSON key.

--- a/crates/luminal_python/rust/src/translator/mod.rs
+++ b/crates/luminal_python/rust/src/translator/mod.rs
@@ -52,7 +52,6 @@ pub(crate) struct Translator<'a> {
     pub(crate) output_ids: Vec<(String, NodeIndex)>,
     /// Extra tensor metadata from inlined subgraphs.
     pub(crate) extra_tensor_values: HashMap<String, TensorMeta>,
-    pub(crate) input_backed_write_backs: HashMap<NodeIndex, GraphTensor>,
 }
 
 impl<'a> Translator<'a> {
@@ -66,7 +65,6 @@ impl<'a> Translator<'a> {
             user_input_ids: Vec::new(),
             output_ids: Vec::new(),
             extra_tensor_values: HashMap::new(),
-            input_backed_write_backs: HashMap::new(),
         })
     }
 
@@ -82,11 +80,6 @@ impl<'a> Translator<'a> {
         let output_names = self.parsed.output_names();
         for name in &output_names {
             let tensor = self.get_tensor(name)?;
-            if let Some(dest) = self.input_backed_write_backs.get(&tensor.id) {
-                dest.output();
-                self.output_ids.push((name.clone(), dest.id));
-                continue;
-            }
             let tensor = if tensor.dtype == DType::Bool {
                 tensor.cast(DType::Int).cast(DType::Bool)
             } else if tensor.dtype == DType::Int {

--- a/crates/luminal_python/rust/src/translator/movement.rs
+++ b/crates/luminal_python/rust/src/translator/movement.rs
@@ -658,13 +658,6 @@ impl<'a> Translator<'a> {
                 values.cast(a.dtype)
             };
             let result = super::movement_dynamic::pt2_scatter_elements(a, idx_full, values, axis);
-            if self
-                .user_input_ids
-                .iter()
-                .any(|(_, input_id)| *input_id == a.id)
-            {
-                self.input_backed_write_backs.insert(result.id, a);
-            }
             return Ok(result);
         }
         let index_names = if let Some(names) = node.inputs[1].arg.as_tensors() {

--- a/crates/luminal_python/src/luminal/compiled_model.py
+++ b/crates/luminal_python/src/luminal/compiled_model.py
@@ -41,6 +41,11 @@ class CompiledModel:
         self._graph = graph_result
         self._input_names = input_names or graph_result.input_names
         self._output_names = graph_result.output_names
+        # {output position: mutated input name} for the write-back outputs
+        # torch.export's functionalization appends for in-place input
+        # mutations. Keyed by position, not name: a model that mutates an
+        # input and also returns it yields two same-named outputs.
+        self._writeback_by_pos = dict(graph_result.writeback_outputs)
         self._output_shapes = graph_result.output_shapes
         self._has_dynamic_dims = getattr(graph_result, "has_dynamic_dims", False)
         self._weight_refs = weight_refs or []
@@ -66,6 +71,15 @@ class CompiledModel:
     def set_dim(self, param_name: str, value: int) -> None:
         """Set a dynamic dimension value by its param name."""
         self._graph.set_dim(param_name, value)
+
+    @property
+    def writeback_inputs(self) -> dict:
+        """{output name: input name it writes back to} for the in-place input
+        mutations `__call__` applies to the caller's tensors."""
+        return {
+            self._output_names[pos]: input_name
+            for pos, input_name in self._writeback_by_pos.items()
+        }
 
     @property
     def has_dynamic_dims(self) -> bool:
@@ -241,6 +255,11 @@ class CompiledModel:
         if _use_zero_copy:
             for i, (name, shape) in enumerate(zip(self._output_names, output_shapes)):
                 out_dtype = output_torch_dtypes[i]
+                if i in self._writeback_by_pos:
+                    # Write-backs land in the caller's input tensor below, not
+                    # in a fresh output buffer.
+                    output_tensors.append(None)
+                    continue
                 out = torch.empty(shape, dtype=out_dtype, device=input_device)
                 if out_dtype in _zero_copy_native_floats:
                     self._graph.set_output_device_ptr(
@@ -253,6 +272,14 @@ class CompiledModel:
         outputs = []
         for i, (name, shape) in enumerate(zip(self._output_names, output_shapes)):
             out_dtype = output_torch_dtypes[i]
+            if i in self._writeback_by_pos:
+                # In-place input mutation: copy the computed state back into
+                # the caller's tensor (the same object the model would have
+                # mutated eagerly); it is not part of the returned tuple.
+                input_name = self._writeback_by_pos[i]
+                target = user_inputs[self._input_names.index(input_name)]
+                target.copy_(_read_typed_output(name, shape, out_dtype))
+                continue
             if _use_zero_copy and out_dtype in _zero_copy_native_floats:
                 out = output_tensors[i]
                 if not self._graph.output_is_zero_copy(name):

--- a/crates/luminal_python/tests/test_hlir_ops.py
+++ b/crates/luminal_python/tests/test_hlir_ops.py
@@ -1,4 +1,3 @@
-import re
 from typing import Callable
 
 import pytest
@@ -2549,14 +2548,26 @@ def test_scatter_nd(device: torch.device):
     assert torch.allclose(output, original)
 
 
-def test_input_backed_index_put_output_aliases_destination_input(tmp_path):
-    from luminal import process_pt2
+def test_input_backed_index_put_mutates_caller_tensor(tmp_path):
+    """In-place mutation of a graph input is applied back to the caller's
+    tensor and reported in `writeback_inputs`, and only the real user outputs
+    are returned.
+
+    `cache[:, positions] = values; return cache, None` is the sharpest case:
+    the functionalized graph has TWO outputs with the same tensor name — the
+    mutation write-back and the returned user output — so the write-back
+    bookkeeping must key on output position, not name; and the `None` user
+    output (serialized as `as_none`, filtered out of the translator's output
+    list) checks that write-back positions index the tensor-only output
+    space, not raw signature-spec order.
+    """
+    from luminal import CompiledModel, process_pt2
     from luminal.luminal import _reference_factory_capsule
 
     class InputBackedIndexPut(torch.nn.Module):
         def forward(self, cache, positions, values):
             cache[:, positions] = values
-            return cache
+            return cache, None
 
     exported = torch.export.export(
         InputBackedIndexPut(),
@@ -2567,17 +2578,28 @@ def test_input_backed_index_put_output_aliases_destination_input(tmp_path):
         ),
         strict=False,
     )
+    # Both real compile paths (pt2.compile and pt2_backend) decompose before
+    # saving; decomposition is also what functionalizes the in-place
+    # `index_put_` into a write-back output declared by the graph signature.
+    exported = exported.run_decompositions()
     pt2_path = tmp_path / "input_backed_index_put.pt2"
     torch.export.save(exported, pt2_path)
-    compiled = process_pt2(str(pt2_path), "", 0, _reference_factory_capsule())
+    graph_result = process_pt2(str(pt2_path), "", 0, _reference_factory_capsule())
+    model = CompiledModel(graph_result)
 
-    dot = compiled.to_dot()
-    cache_node = re.search(r'Input \{ node: (\d+), label: \\"cache\\"', dot)
-    output_nodes = re.findall(r"Output \{ node: (\d+), persist_only: false \}", dot)
+    assert model.writeback_inputs == {"index_put": "cache"}
 
-    assert cache_node is not None
-    assert output_nodes
-    assert set(output_nodes) == {cache_node.group(1)}
+    cache = torch.zeros(2, 4)
+    outs = model(cache, torch.tensor([1], dtype=torch.int64), torch.ones(2, 1))
+
+    expected = torch.zeros(2, 4)
+    expected[:, 1] = 1.0
+    # The caller's tensor was mutated in place, eager-style.
+    assert torch.equal(cache, expected)
+    # Only the user output (the returned cache) comes back — the write-back
+    # output is consumed by the mutation, not returned.
+    assert len(outs) == 1
+    assert torch.equal(outs[0], expected)
 
 
 # ========== Bool-mask index_put correctness tests ==========

--- a/crates/luminal_python/tests/test_writeback_mutations.py
+++ b/crates/luminal_python/tests/test_writeback_mutations.py
@@ -1,0 +1,104 @@
+"""In-place input mutations (HF StaticCache) through the compiled path.
+
+transformers' StaticLayer.update mutates the cache tensors (and its
+cumulative_length counter) in place; torch.export functionalizes those
+mutations into extra outputs declared by the graph signature. CompiledModel
+applies them back to the caller's tensors and returns only the user outputs,
+matching eager semantics and torch.compile's calling contract.
+"""
+
+import torch
+from luminal import luminal_backend
+
+TINY_LLAMA_KWARGS = dict(
+    hidden_size=64,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    num_hidden_layers=2,
+    intermediate_size=128,
+    vocab_size=256,
+    max_position_embeddings=64,
+    use_cache=True,
+    attn_implementation="eager",
+)
+
+
+def tiny_llama():
+    from transformers import LlamaConfig, LlamaForCausalLM
+
+    torch.manual_seed(0)
+    config = LlamaConfig(**TINY_LLAMA_KWARGS)
+    return config, LlamaForCausalLM(config).eval()
+
+
+def make_static_cache(config, max_cache_len, device):
+    from transformers.cache_utils import StaticCache
+
+    cache = StaticCache(config=config, max_cache_len=max_cache_len)
+    cache.early_initialization(
+        batch_size=1,
+        num_heads=config.num_key_value_heads,
+        head_dim=config.hidden_size // config.num_attention_heads,
+        dtype=torch.float32,
+        device=device,
+    )
+    return cache
+
+
+def static_cache_forward(model, cache, input_ids):
+    cache_position = torch.arange(input_ids.shape[1], device=input_ids.device)
+    return model(
+        input_ids,
+        past_key_values=cache,
+        cache_position=cache_position,
+        position_ids=cache_position.unsqueeze(0),
+        logits_to_keep=1,
+        use_cache=True,
+        return_dict=True,
+    )
+
+
+def test_static_cache_prefill_smoke(device):
+    """One StaticCache forward through the compiled path matches eager —
+    logits, cache contents, and the in-place mutation semantics."""
+    config, model = tiny_llama()
+    model = model.to(device)
+    input_ids = torch.tensor([[1, 2, 3, 4]], device=device)
+
+    ref_cache = make_static_cache(config, 16, device)
+    lum_cache = make_static_cache(config, 16, device)
+    compiled = torch.compile(model, backend=luminal_backend, fullgraph=True)
+
+    with torch.inference_mode():
+        ref = static_cache_forward(model, ref_cache, input_ids)
+        lum = static_cache_forward(compiled, lum_cache, input_ids)
+    assert torch.allclose(lum.logits, ref.logits, atol=1e-4)
+    for ref_layer, lum_layer in zip(ref_cache.layers, lum_cache.layers):
+        assert torch.allclose(lum_layer.keys, ref_layer.keys, atol=1e-4)
+        assert torch.allclose(lum_layer.values, ref_layer.values, atol=1e-4)
+
+
+def test_writeback_metadata_exposed(device):
+    """The compiled artifact names its write-back outputs and their inputs."""
+    config, model = tiny_llama()
+    model = model.to(device)
+    input_ids = torch.tensor([[1, 2, 3, 4]], device=device)
+
+    captured = []
+
+    def capturing_backend(gm, example_inputs, options=None):
+        compiled = luminal_backend(gm, example_inputs)
+        captured.append(compiled)
+        return compiled
+
+    cache = make_static_cache(config, 16, device)
+    compiled_model = torch.compile(model, backend=capturing_backend, fullgraph=True)
+    with torch.inference_mode():
+        static_cache_forward(compiled_model, cache, input_ids)
+
+    (compiled,) = captured
+    writebacks = compiled.writeback_inputs
+    # 2 layers x (keys, values) index_put mutations + 2 cumulative_length
+    # counters = 6 write-back outputs, each bound to a distinct input.
+    assert len(writebacks) == 2 * config.num_hidden_layers + config.num_hidden_layers
+    assert len(set(writebacks.values())) == len(writebacks)


### PR DESCRIPTION
Main rejoin, batch 1, second of three stacked PRs; builds on PR 1 (main commit aa5664bb, cherry-picked with -x).

## Summary
torch.export functionalizes in-place input mutations into extra graph outputs. The compiled model now parses signature.output_specs, exposes (output position, mutated input name) pairs as writeback_outputs, has the translator emit each write-back against the computed result node instead of aliasing it to the input, copies write-backs into the caller's tensors, and returns only user outputs. New test_writeback_mutations.py.

## What was re-expressed and why
Nothing. The cherry-pick applied clean on top of PR 1; all nine files' added and removed lines are byte-identical to main's. Two context lines differ only by the branch's pre-existing IntExpr rename.

## Audit
Per-commit diff-of-diffs against the main commit: zero dropped hunks; the only deltas are the branch renames listed above. Only crates/luminal_python paths change. Reviewer verdict: READY (source-level review).

## Not verified
crates/luminal_python is parked: it is not a workspace member on this branch and the A2 quarantine accessors (legacy_tracker_ref / legacy_tracker_mut) have no definition yet, so nothing here was compiled or tested. rustfmt (edition 2024) is clean on the rewritten files; the remaining --check diffs are pre-existing drift on the branch base. py_compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
