### PR TITLE
Main rejoin 2+3/3: #385 write-back contract and #387 translator robustness (re-landed)

### DIFF
--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -98,6 +98,9 @@ pub struct GraphTranslation {
     pub output_dtypes: Vec<u32>,
     pub input_shape_exprs: Vec<Vec<IntExpr>>,
     pub dim_param_map: DimParamMap,
+    /// (output position, user-input name) for outputs that write back into a
+    /// user input's buffer (in-place state updates like HF StaticCache k/v).
+    pub writeback_outputs: Vec<(usize, String)>,
 }
 
 /// Pre-loaded weight data from any model format (dtype-aware).
@@ -126,6 +129,8 @@ pub struct CompiledGraph {
     pub output_dtypes: Vec<u32>,
     pub input_shape_exprs: Vec<Vec<IntExpr>>,
     pub dim_param_map: DimParamMap,
+    /// See [`GraphTranslation::writeback_outputs`].
+    pub writeback_outputs: Vec<(usize, String)>,
 }
 
 impl CompiledGraph {
@@ -149,6 +154,7 @@ impl CompiledGraph {
             output_dtypes,
             input_shape_exprs,
             dim_param_map,
+            writeback_outputs,
         } = translation;
         let WeightData {
             weights,
@@ -191,6 +197,7 @@ impl CompiledGraph {
             output_dtypes,
             input_shape_exprs,
             dim_param_map,
+            writeback_outputs,
         })
     }
 }
@@ -237,6 +244,13 @@ impl CompiledGraph {
     #[getter]
     fn tensor_names(&self) -> Vec<String> {
         self.tensor_ids.keys().cloned().collect()
+    }
+
+    /// (output position, input name) pairs for outputs that write back into a
+    /// user input's buffer (in-place state updates like HF StaticCache k/v).
+    #[getter]
+    fn writeback_outputs(&self) -> Vec<(usize, String)> {
+        self.writeback_outputs.clone()
     }
 
     /// Get the name of the active backend.

--- a/crates/luminal_python/rust/src/pt2_compiled_model.rs
+++ b/crates/luminal_python/rust/src/pt2_compiled_model.rs
@@ -261,6 +261,7 @@ pub fn translate_pt2(
         output_shape_exprs,
         input_shape_exprs,
         dim_param_map,
+        writeback_outputs: parsed.writeback_outputs(),
     };
 
     let weight_data = WeightData {

--- a/crates/luminal_python/rust/src/pt2_parser.rs
+++ b/crates/luminal_python/rust/src/pt2_parser.rs
@@ -96,6 +96,37 @@ impl ParsedPT2 {
             .collect()
     }
 
+    /// (output position, mutated user-input name) for every output the export
+    /// signature declares as an in-place input mutation — the extra outputs
+    /// functionalization appends for `index_put_`/`copy_`/`add_` on graph
+    /// inputs (e.g. HF StaticCache updates). Keyed by position, not name: a
+    /// model that mutates an input *and* returns it yields two outputs with
+    /// the same tensor name.
+    ///
+    /// Positions index the same tensor-only output list `output_names()`
+    /// returns: output_specs is parallel to graph.outputs, but non-tensor
+    /// user outputs (e.g. a returned `None` serializes as `as_none`) are
+    /// filtered out of `output_names()`, so counting raw spec positions
+    /// would skew everything after one.
+    pub fn writeback_outputs(&self) -> Vec<(usize, String)> {
+        let outputs = &self.program.graph_module.graph.outputs;
+        self.program
+            .graph_module
+            .signature
+            .output_specs
+            .iter()
+            .zip(outputs)
+            .filter(|(_, output)| output.as_tensor.is_some())
+            .enumerate()
+            .filter_map(|(position, (spec, _))| match spec {
+                OutputSpec::UserInputMutation {
+                    user_input_mutation,
+                } => Some((position, user_input_mutation.user_input_name.clone())),
+                _ => None,
+            })
+            .collect()
+    }
+
     /// Get tensor metadata by name.
     pub fn tensor_meta(&self, name: &str) -> Option<&TensorMeta> {
         self.program.graph_module.graph.tensor_values.get(name)

--- a/crates/luminal_python/rust/src/pt2_schema.rs
+++ b/crates/luminal_python/rust/src/pt2_schema.rs
@@ -324,6 +324,29 @@ impl DimSize {
 #[derive(Debug, Deserialize)]
 pub struct Signature {
     pub input_specs: Vec<InputSpec>,
+    /// Output specs — distinguish real user outputs from the extra outputs
+    /// torch.export's functionalization appends for in-place input mutations
+    /// (e.g. HF StaticCache k/v updates, cumulative_length counters).
+    #[serde(default)]
+    pub output_specs: Vec<OutputSpec>,
+}
+
+/// An output spec — tagged enum via JSON key. Only mutations are modeled;
+/// user outputs (and anything else) fall through to `Other`.
+/// `{"user_input_mutation": {"arg": {...}, "user_input_name": "cache"}}`
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum OutputSpec {
+    UserInputMutation {
+        user_input_mutation: UserInputMutation,
+    },
+    #[allow(dead_code)] // Serde catch-all for untagged enum
+    Other(serde_json::Value),
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UserInputMutation {
+    pub user_input_name: String,
 }
 
 /// An input spec — tagged enum via JSON key.

--- a/crates/luminal_python/rust/src/pt2_util.rs
+++ b/crates/luminal_python/rust/src/pt2_util.rs
@@ -83,8 +83,22 @@ pub fn ensure_same_dtype(a: GraphTensor, b: GraphTensor) -> (GraphTensor, GraphT
     if a.dtype == b.dtype {
         return (a, b);
     }
+    // Promotion lattice mirroring torch's type-promotion rules, as
+    // implemented by `torch.promote_types` (documented under "Type
+    // promotion",
+    // https://docs.pytorch.org/docs/stable/tensor_attributes.html#type-promotion-doc):
+    // wider wins, floats
+    // beat ints, and a mixed f16/bf16 pair promotes to f32 — verifiable
+    // directly: promote_types(int32, int64) == int64,
+    // promote_types(float16, bfloat16) == float32. The old table promoted
+    // (Int, I64) to Int, silently truncating the 64-bit side.
     let target = match (a.dtype, b.dtype) {
+        (DType::F64, _) | (_, DType::F64) => DType::F64,
         (DType::F32, _) | (_, DType::F32) => DType::F32,
+        (DType::F16, DType::Bf16) | (DType::Bf16, DType::F16) => DType::F32,
+        (DType::F16, _) | (_, DType::F16) => DType::F16,
+        (DType::Bf16, _) | (_, DType::Bf16) => DType::Bf16,
+        (DType::I64, _) | (_, DType::I64) => DType::I64,
         (DType::Int, _) | (_, DType::Int) => DType::Int,
         _ => DType::F32,
     };

--- a/crates/luminal_python/rust/src/translator/dispatch.rs
+++ b/crates/luminal_python/rust/src/translator/dispatch.rs
@@ -134,7 +134,9 @@ impl<'a> Translator<'a> {
                 let mat2 = self.get_input_tensor(node, 2)?;
                 let beta = self.get_float_arg(node, 3).unwrap_or(1.0) as f32;
                 let alpha = self.get_float_arg(node, 4).unwrap_or(1.0) as f32;
+                let (mat1, mat2) = ensure_same_dtype(mat1, mat2);
                 let mm = mat1.matmul(mat2);
+                let (input, mm) = ensure_same_dtype(input, mm);
                 let (input, mm) = broadcast_binary(input, mm);
                 input * beta + mm * alpha
             }
@@ -381,12 +383,14 @@ impl<'a> Translator<'a> {
             "torch.ops.aten.maximum.default" => {
                 let a = self.get_input_tensor(node, 0)?;
                 let b = self.get_input_tensor(node, 1)?;
+                let (a, b) = ensure_same_dtype(a, b);
                 let (a, b) = broadcast_binary(a, b);
                 a.maximum(b)
             }
             "torch.ops.aten.minimum.default" => {
                 let a = self.get_input_tensor(node, 0)?;
                 let b = self.get_input_tensor(node, 1)?;
+                let (a, b) = ensure_same_dtype(a, b);
                 let (a, b) = broadcast_binary(a, b);
                 a.minimum(b)
             }

--- a/crates/luminal_python/rust/src/translator/mod.rs
+++ b/crates/luminal_python/rust/src/translator/mod.rs
@@ -52,7 +52,6 @@ pub(crate) struct Translator<'a> {
     pub(crate) output_ids: Vec<(String, NodeIndex)>,
     /// Extra tensor metadata from inlined subgraphs.
     pub(crate) extra_tensor_values: HashMap<String, TensorMeta>,
-    pub(crate) input_backed_write_backs: HashMap<NodeIndex, GraphTensor>,
 }
 
 impl<'a> Translator<'a> {
@@ -66,7 +65,6 @@ impl<'a> Translator<'a> {
             user_input_ids: Vec::new(),
             output_ids: Vec::new(),
             extra_tensor_values: HashMap::new(),
-            input_backed_write_backs: HashMap::new(),
         })
     }
 
@@ -82,11 +80,6 @@ impl<'a> Translator<'a> {
         let output_names = self.parsed.output_names();
         for name in &output_names {
             let tensor = self.get_tensor(name)?;
-            if let Some(dest) = self.input_backed_write_backs.get(&tensor.id) {
-                dest.output();
-                self.output_ids.push((name.clone(), dest.id));
-                continue;
-            }
             let tensor = if tensor.dtype == DType::Bool {
                 tensor.cast(DType::Int).cast(DType::Bool)
             } else if tensor.dtype == DType::Int {

--- a/crates/luminal_python/rust/src/translator/movement.rs
+++ b/crates/luminal_python/rust/src/translator/movement.rs
@@ -658,13 +658,6 @@ impl<'a> Translator<'a> {
                 values.cast(a.dtype)
             };
             let result = super::movement_dynamic::pt2_scatter_elements(a, idx_full, values, axis);
-            if self
-                .user_input_ids
-                .iter()
-                .any(|(_, input_id)| *input_id == a.id)
-            {
-                self.input_backed_write_backs.insert(result.id, a);
-            }
             return Ok(result);
         }
         let index_names = if let Some(names) = node.inputs[1].arg.as_tensors() {

--- a/crates/luminal_python/rust/src/translator/movement.rs
+++ b/crates/luminal_python/rust/src/translator/movement.rs
@@ -198,13 +198,17 @@ impl<'a> Translator<'a> {
     pub(crate) fn translate_expand(&mut self, node: &Node) -> Result<GraphTensor> {
         let mut a = self.get_input_tensor(node, 0)?;
         let neg1_expr = IntExpr::from(-1i32);
-        let target_shape: Vec<IntExpr> = if let Ok(sizes) = self.get_ints_arg(node, 1) {
+        // torch's expand PREPENDS new dims when the target rank exceeds the
+        // source rank, so `-1`/existing sizes resolve RIGHT-aligned against
+        // the source shape (`class_embedding.expand(B, 1, -1)`: 1-D -> 3-D).
+        // Unsqueeze leading dims first so the tracker expand sees matching
+        // ranks; left-aligned indexing walks off the source shape.
+        let raw: Vec<IntExpr> = if let Ok(sizes) = self.get_ints_arg(node, 1) {
             sizes
                 .iter()
-                .enumerate()
-                .map(|(i, &s)| {
+                .map(|&s| {
                     if s == -1 {
-                        a.legacy_tracker_ref().dims[i]
+                        neg1_expr
                     } else {
                         IntExpr::from(s as usize)
                     }
@@ -212,11 +216,32 @@ impl<'a> Translator<'a> {
                 .collect()
         } else {
             self.get_exprs_arg(node, 1)?
-                .into_iter()
-                .enumerate()
-                .map(|(i, e)| if e == neg1_expr { a.legacy_tracker_ref().dims[i] } else { e })
-                .collect()
         };
+        anyhow::ensure!(
+            raw.len() >= a.legacy_tracker_ref().len(),
+            "expand: target rank {} below source rank {}",
+            raw.len(),
+            a.legacy_tracker_ref().len()
+        );
+        let offset = raw.len() - a.legacy_tracker_ref().len();
+        for _ in 0..offset {
+            a = a.unsqueeze(0);
+        }
+        let target_shape: Vec<IntExpr> = raw
+            .into_iter()
+            .enumerate()
+            .map(|(i, e)| {
+                if e == neg1_expr {
+                    anyhow::ensure!(
+                        i >= offset,
+                        "expand: -1 is only valid for existing (right-aligned) dims"
+                    );
+                    Ok(a.legacy_tracker_ref().dims[i])
+                } else {
+                    Ok(e)
+                }
+            })
+            .collect::<Result<_>>()?;
         crate::pt2_util::tracker_expand(a.legacy_tracker_mut(), target_shape);
         Ok(a)
     }

--- a/crates/luminal_python/rust/src/translator/unary.rs
+++ b/crates/luminal_python/rust/src/translator/unary.rs
@@ -114,23 +114,32 @@ impl<'a> Translator<'a> {
         // eps is arg 4 (after input, normalized_shape, weight, bias), default 1e-5
         let eps = self.get_float_arg(node, 4).unwrap_or(1e-5) as f32;
 
-        let mut result = input.layer_norm(axes, eps);
+        // torch computes LN statistics in fp32 (opmath) even for fp16/bf16
+        // inputs — "For FP16 or BFloat16 inputs, ops should perform internal
+        // math in FP32" (aten/src/ATen/OpMathType.h; used by
+        // layer_norm_kernel.cpp as `opmath_t`). fp16 statistics overflow on
+        // outlier activations (x^2 > 65504 at |x| > ~256 — the OPT-family
+        // residual-stream profile).
+        // Mirror translate_fused_rms_norm: normalize + affine in F32, cast
+        // the result back to the input dtype.
+        let out_dtype = input.dtype;
+        let mut result = input.cast(DType::F32).layer_norm(axes, eps);
 
         // Apply weight (arg 2) if present and not None
         if let Some(weight_name) = node.inputs.get(2).and_then(|i| i.arg.as_tensor_name()) {
-            let w = self.get_tensor(weight_name)?;
+            let w = self.get_tensor(weight_name)?.cast(DType::F32);
             let (r, w) = broadcast_binary(result, w);
             result = r * w;
         }
 
         // Apply bias (arg 3) if present and not None
         if let Some(bias_name) = node.inputs.get(3).and_then(|i| i.arg.as_tensor_name()) {
-            let b = self.get_tensor(bias_name)?;
+            let b = self.get_tensor(bias_name)?.cast(DType::F32);
             let (r, b) = broadcast_binary(result, b);
             result = r + b;
         }
 
-        Ok(result)
+        Ok(result.cast(out_dtype))
     }
 
     /// `aten._fused_rms_norm` (F.rms_norm on CUDA): frontend `std_norm` +
@@ -213,9 +222,13 @@ impl<'a> Translator<'a> {
         let spatial: IntExpr = orig_dims[2..].iter().cloned().product();
         let group_volume = spatial * IntExpr::from(group_size);
 
+        // torch computes group-norm statistics in fp32 (opmath); fp16 stats
+        // overflow on outlier activations. Normalize + affine in F32 and
+        // cast back at the end (mirrors translate_fused_rms_norm).
+        let out_dtype = input.dtype;
         // Flatten everything after the batch dim into one axis: (N, C, ...) -> (N, M),
         // where M = C * spatial. Group volumes are contiguous in this layout.
-        let mut t = input;
+        let mut t = input.cast(DType::F32);
         while t.legacy_tracker_ref().len() > 2 {
             t = t.merge_dims(1, 2);
         }
@@ -239,19 +252,19 @@ impl<'a> Translator<'a> {
         // broadcast them onto every axis except the channel axis.
         let non_channel_axes: Vec<usize> = (0..ndim).filter(|&a| a != 1).collect();
         if let Some(weight_name) = node.inputs.get(1).and_then(|i| i.arg.as_tensor_name()) {
-            let w = self.get_tensor(weight_name)?;
+            let w = self.get_tensor(weight_name)?.cast(DType::F32);
             let w = w.expand_to_shape_on_axes(t.dims(), non_channel_axes.clone());
             let (r, w) = broadcast_binary(t, w);
             t = r * w;
         }
         if let Some(bias_name) = node.inputs.get(2).and_then(|i| i.arg.as_tensor_name()) {
-            let b = self.get_tensor(bias_name)?;
+            let b = self.get_tensor(bias_name)?.cast(DType::F32);
             let b = b.expand_to_shape_on_axes(t.dims(), non_channel_axes);
             let (r, b) = broadcast_binary(t, b);
             t = r + b;
         }
 
-        Ok(t)
+        Ok(t.cast(out_dtype))
     }
 
     pub(crate) fn translate_sign(&mut self, node: &Node) -> Result<GraphTensor> {

--- a/crates/luminal_python/src/luminal/compiled_model.py
+++ b/crates/luminal_python/src/luminal/compiled_model.py
@@ -41,6 +41,11 @@ class CompiledModel:
         self._graph = graph_result
         self._input_names = input_names or graph_result.input_names
         self._output_names = graph_result.output_names
+        # {output position: mutated input name} for the write-back outputs
+        # torch.export's functionalization appends for in-place input
+        # mutations. Keyed by position, not name: a model that mutates an
+        # input and also returns it yields two same-named outputs.
+        self._writeback_by_pos = dict(graph_result.writeback_outputs)
         self._output_shapes = graph_result.output_shapes
         self._has_dynamic_dims = getattr(graph_result, "has_dynamic_dims", False)
         self._weight_refs = weight_refs or []
@@ -66,6 +71,15 @@ class CompiledModel:
     def set_dim(self, param_name: str, value: int) -> None:
         """Set a dynamic dimension value by its param name."""
         self._graph.set_dim(param_name, value)
+
+    @property
+    def writeback_inputs(self) -> dict:
+        """{output name: input name it writes back to} for the in-place input
+        mutations `__call__` applies to the caller's tensors."""
+        return {
+            self._output_names[pos]: input_name
+            for pos, input_name in self._writeback_by_pos.items()
+        }
 
     @property
     def has_dynamic_dims(self) -> bool:
@@ -241,6 +255,11 @@ class CompiledModel:
         if _use_zero_copy:
             for i, (name, shape) in enumerate(zip(self._output_names, output_shapes)):
                 out_dtype = output_torch_dtypes[i]
+                if i in self._writeback_by_pos:
+                    # Write-backs land in the caller's input tensor below, not
+                    # in a fresh output buffer.
+                    output_tensors.append(None)
+                    continue
                 out = torch.empty(shape, dtype=out_dtype, device=input_device)
                 if out_dtype in _zero_copy_native_floats:
                     self._graph.set_output_device_ptr(
@@ -253,6 +272,14 @@ class CompiledModel:
         outputs = []
         for i, (name, shape) in enumerate(zip(self._output_names, output_shapes)):
             out_dtype = output_torch_dtypes[i]
+            if i in self._writeback_by_pos:
+                # In-place input mutation: copy the computed state back into
+                # the caller's tensor (the same object the model would have
+                # mutated eagerly); it is not part of the returned tuple.
+                input_name = self._writeback_by_pos[i]
+                target = user_inputs[self._input_names.index(input_name)]
+                target.copy_(_read_typed_output(name, shape, out_dtype))
+                continue
             if _use_zero_copy and out_dtype in _zero_copy_native_floats:
                 out = output_tensors[i]
                 if not self._graph.output_is_zero_copy(name):

--- a/crates/luminal_python/tests/test_hlir_ops.py
+++ b/crates/luminal_python/tests/test_hlir_ops.py
@@ -1,4 +1,3 @@
-import re
 from typing import Callable
 
 import pytest
@@ -2549,14 +2548,26 @@ def test_scatter_nd(device: torch.device):
     assert torch.allclose(output, original)
 
 
-def test_input_backed_index_put_output_aliases_destination_input(tmp_path):
-    from luminal import process_pt2
+def test_input_backed_index_put_mutates_caller_tensor(tmp_path):
+    """In-place mutation of a graph input is applied back to the caller's
+    tensor and reported in `writeback_inputs`, and only the real user outputs
+    are returned.
+
+    `cache[:, positions] = values; return cache, None` is the sharpest case:
+    the functionalized graph has TWO outputs with the same tensor name — the
+    mutation write-back and the returned user output — so the write-back
+    bookkeeping must key on output position, not name; and the `None` user
+    output (serialized as `as_none`, filtered out of the translator's output
+    list) checks that write-back positions index the tensor-only output
+    space, not raw signature-spec order.
+    """
+    from luminal import CompiledModel, process_pt2
     from luminal.luminal import _reference_factory_capsule
 
     class InputBackedIndexPut(torch.nn.Module):
         def forward(self, cache, positions, values):
             cache[:, positions] = values
-            return cache
+            return cache, None
 
     exported = torch.export.export(
         InputBackedIndexPut(),
@@ -2567,17 +2578,28 @@ def test_input_backed_index_put_output_aliases_destination_input(tmp_path):
         ),
         strict=False,
     )
+    # Both real compile paths (pt2.compile and pt2_backend) decompose before
+    # saving; decomposition is also what functionalizes the in-place
+    # `index_put_` into a write-back output declared by the graph signature.
+    exported = exported.run_decompositions()
     pt2_path = tmp_path / "input_backed_index_put.pt2"
     torch.export.save(exported, pt2_path)
-    compiled = process_pt2(str(pt2_path), "", 0, _reference_factory_capsule())
+    graph_result = process_pt2(str(pt2_path), "", 0, _reference_factory_capsule())
+    model = CompiledModel(graph_result)
 
-    dot = compiled.to_dot()
-    cache_node = re.search(r'Input \{ node: (\d+), label: \\"cache\\"', dot)
-    output_nodes = re.findall(r"Output \{ node: (\d+), persist_only: false \}", dot)
+    assert model.writeback_inputs == {"index_put": "cache"}
 
-    assert cache_node is not None
-    assert output_nodes
-    assert set(output_nodes) == {cache_node.group(1)}
+    cache = torch.zeros(2, 4)
+    outs = model(cache, torch.tensor([1], dtype=torch.int64), torch.ones(2, 1))
+
+    expected = torch.zeros(2, 4)
+    expected[:, 1] = 1.0
+    # The caller's tensor was mutated in place, eager-style.
+    assert torch.equal(cache, expected)
+    # Only the user output (the returned cache) comes back — the write-back
+    # output is consumed by the mutation, not returned.
+    assert len(outs) == 1
+    assert torch.equal(outs[0], expected)
 
 
 # ========== Bool-mask index_put correctness tests ==========

--- a/crates/luminal_python/tests/test_hlir_ops.py
+++ b/crates/luminal_python/tests/test_hlir_ops.py
@@ -2161,6 +2161,95 @@ def test_sdpa_f32_unaffected_by_upcast(device: torch.device):
     )
 
 
+# ---- mixed-dtype operand unification ---------------------------------------
+
+
+@pytest.mark.parametrize("op", ["sum", "mean", "softmax", "cumsum", "amax"])
+def test_reduction_fp16_opmath_parity(op: str, device: torch.device):
+    """Reduction-class ops at fp16 outlier scale must match eager (which
+    accumulates in fp32 opmath). Guards against input-dtype statistic
+    chains — the layer_norm/sdpa overflow class."""
+    from test_models import ReductionParityModel
+
+    torch.manual_seed(0)
+    model = ReductionParityModel(op).to(device)
+    compiled: Callable = torch.compile(model, backend=luminal_backend)
+    if op in ("sum", "mean", "cumsum"):
+        x = (torch.rand(2, 8, 2048) * 30 + 1).half().to(device)  # big positive sums
+    else:
+        x = (torch.randn(2, 8, 2048) * 40).half().to(device)  # ~300-magnitude tails
+    expected = model(x)
+    actual = compiled(x)
+    assert torch.isfinite(actual).all(), f"{op}: non-finite output"
+    rel = (
+        (actual.double() - expected.double()).abs().max()
+        / expected.double().abs().max().clamp(min=1e-9)
+    ).item()
+    assert rel < 0.01, f"{op}: rel_err={rel:.4f} vs eager"
+
+
+def test_layer_norm_fp16_outliers(device: torch.device):
+    """LN statistics must be computed in fp32 for low-precision inputs —
+    fp16 stats overflow on outlier activations (x^2 > fp16 max)."""
+    from test_models import LayerNormOutlierModel
+
+    torch.manual_seed(0)
+    model = LayerNormOutlierModel().to(device).half()
+    compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = (torch.randn(1, 8, 64) * 40.0).half().to(device)
+    x[..., 0] = 350.0  # outlier channel: 350^2 overflows fp16
+    expected: torch.Tensor = model(x)
+    actual: torch.Tensor = compiled(x)
+    assert torch.isfinite(actual).all(), "LN produced non-finite output"
+    assert torch.allclose(actual.float(), expected.float(), atol=2e-2), (
+        f"max_diff={torch.max(torch.abs(actual.float() - expected.float())).item():.4f}"
+    )
+
+
+def test_expand_rank_extending(device: torch.device):
+    """1-D -> 3-D expand with -1 must resolve source dims right-aligned
+    (torch prepends new dims); left-aligned indexing walks off the end."""
+    from test_models import ExpandRankExtendModel
+
+    model: torch.nn.Module = ExpandRankExtendModel().to(device)
+    compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.randn(2, 3, 16, device=device)
+    expected: torch.Tensor = model(x)
+    actual: torch.Tensor = compiled(x)
+    assert torch.allclose(actual, expected, atol=1e-5), (
+        f"max_diff={torch.max(torch.abs(actual - expected)).item():.2e}"
+    )
+
+
+def test_minimum_mixed_int_widths(device: torch.device):
+    """`torch.minimum(int64, int32)`: operands must be dtype-unified before
+    the core compare (panics with "Dtypes must match" otherwise). The
+    T5-family relative-position bucketing hits exactly this."""
+    from test_models import MixedIntMinimumModel
+
+    model: torch.nn.Module = MixedIntMinimumModel().to(device)
+    compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.tensor([[1, 3, 7, 9]], dtype=torch.int64, device=device)
+    expected: torch.Tensor = model(x)
+    actual: torch.Tensor = compiled(x)
+    assert torch.equal(actual, expected)
+
+
+def test_compare_promotes_to_int64(device: torch.device):
+    """Mixed int widths must promote UP to int64 (torch semantics) — an
+    int64 operand beyond i32 range flips the comparison if truncated."""
+    from test_models import WideIntCompareModel
+
+    model: torch.nn.Module = WideIntCompareModel().to(device)
+    compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.tensor(
+        [[3_000_000_000, 2, 6_000_000_000]], dtype=torch.int64, device=device
+    )
+    expected: torch.Tensor = model(x)  # [1, 0, 1]
+    actual: torch.Tensor = compiled(x)
+    assert torch.equal(actual, expected), f"{actual=} {expected=}"
+
+
 def test_mlp_block(device: torch.device):
     """Test two-layer MLP: Linear(8,16) -> ReLU -> Linear(16,4) on input (2,8)."""
     model: torch.nn.Module = MLPBlockModel().to(device)

--- a/crates/luminal_python/tests/test_models.py
+++ b/crates/luminal_python/tests/test_models.py
@@ -2497,6 +2497,76 @@ class SdpaGqaModel(torch.nn.Module):
         )
 
 
+class ReductionParityModel(torch.nn.Module):
+    """One reduction-class op, for the fp16 opmath parity battery: torch
+    accumulates reductions in fp32 for half inputs; these pin luminal to the
+    same contract at outlier magnitudes."""
+
+    OPS = {
+        "sum": lambda x: x.sum(-1),
+        "mean": lambda x: x.mean(-1),
+        "softmax": lambda x: torch.softmax(x, -1),
+        "cumsum": lambda x: x.cumsum(-1),
+        "amax": lambda x: x.amax(-1),
+    }
+
+    def __init__(self, op: str) -> None:
+        super().__init__()
+        self.op = op
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.OPS[self.op](x)
+
+
+class LayerNormOutlierModel(torch.nn.Module):
+    """LayerNorm over fp16 activations with outlier magnitudes (~350, the
+    OPT-family residual-stream profile). torch computes LN statistics in
+    fp32 (opmath); fp16 statistics overflow at |x| > ~256 since x^2
+    exceeds fp16 max (65504)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.ln = torch.nn.LayerNorm(64)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.ln(x)
+
+
+class ExpandRankExtendModel(torch.nn.Module):
+    """Rank-extending `expand` with `-1`: a 1-D parameter grown to 3-D
+    (`class_embedding.expand(B, 1, -1)` — the CLIP vision-tower pattern).
+    torch prepends the new dims, so `-1`/existing sizes resolve
+    RIGHT-aligned against the source shape."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.emb = torch.nn.Parameter(torch.randn(16))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        cls = self.emb.expand(x.shape[0], 1, -1)
+        return torch.cat([cls, x], dim=1)
+
+
+class MixedIntMinimumModel(torch.nn.Module):
+    """`torch.minimum` between int64 and int32 tensors — torch promotes to
+    int64 inside the kernel, so the exported graph carries mixed operand
+    dtypes with no explicit cast."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        cap = torch.full_like(x, 4, dtype=torch.int32)
+        return torch.minimum(x, cap).to(torch.float32)
+
+
+class WideIntCompareModel(torch.nn.Module):
+    """int64-vs-int32 comparison where the int64 side exceeds i32 range —
+    detects wrong-direction promotion (truncating i64 to i32 flips the
+    comparison for values beyond 2^31)."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        small = torch.full_like(x, 5, dtype=torch.int32)
+        return (x > small).to(torch.float32)
+
+
 class RepeatModel(torch.nn.Module):
     """`Tensor.repeat(*repeats)` — tiles `repeats[d]` copies along each dim;
     when `len(repeats) > ndim`, size-1 leading dims are prepended first."""

--- a/crates/luminal_python/tests/test_writeback_mutations.py
+++ b/crates/luminal_python/tests/test_writeback_mutations.py
@@ -1,0 +1,104 @@
+"""In-place input mutations (HF StaticCache) through the compiled path.
+
+transformers' StaticLayer.update mutates the cache tensors (and its
+cumulative_length counter) in place; torch.export functionalizes those
+mutations into extra outputs declared by the graph signature. CompiledModel
+applies them back to the caller's tensors and returns only the user outputs,
+matching eager semantics and torch.compile's calling contract.
+"""
+
+import torch
+from luminal import luminal_backend
+
+TINY_LLAMA_KWARGS = dict(
+    hidden_size=64,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    num_hidden_layers=2,
+    intermediate_size=128,
+    vocab_size=256,
+    max_position_embeddings=64,
+    use_cache=True,
+    attn_implementation="eager",
+)
+
+
+def tiny_llama():
+    from transformers import LlamaConfig, LlamaForCausalLM
+
+    torch.manual_seed(0)
+    config = LlamaConfig(**TINY_LLAMA_KWARGS)
+    return config, LlamaForCausalLM(config).eval()
+
+
+def make_static_cache(config, max_cache_len, device):
+    from transformers.cache_utils import StaticCache
+
+    cache = StaticCache(config=config, max_cache_len=max_cache_len)
+    cache.early_initialization(
+        batch_size=1,
+        num_heads=config.num_key_value_heads,
+        head_dim=config.hidden_size // config.num_attention_heads,
+        dtype=torch.float32,
+        device=device,
+    )
+    return cache
+
+
+def static_cache_forward(model, cache, input_ids):
+    cache_position = torch.arange(input_ids.shape[1], device=input_ids.device)
+    return model(
+        input_ids,
+        past_key_values=cache,
+        cache_position=cache_position,
+        position_ids=cache_position.unsqueeze(0),
+        logits_to_keep=1,
+        use_cache=True,
+        return_dict=True,
+    )
+
+
+def test_static_cache_prefill_smoke(device):
+    """One StaticCache forward through the compiled path matches eager —
+    logits, cache contents, and the in-place mutation semantics."""
+    config, model = tiny_llama()
+    model = model.to(device)
+    input_ids = torch.tensor([[1, 2, 3, 4]], device=device)
+
+    ref_cache = make_static_cache(config, 16, device)
+    lum_cache = make_static_cache(config, 16, device)
+    compiled = torch.compile(model, backend=luminal_backend, fullgraph=True)
+
+    with torch.inference_mode():
+        ref = static_cache_forward(model, ref_cache, input_ids)
+        lum = static_cache_forward(compiled, lum_cache, input_ids)
+    assert torch.allclose(lum.logits, ref.logits, atol=1e-4)
+    for ref_layer, lum_layer in zip(ref_cache.layers, lum_cache.layers):
+        assert torch.allclose(lum_layer.keys, ref_layer.keys, atol=1e-4)
+        assert torch.allclose(lum_layer.values, ref_layer.values, atol=1e-4)
+
+
+def test_writeback_metadata_exposed(device):
+    """The compiled artifact names its write-back outputs and their inputs."""
+    config, model = tiny_llama()
+    model = model.to(device)
+    input_ids = torch.tensor([[1, 2, 3, 4]], device=device)
+
+    captured = []
+
+    def capturing_backend(gm, example_inputs, options=None):
+        compiled = luminal_backend(gm, example_inputs)
+        captured.append(compiled)
+        return compiled
+
+    cache = make_static_cache(config, 16, device)
+    compiled_model = torch.compile(model, backend=capturing_backend, fullgraph=True)
+    with torch.inference_mode():
+        static_cache_forward(compiled_model, cache, input_ids)
+
+    (compiled,) = captured
+    writebacks = compiled.writeback_inputs
+    # 2 layers x (keys, values) index_put mutations + 2 cumulative_length
+    # counters = 6 write-back outputs, each bound to a distinct input.
+    assert len(writebacks) == 2 * config.num_hidden_layers + config.num_hidden_layers
+    assert len(set(writebacks.values())) == len(writebacks)


### PR DESCRIPTION
Main rejoin, batch 1, parts 2 and 3 re-landed as one PR.

The stacked PRs #446 (#385) and #447 (#387) did not reach logical-ssa-project: merging #445 with its branch deleted made GitHub close #446 instead of retargeting it, and #447 then merged into the #446 branch. This PR carries the same two commits, cherry-picked unchanged (same content, same -x trailers) onto the current tip, which already contains #444 and #445.

## #385 luminal_python: honor the in-place mutation contract (write-back outputs)
torch.export functionalizes in-place input mutations into extra graph outputs. The compiled model parses signature.output_specs, exposes (output position, mutated input name) pairs as writeback_outputs, has the translator emit each write-back against the computed result node, copies write-backs into the caller's tensors, and returns only user outputs. New test_writeback_mutations.py. Applied clean; all nine files byte-identical to main.

## #387 translator robustness
Torch-faithful dtype promotion lattice, rank-extending right-aligned expand, fp32 opmath for layer_norm and group_norm. movement.rs and unary.rs kept the branch's structure and spellings (A2 quarantine, coordinate-form gather/scatter, pad family) with main's behaviour expressed against them; translate_expand's tail stays on the branch's pt2_util::tracker_expand (same broadcast semantics). Other files byte-identical to main.

## Audit
Diff-of-diffs against the main commits: zero dropped hunks. Only crates/luminal_python paths change. Reviewer verdicts: READY.

## Not verified
crates/luminal_python is parked (not a workspace member; the quarantine accessors have no definition on the branch yet), so nothing was compiled or tested. rustfmt (edition 2024) clean on the rewritten files; py_compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
