### PR TITLE
Main rejoin 5-7: 7d2817fa search_iterations, #389 Sdpa gqa fixes, #386 early-stop (running mean, fifth profiler argument, park stubs)

### DIFF
--- a/ci/example_output.py
+++ b/ci/example_output.py
@@ -22,14 +22,14 @@ PERF_GATES = {
     # deployment graphs directly). GH200 references: llama 71/6.4,
     # gemma 74/10.0, qwen 99/6.7, qwen3_moe 74/7.4, gemma4_moe 149/10.8.
     "llama": {"max_ttft_ms": 150.0, "max_tpot_ms": 15.0},
-    "gemma": {"max_ttft_ms": 300.0, "max_tpot_ms": 22.0},
+    "gemma": {"max_ttft_ms": 300.0, "max_tpot_ms": 30.0},
     "qwen": {"max_ttft_ms": 180.0, "max_tpot_ms": 22.0},
     "qwen3_moe": {"max_ttft_ms": 450.0, "max_tpot_ms": 35.0},
     # gemma4_moe's decode search still has run-to-run family variance
     # (A100 draws observed 25-52 ms TPOT vs 10.8 best; exploration work
     # tracked separately) — gate above the draw spread, below the
     # 100+ ms failure modes.
-    "gemma4_moe": {"max_ttft_ms": 450.0, "max_tpot_ms": 35.0},
+    "gemma4_moe": {"max_ttft_ms": 450.0, "max_tpot_ms": 60.0},
     "whisper": {"min_tps": 5.0},
 }
 

--- a/crates/luminal_cuda_lite_hlir/src/runtime.rs
+++ b/crates/luminal_cuda_lite_hlir/src/runtime.rs
@@ -38,6 +38,23 @@ use std::{
 use tracing::{Level, span, trace};
 use uuid::Uuid;
 
+/// LOCAL STUB: `luminal::op` does not exist on this branch (`src/op.rs`
+/// is deleted); the parks track main's spelling, so main's shared
+/// predicate is copied here verbatim from its `src/op.rs` at 499d0779
+/// instead of depending on a core symbol this branch does not have.
+///
+/// Shared early-stop predicate for duration-metric runtimes: true once a
+/// candidate's running mean trial time exceeds `best * factor`, i.e. the
+/// candidate has already lost by at least the configured margin and further
+/// trials can only refine a metric that is out of contention.
+pub fn early_stop_exceeded(
+    mean: std::time::Duration,
+    best: std::time::Duration,
+    factor: f64,
+) -> bool {
+    mean.as_secs_f64() > best.as_secs_f64() * factor
+}
+
 const ARENA_ALIGNMENT: usize = 256;
 const MIN_ARENA_ALLOCATION_BYTES: usize = 16 * 1024 * 1024;
 
@@ -3139,7 +3156,7 @@ impl CudaRuntime {
             // slow warmup must not disqualify a fast steady-state candidate.
             if early_stop.is_some_and(|(best, factor)| {
                 let mean = durations.iter().sum::<Duration>() / durations.len() as u32;
-                luminal::op::early_stop_exceeded(mean, best, factor)
+                early_stop_exceeded(mean, best, factor)
             }) {
                 break;
             }

--- a/crates/luminal_cuda_lite_hlir/src/runtime.rs
+++ b/crates/luminal_cuda_lite_hlir/src/runtime.rs
@@ -3098,6 +3098,7 @@ impl CudaRuntime {
         dyn_map: &FxHashMap<char, usize>,
         trials: usize,
         timeout: Option<std::time::Duration>,
+        early_stop: Option<(Duration, f64)>,
     ) -> (Duration, String) {
         self.profiling = true;
         let profile_start = std::time::Instant::now();
@@ -3128,6 +3129,18 @@ impl CudaRuntime {
             self.execute(dyn_map);
             durations.push(start.elapsed());
             if timeout.is_some_and(|timeout| profile_start.elapsed() >= timeout) {
+                break;
+            }
+            // Early stop against the search's best-so-far: once this
+            // candidate's running mean has lost by the configured margin,
+            // remaining trials can't change the outcome — return the partial
+            // mean and let ranking handle it. Deliberately checked only on
+            // timed trials: the warmup above absorbs one-time costs, and a
+            // slow warmup must not disqualify a fast steady-state candidate.
+            if early_stop.is_some_and(|(best, factor)| {
+                let mean = durations.iter().sum::<Duration>() / durations.len() as u32;
+                luminal::op::early_stop_exceeded(mean, best, factor)
+            }) {
                 break;
             }
         }
@@ -3587,6 +3600,7 @@ impl Runtime for CudaRuntime {
         dyn_map: &FxHashMap<char, usize>,
         trials: usize,
         timeout: Option<std::time::Duration>,
+        early_stop: Option<(Self::ProfileMetric, f64)>,
     ) -> (Self::ProfileMetric, String) {
         Self::dump_candidate_llir_for_postmortem(llir_graph, dyn_map);
         // Clear active bucket's arena before loading new LLIR for profiling.
@@ -3599,7 +3613,7 @@ impl Runtime for CudaRuntime {
         if let Err(e) = self.try_load_llir(llir_graph) {
             return Self::invalid_profile_metric(e);
         }
-        self.profile_loaded_llir(llir_graph, dyn_map, trials, timeout)
+        self.profile_loaded_llir(llir_graph, dyn_map, trials, timeout, early_stop)
     }
 
     fn profile_with_bucket_context(
@@ -3608,12 +3622,13 @@ impl Runtime for CudaRuntime {
         dyn_map: &FxHashMap<char, usize>,
         trials: usize,
         timeout: Option<std::time::Duration>,
+        early_stop: Option<(Self::ProfileMetric, f64)>,
         bucket_context: luminal::op::ProfileBucketContext<'_>,
     ) -> (Self::ProfileMetric, String) {
         // Profile with the same bucket metadata that final bucket compilation
         // uses, so bucket-sensitive graph packaging decisions match search.
         if bucket_context.dim_buckets.is_empty() {
-            return self.profile(llir_graph, dyn_map, trials, timeout);
+            return self.profile(llir_graph, dyn_map, trials, timeout, early_stop);
         }
         Self::dump_candidate_llir_for_postmortem(llir_graph, dyn_map);
         if !self.compiled_buckets.is_empty() {
@@ -3630,7 +3645,7 @@ impl Runtime for CudaRuntime {
         if let Err(e) = self.try_load_llir_buckets(bucket_context.dim_buckets, &bucket_llirs) {
             return Self::invalid_profile_metric(e);
         }
-        self.profile_loaded_llir(llir_graph, dyn_map, trials, timeout)
+        self.profile_loaded_llir(llir_graph, dyn_map, trials, timeout, early_stop)
     }
 
     #[tracing::instrument(skip_all)]

--- a/crates/luminal_metal/src/runtime.rs
+++ b/crates/luminal_metal/src/runtime.rs
@@ -383,6 +383,7 @@ impl Runtime for MetalRuntime {
         dyn_map: &FxHashMap<char, usize>,
         trials: usize,
         timeout: Option<std::time::Duration>,
+        early_stop: Option<(Self::ProfileMetric, f64)>,
     ) -> (Self::ProfileMetric, String) {
         self.load_llir(llir_graph);
         self.allocate_intermediate_buffers(dyn_map);
@@ -397,6 +398,14 @@ impl Runtime for MetalRuntime {
             duration += start.elapsed();
             completed_trials += 1;
             if timeout.is_some_and(|timeout| profile_start.elapsed() >= timeout) {
+                break;
+            }
+            // A candidate whose running mean has already lost by the
+            // early-stop margin keeps its partial mean; further trials
+            // can only refine a metric that is out of contention.
+            if early_stop.is_some_and(|(best, factor)| {
+                luminal::op::early_stop_exceeded(duration / completed_trials as u32, best, factor)
+            }) {
                 break;
             }
         }

--- a/crates/luminal_metal/src/runtime.rs
+++ b/crates/luminal_metal/src/runtime.rs
@@ -18,6 +18,23 @@ use objc::runtime::Object;
 use safetensors::{Dtype, SafeTensors};
 use std::{cell::RefCell, fs::File, time::Duration};
 
+/// LOCAL STUB: `luminal::op` does not exist on this branch (`src/op.rs`
+/// is deleted); the parks track main's spelling, so main's shared
+/// predicate is copied here verbatim from its `src/op.rs` at 499d0779
+/// instead of depending on a core symbol this branch does not have.
+///
+/// Shared early-stop predicate for duration-metric runtimes: true once a
+/// candidate's running mean trial time exceeds `best * factor`, i.e. the
+/// candidate has already lost by at least the configured margin and further
+/// trials can only refine a metric that is out of contention.
+pub fn early_stop_exceeded(
+    mean: std::time::Duration,
+    best: std::time::Duration,
+    factor: f64,
+) -> bool {
+    mean.as_secs_f64() > best.as_secs_f64() * factor
+}
+
 #[derive(Clone)]
 struct MetalExecutionStep {
     node: NodeIndex,
@@ -404,7 +421,7 @@ impl Runtime for MetalRuntime {
             // early-stop margin keeps its partial mean; further trials
             // can only refine a metric that is out of contention.
             if early_stop.is_some_and(|(best, factor)| {
-                luminal::op::early_stop_exceeded(duration / completed_trials as u32, best, factor)
+                early_stop_exceeded(duration / completed_trials as u32, best, factor)
             }) {
                 break;
             }

--- a/crates/luminal_python/src/luminal/main.py
+++ b/crates/luminal_python/src/luminal/main.py
@@ -83,7 +83,10 @@ def register_backend(factory_capsule):
     """
 
     def backend(gm, example_inputs, options=None):
-        return _compile_pt2(gm, example_inputs, factory_capsule)
+        return _compile_pt2(
+            gm, example_inputs, factory_capsule,
+            search_iterations=(options or {}).get("search_iterations"),
+        )
 
     return backend
 
@@ -97,12 +100,17 @@ def luminal_backend(gm, example_inputs, options=None):
     """Auto-detecting torch.compile backend.
 
     Picks cuda_lite if inputs are on CUDA (and cuda feature is compiled in),
-    reference otherwise.
+    reference otherwise. `options={"search_iterations": N}` (torch.compile's
+    backend-options dict) sets the schedule-search budget; default lives in
+    pt2._BACKEND_DEFAULT_SEARCH_ITERATIONS.
 
     For external backends, use register_backend with the backend's factory capsule.
     """
     capsule = _detect_factory_capsule(example_inputs)
-    return _compile_pt2(gm, example_inputs, capsule)
+    return _compile_pt2(
+        gm, example_inputs, capsule,
+        search_iterations=(options or {}).get("search_iterations"),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -110,8 +118,11 @@ def luminal_backend(gm, example_inputs, options=None):
 # ---------------------------------------------------------------------------
 
 
-def _compile_pt2(gm, example_inputs, factory_capsule):
+def _compile_pt2(gm, example_inputs, factory_capsule, search_iterations=None):
     """PT2/torch.export path — delegates to pt2.pt2_backend."""
     from .pt2 import pt2_backend
 
-    return pt2_backend(gm, example_inputs, factory=factory_capsule)
+    return pt2_backend(
+        gm, example_inputs, factory=factory_capsule,
+        search_iterations=search_iterations,
+    )

--- a/crates/luminal_python/src/luminal/pt2.py
+++ b/crates/luminal_python/src/luminal/pt2.py
@@ -163,6 +163,68 @@ def _collect_input_device_ptrs(ep, user_inputs):
     return ptrs
 
 
+def _lower_sym_sum(ep) -> None:
+    """Rewrite `torch.sym_sum` nodes into chains of `operator.add` so the
+    ExportedProgram survives `torch.export.save`.
+
+    WORKAROUND for a torch.export inconsistency: the export VERIFIER allows
+    sym_sum in graphs (pytorch#159111, landed 2025-07), but the PT2 serde's
+    `_SYM_OPS` table never got the matching entry, so `torch.export.save`
+    raises `AssertionError: op sym_sum is not in _SYM_OPS` on any graph the
+    verifier just blessed. sym_sum appears whenever shape arithmetic sums
+    three or more SymInts (sympy's Add is n-ary) — e.g. HF llama under
+    attn_implementation="sdpa" with a growing KV cache.
+
+    The upstream one-line fix exists inside the (larger, still-open)
+    duck-sizing PR: https://github.com/pytorch/pytorch/pull/186373
+    This pass checks torch's own table first, so it becomes a no-op — and
+    can be DELETED — once we run a torch that includes that fix.
+    """
+    import operator
+
+    if not hasattr(torch, "sym_sum"):
+        return  # torch too old to ever emit it
+    try:
+        from torch._export.serde.serialize import _SYM_OPS
+
+        if torch.sym_sum in _SYM_OPS:
+            return  # torch can serialize it natively (pytorch#186373 landed)
+    except ImportError:
+        pass  # private module moved — fall through and lower defensively
+
+    def _val(x):
+        # SymInt/int value of a term: fx Nodes carry it in meta["val"];
+        # bare ints are their own value.
+        return x.meta["val"] if hasattr(x, "meta") else x
+
+    gm = ep.graph_module
+    changed = False
+    for node in list(gm.graph.nodes):
+        if node.op != "call_function" or node.target is not torch.sym_sum:
+            continue
+        (terms,) = node.args
+        terms = list(terms)
+        with gm.graph.inserting_before(node):
+            acc = terms[0]
+            acc_val = _val(acc)
+            for term in terms[1:]:
+                acc = gm.graph.call_function(operator.add, (acc, term))
+                # Every ExportedProgram node must carry meta["val"] (the
+                # verifier's _check_val rejects the graph otherwise). The
+                # partial sums are real SymInt arithmetic over the terms'
+                # vals; the FINAL node inherits the original node's meta
+                # wholesale so downstream consumers see an exact swap.
+                acc_val = acc_val + _val(term)
+                acc.meta["val"] = acc_val
+        acc.meta = {**node.meta, **acc.meta}
+        node.replace_all_uses_with(acc)
+        gm.graph.erase_node(node)
+        changed = True
+    if changed:
+        gm.graph.lint()
+        gm.recompile()
+
+
 def _save_and_compile(
     ep_or_path, factory, search_iterations, user_indices=None, input_device_ptrs=None
 ):
@@ -180,6 +242,7 @@ def _save_and_compile(
     try:
         if owns_tmpdir:
             pt2_path = os.path.join(tmpdir, "model.pt2")
+            _lower_sym_sum(ep_or_path)  # serde gap workaround; see docstring
             torch.export.save(ep_or_path, pt2_path)
             weight_source = ep_or_path.state_dict
         else:
@@ -614,6 +677,7 @@ def _eager_pt2_compile(
     # archive; with weights flowing as inputs that is the entire parameter
     # set per compile. Nothing reads them back — drop before saving.
     ep._example_inputs = None
+    _lower_sym_sum(ep)  # serde gap workaround; see docstring
     torch.export.save(ep, pt2_path)
 
     # Search-time aliases: hand the kernel search the live CUDA tensors for

--- a/crates/luminal_python/src/luminal/pt2.py
+++ b/crates/luminal_python/src/luminal/pt2.py
@@ -574,7 +574,9 @@ def _build_dynamic_shapes_from_dim_arg(dynamic_dim, example_args):
     return (spec,) + rest
 
 
-def _eager_pt2_compile(gm, user_inputs, user_indices, dynamic_shapes, factory):
+def _eager_pt2_compile(
+    gm, user_inputs, user_indices, dynamic_shapes, factory, search_iterations
+):
     """Run torch.export → save → Rust compile end-to-end. Returns CompiledModel.
 
     Factored out so both the eager (static-shapes) and lazy (dynamic-shapes)
@@ -631,12 +633,20 @@ def _eager_pt2_compile(gm, user_inputs, user_indices, dynamic_shapes, factory):
         return _save_and_compile(
             pt2_path,
             factory,
-            10,
+            search_iterations,
             user_indices=user_indices,
             input_device_ptrs=input_device_ptrs,
         )
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# Schedule-search budget for the torch.compile backend path when the caller
+# passes no options. Was an anonymous literal 10 buried in _eager_pt2_compile;
+# raised to 25 to match the direct compile() API's default — the two entry
+# points now agree. (10 was the budget the bench's config notes call
+# maximally lottery-prone.)
+_BACKEND_DEFAULT_SEARCH_ITERATIONS = 25
 
 
 class _LazyDynamicCompiledModel:
@@ -663,11 +673,13 @@ class _LazyDynamicCompiledModel:
         user_indices,
         dynamic_shapes,
         factory,
+        search_iterations,
     ):
         self._gm = gm
         self._user_inputs = user_inputs
         self._user_indices = user_indices
         self._dynamic_shapes = dynamic_shapes
+        self._search_iterations = search_iterations
         self._factory = factory
         self._compiled = None
 
@@ -679,6 +691,7 @@ class _LazyDynamicCompiledModel:
                 self._user_indices,
                 self._dynamic_shapes,
                 self._factory,
+                self._search_iterations,
             )
             # Drop references we no longer need post-compile.
             self._gm = None
@@ -700,11 +713,17 @@ class _LazyDynamicCompiledModel:
         return self._ensure_compiled().set_dim(name, value)
 
 
-def pt2_backend(gm, example_inputs, factory=None):
+def pt2_backend(gm, example_inputs, factory=None, search_iterations=None):
     """torch.compile backend using PT2 pipeline.
 
     Usage: torch.compile(model, backend=luminal.register_backend(capsule))
+
+    `search_iterations`: schedule-search budget; None means
+    _BACKEND_DEFAULT_SEARCH_ITERATIONS. (The direct `compile()` API keeps its
+    own default — unifying the two is a deliberate follow-up, not implied.)
     """
+    if search_iterations is None:
+        search_iterations = _BACKEND_DEFAULT_SEARCH_ITERATIONS
     import copy as _copy
 
     if factory is None:
@@ -747,7 +766,10 @@ def pt2_backend(gm, example_inputs, factory=None):
         # Dynamo is still relying on, and running it inside the backend frame
         # corrupts the freshly-installed guards.
         return _LazyDynamicCompiledModel(
-            gm, user_inputs, user_indices, dynamic_shapes, factory
+            gm, user_inputs, user_indices, dynamic_shapes, factory,
+            search_iterations,
         )
 
-    return _eager_pt2_compile(gm, user_inputs, user_indices, None, factory)
+    return _eager_pt2_compile(
+        gm, user_inputs, user_indices, None, factory, search_iterations
+    )

--- a/crates/luminal_python/tests/_test_kv_cache_comparison.py
+++ b/crates/luminal_python/tests/_test_kv_cache_comparison.py
@@ -41,7 +41,6 @@ def test_kv_cache_decode_loop():
         vocab_size=256,
         max_position_embeddings=128,
         use_cache=True,
-        attn_implementation="eager",
     )
     model = LlamaForCausalLM(config).eval()
     input_ids = torch.tensor([[1, 2, 3, 4]])

--- a/crates/luminal_python/tests/_test_kv_cache_growing.py
+++ b/crates/luminal_python/tests/_test_kv_cache_growing.py
@@ -40,7 +40,6 @@ def test_kv_cache_growing():
         vocab_size=256,
         max_position_embeddings=128,
         use_cache=True,
-        attn_implementation="eager",
     )
     model = LlamaForCausalLM(config).eval()
     compiled = torch.compile(model, backend=luminal_backend)

--- a/crates/luminal_python/tests/_test_qwen3.py
+++ b/crates/luminal_python/tests/_test_qwen3.py
@@ -33,7 +33,6 @@ def _make_qwen3_config(
         vocab_size=vocab_size,
         max_position_embeddings=128,
         use_cache=False,
-        attn_implementation="eager",
     )
 
 
@@ -115,7 +114,6 @@ def test_hf_qwen3_real_config_1layer(device: torch.device):
     config = AutoConfig.from_pretrained("Qwen/Qwen3-8B")
     config.num_hidden_layers = 1
     config.use_cache = False
-    config._attn_implementation = "eager"
 
     model = Qwen3ForCausalLM(config).eval().to(device)
     compiled = torch.compile(model, backend=luminal_backend)
@@ -141,7 +139,6 @@ def test_hf_qwen3_decode_loop_static(device: torch.device):
         vocab_size=256,
         max_position_embeddings=128,
         use_cache=False,
-        attn_implementation="eager",
     )
     model = Qwen3ForCausalLM(config).eval().to(device)
     tokens = [1, 2, 3, 4]
@@ -170,7 +167,6 @@ def test_hf_qwen3_8b_full(device: torch.device):
 
     config = AutoConfig.from_pretrained("Qwen/Qwen3-8B")
     config.use_cache = False
-    config._attn_implementation = "eager"
 
     model = (
         Qwen3ForCausalLM.from_pretrained(

--- a/crates/luminal_python/tests/test_bf16_nondeterminism.py
+++ b/crates/luminal_python/tests/test_bf16_nondeterminism.py
@@ -31,7 +31,6 @@ def _model(device):
         vocab_size=2048,
         max_position_embeddings=64,
         use_cache=False,
-        attn_implementation="eager",
         head_dim=128,
     )
     torch.manual_seed(0)

--- a/crates/luminal_python/tests/test_kv_cache_comparison.py
+++ b/crates/luminal_python/tests/test_kv_cache_comparison.py
@@ -41,7 +41,6 @@ def test_kv_cache_decode_loop():
         vocab_size=256,
         max_position_embeddings=128,
         use_cache=True,
-        attn_implementation="eager",
     )
     model = LlamaForCausalLM(config).eval()
     input_ids = torch.tensor([[1, 2, 3, 4]])

--- a/crates/luminal_python/tests/test_kv_cache_growing.py
+++ b/crates/luminal_python/tests/test_kv_cache_growing.py
@@ -41,7 +41,6 @@ def test_kv_cache_growing():
         vocab_size=256,
         max_position_embeddings=128,
         use_cache=True,
-        attn_implementation="eager",
     )
     model = LlamaForCausalLM(config).eval()
     compiled = torch.compile(model, backend=luminal_backend)
@@ -131,7 +130,6 @@ def test_dynamic_kv_cache_torch_compile_matches_reference_and_reuses_decode_grap
                     vocab_size=256,
                     max_position_embeddings=128,
                     use_cache=True,
-                    attn_implementation="eager",
                 )
             )
             .eval()
@@ -210,7 +208,6 @@ def test_kv_cache_growing_r1_mla(device: torch.device):
     config.num_hidden_layers = 1
     # first_k_dense_replace=3 (default) makes the 1 layer dense, so we avoid
     # the 256-expert MoE path and the associated memory pressure.
-    config._attn_implementation = "eager"
     config.torch_dtype = torch.float32
     # Aggressively shrink the embedding / LM head / FFN dimensions while
     # preserving the MLA-specific knobs that the test is actually exercising

--- a/crates/luminal_python/tests/test_llama3.py
+++ b/crates/luminal_python/tests/test_llama3.py
@@ -100,7 +100,6 @@ def _make_llama_config(
         vocab_size=vocab_size,
         max_position_embeddings=128,
         use_cache=False,
-        attn_implementation="eager",
     )
 
 
@@ -209,7 +208,6 @@ def test_hf_llama3_real_config_1layer(device: torch.device):
     config = AutoConfig.from_pretrained("NousResearch/Llama-3.2-1B")
     config.num_hidden_layers = 1
     config.use_cache = False
-    config._attn_implementation = "eager"
 
     model = LlamaForCausalLM(config).eval().to(device)
     compiled = torch.compile(model, backend=luminal_backend)
@@ -235,7 +233,6 @@ def test_hf_llama_decode_loop_static(device: torch.device):
         vocab_size=256,
         max_position_embeddings=128,
         use_cache=False,
-        attn_implementation="eager",
     )
     model = LlamaForCausalLM(config).eval().to(device)
     tokens = [1, 2, 3, 4]
@@ -265,7 +262,6 @@ def test_hf_llama3_1b_decode_loop_dynamic(device: torch.device):
 
     config = AutoConfig.from_pretrained("NousResearch/Llama-3.2-1B")
     config.use_cache = False
-    config._attn_implementation = "eager"
 
     model = (
         LlamaForCausalLM.from_pretrained(
@@ -307,54 +303,6 @@ def _gpu_mem(label):
 
 
 @pytest.mark.slow
-def test_hf_llama3_full(device: torch.device):
-    """HuggingFace LlamaForCausalLM — full Llama3.2-1B with real pretrained weights.
-
-    No config alterations except use_cache=False and eager attention.
-    Loads actual weights from NousResearch/Llama-3.2-1B.
-    """
-    from transformers import AutoConfig, LlamaForCausalLM
-
-    if torch.cuda.is_available():
-        torch.cuda.reset_peak_memory_stats()
-    _gpu_mem("before model load")
-
-    config = AutoConfig.from_pretrained("NousResearch/Llama-3.2-1B")
-    config.use_cache = False
-    config._attn_implementation = "eager"
-
-    model = (
-        LlamaForCausalLM.from_pretrained(
-            "NousResearch/Llama-3.2-1B",
-            config=config,
-        )
-        .eval()
-        .to(device)
-    )
-    n_params = sum(p.numel() for p in model.parameters())
-    print(
-        f"[MODEL] Total parameters: {n_params:,} ({n_params * 4 / 1024**3:.3f} GiB in f32)"
-    )
-    _gpu_mem("after model load")
-
-    compiled = torch.compile(model, backend=luminal_backend)
-    _gpu_mem("after torch.compile (lazy, no compilation yet)")
-
-    input_ids = torch.tensor([[1, 2, 3, 4]], device=device)
-    with torch.no_grad():
-        ref = model(input_ids)
-        _gpu_mem("after PyTorch reference forward")
-
-        if torch.cuda.is_available():
-            torch.cuda.reset_peak_memory_stats()
-        _gpu_mem("before compiled forward (peak reset)")
-        out = compiled(input_ids)
-        _gpu_mem("after compiled forward (includes compilation)")
-
-    _assert_bf16_logits_match(out.logits, ref.logits)
-
-
-@pytest.mark.slow
 def test_hf_llama3_large_full(device: torch.device):
     """HuggingFace LlamaForCausalLM — full Llama-3.1-8B-Instruct with real pretrained weights.
 
@@ -365,7 +313,6 @@ def test_hf_llama3_large_full(device: torch.device):
 
     config = AutoConfig.from_pretrained("NousResearch/Meta-Llama-3.1-8B-Instruct")
     config.use_cache = False
-    config._attn_implementation = "eager"
 
     model = (
         LlamaForCausalLM.from_pretrained(
@@ -443,7 +390,6 @@ def test_hf_llama38b_full(device: torch.device):
 
     config = AutoConfig.from_pretrained("NousResearch/Meta-Llama-3.1-8B-Instruct")
     config.use_cache = False
-    config._attn_implementation = "eager"
 
     model = (
         LlamaForCausalLM.from_pretrained(

--- a/crates/luminal_python/tests/test_lower_sym_sum.py
+++ b/crates/luminal_python/tests/test_lower_sym_sum.py
@@ -1,0 +1,43 @@
+"""_lower_sym_sum: sym_sum nodes must not survive to torch.export.save.
+
+Three distinct-sized dynamic inputs concatenated force the output length
+s0+s1+s2 — an n-ary sympy Add that torch FX-ifies as torch.sym_sum on
+affected versions. Whether or not this torch build emits sym_sum, the
+contract is the same: after the pass, no sym_sum nodes remain and save()
+succeeds. CPU-only.
+"""
+
+import os
+import tempfile
+
+import torch
+from torch.export import Dim, export
+
+from luminal.pt2 import _lower_sym_sum
+
+
+class Cat3(torch.nn.Module):
+    def forward(self, a, b, c):
+        out = torch.cat([a, b, c])
+        return out + out.shape[0]
+
+
+def test_lower_sym_sum_roundtrip():
+    m = Cat3()
+    ex = (torch.randn(3), torch.randn(5), torch.randn(7))
+    dyn = {"a": {0: Dim("s0")}, "b": {0: Dim("s1")}, "c": {0: Dim("s2")}}
+    ep = export(m, ex, dynamic_shapes=dyn)
+
+    _lower_sym_sum(ep)
+
+    assert not any(
+        n.op == "call_function" and n.target is getattr(torch, "sym_sum", None)
+        for n in ep.graph_module.graph.nodes
+    )
+    with tempfile.TemporaryDirectory() as td:
+        torch.export.save(ep, os.path.join(td, "m.pt2"))  # must not raise
+
+    # Semantics preserved.
+    got = ep.module()(*ex)
+    want = m(*ex)
+    torch.testing.assert_close(got, want)

--- a/crates/luminal_python/tests/test_qwen3_moe.py
+++ b/crates/luminal_python/tests/test_qwen3_moe.py
@@ -66,7 +66,6 @@ def _make_qwen3_moe_config(
         vocab_size=vocab_size,
         max_position_embeddings=128,
         use_cache=False,
-        attn_implementation="eager",
     )
 
 
@@ -230,7 +229,6 @@ def test_hf_qwen3_moe_real_config_1layer(device: torch.device):
     config = AutoConfig.from_pretrained("Qwen/Qwen3-30B-A3B")
     config.num_hidden_layers = 1
     config.use_cache = False
-    config._attn_implementation = "eager"
 
     model = Qwen3MoeForCausalLM(config).eval().to(device)
     compiled = torch.compile(model, backend=luminal_backend)
@@ -288,7 +286,6 @@ def test_hf_qwen3_moe_real_config_full(device: torch.device):
 
     config = AutoConfig.from_pretrained("Qwen/Qwen3-30B-A3B")
     config.use_cache = False
-    config._attn_implementation = "eager"
 
     model = (
         Qwen3MoeForCausalLM.from_pretrained(

--- a/crates/luminal_python/tests/test_writeback_mutations.py
+++ b/crates/luminal_python/tests/test_writeback_mutations.py
@@ -19,7 +19,6 @@ TINY_LLAMA_KWARGS = dict(
     vocab_size=256,
     max_position_embeddings=64,
     use_cache=True,
-    attn_implementation="eager",
 )
 
 

--- a/crates/luminal_reference/src/search.rs
+++ b/crates/luminal_reference/src/search.rs
@@ -11,13 +11,22 @@ use rustc_hash::FxHashMap;
 
 use luminal::graph::LogicalProgram;
 use luminal::implementation_search::{
-    search_implementations_with_runtime, ImplementationSearchOptions, PlanProfiler, SearchOutcome,
+    early_stop_exceeded, search_implementations_with_runtime, ImplementationSearchOptions,
+    PlanProfiler, SearchOutcome,
 };
 
 use crate::layouts::{RefLayout, ReferenceLayoutDecoder};
 use crate::runtime::{reference_allow_list, ReferenceRuntime};
 
 /// The historical profiler: execute on the reference host runtime.
+///
+/// THE METRIC IS THE MEAN over trials (ruling 2, 2026-09-02), not the
+/// best-of-trials minimum it used to be. A minimum can still fall on a
+/// later trial, so truncating a minimum is a heuristic that can promote
+/// a candidate whose truncated metric flatters it; a mean only rises as
+/// trials accumulate, which is what makes #386's early stop an exact
+/// argument rather than a guess. Every reader of `best_nanos` is now
+/// reading a mean.
 #[derive(Default)]
 pub struct ReferenceProfiler;
 
@@ -28,6 +37,7 @@ impl PlanProfiler<RefLayout> for ReferenceProfiler {
         input_data: &FxHashMap<i64, luminal::buffer_tensor_ir::TypedBuffer>,
         trials: usize,
         _heuristic_cost: u64,
+        best_so_far: Option<u128>,
     ) -> Result<u128> {
         let mut runtime = ReferenceRuntime::default();
         runtime.load_plan(plan.clone());
@@ -35,13 +45,32 @@ impl PlanProfiler<RefLayout> for ReferenceProfiler {
             runtime.set_data_buffer(*id, data.clone());
         }
         runtime.execute()?; // warmup + validity
-        let mut best_nanos = u128::MAX;
-        for _ in 0..trials.max(1) {
+        let total = trials.max(1);
+        let mut sum = 0u128;
+        for trial in 0..total {
             let start = Instant::now();
             runtime.execute()?;
-            best_nanos = best_nanos.min(start.elapsed().as_nanos());
+            sum += start.elapsed().as_nanos();
+            let completed = trial + 1;
+            // EARLY STOP (#386). The cutoff is applied to a LOWER BOUND
+            // on this candidate's FINAL mean — the trials so far
+            // averaged over ALL of them, i.e. assuming every remaining
+            // trial costs zero. Once even that bound exceeds the
+            // incumbent, no continuation can win and the remaining
+            // trials are pure waste. Factor 1.0: main's margin knob
+            // (`early_stop_factor`) is a device-runtime tuning
+            // parameter; here the exact bound is available, so the stop
+            // is taken exactly when the candidate has provably lost.
+            // The partial mean returned is >= that bound, so it is
+            // still a loss when ranked, exactly as on main.
+            if completed < total
+                && best_so_far
+                    .is_some_and(|best| early_stop_exceeded(sum / total as u128, best, 1.0))
+            {
+                return Ok(sum / completed as u128);
+            }
         }
-        Ok(best_nanos)
+        Ok(sum / total as u128)
     }
 }
 

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -27,10 +27,10 @@ Dispositions:
 | `cd0aa58f` | #384 | translate_sdpa: close the SDPA surface — precision, masks, GQA, dynamic shapes | FILE-LEVEL | PR #445 (branch `e2f5cd0a`) | — |
 | `aa5664bb` | #385 | luminal_python: honor the in-place mutation contract (write-back outputs) | FILE-LEVEL | PR #448 (branch `16fbb5bd`) | — |
 | `be3e2fe5` | #387 | translator: robustness fixes — dtype promotion, rank-extending expand, norm opmath | RE-EXPRESSED (movement / unary) | PR #448 (branch `5817a012`) | — |
-| `7423ca37` | #391 | compile search progress UI | RE-EXPRESSED (`search_log` + Start/Faster/Slower) | branch `merge/main-391-search-ui` (this commit) | see **#391 progress UI** below |
-| `7d2817fa` | — | luminal_python: search_iterations pass through more places | FILE-LEVEL | branch `7b25c63d` (`merge/main-7d2817fa-search-iterations`) | parked crate: re-point `search_iterations` at `ImplementationSearchOptions` when luminal_python is re-attached to the recorder |
-| `bea18ecf` | #389 | Sdpa gqa fixes | FILE-LEVEL | branch `201aa15b` (`merge/main-389-sdpa-gqa`) | parked crate + non-gating `ci/`: the loosened gemma / gemma4_moe TPOT numbers are main's HLIR cuda_lite numbers and must be re-baselined against CL A100 draws before they gate anything here |
-| `499d0779` | #386 | Search: early-stop candidate profiling against the best-so-far metric | MIXED — FILE-LEVEL (park + metal) / INTENT-ONLY (core) | this commit, on `merge/main-386-early-stop` | see **#386 early-stop profiling** below |
+| `7423ca37` | #391 | compile search progress UI | RE-EXPRESSED (`search_log` + Start/Faster/Slower) | branch `merge/main-391-search-ui` (2nd commit) | see **#391 progress UI** below |
+| `7d2817fa` | — | luminal_python: search_iterations pass through more places | FILE-LEVEL | branch `merge/main-7d2817fa-search-iterations` | parked crate: re-point `search_iterations` at `ImplementationSearchOptions` when luminal_python is re-attached to the recorder |
+| `bea18ecf` | #389 | Sdpa gqa fixes | FILE-LEVEL | branch `merge/main-389-sdpa-gqa` | parked crate + non-gating `ci/`: RULED 2026-09-02 (ruling 1) — `ci/example_output.py` SYNCS main's numbers for now, by decision; the loosened gemma / gemma4_moe TPOT figures are main's HLIR cuda_lite draws and still have to be re-baselined against CL A100 draws before they gate anything here |
+| `499d0779` | #386 | Search: early-stop candidate profiling against the best-so-far metric | MIXED — RE-EXPRESSED (core: running mean + fifth positional cutoff + predicate) / FILE-LEVEL (parks, with a stubbed predicate) | branch `merge/main-386-early-stop` (two commits) | REQUIREMENT FOR CL (ruling 4): a device `PlanProfiler` that times candidates on device, mirroring `ReferenceProfiler`'s design, and then honours the cutoff — until then `StaticProfiler` accepts and ignores it; see **#386 early-stop profiling** below |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -140,17 +140,25 @@ untouched so a slow-warmup / fast-steady candidate is not disqualified.
 - `crates/luminal_metal/src/runtime.rs` — file-level, per the ruling that metal
   becomes a runtime like the others and is ported later.
 
-Both now reference `luminal::op::early_stop_exceeded`, which does not exist on
-this branch (`src/op.rs` is deleted). Neither crate is a workspace member, so
-nothing fails to build; the dangling reference is the standing cost of parking
-these files at main's spelling, and it resolves when each crate is ported.
+Both called `luminal::op::early_stop_exceeded`, which does not exist on this
+branch (`src/op.rs` is deleted). Per ruling 6 (2026-09-02) that dangling
+reference is gone: each park now carries a LOCAL `early_stop_exceeded` copied
+verbatim from main's `src/op.rs` at 499d0779 (`crates/luminal_metal/src/
+runtime.rs`, `crates/luminal_cuda_lite_hlir/src/runtime.rs`, each marked "local
+stub: `luminal::op` does not exist on this branch; parks track main's
+spelling"), and the call sites point at it. The parks keep main's spelling
+without depending on a core symbol this branch does not have; the stub is
+deleted when each crate is ported.
 
 **Not landed (no counterpart on this branch):**
 
 - `src/op.rs` (+41: the `Runtime::profile` / `profile_with_bucket_context`
   signature change, the `early_stop_exceeded` predicate, and its
   `#[cfg(test)] mod early_stop_tests`) and `src/hlir.rs` (+1: the
-  `ReferenceRuntime` impl) — both files are deleted on this branch.
+  `ReferenceRuntime` impl) — both files are deleted on this branch. The
+  predicate and its test DID land, re-expressed, in
+  `src/implementation_search.rs` (below); the `Runtime` trait they sat on
+  did not, because it does not exist.
 - `examples/llama/src/main.rs` (opts in at `.early_stop_factor(2.0)`) — this
   branch has no `examples/llama`; the zoo is `examples/llama3`,
   `examples/paged_llama3`, … and none of them use `CompileOptions`.
@@ -161,51 +169,76 @@ these files at main's spelling, and it resolves when each crate is ported.
   branch's `src/graph.rs` is the LogicalGraph recorder, with no
   `CompileOptions`, no search loop, no `trials` and no `timeout`.
 
-**Why the re-expression was NOT done here.** The brief allows re-expressing the
-idea against `src/implementation_search.rs` only if it is small and mechanical.
-It is not — it needs two decisions that are not the implementer's to make:
+**What was ruled, and what landed (2026-09-02).** The two decisions this row
+was waiting on were taken, and the core re-expression landed in
+`src/implementation_search.rs`:
 
-1. **Which metric.** Main's guarantee ("remaining trials cannot change the
-   outcome") is an argument about a running *mean*, which only rises as trials
-   accumulate. This branch's `ReferenceProfiler` (`crates/luminal_reference/src/
-   search.rs`) ranks by the running *minimum* — `best_nanos.min(...)` over
-   `trials` timed executes after one warmup — and a running minimum can still
-   fall on a later trial. Early-stopping on a minimum is therefore a heuristic
-   truncation of a metric bounded only from below: it can promote a candidate
-   whose truncated min is worse than its true min. Adopting a mean instead
-   changes what `best_nanos` means everywhere that reads it
-   (`SearchOutcome::best_nanos`, search logs, anything baselined on it).
-2. **Where the cutoff hooks in.** The trial loop lives inside the profiler, not
-   inside the selection loop, so the cutoff has to cross `PlanProfiler::profile`
-   — the deliberately thin runtime-owned-execution seam (ruling 2026-08-17,
-   "every runtime owns its execution", including how its candidates are timed).
-   That is either a fifth positional argument on a public trait method that
-   already has four, or an options/context struct — a seam decision, not a
-   mechanical edit.
+1. **Which metric — ruling 2: the RUNNING MEAN.** `ReferenceProfiler`
+   (`crates/luminal_reference/src/search.rs`) used to rank by the best-of-trials
+   MINIMUM, which can still fall on a later trial, so truncating it is a
+   heuristic that can flatter a candidate. It now sums the timed trials and
+   returns `sum / trials` — a mean, which only rises as trials accumulate. Every
+   reader of `best_nanos` is therefore reading a mean now; the re-baselining is
+   recorded below.
+2. **Where the cutoff hooks in — ruling 3: a FIFTH POSITIONAL ARGUMENT.**
+   `PlanProfiler::profile` gains `best_so_far: Option<u128>` after
+   `heuristic_cost` — not an options struct, for now. The selection loop passes
+   `None` for the first profiled candidate (it IS the baseline) and
+   `Some(best_nanos)` — the incumbent — for every later one.
 
-**The requirement, for whenever it is taken up.** (a) `early_stop_factor:
-Option<f64>` on `ImplementationSearchOptions`, default `None` (off), with main's
-`>= 1.0` assertion; behaviour identical to today when unset. (b) The selection
-loop in `src/implementation_search.rs` passes `None` while `best.is_none()` and
-`Some((best_nanos, factor))` afterwards — the loop already holds exactly that
-`best: Option<(nanos, genome, plan)>`. (c) `ReferenceProfiler::profile` checks
-after each timed execute and returns the partial metric; `StaticProfiler`
-ignores it (it never runs trials). (d) The predicate re-expresses as a free
-function over `u128` nanos rather than main's `Duration`, and main's
-`test_early_stop_exceeded` moves essentially verbatim once retyped. (e) Main's
-`search_passes_best_so_far_to_profile_early_stop` regression test cannot move —
-it is built on `Runtime` / `LLIRGraph` / `compile_with_rng` / `CompileOptions` —
-but its intent re-expresses as a recording `PlanProfiler` that asserts `None`
-for the first candidate and `Some((best, factor))` for every later one under a
-fixed seed.
+**The core code, as landed.**
 
-**And the precondition that decides whether it is worth anything.** The only
-profiler on this branch that actually executes candidates is the host
-`ReferenceProfiler`, at `trials: 3` — a maximum saving of two executes per
-losing candidate — and the search already suppresses duplicate work with the
-plan-fingerprint cache. CL does not time candidates at all: `crates/
-luminal_cuda_lite/src/runtime.rs` searches with `StaticProfiler`, ranking by the
-heuristic bytes-moved cost with no execution. So the CUDA half of main's commit
-— the half where this feature pays what the PR claims — has no landing target
-until CL grows a real device `PlanProfiler`. That is the follow-on this row is
-waiting on, and it is a much larger question than the cutoff itself.
+- `luminal::implementation_search::early_stop_exceeded(mean_nanos, best_nanos,
+  factor)` — main's `src/op.rs` predicate retyped from `Duration` to u128 nanos,
+  same comparison (`mean > best * factor`). The factor survives because it is
+  main's semantics and main's device-tuning knob. There is NO
+  `early_stop_factor` option on `ImplementationSearchOptions`: the cutoff is the
+  bare incumbent (ruling 3), and the one in-core caller needs no margin.
+- `ReferenceProfiler::profile` applies the predicate at `factor = 1.0` to a
+  LOWER BOUND on
+  the candidate's final mean — the trials run so far divided by the TOTAL trial
+  count, i.e. assuming every remaining trial costs zero. Once even that bound
+  exceeds the incumbent, no continuation of this candidate can win, so the stop
+  is EXACT rather than heuristic: it never changes which candidate is selected,
+  only how long the losers are timed. The partial mean (`sum / completed`) is
+  returned and ranked normally, and is `>=` the bound, so it is still a loss.
+- `StaticProfiler` accepts and ignores the argument (ruling 4): it runs no
+  trials, so it has nothing to cut short. Note it lives in core
+  (`src/implementation_search.rs`), not in `crates/luminal_cuda_lite/src/
+  runtime.rs` — CL only *elects* it, at its one `search` call site.
+
+**Tests.** `implementation_search::early_stop_tests::
+early_stop_exceeded_keeps_mains_margin_semantics` is main's
+`test_early_stop_exceeded` retyped (10 ms at a 2x cutoff is the boundary and
+does NOT stop, 11 ms does, a faster-than-best candidate never stops, factor 1.0
+stops anything slower than best), plus a tie case for the 1.0 factor the in-core
+caller uses. `implementation_search::tests::
+search_passes_the_incumbent_metric_to_every_later_profile_call` is main's
+`search_passes_best_so_far_to_profile_early_stop` re-expressed: a recording
+`PlanProfiler` over a real two-output search (fixed seed) that returns strictly
+increasing metrics, asserting `None` for the first profile call and `Some(0)` —
+the incumbent — for every later one.
+
+**Re-baselining (mean vs min).** Nothing in the tree asserts an exact or
+relative profiler figure, so no expectation changed:
+`SearchOutcome::best_nanos` has exactly one reader outside the search loop,
+`crates/luminal_nn/src/models.rs` (a `#[cfg(test)]` ladder that PRINTS
+`outcome.best_nanos as f64 / 1e6` in its report row), and the loop's own
+comparisons (`nanos < *best_nanos`) are metric-agnostic. What changed is the
+MEANING: a plan's recorded cost is now its mean trial time, which for a noisy
+host is larger and less spiky than the old minimum, and the search now prefers
+consistently-fast plans over occasionally-fast ones.
+
+**And the precondition that decides whether it is worth anything (ruling 4:
+QUEUED, out of scope here).** The only profiler on this branch that actually
+executes candidates is the host `ReferenceProfiler`, at `trials: 3` — a maximum
+saving of two executes per losing candidate — and the search already suppresses
+duplicate work with the plan-fingerprint cache. CL does not time candidates at
+all: `crates/luminal_cuda_lite/src/runtime.rs` searches with `StaticProfiler`,
+ranking by the heuristic bytes-moved cost with no execution. The requirement
+carried forward, and the half of main's commit where this feature pays what the
+PR claims: **CL must eventually profile on device, mirroring the reference
+profiler's design** — warmup, timed trials, a mean metric, and the same
+lower-bound cutoff — at which point `StaticProfiler`'s ignored argument becomes
+a real one. That is a larger question than the cutoff itself, and it is not in
+this batch.

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -28,6 +28,9 @@ Dispositions:
 | `aa5664bb` | #385 | luminal_python: honor the in-place mutation contract (write-back outputs) | FILE-LEVEL | PR #448 (branch `16fbb5bd`) | — |
 | `be3e2fe5` | #387 | translator: robustness fixes — dtype promotion, rank-extending expand, norm opmath | RE-EXPRESSED (movement / unary) | PR #448 (branch `5817a012`) | — |
 | `7423ca37` | #391 | compile search progress UI | RE-EXPRESSED (`search_log` + Start/Faster/Slower) | branch `merge/main-391-search-ui` (this commit) | see **#391 progress UI** below |
+| `7d2817fa` | — | luminal_python: search_iterations pass through more places | FILE-LEVEL | branch `7b25c63d` (`merge/main-7d2817fa-search-iterations`) | parked crate: re-point `search_iterations` at `ImplementationSearchOptions` when luminal_python is re-attached to the recorder |
+| `bea18ecf` | #389 | Sdpa gqa fixes | FILE-LEVEL | branch `201aa15b` (`merge/main-389-sdpa-gqa`) | parked crate + non-gating `ci/`: the loosened gemma / gemma4_moe TPOT numbers are main's HLIR cuda_lite numbers and must be re-baselined against CL A100 draws before they gate anything here |
+| `499d0779` | #386 | Search: early-stop candidate profiling against the best-so-far metric | MIXED — FILE-LEVEL (park + metal) / INTENT-ONLY (core) | this commit, on `merge/main-386-early-stop` | see **#386 early-stop profiling** below |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -112,3 +115,97 @@ drives the reporter over an in-memory writer and pins `Start` exactly once (with
 the baseline metric), one `Faster` carrying the new best, the `x1 → x2` climb,
 the reset back to `x1` after an improvement, and the five `\r\x1b[2K` in-place
 rewrites. It strips ANSI so it passes whether or not `colored` colorizes.
+
+## #386 early-stop profiling — what landed, and what is owed
+
+Main's commit is one idea spread over six files: an opt-in
+`CompileOptions::early_stop_factor(f64)` threads `Option<(best_metric, factor)>`
+through `Runtime::profile` / `Runtime::profile_with_bucket_context`; each device
+runtime, after every *timed* trial, compares the candidate's running MEAN trial
+time against `best * factor` (the shared predicate `luminal::op::
+early_stop_exceeded`) and breaks out, returning the partial mean. Selection is
+explicitly unchanged: the truncated metric is still ranked, so early stop only
+shortens the timing of candidates already out of contention. The initial genome
+passes `None` because it *is* the baseline, and CUDA's warmup bail is left
+untouched so a slow-warmup / fast-steady candidate is not disqualified.
+
+**Landed FILE-LEVEL (parked, does not build):**
+
+- `crates/luminal_cuda_lite_hlir/src/runtime.rs` — main's
+  `crates/luminal_cuda_lite/` hunks with the path rewritten, per the ruling that
+  the hlir park TRACKS main so the target CL must reach keeps moving. Applied
+  cleanly against the park's existing branch drift (`IntExpr`, `alias_state` →
+  `alloc_state_buffer` + `bind_*_buffer`, no `mask_events`); only hunk offsets
+  moved.
+- `crates/luminal_metal/src/runtime.rs` — file-level, per the ruling that metal
+  becomes a runtime like the others and is ported later.
+
+Both now reference `luminal::op::early_stop_exceeded`, which does not exist on
+this branch (`src/op.rs` is deleted). Neither crate is a workspace member, so
+nothing fails to build; the dangling reference is the standing cost of parking
+these files at main's spelling, and it resolves when each crate is ported.
+
+**Not landed (no counterpart on this branch):**
+
+- `src/op.rs` (+41: the `Runtime::profile` / `profile_with_bucket_context`
+  signature change, the `early_stop_exceeded` predicate, and its
+  `#[cfg(test)] mod early_stop_tests`) and `src/hlir.rs` (+1: the
+  `ReferenceRuntime` impl) — both files are deleted on this branch.
+- `examples/llama/src/main.rs` (opts in at `.early_stop_factor(2.0)`) — this
+  branch has no `examples/llama`; the zoo is `examples/llama3`,
+  `examples/paged_llama3`, … and none of them use `CompileOptions`.
+- `src/graph.rs` (+109: the `CompileOptions::early_stop_factor` builder, passing
+  `None` for the initial genome and `Some((best, factor))` thereafter, and the
+  regression test `search_passes_best_so_far_to_profile_early_stop`) — main's
+  `src/graph.rs` is the HLIR `CompileOptions` / `Graph::search` file; this
+  branch's `src/graph.rs` is the LogicalGraph recorder, with no
+  `CompileOptions`, no search loop, no `trials` and no `timeout`.
+
+**Why the re-expression was NOT done here.** The brief allows re-expressing the
+idea against `src/implementation_search.rs` only if it is small and mechanical.
+It is not — it needs two decisions that are not the implementer's to make:
+
+1. **Which metric.** Main's guarantee ("remaining trials cannot change the
+   outcome") is an argument about a running *mean*, which only rises as trials
+   accumulate. This branch's `ReferenceProfiler` (`crates/luminal_reference/src/
+   search.rs`) ranks by the running *minimum* — `best_nanos.min(...)` over
+   `trials` timed executes after one warmup — and a running minimum can still
+   fall on a later trial. Early-stopping on a minimum is therefore a heuristic
+   truncation of a metric bounded only from below: it can promote a candidate
+   whose truncated min is worse than its true min. Adopting a mean instead
+   changes what `best_nanos` means everywhere that reads it
+   (`SearchOutcome::best_nanos`, search logs, anything baselined on it).
+2. **Where the cutoff hooks in.** The trial loop lives inside the profiler, not
+   inside the selection loop, so the cutoff has to cross `PlanProfiler::profile`
+   — the deliberately thin runtime-owned-execution seam (ruling 2026-08-17,
+   "every runtime owns its execution", including how its candidates are timed).
+   That is either a fifth positional argument on a public trait method that
+   already has four, or an options/context struct — a seam decision, not a
+   mechanical edit.
+
+**The requirement, for whenever it is taken up.** (a) `early_stop_factor:
+Option<f64>` on `ImplementationSearchOptions`, default `None` (off), with main's
+`>= 1.0` assertion; behaviour identical to today when unset. (b) The selection
+loop in `src/implementation_search.rs` passes `None` while `best.is_none()` and
+`Some((best_nanos, factor))` afterwards — the loop already holds exactly that
+`best: Option<(nanos, genome, plan)>`. (c) `ReferenceProfiler::profile` checks
+after each timed execute and returns the partial metric; `StaticProfiler`
+ignores it (it never runs trials). (d) The predicate re-expresses as a free
+function over `u128` nanos rather than main's `Duration`, and main's
+`test_early_stop_exceeded` moves essentially verbatim once retyped. (e) Main's
+`search_passes_best_so_far_to_profile_early_stop` regression test cannot move —
+it is built on `Runtime` / `LLIRGraph` / `compile_with_rng` / `CompileOptions` —
+but its intent re-expresses as a recording `PlanProfiler` that asserts `None`
+for the first candidate and `Some((best, factor))` for every later one under a
+fixed seed.
+
+**And the precondition that decides whether it is worth anything.** The only
+profiler on this branch that actually executes candidates is the host
+`ReferenceProfiler`, at `trials: 3` — a maximum saving of two executes per
+losing candidate — and the search already suppresses duplicate work with the
+plan-fingerprint cache. CL does not time candidates at all: `crates/
+luminal_cuda_lite/src/runtime.rs` searches with `StaticProfiler`, ranking by the
+heuristic bytes-moved cost with no execution. So the CUDA half of main's commit
+— the half where this feature pays what the PR claims — has no landing target
+until CL grows a real device `PlanProfiler`. That is the follow-on this row is
+waiting on, and it is a much larger question than the cutoff itself.

--- a/src/implementation_search.rs
+++ b/src/implementation_search.rs
@@ -384,16 +384,68 @@ impl SearchTimings {
 /// reference host executor (the historical behavior) and a static
 /// ranker that never executes.
 pub trait PlanProfiler<L: crate::bufferize::PlanLayout> {
-    /// Best-of-`trials` cost for the plan with buffer-keyed inputs;
-    /// smaller wins. `heuristic_cost` is the extracted graph's summed
+    /// The plan's cost over `trials` with buffer-keyed inputs; smaller
+    /// wins. `heuristic_cost` is the extracted graph's summed
     /// bytes-moved estimate, for profilers that rank without running.
+    ///
+    /// `best_so_far` is the INCUMBENT's metric in nanos — `None` while
+    /// the search holds no candidate yet, since the first candidate IS
+    /// the baseline. It is the early-stop cutoff (#386, ruling 3 of
+    /// 2026-09-02: the cutoff crosses this seam as a fifth POSITIONAL
+    /// argument, not a struct). A profiler may use it to stop trialing
+    /// a candidate that has already lost; whatever it then returns is
+    /// still ranked normally, so early stop never changes which
+    /// candidates are eligible — only how much time is spent timing
+    /// ones already out of contention. Ignoring it is always correct.
     fn profile(
         &mut self,
         plan: &crate::bufferize::BufferIrGraph<L>,
         input_data: &FxHashMap<i64, crate::buffer_tensor_ir::TypedBuffer>,
         trials: usize,
         heuristic_cost: u64,
+        best_so_far: Option<u128>,
     ) -> Result<u128>;
+}
+
+/// Main's `early_stop_exceeded` (its `src/op.rs`), retyped from
+/// `Duration` to this branch's u128 nanos: true once a candidate's mean
+/// trial cost exceeds `best * factor`, i.e. the candidate has already
+/// lost by at least that margin and further trials can only refine a
+/// metric that is out of contention.
+///
+/// The in-core caller ([`crate::implementation_search`]'s reference
+/// profiler, in `luminal_reference`) applies it at `factor = 1.0` to a
+/// LOWER BOUND on the candidate's final mean, which makes the stop
+/// exact rather than heuristic: a candidate whose best conceivable
+/// final mean already exceeds the incumbent cannot win. The factor
+/// survives because it is main's semantics and main's tuning knob
+/// (`CompileOptions::early_stop_factor`), and a device profiler
+/// mirroring this design will want it.
+pub fn early_stop_exceeded(mean_nanos: u128, best_nanos: u128, factor: f64) -> bool {
+    mean_nanos as f64 > best_nanos as f64 * factor
+}
+
+#[cfg(test)]
+mod early_stop_tests {
+    use super::early_stop_exceeded;
+
+    /// Main's `test_early_stop_exceeded` (`src/op.rs`), retyped from
+    /// `Duration` to nanos.
+    #[test]
+    fn early_stop_exceeded_keeps_mains_margin_semantics() {
+        const MS: u128 = 1_000_000;
+        let best = 5 * MS;
+        // 2x cutoff: 10ms mean is at the boundary, not over it.
+        assert!(!early_stop_exceeded(10 * MS, best, 2.0));
+        assert!(early_stop_exceeded(11 * MS, best, 2.0));
+        // A candidate faster than best never stops early.
+        assert!(!early_stop_exceeded(4 * MS, best, 2.0));
+        // Factor 1.0 stops anything slower than best.
+        assert!(early_stop_exceeded(6 * MS, best, 1.0));
+        // ...and NOT a tie: the incumbent keeps its seat, but a tied
+        // candidate is still worth finishing (it is not yet losing).
+        assert!(!early_stop_exceeded(5 * MS, best, 1.0));
+    }
 }
 
 /// Rank by the heuristic byte-move estimate without executing —
@@ -409,6 +461,11 @@ impl<L: crate::bufferize::PlanLayout> PlanProfiler<L> for StaticProfiler {
         _input_data: &FxHashMap<i64, crate::buffer_tensor_ir::TypedBuffer>,
         _trials: usize,
         heuristic_cost: u64,
+        // Ruling 4 (2026-09-02): CL must eventually profile ON DEVICE,
+        // mirroring the reference profiler's design; until it does, the
+        // static ranker runs no trials, so there is nothing to cut
+        // short and the cutoff is accepted and ignored.
+        _best_so_far: Option<u128>,
     ) -> Result<u128> {
         Ok(u128::from(heuristic_cost).saturating_add(1))
     }
@@ -924,8 +981,17 @@ pub fn search_implementations_with_runtime<L: crate::bufferize::PlanLayout>(
                         })
                         .sum();
                     let profile_start = Instant::now();
-                    let profiled =
-                        profiler.profile(&plan, input_data, options.trials, heuristic_total);
+                    // The incumbent's metric is the early-stop cutoff
+                    // (#386). `None` on the first candidate: it IS the
+                    // baseline, so there is nothing to have lost to.
+                    let best_so_far = best.as_ref().map(|(best_nanos, _, _)| *best_nanos);
+                    let profiled = profiler.profile(
+                        &plan,
+                        input_data,
+                        options.trials,
+                        heuristic_total,
+                        best_so_far,
+                    );
                     timings.profile_nanos += profile_start.elapsed().as_nanos();
                     let nanos = match profiled {
                         Ok(nanos) => nanos,
@@ -1251,6 +1317,110 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Main's `search_passes_best_so_far_to_profile_early_stop`
+    /// (`src/graph.rs`, #386), re-expressed against this branch's seam:
+    /// the selection loop passes `None` for the FIRST profiled
+    /// candidate — it is the baseline — and the incumbent's metric for
+    /// every later one. Main's version asserts `Some((best, factor))`;
+    /// here the cutoff is the bare incumbent (ruling 3, 2026-09-02).
+    #[test]
+    fn search_passes_the_incumbent_metric_to_every_later_profile_call() {
+        #[derive(Default)]
+        struct RecordingProfiler {
+            seen: Vec<Option<u128>>,
+        }
+
+        impl luminal::implementation_search::PlanProfiler<luminal_reference::RefLayout>
+            for RecordingProfiler
+        {
+            fn profile(
+                &mut self,
+                _plan: &luminal::bufferize::BufferIrGraph<luminal_reference::RefLayout>,
+                _input_data: &FxHashMap<i64, luminal::buffer_tensor_ir::TypedBuffer>,
+                _trials: usize,
+                _heuristic_cost: u64,
+                best_so_far: Option<u128>,
+            ) -> anyhow::Result<u128> {
+                self.seen.push(best_so_far);
+                // Strictly increasing metrics (main's trick): the first
+                // candidate scores 0 and stays the incumbent, so every
+                // later call must see exactly that.
+                Ok(self.seen.len() as u128 - 1)
+            }
+        }
+
+        let mut cx = Graph::new();
+        let x = cx.tensor(4);
+        let y = cx.tensor(4);
+        let _sum = (x + y).output();
+        let _product = (x * y).output();
+        let program = cx
+            .logical
+            .bound_program(&luminal_reference::ReferenceBindings)
+            .expect("native program");
+        let text = format!(
+            "{}\n\n{}",
+            luminal_reference::assembled_program(),
+            program.text
+        );
+        let mut egraph = luminal::egglog_snippet::new_egraph();
+        egraph
+            .parse_and_run_program(None, &text)
+            .expect("program runs");
+        let serialized = egraph.serialize(SerializeConfig::default()).egraph;
+
+        let mut inputs = FxHashMap::default();
+        inputs.insert(x.id, vec![1.0f32, 2.0, 3.0, 4.0].into());
+        inputs.insert(y.id, vec![10.0f32, 20.0, 30.0, 40.0].into());
+
+        let options = ImplementationSearchOptions {
+            generations: 3,
+            generation_size: 4,
+            mutations: 2,
+            trials: 1,
+            seed: 0,
+            search_log: false,
+        };
+        let mut profiler = RecordingProfiler::default();
+        let outcome = luminal::implementation_search::search_implementations_with_runtime(
+            &serialized,
+            &program,
+            &inputs,
+            &options,
+            Some(luminal_reference::reference_allow_list()),
+            luminal_reference::ops::built_in_matchers(),
+            &luminal_reference::ReferenceLayoutDecoder,
+            &mut profiler,
+        )
+        .expect("search finds an executable plan");
+
+        assert!(
+            profiler.seen.len() > 1,
+            "the search must profile more than the baseline candidate: {:?}",
+            profiler.seen
+        );
+        assert_eq!(
+            profiler.seen.len(),
+            outcome.plans_profiled,
+            "one profile call per profiled plan (the rest are cache hits)"
+        );
+        assert_eq!(
+            profiler.seen[0], None,
+            "no incumbent exists before the first candidate is profiled"
+        );
+        for (index, seen) in profiler.seen.iter().enumerate().skip(1) {
+            assert_eq!(
+                *seen,
+                Some(0),
+                "candidate {index} must receive the incumbent's metric"
+            );
+        }
+        assert_eq!(
+            outcome.best_nanos, 0,
+            "the first candidate's metric is the running best"
+        );
     }
 
     /// BUCKETED: two buckets over 'a', each validated bucket-wide


### PR DESCRIPTION
Main rejoin batch 2, the three commits after #449, as a linear stack: 7d2817fa (luminal_python search_iterations pass-through) → bea18ecf (#389 Sdpa gqa fixes) → 499d0779 (#386 search early-stop, parks + core).

## What was re-expressed and why
- **7d2817fa and #389**: file-level into the parked `luminal_python` crate (not a workspace member); `ci/example_output.py` syncs main's perf numbers per ruling 1 (provisional until a CL A100 re-baseline).
- **#386, ruling 2**: `ReferenceProfiler` ranks by the running MEAN over trials (was best-of-trials minimum). `best_nanos` is now a mean. Nothing in the tree asserted a profiler figure, so no expectation changed; the search now prefers consistently fast plans over occasionally fast ones.
- **#386, ruling 3**: the cutoff crosses `PlanProfiler::profile` as a fifth positional argument `best_so_far: Option<u128>` (`None` for the baseline, the incumbent after). Exactly two impls in the tree: `ReferenceProfiler` applies it to an exact lower bound (sum so far divided by total trials; stop when that already exceeds the incumbent; the partial mean is returned and ranks as a loss, so selection is unchanged). `StaticProfiler` accepts and ignores it (ruling 4: CL device profiling queued).
- **#386, ruling 6**: `luminal_metal` and `luminal_cuda_lite_hlir` carry a local `early_stop_exceeded` copied verbatim from main's `src/op.rs`; no `luminal::op` dependency. Their cuda_lite hunks landed in the hlir park path-rewritten; `src/op.rs`, `src/hlir.rs`, `src/graph.rs` and `examples/llama` hunks are uncarried and recorded in the ledger.
- Predicate and both of main's tests re-expressed against the branch types.

## Audit
Diff-of-diffs: 7d2817fa and #389 byte-identical to main; #386's park hunks content-identical modulo path and offsets. Early-stop exactness brute-forced over 200k random trial sequences with integer division: zero selection changes. Reviewer verdicts: READY.

## Gates (rebased onto #454 / d3addb77)
luminal --lib 243 passed / 0 failed; luminal_reference green; test_runtime green; luminal_cuda_lite green; clippy and fmt clean; `cargo check --workspace --all-targets` green.

## Not verified
`ReferenceProfiler`'s early-return branch has no test that reaches it (the suites run with `trials: 1`); verified by arithmetic. Divergence from main by ruling: the cutoff is always-on and exact at factor 1.0 (main: opt-in heuristic), so it fires less often than main's factor-1.0 would. Parks are not built; the hlir park's `luminal::op::ProfileBucketContext` reference remains dangling (pre-existing). No device run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
