### PR TITLE
SCC follow-ups: delete the dead row-less contraction; drop the redundant terminal skip in the cuBLASLt election helper

### DIFF
--- a/crates/luminal_cuda_lite/src/ops/cublaslt/election.rs
+++ b/crates/luminal_cuda_lite/src/ops/cublaslt/election.rs
@@ -119,13 +119,13 @@ pub fn genome_with_ordering(
     // (extractor.rs collect_input_terminals): a BufferTensorLit whose
     // BufferTensor class is an explicit input (BufferInputLit list) when
     // explicit inputs exist, else any BufferTensorLit not reachable from
-    // the BufferOutputLit list. These classes take the extractor's Input
-    // plan; CRUCIALLY (round 11), the genome must carry NO row for them:
-    // under genome authority a producer row OVERRIDES the Input plan
-    // (observed: the transpose-view re-descriptions give input layout
-    // tensors their first producers, and total-genome rows then
-    // instantiated view 2-cycles over bound inputs — the bufferize
-    // "extracted graph has a cycle" failure).
+    // the BufferOutputLit list. These classes are leaves: they
+    // take the extractor's Input plan, and the producer index carries no
+    // rows for them at all (Extractor::new drops every input-terminal
+    // key), so no genome row over one is even constructible here. This
+    // helper's terminal set therefore exists for ONE purpose: the demand
+    // walk's leaf check, which stops a candidate's subtree at a bound
+    // input instead of declaring it unreachable.
     let buffer_list_classes = |root_op: &str| -> BTreeSet<ClassId> {
         let mut out: BTreeSet<ClassId> = BTreeSet::new();
         for node in egraph.nodes.values() {
@@ -340,11 +340,6 @@ pub fn genome_with_ordering(
     let mut memo: HashMap<(ClassId, usize), Outcome> = HashMap::new();
     let mut genome = luminal::extractor::Genome::default();
     for (class, candidates) in &index {
-        // Input terminals take the extractor's Input plan; a genome row
-        // would OVERRIDE it with a producer (genome authority) — omit.
-        if terminals.contains(class) {
-            continue;
-        }
         // Escalate strictness only when nothing viable exists below.
         let mut pick: Option<luminal::extractor::ProducerChoice> = None;
         for level in 0..3usize {

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -207,13 +207,17 @@ impl<'a> ExtractionSession<'a> {
     /// extractor's OWN per-candidate input enumeration (so the sampler
     /// and the planner agree on what an input is, by construction).
     ///
-    /// ONE LEAF NOTION: a class with no genome row. Input terminals are
-    /// leaves because they hold no row (they are produced by nothing —
-    /// see `Extractor::candidates_for_class`), not by a special case
-    /// here; every other row-less class is CONTRACTED rather than
-    /// dropped, so the dependency `C -> D(no row) -> E(row)` shows up as
-    /// the edge `C -> E` it really is and a cycle closing through `D`
-    /// cannot hide from the component analysis.
+    /// ONE LEAF NOTION: a class with no genome row. Edges are the
+    /// candidate's input classes FILTERED to the classes that hold a
+    /// row; a row-less input is simply dropped, never contracted
+    /// through. That is sound because after `apply_viability_filter`
+    /// the genome index's keys ARE the producer index's keys, so a
+    /// row-less class an `OpSpec` input names is either an INPUT
+    /// TERMINAL — produced by nothing, planned from the boundary on
+    /// `relax_to_fixpoint`'s first pass, never blocked, and holding no
+    /// row for exactly that reason (see
+    /// `Extractor::candidates_for_class`) — or a DEAD END with no
+    /// candidate at all, which no cycle can run through.
     pub fn sampling_space(
         &self,
         index: &std::collections::BTreeMap<ClassId, Vec<(String, ProducerChoice)>>,
@@ -224,11 +228,9 @@ impl<'a> ExtractionSession<'a> {
                 let per_candidate = entries
                     .iter()
                     .map(|(_, choice)| {
-                        contract_candidate_inputs(
-                            &self.extractor.choice_input_classes(class, choice),
-                            &|input| index.contains_key(input),
-                            &|input| self.extractor.demanded_input_classes(input),
-                        )
+                        let mut inputs = self.extractor.choice_input_classes(class, choice);
+                        inputs.retain(|input| index.contains_key(input));
+                        inputs
                     })
                     .collect();
                 (class.clone(), per_candidate)
@@ -640,15 +642,16 @@ fn producer_index_from(
 /// inputs include `D` (see [`Extractor::choice_input_classes`] — the
 /// SAME `OpSpec::inputs` enumeration `producer_candidates_for_output`
 /// hands the planner, never a second notion of "input"). A class the
-/// genome index has no row for is not a node; it is CONTRACTED, not
-/// dropped — the candidate reading it inherits its demands (see
-/// [`contract_candidate_inputs`]), so `C -> D(no row) -> E(row)` draws
-/// the edge `C -> E`. THE ONLY LEAVES are therefore the classes that
-/// demand nothing, which after contraction means the INPUT TERMINALS:
-/// produced by nothing, planned from the boundary on
+/// genome index has no row for is not a node, and an input naming one
+/// is simply dropped from the edge list. Nothing is contracted through
+/// such a class, and nothing needs to be: after
+/// `Extractor::apply_viability_filter` the genome index's keys are the
+/// producer index's keys, so a row-less input class is either an INPUT
+/// TERMINAL — produced by nothing, planned from the boundary on
 /// `relax_to_fixpoint`'s first pass, never blocked, and so never part
-/// of a blocking cycle. They hold no genome row either (the producer
-/// index drops them), which is the same fact, not a second rule.
+/// of a blocking cycle — or a DEAD END with no candidate at all. Both
+/// are leaves; the row-less-ness is the same fact as the leaf-ness,
+/// not a second rule.
 ///
 /// THE COMPONENT CRITERION. A choice cycle is possible only where the
 /// candidate graph has a cycle, so the re-description groups are
@@ -823,50 +826,6 @@ impl SamplingSpace {
             })
             .collect()
     }
-}
-
-/// CONTRACT THE ROW-LESS CLASSES out of one candidate's input list.
-///
-/// The candidate graph has a node per class holding a genome row, so an
-/// input that holds no row is not a node — but it is not necessarily a
-/// LEAF either. A row-less class is planned WITHOUT a choice (there is
-/// nothing to choose), yet whatever it demands, the candidate reading it
-/// demands transitively: `C -> D(no row) -> E(row)` IS the edge
-/// `C -> E`, and a cycle closing through `D` would otherwise be
-/// invisible to the component analysis and survive sampling.
-///
-/// So each row-less input is replaced by what it demands (`demanded`),
-/// transitively — a row-less class may lead to further row-less classes
-/// — with a visited set so a re-description ring among row-less classes
-/// terminates. Input terminals demand NOTHING (they are produced by
-/// nothing), which is what makes them leaves; no leaf case is written
-/// here.
-///
-/// `has_row`: does this class hold a genome row (is it a node)?
-/// `demanded`: what does this row-less class demand? Both are supplied
-/// by the caller so the rule is testable without an e-graph.
-pub fn contract_candidate_inputs(
-    inputs: &[ClassId],
-    has_row: &dyn Fn(&ClassId) -> bool,
-    demanded: &dyn Fn(&ClassId) -> Vec<ClassId>,
-) -> Vec<ClassId> {
-    let mut out: Vec<ClassId> = Vec::new();
-    let mut stack: Vec<ClassId> = inputs.to_vec();
-    let mut expanded: HashSet<ClassId> = HashSet::new();
-    while let Some(input) = stack.pop() {
-        if has_row(&input) {
-            if !out.contains(&input) {
-                out.push(input);
-            }
-            continue;
-        }
-        if !expanded.insert(input.clone()) {
-            continue;
-        }
-        stack.extend(demanded(&input));
-    }
-    out.sort();
-    out
 }
 
 /// Does a chosen-edge graph close a cycle? (Iterative three-colour DFS;
@@ -1465,36 +1424,6 @@ impl<'a> Extractor<'a> {
             {
                 continue;
             }
-            let Some(spec) = self
-                .op_specs
-                .get(&producer.op_class)
-                .and_then(|specs| specs.get(producer.spec_index))
-            else {
-                continue;
-            };
-            inputs.extend(spec.inputs.iter().cloned());
-        }
-        inputs.sort();
-        inputs.dedup();
-        inputs
-    }
-
-    /// What a class the genome index has NO row for demands, for the
-    /// candidate-graph contraction (see [`contract_candidate_inputs`]).
-    ///
-    /// Such a class is planned without a choice, so every route the
-    /// planner might take through it counts: the union of `OpSpec::inputs`
-    /// over all its producers — the same enumeration
-    /// [`Extractor::choice_input_classes`] restricts to one chosen enode.
-    /// An INPUT TERMINAL demands nothing, for the one reason it has no
-    /// row either: it is produced by nothing (see
-    /// [`Extractor::candidates_for_class`]).
-    fn demanded_input_classes(&self, class: &ClassId) -> Vec<ClassId> {
-        if self.is_input_terminal(class) {
-            return Vec::new();
-        }
-        let mut inputs: Vec<ClassId> = Vec::new();
-        for producer in self.producer_index.get(class).into_iter().flatten() {
             let Some(spec) = self
                 .op_specs
                 .get(&producer.op_class)

--- a/src/implementation_search.rs
+++ b/src/implementation_search.rs
@@ -1126,9 +1126,7 @@ mod sampler_tests {
     use rand::SeedableRng;
     use rand::rngs::StdRng;
 
-    use crate::extractor::{
-        Genome, ProducerChoice, SamplingSpace, contract_candidate_inputs, edges_have_cycle,
-    };
+    use crate::extractor::{Genome, ProducerChoice, SamplingSpace, edges_have_cycle};
 
     use super::{ProducerIndex, bufferize_cycle_tripwire, mutate_genome, sample_genome};
 
@@ -1172,50 +1170,6 @@ mod sampler_tests {
                     .collect(),
             );
         }
-        let space = SamplingSpace::from_candidate_inputs(inputs);
-        (index, space)
-    }
-
-    /// [`build`] with ROW-LESS classes in the picture: `rows` is the
-    /// board's producer index as above, and `row_less` names classes the
-    /// index has NO row for together with what each DEMANDS. Candidate
-    /// inputs are contracted exactly as `ExtractionSession::sampling_space`
-    /// contracts them, so the edges under test are the ones the real
-    /// analysis draws.
-    fn build_with_row_less(
-        rows: &[BoardRow<'_>],
-        row_less: &[(&str, &[&str])],
-    ) -> (ProducerIndex, SamplingSpace) {
-        let (index, _) = build(rows);
-        let demands: BTreeMap<ClassId, Vec<ClassId>> = row_less
-            .iter()
-            .map(|(owner, demanded)| {
-                (
-                    class(owner),
-                    demanded.iter().map(|name| class(name)).collect(),
-                )
-            })
-            .collect();
-        let inputs: BTreeMap<ClassId, Vec<Vec<ClassId>>> = rows
-            .iter()
-            .map(|(owner, candidates)| {
-                (
-                    class(owner),
-                    candidates
-                        .iter()
-                        .map(|(_, sources)| {
-                            let raw: Vec<ClassId> =
-                                sources.iter().map(|name| class(name)).collect();
-                            contract_candidate_inputs(
-                                &raw,
-                                &|input| index.contains_key(input),
-                                &|input| demands.get(input).cloned().unwrap_or_default(),
-                            )
-                        })
-                        .collect(),
-                )
-            })
-            .collect();
         let space = SamplingSpace::from_candidate_inputs(inputs);
         (index, space)
     }
@@ -1412,115 +1366,6 @@ mod sampler_tests {
             let child = mutate_genome(&genome, &index, &space, &classes, &mut rng, 3);
             assert_eq!(spelling(&index, &child), vec!["a=prog".to_string()]);
         }
-    }
-
-    /// (vi) A CYCLE THAT CLOSES THROUGH A ROW-LESS CLASS. `a` reads `d`,
-    /// which the genome index has no row for; `d` demands `b`; `b` reads
-    /// `a`. Nothing chooses anything at `d` — it is planned whichever way
-    /// the two ends go — so `a -> d -> b` IS the edge `a -> b` and the
-    /// only cycle in the board runs a -> b -> a. Contracting `d` is what
-    /// makes the component visible; leaving `d` out (round 1) left `a`
-    /// with no edges at all, no component, and the cyclic pair reachable.
-    #[test]
-    fn a_cycle_through_a_row_less_class_is_one_component() {
-        let (index, space) = build_with_row_less(
-            &[
-                ("a", &[("prog", &[]), ("reads_d", &["d"])]),
-                ("b", &[("prog", &[]), ("reads_a", &["a"])]),
-            ],
-            &[("d", &["b"])],
-        );
-        assert_eq!(
-            space.candidate_inputs[&class("a")],
-            vec![vec![], vec![class("b")]],
-            "`d` holds no row, so `a`'s second candidate depends on what `d` demands"
-        );
-        assert_eq!(
-            space.components,
-            vec![vec![class("a"), class("b")]],
-            "the cycle closes through a row-less class, and the component must contain \
-             both classes that DO hold rows"
-        );
-
-        // THE FREE SAMPLER REACHES IT: uniform over every candidate, the
-        // cyclic pair is one of the four combinations, and it is cyclic.
-        let free = genome_electing(&index, &[("a", "reads_d"), ("b", "reads_a")]);
-        assert!(
-            cyclic(&index, &space, &free),
-            "the (reads_d, reads_a) pair is the cycle this board is made of"
-        );
-
-        // THE FOREST SAMPLER NEVER DOES, and still reaches everything else.
-        let mut seen: std::collections::BTreeSet<Vec<String>> = std::collections::BTreeSet::new();
-        for seed in 0..200u64 {
-            let genome = sample_genome(&index, &space, &mut StdRng::seed_from_u64(seed));
-            assert!(
-                !cyclic(&index, &space, &genome),
-                "seed {seed} sampled the cycle through the row-less class: {:?}",
-                spelling(&index, &genome)
-            );
-            seen.insert(spelling(&index, &genome));
-        }
-        let expected: std::collections::BTreeSet<Vec<String>> = [
-            vec!["a=prog".to_string(), "b=prog".to_string()],
-            vec!["a=prog".to_string(), "b=reads_a".to_string()],
-            vec!["a=reads_d".to_string(), "b=prog".to_string()],
-        ]
-        .into_iter()
-        .collect();
-        assert_eq!(
-            seen, expected,
-            "exactly the three acyclic genomes stay reachable"
-        );
-    }
-
-    /// CONTRACTION IS TRANSITIVE AND TERMINATES: `a` reads `d`, `d`
-    /// demands `e`, `e` demands `b` AND `d` (a ring among the row-less
-    /// classes). The contraction must walk through both and stop, and
-    /// the edge that comes out is `a -> b`.
-    #[test]
-    fn contraction_walks_chains_of_row_less_classes_and_terminates() {
-        let (_index, space) = build_with_row_less(
-            &[
-                ("a", &[("prog", &[]), ("reads_d", &["d"])]),
-                ("b", &[("prog", &[]), ("reads_a", &["a"])]),
-            ],
-            &[("d", &["e"]), ("e", &["b", "d"])],
-        );
-        assert_eq!(
-            space.candidate_inputs[&class("a")],
-            vec![vec![], vec![class("b")]],
-            "a -> d -> e -> b contracts to a -> b, and the d/e ring does not hang"
-        );
-        assert_eq!(space.components, vec![vec![class("a"), class("b")]]);
-    }
-
-    /// A ROW-LESS CLASS THAT DEMANDS NOTHING IS A LEAF — the input
-    /// terminal's shape (produced by nothing, planned from the boundary).
-    /// Its readers keep no edge at all, so no component forms.
-    #[test]
-    fn a_row_less_class_that_demands_nothing_is_a_leaf() {
-        let (index, space) = build_with_row_less(
-            &[
-                ("a", &[("prog", &[]), ("reads_t", &["t"])]),
-                ("b", &[("prog", &[]), ("reads_a", &["a"])]),
-            ],
-            &[("t", &[])],
-        );
-        assert_eq!(
-            space.candidate_inputs[&class("a")],
-            vec![vec![], vec![]],
-            "a terminal demands nothing, so reading one draws no edge"
-        );
-        assert!(space.components.is_empty());
-        let mut seen: std::collections::BTreeSet<Vec<String>> = std::collections::BTreeSet::new();
-        for seed in 0..200u64 {
-            seen.insert(spelling(
-                &index,
-                &sample_genome(&index, &space, &mut StdRng::seed_from_u64(seed)),
-            ));
-        }
-        assert_eq!(seen.len(), 4, "all four combinations stay reachable");
     }
 
     /// THE BUFFERIZE TRIPWIRE fires on the cyclic-graph refusal and on


### PR DESCRIPTION
Follow-ups to #444, both per Austin's rulings on the #444 review.

## 1. Delete the row-less contraction (provably a no-op)
Round 2 added `contract_candidate_inputs` / `demanded_input_classes` to draw component edges through classes that hold no genome row. The review proved it dead in production: after the viability filter the genome-index key set equals the producer-index key set, so every row-less class an op input can name is an input terminal (a leaf) or a dead end with no candidate. Ruling: delete for the minimal repo. Removed the two functions, their three unit tests and helper (−250 / +24); the sampling space builds edges from candidate inputs filtered to row-holding classes, as round 1 did, and its docs now state the invariant instead of describing a contraction.

## 2. cuBLASLt election helper: drop the redundant no-row-for-terminals skip
`genome_with_ordering` carried its own "the genome must carry NO row for input terminals" skip. Round 2's A2 drops every input-terminal key from the producer index in `Extractor::new`, so the skip was unreachable. Verified before deleting: the `continue` was temporarily replaced by a panic and both the cuda_lite and TestRuntime suites ran with zero hits. The helper keeps its terminal derivation and the demand walk's leaf check, which are the walk's own leaf notion; only the skip and the comment claiming it load-bearing are gone.

## Gates (on ab8aff70)
luminal --lib 240 passed / 0 failed; test_runtime all suites 0 failed; luminal_reference green; luminal_cuda_lite 62 passed / 0 failed; clippy clean for both crates (the only warnings belong to an uncommitted local instrument); fmt clean. `grep contract_candidate_inputs|demanded_input_classes` → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
