### PR TITLE
main rejoin: OpInfo tests (#398): python banked, F64 becomes a real executable dtype

### DIFF
--- a/.github/workflows/test-python-native.yml
+++ b/.github/workflows/test-python-native.yml
@@ -29,3 +29,76 @@ jobs:
               run: uv run maturin develop --manifest-path rust/Cargo.toml --profile release
             - name: Run pytest
               run: uv run pytest tests/test_hlir_ops.py tests/test_unary.py -v -m "not slow"
+
+    # OpInfo CI is intentionally disabled while backend coverage is widened.
+    # Uncomment this job when its expected failures are ready to run in CI.
+    # python_opinfo_tests:
+    #     name: Python OpInfo (${{ matrix.shard }}/32)
+    #     runs-on: ubuntu-latest
+    #     container:
+    #         image: ghcr.io/luminal-ai/luminal-docker:cpu
+    #     timeout-minutes: 45
+    #     strategy:
+    #         # Unsupported operators are expected to fail while coverage widens.
+    #         # Every shard must still run so their union remains the full suite.
+    #         fail-fast: false
+    #         matrix:
+    #             shard:
+    #                 - 0
+    #                 - 1
+    #                 - 2
+    #                 - 3
+    #                 - 4
+    #                 - 5
+    #                 - 6
+    #                 - 7
+    #                 - 8
+    #                 - 9
+    #                 - 10
+    #                 - 11
+    #                 - 12
+    #                 - 13
+    #                 - 14
+    #                 - 15
+    #                 - 16
+    #                 - 17
+    #                 - 18
+    #                 - 19
+    #                 - 20
+    #                 - 21
+    #                 - 22
+    #                 - 23
+    #                 - 24
+    #                 - 25
+    #                 - 26
+    #                 - 27
+    #                 - 28
+    #                 - 29
+    #                 - 30
+    #                 - 31
+    #     defaults:
+    #         run:
+    #             working-directory: crates/luminal_python
+    #     env:
+    #         LUMINAL_OPINFO_SHARD_COUNT: "32"
+    #         LUMINAL_OPINFO_SHARD_INDEX: ${{ matrix.shard }}
+    #         LUMINAL_TEST_DEVICE: cpu
+    #
+    #     steps:
+    #         - uses: actions/checkout@v6
+    #         - name: Update Rust toolchain
+    #           run: rustup update
+    #         - name: Build maturin extension
+    #           run: uv run maturin develop --manifest-path rust/Cargo.toml --profile release
+    #         - name: Run complete OpInfo shard
+    #           run: >-
+    #               uv run pytest tests/test_opinfo.py -v -m "not slow"
+    #               --randomly-dont-reorganize --randomly-seed=0
+    #               --junitxml=opinfo-shard-${{ matrix.shard }}.xml
+    #         - name: Upload OpInfo report
+    #           if: always()
+    #           uses: actions/upload-artifact@v6
+    #           with:
+    #               name: python-opinfo-${{ matrix.shard }}
+    #               path: crates/luminal_python/opinfo-shard-${{ matrix.shard }}.xml
+    #               if-no-files-found: warn

--- a/crates/luminal_cuda_lite/src/device.rs
+++ b/crates/luminal_cuda_lite/src/device.rs
@@ -48,6 +48,11 @@ fn typed_to_bytes(data: &TypedBuffer) -> &[u8] {
         TypedBuffer::I64(v) => bytemuck_cast(v),
         TypedBuffer::Bool8(v) => v.as_slice(),
         TypedBuffer::F8E4M3(_) => unreachable!("dtype_bytes refuses F8 first"),
+        // F64 is executable on the reference runtime (ruling
+        // 2026-09-02) but has no CL kernel and no device
+        // representation, so `dtype_bytes` refuses it by name before a
+        // buffer ever reaches this bridge.
+        TypedBuffer::F64(_) => unreachable!("dtype_bytes refuses F64 first"),
     }
 }
 

--- a/crates/luminal_python/pyproject.toml
+++ b/crates/luminal_python/pyproject.toml
@@ -37,9 +37,12 @@ markers = [
 
 [dependency-groups]
 dev = [
+    "expecttest>=0.3.0",
+    "hypothesis",
     "maturin>=1.0,<2.0",
     "pytest>=9.0.2",
     "pytest-profiling",
+    "pytest-subtests",
     "snakeviz",
     "maturin-import-hook>=0.3.0",
     "pytest-randomly>=4.0.1",

--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -10,6 +10,28 @@ use std::collections::HashMap;
 
 use crate::typed_data::TypedData;
 
+/// Copy a CPU buffer into Rust-owned storage.
+///
+/// PyTorch legitimately reports `data_ptr() == 0` for an empty tensor, so a
+/// null pointer is valid exactly when there are no bytes to read.  Keeping
+/// this check in one helper gives inputs and weights the same boundary
+/// contract and prevents `from_raw_parts` from ever receiving a null pointer.
+fn copy_host_bytes(ptr: u64, n_bytes: usize, buffer_kind: &str) -> PyResult<Vec<u8>> {
+    if n_bytes == 0 {
+        return Ok(Vec::new());
+    }
+    if ptr == 0 {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "{buffer_kind} pointer is null for a non-empty buffer of {n_bytes} bytes"
+        )));
+    }
+
+    // SAFETY: the caller guarantees that a non-null pointer addresses at
+    // least `n_bytes` readable bytes for the duration of this call.  We copy
+    // immediately, so the resulting Vec does not borrow the source buffer.
+    Ok(unsafe { std::slice::from_raw_parts(ptr as *const u8, n_bytes).to_vec() })
+}
+
 /// Maps symbolic dimension parameter names (e.g. "seq_len") to luminal IntExpr variable chars.
 pub type DimParamMap = HashMap<String, char>;
 
@@ -355,9 +377,10 @@ impl CompiledGraph {
     }
 
     /// Set input tensor data from a CPU host memory pointer (dtype-aware).
-    /// The pointer must point to contiguous data. `n_bytes` is the total byte count.
+    /// The pointer must point to contiguous data. It may be null only when
+    /// `n_bytes == 0`; otherwise it must address at least `n_bytes` readable bytes.
     /// `dtype_code` uses PT2 numbering (7=f32, 6=f16, 13=bf16, etc.).
-    /// Converts source format to luminal's native format (e.g., i64→i32, f64→f32).
+    /// Preserves the source dtype and width in luminal's typed input buffer.
     fn set_input_from_ptr(
         &mut self,
         name: &str,
@@ -365,11 +388,10 @@ impl CompiledGraph {
         n_bytes: usize,
         dtype_code: u32,
     ) -> PyResult<()> {
-        debug_assert!(ptr != 0, "set_input_from_ptr called with null pointer");
         let node_id = self.tensor_ids.get(name).ok_or_else(|| {
             PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!("Unknown input tensor: {}", name))
         })?;
-        let raw_bytes = unsafe { std::slice::from_raw_parts(ptr as *const u8, n_bytes).to_vec() };
+        let raw_bytes = copy_host_bytes(ptr, n_bytes, "input")?;
         let typed = TypedData::from_pytorch_bytes(raw_bytes, dtype_code);
         self.runtime
             .set_data_bytes(*node_id, typed.bytes, typed.dtype);
@@ -459,7 +481,9 @@ impl CompiledGraph {
     }
 
     /// Register a weight tensor from a CPU host pointer, matching by Input node label (dtype-aware).
-    /// `n_bytes` is the total byte count. `dtype_code` uses PT2 numbering (7=f32, 6=f16, 13=bf16, etc.).
+    /// `ptr` may be null only when `n_bytes == 0`; otherwise it must address at
+    /// least `n_bytes` readable bytes. `dtype_code` uses PT2 numbering
+    /// (7=f32, 6=f16, 13=bf16, etc.).
     fn set_weight_from_ptr(
         &mut self,
         label: &str,
@@ -467,11 +491,10 @@ impl CompiledGraph {
         n_bytes: usize,
         dtype_code: u32,
     ) -> PyResult<()> {
-        debug_assert!(ptr != 0, "set_weight_from_ptr called with null pointer");
         let &node_id = self.label_map.get(label).ok_or_else(|| {
             pyo3::exceptions::PyKeyError::new_err(format!("No Input node with label: {}", label))
         })?;
-        let bytes = unsafe { std::slice::from_raw_parts(ptr as *const u8, n_bytes).to_vec() };
+        let bytes = copy_host_bytes(ptr, n_bytes, "weight")?;
         let typed = TypedData::from_pytorch_bytes(bytes, dtype_code);
         self.runtime
             .set_data_bytes(node_id, typed.bytes, typed.dtype);

--- a/crates/luminal_python/rust/src/pt2_schema.rs
+++ b/crates/luminal_python/rust/src/pt2_schema.rs
@@ -50,11 +50,43 @@ pub struct TensorRef {
     pub as_tensor: Option<TensorName>,
     #[serde(default)]
     pub as_tensors: Option<Vec<TensorName>>,
+    #[serde(default)]
+    pub as_sym_int: Option<ScalarName>,
+    #[serde(default)]
+    pub as_sym_float: Option<ScalarName>,
+    #[serde(default)]
+    pub as_sym_bool: Option<ScalarName>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct TensorName {
     pub name: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ScalarName {
+    pub as_name: String,
+}
+
+impl TensorRef {
+    /// Name of either a tensor value or a PT2 scalar value. Luminal represents
+    /// both as GraphTensors; scalar references have an empty shape.
+    pub fn value_name(&self) -> Option<&str> {
+        self.as_tensor
+            .as_ref()
+            .map(|value| value.name.as_str())
+            .or_else(|| self.as_sym_int.as_ref().map(|value| value.as_name.as_str()))
+            .or_else(|| {
+                self.as_sym_float
+                    .as_ref()
+                    .map(|value| value.as_name.as_str())
+            })
+            .or_else(|| {
+                self.as_sym_bool
+                    .as_ref()
+                    .map(|value| value.as_name.as_str())
+            })
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -70,6 +102,7 @@ pub struct NodeInput {
     pub arg: Argument,
     /// 1 = positional, 2 = keyword (not formally documented, but observed)
     #[serde(default)]
+    #[allow(dead_code)]
     pub kind: u32,
 }
 
@@ -85,6 +118,8 @@ pub enum Argument {
     Ints(IntsArg),
     SymInts(SymIntsArg),
     SymInt(SymIntArg),
+    SymFloat(SymFloatArg),
+    SymBool(SymBoolArg),
     Expr(ExprArg),
     #[allow(dead_code)]
     ScalarType(ScalarTypeArg),
@@ -160,6 +195,16 @@ pub struct SymIntValue {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct SymFloatArg {
+    pub as_sym_float: ScalarName,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SymBoolArg {
+    pub as_sym_bool: ScalarName,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct ExprArg {
     pub as_expr: ExprValue,
 }
@@ -205,6 +250,17 @@ impl Argument {
             Argument::Tensor(t) => Some(&t.as_tensor.name),
             _ => None,
         }
+    }
+
+    /// Resolve a PT2 tensor or scalar dataflow reference. Scalar references
+    /// are backed by typed zero-dimensional GraphTensors in the translator.
+    pub fn as_value_name(&self) -> Option<&str> {
+        self.as_tensor_name().or(match self {
+            Argument::SymInt(value) => Some(value.as_sym_int.as_name.as_str()),
+            Argument::SymFloat(value) => Some(value.as_sym_float.as_name.as_str()),
+            Argument::SymBool(value) => Some(value.as_sym_bool.as_name.as_str()),
+            _ => None,
+        })
     }
 
     pub fn as_int(&self) -> Option<i64> {

--- a/crates/luminal_python/rust/src/translator/attention.rs
+++ b/crates/luminal_python/rust/src/translator/attention.rs
@@ -76,7 +76,7 @@ impl<'a> Translator<'a> {
         // Default scale 1/sqrt(head_dim) needs a concrete head_dim;
         // symbolic-shape HF graphs always pass `scale` explicitly.
         let scale = match float_arg("scale") {
-            Some(v) => v as f32,
+            Some(v) => v,
             None => {
                 let head_dim = query
                     .legacy_tracker_ref()
@@ -87,7 +87,7 @@ impl<'a> Translator<'a> {
                         "SDPA: query head_dim must be concrete to derive the default \
                          scale (pass `scale` explicitly for symbolic head dims)",
                     )?;
-                1.0_f32 / (head_dim as f32).sqrt()
+                1.0_f64 / (head_dim as f64).sqrt()
             }
         };
 

--- a/crates/luminal_python/rust/src/translator/binary.rs
+++ b/crates/luminal_python/rust/src/translator/binary.rs
@@ -36,12 +36,35 @@ fn same_dims(
 }
 
 impl<'a> Translator<'a> {
+    fn scalar_constant(&mut self, val: f64, dtype: DType) -> GraphTensor {
+        if dtype == DType::F64 {
+            self.graph.constant_float64(val)
+        } else {
+            self.graph.constant_float(val as f32).cast(dtype)
+        }
+    }
+
+    fn get_explicit_alpha(&self, node: &Node, op: BinaryOp) -> Result<Option<f64>> {
+        if !matches!(op, BinaryOp::Add | BinaryOp::Sub) {
+            return Ok(None);
+        }
+        node.inputs
+            .iter()
+            .position(|input| input.name == "alpha")
+            .map(|idx| self.get_float_arg(node, idx))
+            .transpose()
+    }
+
     pub(crate) fn translate_binary_op(&mut self, node: &Node, op: BinaryOp) -> Result<GraphTensor> {
         let a = self.get_input_tensor(node, 0)?;
+        let alpha = self.get_explicit_alpha(node, op)?;
         let arg1 = &node.inputs[1].arg;
         if let Some(name) = arg1.as_tensor_name() {
             let b = self.get_tensor(name)?;
-            let (a, b) = ensure_same_dtype(a, b);
+            let (a, mut b) = ensure_same_dtype(a, b);
+            if let Some(alpha) = alpha {
+                b = self.apply_scalar_op(b, alpha, BinaryOp::Mul);
+            }
             let (mut a, mut b) = broadcast_binary(a, b);
             let sym_ranges = sym_char_ranges(&self.sym_map);
             normalize_equal_dims(&mut a, &mut b, &sym_ranges);
@@ -62,13 +85,18 @@ impl<'a> Translator<'a> {
             })
         } else {
             if let Some(f) = arg1.as_float() {
-                return Ok(self.apply_scalar_op(a, f as f32, op));
+                return Ok(self.apply_scalar_op_with_alpha(a, f, alpha, op));
             }
             if let Some(expr) = self.resolve_arg_as_expression(arg1) {
+                anyhow::ensure!(
+                    alpha.is_none(),
+                    "{} with an explicit alpha and symbolic scalar operand is not supported",
+                    node.target
+                );
                 return Ok(self.apply_symbolic_scalar_op(a, expr, op));
             }
-            let val = self.get_float_arg(node, 1)? as f32;
-            Ok(self.apply_scalar_op(a, val, op))
+            let val = self.get_float_arg(node, 1)?;
+            Ok(self.apply_scalar_op_with_alpha(a, val, alpha, op))
         }
     }
 
@@ -78,33 +106,56 @@ impl<'a> Translator<'a> {
         op: BinaryOp,
     ) -> Result<GraphTensor> {
         let a = self.get_input_tensor(node, 0)?;
+        let alpha = self.get_explicit_alpha(node, op)?;
         let arg1 = &node.inputs[1].arg;
         if let Some(f) = arg1.as_float() {
-            return Ok(self.apply_scalar_op(a, f as f32, op));
+            return Ok(self.apply_scalar_op_with_alpha(a, f, alpha, op));
         }
         if let Some(expr) = self.resolve_arg_as_expression(arg1) {
+            anyhow::ensure!(
+                alpha.is_none(),
+                "{} with an explicit alpha and symbolic scalar operand is not supported",
+                node.target
+            );
             return Ok(self.apply_symbolic_scalar_op(a, expr, op));
         }
-        let val = self.get_float_arg(node, 1)? as f32;
-        Ok(self.apply_scalar_op(a, val, op))
+        let val = self.get_float_arg(node, 1)?;
+        Ok(self.apply_scalar_op_with_alpha(a, val, alpha, op))
     }
 
     pub(crate) fn apply_scalar_op(
         &mut self,
         a: GraphTensor,
-        val: f32,
+        val: f64,
         op: BinaryOp,
     ) -> GraphTensor {
-        let scalar = self
-            .graph
-            .constant_float(val)
-            .cast(a.dtype)
-            .expand_rhs(a.dims());
+        let scalar = self.scalar_constant(val, a.dtype).expand_rhs(a.dims());
         match op {
             BinaryOp::Add => a + scalar,
             BinaryOp::Mul => a * scalar,
             BinaryOp::Sub => a - scalar,
             BinaryOp::Div => a / scalar,
+        }
+    }
+
+    fn apply_scalar_op_with_alpha(
+        &mut self,
+        a: GraphTensor,
+        val: f64,
+        alpha: Option<f64>,
+        op: BinaryOp,
+    ) -> GraphTensor {
+        if let Some(alpha) = alpha {
+            let scalar = self.scalar_constant(val, a.dtype).expand_rhs(a.dims());
+            let scaled = self.apply_scalar_op(scalar, alpha, BinaryOp::Mul);
+            match op {
+                BinaryOp::Add => a + scaled,
+                BinaryOp::Mul => a * scaled,
+                BinaryOp::Sub => a - scaled,
+                BinaryOp::Div => a / scaled,
+            }
+        } else {
+            self.apply_scalar_op(a, val, op)
         }
     }
 

--- a/crates/luminal_python/rust/src/translator/dispatch.rs
+++ b/crates/luminal_python/rust/src/translator/dispatch.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use luminal::prelude::*;
 
 use crate::pt2_schema::*;
@@ -32,6 +32,24 @@ impl<'a> Translator<'a> {
             _ => {}
         }
 
+        // PT2 scalar values remain tensor-backed in Luminal. `item` and
+        // `_local_scalar_dense` therefore bind their scalar output name to a
+        // zero-dimensional view of the one-element input instead of creating
+        // a separate host-scalar IR value.
+        if matches!(
+            target.as_str(),
+            "torch.ops.aten.item.default" | "torch.ops.aten._local_scalar_dense.default"
+        ) {
+            let name = node
+                .outputs
+                .first()
+                .and_then(TensorRef::value_name)
+                .context("item/local_scalar_dense is missing its scalar output name")?;
+            let scalar = reshape_tensor(self.get_input_tensor(node, 0)?, vec![]);
+            self.tensors.insert(name.to_string(), scalar);
+            return Ok(());
+        }
+
         let has_tensor_output = node
             .outputs
             .iter()
@@ -59,6 +77,8 @@ impl<'a> Translator<'a> {
             "torch.ops.aten.exp.default" => self.translate_unary_op(node, |a| a.exp())?,
             "torch.ops.aten.sin.default" => self.translate_unary_op(node, |a| a.sin())?,
             "torch.ops.aten.cos.default" => self.translate_unary_op(node, |a| a.cos())?,
+            "torch.ops.aten.acos.default" => self.translate_acos(node)?,
+            "torch.ops.aten.acosh.default" => self.translate_acosh(node)?,
             "torch.ops.aten.sqrt.default" => self.translate_unary_op(node, |a| a.sqrt())?,
             "torch.ops.aten.rsqrt.default" => {
                 self.translate_unary_op(node, |a| a.sqrt().reciprocal())?
@@ -224,8 +244,7 @@ impl<'a> Translator<'a> {
                 self.translate_grouped_mm(node)?
             }
             "torch.ops.aten.scalar_tensor.default" => {
-                let val = self.get_float_arg(node, 0)? as f32;
-                self.graph.constant_float(val)
+                self.translate_scalar_tensor(node, &output_name)?
             }
             // Scalar comparisons
             "torch.ops.aten.gt.Scalar" => self.translate_scalar_comparison(node, |a, s| a.gt(s))?,
@@ -524,6 +543,43 @@ impl<'a> Translator<'a> {
 }
 
 impl<'a> Translator<'a> {
+    fn translate_scalar_tensor(&mut self, node: &Node, output_name: &str) -> Result<GraphTensor> {
+        let meta = self
+            .tensor_meta(output_name)
+            .context("scalar_tensor is missing output tensor metadata")?;
+        let dtype = torch_dtype_int_to_luminal(meta.dtype);
+        let arg = &node
+            .inputs
+            .first()
+            .context("scalar_tensor is missing its scalar input")?
+            .arg;
+
+        if let Some(name) = arg.as_value_name() {
+            let value = reshape_tensor(self.get_tensor(name)?, vec![]);
+            return Ok(if value.dtype == dtype {
+                value
+            } else {
+                value.cast(dtype)
+            });
+        }
+
+        if let Some(value) = arg.as_float() {
+            return Ok(if dtype == DType::F64 {
+                self.graph.constant_float64(value)
+            } else {
+                self.graph.constant_float(value as f32).cast(dtype)
+            });
+        }
+        if let Some(value) = arg.as_int() {
+            return Ok(self.graph.constant(value).cast(dtype));
+        }
+        if let Some(value) = arg.as_bool() {
+            return Ok(self.graph.constant(i64::from(value)).cast(dtype));
+        }
+
+        bail!("scalar_tensor input is not tensor-backed or a literal: {arg:?}")
+    }
+
     fn translate_scalar_comparison(
         &mut self,
         node: &Node,

--- a/crates/luminal_python/rust/src/translator/mod.rs
+++ b/crates/luminal_python/rust/src/translator/mod.rs
@@ -45,7 +45,8 @@ pub fn translate(parsed: &ParsedPT2) -> Result<TranslatedGraph> {
 pub(crate) struct Translator<'a> {
     pub(crate) parsed: &'a ParsedPT2,
     pub(crate) graph: Graph,
-    /// Maps tensor name -> GraphTensor
+    /// Maps PT2 tensor and scalar value names to GraphTensors. Scalars are
+    /// represented as typed zero-dimensional tensors.
     pub(crate) tensors: HashMap<String, GraphTensor>,
     pub(crate) sym_map: SymDimMap,
     pub(crate) user_input_ids: Vec<(String, NodeIndex)>,
@@ -175,8 +176,11 @@ impl<'a> Translator<'a> {
             .get(idx)
             .with_context(|| format!("Node {} missing input {idx}", node.target))?
             .arg;
-        let name = arg.as_tensor_name().with_context(|| {
-            format!("Input {idx} of {} is not a tensor: {:?}", node.target, arg)
+        let name = arg.as_value_name().with_context(|| {
+            format!(
+                "Input {idx} of {} is not a tensor-backed value: {:?}",
+                node.target, arg
+            )
         })?;
         self.get_tensor(name)
     }

--- a/crates/luminal_python/rust/src/translator/tensor.rs
+++ b/crates/luminal_python/rust/src/translator/tensor.rs
@@ -27,26 +27,91 @@ const WHERE_OTHER_ARG: usize = 2;
 const TRIANGULAR_INPUT_ARG: usize = 0;
 const TRIANGULAR_DIAGONAL_ARG: usize = 1;
 
+#[derive(Clone, Copy, Debug)]
+enum ArangeScalar {
+    Int(i64),
+    Float(f64),
+    Expr(IntExpr),
+}
+
 impl<'a> Translator<'a> {
     pub(crate) fn translate_arange(&mut self, node: &Node) -> Result<GraphTensor> {
-        let positional_args: Vec<IntExpr> = node
+        // PT2's start_step overload names these arguments even when the
+        // original call used a keyword (`torch.arange(0, end=3)`). Resolve by
+        // schema name rather than collecting every decodable positional arg:
+        // the old filter_map silently discarded float/bool values and shifted
+        // the remaining operands into the wrong start/end/step slots.
+        let start = self.arange_scalar_arg(node, "start")?;
+        let step = node
             .inputs
             .iter()
-            .filter(|i| i.kind <= 1)
-            .filter_map(|i| self.resolve_arg_as_expression(&i.arg))
-            .collect();
+            .find(|input| input.name == "step")
+            .map(|input| self.decode_arange_scalar(&input.arg))
+            .transpose()?
+            .unwrap_or(ArangeScalar::Int(1));
 
-        match positional_args.len() {
-            0 => anyhow::bail!("arange: no positional args found"),
-            1 => Ok(self.graph.arange(positional_args[0])),
-            2 => Ok(self
-                .graph
-                .arange_options(positional_args[0], positional_args[1], 1)),
-            _ => Ok(self.graph.arange_options(
-                positional_args[0],
-                positional_args[1],
-                positional_args[2],
-            )),
+        // Export has already applied PyTorch's dtype-sensitive ceiling and
+        // endpoint rules. Its tensor metadata is therefore authoritative for
+        // the number of values, including fractional/negative steps and empty
+        // ranges. Recomputing `(end-start)/step` in IntExpr arithmetic used
+        // truncating division and disagreed with shapes such as arange(-1,2,2).
+        let output_shape = self.output_meta_shape(node)?;
+        anyhow::ensure!(
+            output_shape.len() == 1,
+            "arange: expected rank-1 output metadata, got {output_shape:?}"
+        );
+        let output_dtype = self.output_meta_dtype(node)?;
+        let indices = self.graph.arange(output_shape[0]).cast(output_dtype);
+        let shape = indices.dims();
+        let step = self
+            .arange_scalar_constant(step, output_dtype)
+            .expand_rhs(shape.clone());
+        let start = self
+            .arange_scalar_constant(start, output_dtype)
+            .expand_rhs(shape);
+        Ok(indices * step + start)
+    }
+
+    fn arange_scalar_arg(&self, node: &Node, name: &str) -> Result<ArangeScalar> {
+        let input = node
+            .inputs
+            .iter()
+            .find(|input| input.name == name)
+            .with_context(|| format!("arange: missing `{name}` argument"))?;
+        self.decode_arange_scalar(&input.arg)
+    }
+
+    fn decode_arange_scalar(&self, arg: &Argument) -> Result<ArangeScalar> {
+        if let Some(value) = arg.as_int() {
+            return Ok(ArangeScalar::Int(value));
+        }
+        if let Some(value) = arg.as_float() {
+            return Ok(ArangeScalar::Float(value));
+        }
+        if let Some(value) = arg.as_bool() {
+            return Ok(ArangeScalar::Int(i64::from(value)));
+        }
+        if let Some(value) = self.resolve_arg_as_expression(arg) {
+            return Ok(ArangeScalar::Expr(value));
+        }
+        anyhow::bail!("arange: unsupported scalar argument {arg:?}")
+    }
+
+    fn arange_scalar_constant(&mut self, value: ArangeScalar, dtype: DType) -> GraphTensor {
+        match value {
+            ArangeScalar::Int(value) => match dtype {
+                DType::F64 => self.graph.constant_float64(value as f64),
+                DType::F32 | DType::F16 | DType::Bf16 => {
+                    self.graph.constant_float(value as f32).cast(dtype)
+                }
+                _ => self.graph.constant(value).cast(dtype),
+            },
+            ArangeScalar::Float(value) => match dtype {
+                DType::F64 => self.graph.constant_float64(value),
+                DType::Int | DType::I64 => self.graph.constant_float64(value).cast(dtype),
+                _ => self.graph.constant_float(value as f32).cast(dtype),
+            },
+            ArangeScalar::Expr(value) => self.graph.constant(value).cast(dtype),
         }
     }
 

--- a/crates/luminal_python/rust/src/translator/unary.rs
+++ b/crates/luminal_python/rust/src/translator/unary.rs
@@ -52,6 +52,67 @@ impl<'a> Translator<'a> {
         Ok(f(a))
     }
 
+    /// Translate `aten.acos.default` into existing elementwise HLIR primitives.
+    ///
+    /// For `x >= 0`, approximate `acos(x)` as `sqrt(1 - x) * P(x)`, where
+    /// `P` is a degree-8 Chebyshev approximation of
+    /// `acos(x) / sqrt(1 - x)` on `[0, 1]`. Extend it to negative inputs with
+    /// `acos(-x) = pi - acos(x)`. Factoring out the square-root endpoint
+    /// behavior keeps the polynomial smooth and also makes out-of-domain real
+    /// inputs produce NaN through `sqrt(1 - abs(x))`, matching PyTorch.
+    ///
+    /// PyTorch promotes integral and bool inputs to F32 for inverse trig ops.
+    #[allow(clippy::excessive_precision)]
+    pub(crate) fn translate_acos(&mut self, node: &Node) -> Result<GraphTensor> {
+        let input = self.get_input_tensor(node, 0)?;
+        let input = match input.dtype {
+            DType::Bool | DType::Int | DType::I64 => input.cast(DType::F32),
+            _ => input,
+        };
+        let x = input.abs();
+
+        // Horner form, highest-order coefficient first. The maximum absolute
+        // approximation error in F32 is below 3e-7 over the real acos domain.
+        let polynomial = 0.000_684_531_8 * x - 0.003_974_577_8;
+        let polynomial = polynomial * x + 0.011_028_381;
+        let polynomial = polynomial * x - 0.020_727_666;
+        let polynomial = polynomial * x + 0.032_571_17;
+        let polynomial = polynomial * x - 0.050_593_574;
+        let polynomial = polynomial * x + 0.089_030_14;
+        let polynomial = polynomial * x - 0.214_601_16;
+        let polynomial = polynomial * x + std::f32::consts::FRAC_PI_2;
+        let positive = polynomial * (1.0 - x).sqrt();
+
+        let zero = self
+            .graph
+            .constant_float(0.0)
+            .cast(input.dtype)
+            .expand_rhs(input.dims());
+        let negative = input.lt(zero).cast(input.dtype);
+        Ok(positive + negative * (std::f32::consts::PI - 2.0 * positive))
+    }
+
+    /// Translate `aten.acosh.default` into existing elementwise HLIR primitives.
+    ///
+    /// The textbook `log(x + sqrt(x * x - 1))` form overflows before the log
+    /// for large finite inputs, especially in F16. Use the equivalent form
+    ///
+    /// `log(x) + log(1 + sqrt(1 - 1 / x^2))`
+    ///
+    /// instead. For real inputs below one, either the square root or `log(x)`
+    /// naturally produces NaN, matching PyTorch's real-domain behavior.
+    /// PyTorch promotes integral and bool inputs to F32 for inverse hyperbolic
+    /// operations, while floating inputs retain their dtype.
+    pub(crate) fn translate_acosh(&mut self, node: &Node) -> Result<GraphTensor> {
+        let input = self.get_input_tensor(node, 0)?;
+        let input = match input.dtype {
+            DType::Bool | DType::Int | DType::I64 => input.cast(DType::F32),
+            _ => input,
+        };
+        let reciprocal_squared = input.reciprocal().square();
+        Ok(input.log() + (1.0 + (1.0 - reciprocal_squared).sqrt()).log())
+    }
+
     /// Translate `aten.gelu`, honoring the `approximate` kwarg. PyTorch's default
     /// (`approximate="none"`) is the exact erf form; `"tanh"` selects the tanh
     /// approximation. Mapping both to a single `gelu()` (as before) silently used the

--- a/crates/luminal_python/src/luminal/compiled_model.py
+++ b/crates/luminal_python/src/luminal/compiled_model.py
@@ -26,7 +26,12 @@ class CompiledModel:
     """Wrapper around CompiledGraph that handles PyTorch tensor conversion."""
 
     def __init__(
-        self, graph_result, weight_refs=None, input_names=None, user_indices=None
+        self,
+        graph_result,
+        weight_refs=None,
+        input_names=None,
+        user_indices=None,
+        scalar_output_positions=(),
     ):
         """Initialize with a compiled CompiledGraph from Rust.
 
@@ -50,6 +55,7 @@ class CompiledModel:
         self._has_dynamic_dims = getattr(graph_result, "has_dynamic_dims", False)
         self._weight_refs = weight_refs or []
         self._user_indices = user_indices
+        self._scalar_output_positions = frozenset(scalar_output_positions)
         self.skip_input_names = frozenset()
         self._is_gpu = getattr(graph_result, "device_type", "cpu") != "cpu"
         self._supports_device_ptrs = getattr(
@@ -228,8 +234,10 @@ class CompiledModel:
                 )
             getter_name, read_dtype = entry
             data = getattr(self._graph, getter_name)(name)
-            if len(data) == 0 and all(d != 0 for d in shape):
-                return None
+            if len(data) == 0:
+                if all(d != 0 for d in shape):
+                    return None
+                return torch.empty(tuple(shape), dtype=out_dtype, device=input_device)
             if out_dtype in (torch.float16, torch.bfloat16):
                 # Getter returned an immutable `bytes` from Rust; wrap in
                 # `bytearray` to make the storage writable (suppresses
@@ -290,4 +298,7 @@ class CompiledModel:
                 out = _read_typed_output(name, shape, out_dtype)
             outputs.append(out)
 
-        return tuple(outputs)
+        return tuple(
+            output.item() if i in self._scalar_output_positions else output
+            for i, output in enumerate(outputs)
+        )

--- a/crates/luminal_python/src/luminal/main.py
+++ b/crates/luminal_python/src/luminal/main.py
@@ -84,7 +84,9 @@ def register_backend(factory_capsule):
 
     def backend(gm, example_inputs, options=None):
         return _compile_pt2(
-            gm, example_inputs, factory_capsule,
+            gm,
+            example_inputs,
+            factory_capsule,
             search_iterations=(options or {}).get("search_iterations"),
         )
 
@@ -108,7 +110,9 @@ def luminal_backend(gm, example_inputs, options=None):
     """
     capsule = _detect_factory_capsule(example_inputs)
     return _compile_pt2(
-        gm, example_inputs, capsule,
+        gm,
+        example_inputs,
+        capsule,
         search_iterations=(options or {}).get("search_iterations"),
     )
 
@@ -123,6 +127,8 @@ def _compile_pt2(gm, example_inputs, factory_capsule, search_iterations=None):
     from .pt2 import pt2_backend
 
     return pt2_backend(
-        gm, example_inputs, factory=factory_capsule,
+        gm,
+        example_inputs,
+        factory=factory_capsule,
         search_iterations=search_iterations,
     )

--- a/crates/luminal_python/src/luminal/pt2.py
+++ b/crates/luminal_python/src/luminal/pt2.py
@@ -110,6 +110,68 @@ def _export_kwargs():
     return kwargs
 
 
+def _box_scalar_graph_outputs(gm):
+    """Represent backend scalar outputs as typed zero-dimensional tensors.
+
+    Dynamo's backend graph may return SymInt/SymFloat/SymBool values even
+    though Luminal's HLIR is tensor-only. Box those output leaves before the
+    second torch.export capture and remember their flattened output positions;
+    CompiledModel calls ``.item()`` at those positions after execution to
+    restore the backend contract.
+
+    This is an output-boundary canonicalization, not a symbolic-scalar IR:
+    inside Luminal the values remain ordinary typed rank-zero tensors.
+    """
+
+    output = next(node for node in gm.graph.nodes if node.op == "output")
+    flat_outputs, output_spec = torch.utils._pytree.tree_flatten(output.args[0])
+    scalar_output_positions = []
+    compiled_position = 0
+
+    def scalar_dtype(value):
+        if isinstance(value, (torch.SymBool, bool)):
+            return torch.bool
+        if isinstance(value, (torch.SymInt, int)):
+            return torch.int64
+        if isinstance(value, (torch.SymFloat, float)):
+            return torch.float64
+        return None
+
+    boxed_outputs = []
+    for value in flat_outputs:
+        example = (
+            value.meta.get("example_value")
+            if isinstance(value, torch.fx.Node)
+            else value
+        )
+        if isinstance(example, torch.Tensor):
+            boxed_outputs.append(value)
+            compiled_position += 1
+            continue
+
+        dtype = scalar_dtype(example)
+        if dtype is None:
+            # Non-value outputs such as None remain outside the compiled tensor
+            # output list, matching the existing PT2 parser behavior.
+            boxed_outputs.append(value)
+            continue
+
+        with gm.graph.inserting_before(output):
+            boxed = gm.graph.call_function(
+                torch.scalar_tensor, (value,), {"dtype": dtype}
+            )
+        boxed_outputs.append(boxed)
+        scalar_output_positions.append(compiled_position)
+        compiled_position += 1
+
+    if scalar_output_positions:
+        output.args = (torch.utils._pytree.tree_unflatten(boxed_outputs, output_spec),)
+        gm.graph.lint()
+        gm.recompile()
+
+    return tuple(scalar_output_positions)
+
+
 def _decomp_table():
     """Decomposition table for `ep.run_decompositions()` that preserves SDPA.
 
@@ -226,7 +288,12 @@ def _lower_sym_sum(ep) -> None:
 
 
 def _save_and_compile(
-    ep_or_path, factory, search_iterations, user_indices=None, input_device_ptrs=None
+    ep_or_path,
+    factory,
+    search_iterations,
+    user_indices=None,
+    input_device_ptrs=None,
+    scalar_output_positions=(),
 ):
     """Compile a PT2 model via Rust, return CompiledModel.
 
@@ -265,7 +332,10 @@ def _save_and_compile(
         _load_cpu_weights(compiled, cpu_weights)
 
         return CompiledModel(
-            compiled, weight_refs=keep_alive, user_indices=user_indices
+            compiled,
+            weight_refs=keep_alive,
+            user_indices=user_indices,
+            scalar_output_positions=scalar_output_positions,
         )
     finally:
         if owns_tmpdir and tmpdir:
@@ -638,7 +708,13 @@ def _build_dynamic_shapes_from_dim_arg(dynamic_dim, example_args):
 
 
 def _eager_pt2_compile(
-    gm, user_inputs, user_indices, dynamic_shapes, factory, search_iterations
+    gm,
+    user_inputs,
+    user_indices,
+    dynamic_shapes,
+    factory,
+    search_iterations,
+    scalar_output_positions=(),
 ):
     """Run torch.export → save → Rust compile end-to-end. Returns CompiledModel.
 
@@ -700,6 +776,7 @@ def _eager_pt2_compile(
             search_iterations,
             user_indices=user_indices,
             input_device_ptrs=input_device_ptrs,
+            scalar_output_positions=scalar_output_positions,
         )
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
@@ -738,12 +815,14 @@ class _LazyDynamicCompiledModel:
         dynamic_shapes,
         factory,
         search_iterations,
+        scalar_output_positions=(),
     ):
         self._gm = gm
         self._user_inputs = user_inputs
         self._user_indices = user_indices
         self._dynamic_shapes = dynamic_shapes
         self._search_iterations = search_iterations
+        self._scalar_output_positions = scalar_output_positions
         self._factory = factory
         self._compiled = None
 
@@ -756,6 +835,7 @@ class _LazyDynamicCompiledModel:
                 self._dynamic_shapes,
                 self._factory,
                 self._search_iterations,
+                self._scalar_output_positions,
             )
             # Drop references we no longer need post-compile.
             self._gm = None
@@ -800,6 +880,7 @@ def pt2_backend(gm, example_inputs, factory=None, search_iterations=None):
     # same frame" assertions on the next call. The deepcopy is cheap relative
     # to the rest of the export pipeline.
     gm = _copy.deepcopy(gm).eval()
+    scalar_output_positions = _box_scalar_graph_outputs(gm)
     # Dynamo-lifted weights stay in the args and flow through torch.export
     # as ordinary inputs, so artifact reuse across same-shape module
     # instances is correct by construction (LUM-631).
@@ -830,10 +911,21 @@ def pt2_backend(gm, example_inputs, factory=None, search_iterations=None):
         # Dynamo is still relying on, and running it inside the backend frame
         # corrupts the freshly-installed guards.
         return _LazyDynamicCompiledModel(
-            gm, user_inputs, user_indices, dynamic_shapes, factory,
+            gm,
+            user_inputs,
+            user_indices,
+            dynamic_shapes,
+            factory,
             search_iterations,
+            scalar_output_positions,
         )
 
     return _eager_pt2_compile(
-        gm, user_inputs, user_indices, None, factory, search_iterations
+        gm,
+        user_inputs,
+        user_indices,
+        None,
+        factory,
+        search_iterations,
+        scalar_output_positions,
     )

--- a/crates/luminal_python/tests/test_dtype_boundary.py
+++ b/crates/luminal_python/tests/test_dtype_boundary.py
@@ -1,11 +1,11 @@
-from dataclasses import dataclass
 import warnings
-from typing import Callable
+from collections.abc import Callable
+from dataclasses import dataclass
 
 import pytest
 import torch
-
 from luminal import luminal_backend
+from luminal.dtype_util import torch_dtype_code
 
 
 class BoundaryNoopModel(torch.nn.Module):
@@ -13,6 +13,76 @@ class BoundaryNoopModel(torch.nn.Module):
         if x.dtype is torch.bool:
             return x | torch.zeros((), dtype=torch.bool, device=x.device)
         return x + torch.zeros((), dtype=x.dtype, device=x.device)
+
+
+class EmptyWeightModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.register_buffer("weight", torch.empty((0, 3), dtype=torch.float32))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + self.weight
+
+
+class AddWithoutAlphaModel(torch.nn.Module):
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return torch.add(x, y)
+
+
+class AddWithAlphaModel(torch.nn.Module):
+    def __init__(self, alpha: float) -> None:
+        super().__init__()
+        self.alpha = alpha
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return torch.add(x, y, alpha=self.alpha)
+
+
+class AddScalarWithAlphaModel(torch.nn.Module):
+    def __init__(self, alpha: float) -> None:
+        super().__init__()
+        self.alpha = alpha
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.add(x, 1.0, alpha=self.alpha)
+
+
+class ItemModel(torch.nn.Module):
+    def forward(self, x: torch.Tensor):
+        return x.item()
+
+
+class ArangeModel(torch.nn.Module):
+    def __init__(
+        self,
+        start,
+        end,
+        step,
+        dtype: torch.dtype,
+        *,
+        keyword_end: bool = False,
+    ) -> None:
+        super().__init__()
+        self.start = start
+        self.end = end
+        self.step = step
+        self.dtype = dtype
+        self.keyword_end = keyword_end
+
+    def forward(self) -> torch.Tensor:
+        if self.keyword_end:
+            return torch.arange(
+                self.start,
+                end=self.end,
+                step=self.step,
+                dtype=self.dtype,
+            )
+        return torch.arange(
+            self.start,
+            self.end,
+            self.step,
+            dtype=self.dtype,
+        )
 
 
 @dataclass(frozen=True)
@@ -167,6 +237,193 @@ def test_boundary_noop_preserves_dtype_and_values(
     assert isinstance(actual, torch.Tensor)
     assert actual.dtype == expected.dtype
     assert torch.equal(actual.cpu(), expected.cpu())
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pytest.param(torch.bool, id="bool"),
+        pytest.param(torch.int32, id="int32"),
+        pytest.param(torch.int64, id="int64"),
+        pytest.param(torch.float16, id="float16"),
+        pytest.param(torch.bfloat16, id="bfloat16"),
+        pytest.param(torch.float32, id="float32"),
+        pytest.param(torch.float64, id="float64"),
+    ],
+)
+def test_empty_cpu_input_preserves_shape_and_dtype(dtype: torch.dtype) -> None:
+    """A zero-byte CPU tensor may have a null data pointer and must still
+    cross the compiled boundary with its shape and dtype intact."""
+    model = BoundaryNoopModel()
+    compiled = torch.compile(model, backend=luminal_backend, fullgraph=True)
+
+    x = torch.empty((1, 0, 3), dtype=dtype)
+    expected = model(x)
+    actual = compiled(x)
+
+    assert actual.shape == expected.shape
+    assert actual.dtype == expected.dtype
+    assert torch.equal(actual, expected)
+
+
+def test_empty_cpu_weight_preserves_shape_and_dtype() -> None:
+    """Zero-byte registered weights use the same null-pointer contract as
+    runtime inputs."""
+    model = EmptyWeightModel()
+    compiled = torch.compile(model, backend=luminal_backend, fullgraph=True)
+
+    x = torch.empty((0, 3), dtype=torch.float32)
+    expected = model(x)
+    actual = compiled(x)
+
+    assert actual.shape == expected.shape
+    assert actual.dtype == expected.dtype
+    assert torch.equal(actual, expected)
+
+
+def test_float64_add_without_alpha_matches_eager() -> None:
+    """An omitted alpha stays a direct add rather than adding a multiply."""
+    model = AddWithoutAlphaModel()
+    compiled = torch.compile(model, backend=luminal_backend, fullgraph=True)
+    x = torch.tensor([1.0, 1.0000000000000002], dtype=torch.float64)
+    y = torch.tensor([2.0, -0.5], dtype=torch.float64)
+
+    actual = compiled(x, y)
+    expected = model(x, y)
+
+    assert actual.dtype == torch.float64
+    torch.testing.assert_close(actual, expected, rtol=0.0, atol=0.0)
+
+
+@pytest.mark.parametrize("alpha", [2.0, -3.125, 1.0000000000000002])
+def test_float64_add_with_explicit_alpha_matches_eager(alpha: float) -> None:
+    """Explicit alpha is represented and multiplied as F64 without narrowing."""
+    model = AddWithAlphaModel(alpha)
+    compiled = torch.compile(model, backend=luminal_backend, fullgraph=True)
+    x = torch.zeros(3, dtype=torch.float64)
+    y = torch.tensor([1.0, 2.0, -4.0], dtype=torch.float64)
+
+    actual = compiled(x, y)
+    expected = model(x, y)
+
+    assert actual.dtype == torch.float64
+    torch.testing.assert_close(actual, expected, rtol=0.0, atol=0.0)
+
+
+def test_float64_add_scalar_with_explicit_alpha_matches_eager() -> None:
+    """The scalar-operand lowering also keeps an explicit F64 alpha exact."""
+    alpha = 1.0000000000000002
+    model = AddScalarWithAlphaModel(alpha)
+    compiled = torch.compile(model, backend=luminal_backend, fullgraph=True)
+    x = torch.zeros(3, dtype=torch.float64)
+
+    actual = compiled(x)
+    expected = model(x)
+
+    assert actual.dtype == torch.float64
+    torch.testing.assert_close(actual, expected, rtol=0.0, atol=0.0)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "value", "python_type"),
+    [
+        pytest.param(torch.float16, 1.5, float, id="float16"),
+        pytest.param(torch.bfloat16, -2.25, float, id="bfloat16"),
+        pytest.param(torch.float32, 1.25, float, id="float32"),
+        pytest.param(
+            torch.float64,
+            1.0000000000000002,
+            float,
+            id="float64-precision-sensitive",
+        ),
+        pytest.param(torch.int32, 2**30 + 3, int, id="int32"),
+        pytest.param(torch.int64, 2**40 + 3, int, id="int64"),
+        pytest.param(torch.bool, True, bool, id="bool"),
+    ],
+)
+def test_item_returns_exact_python_scalar(
+    dtype: torch.dtype,
+    value,
+    python_type: type,
+) -> None:
+    """HLIR keeps item values as typed rank-zero tensors and the backend
+    reconstructs the Python scalar only at its output boundary."""
+    model = ItemModel()
+    compiled = torch.compile(model, backend=luminal_backend, fullgraph=True)
+    x = torch.tensor(value, dtype=dtype)
+
+    expected = model(x)
+    actual = compiled(x)
+
+    assert type(actual) is python_type
+    assert type(actual) is type(expected)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ("start", "end", "step", "dtype", "keyword_end"),
+    [
+        pytest.param(-1, 2, 2, torch.float32, False, id="ceil-length"),
+        pytest.param(0.0, -8.000001, -4.0, torch.float64, False, id="negative-step"),
+        pytest.param(-0.9, 2.1, 2.0, torch.int32, False, id="fractional-to-int"),
+        pytest.param(False, True, True, torch.bfloat16, False, id="bool-scalars"),
+        pytest.param(0, 3.1, 1, torch.float16, True, id="keyword-end"),
+        pytest.param(1, 5, 2, torch.int64, False, id="int64-output"),
+        pytest.param(1.1, 1.1, -1.0, torch.float32, False, id="empty"),
+    ],
+)
+def test_arange_uses_exported_shape_and_declared_dtype(
+    start,
+    end,
+    step,
+    dtype: torch.dtype,
+    keyword_end: bool,
+) -> None:
+    """PT2 metadata owns arange's ceiling/endpoint shape semantics, while
+    the lowering preserves every scalar slot and materializes the declared
+    output dtype instead of leaking Iota's internal I32 dtype."""
+    model = ArangeModel(
+        start,
+        end,
+        step,
+        dtype,
+        keyword_end=keyword_end,
+    )
+    compiled = torch.compile(model, backend=luminal_backend, fullgraph=True)
+
+    expected = model()
+    actual = compiled()
+
+    assert actual.dtype == dtype
+    torch.testing.assert_close(actual, expected, rtol=0.0, atol=0.0)
+
+
+def test_nonempty_cpu_input_rejects_null_pointer() -> None:
+    """Null is valid only for an empty host buffer; non-empty buffers fail
+    with a Python exception instead of reaching unsafe pointer conversion."""
+    captured = []
+
+    def capture_backend(gm, example_inputs, options=None):
+        compiled_model = luminal_backend(gm, example_inputs, options)
+        captured.append(compiled_model)
+        return compiled_model
+
+    compiled = torch.compile(
+        BoundaryNoopModel(), backend=capture_backend, fullgraph=True
+    )
+    compiled(torch.ones(1, dtype=torch.float32))
+
+    compiled_model = captured[0]
+    with pytest.raises(
+        ValueError,
+        match="input pointer is null for a non-empty buffer of 4 bytes",
+    ):
+        compiled_model._graph.set_input_from_ptr(
+            compiled_model._input_names[0],
+            0,
+            4,
+            torch_dtype_code(torch.float32),
+        )
 
 
 @pytest.mark.parametrize(

--- a/crates/luminal_python/tests/test_hlir_ops.py
+++ b/crates/luminal_python/tests/test_hlir_ops.py
@@ -4,6 +4,8 @@ import pytest
 import torch
 import torch._dynamo
 from test_models import (
+    AcosTestModel,
+    AcoshTestModel,
     AddAddTestModel,
     AddConstantTestModel,
     AddTestModel,
@@ -386,6 +388,56 @@ def test_cos(device: torch.device):
     output = cos_test_model_compiled(x)
     original = cos_test_model(x)
     assert torch.allclose(output, original)
+
+
+def test_acos(device: torch.device):
+    model = AcosTestModel().to(device)
+    compiled = torch.compile(model, backend=luminal_backend)
+    x = torch.cat(
+        (
+            torch.linspace(-1.0, 1.0, 257, device=device),
+            torch.tensor([-1.5, 1.5, torch.nan], device=device),
+        )
+    )
+    torch.testing.assert_close(
+        compiled(x), model(x), rtol=1e-5, atol=1e-6, equal_nan=True
+    )
+
+
+@pytest.mark.parametrize("dtype", (torch.bool, torch.int32, torch.int64))
+def test_acos_promotes_integral_input(device: torch.device, dtype: torch.dtype):
+    model = AcosTestModel().to(device)
+    compiled = torch.compile(model, backend=luminal_backend)
+    values = [False, True] if dtype == torch.bool else [-1, 0, 1]
+    x = torch.tensor(values, device=device, dtype=dtype)
+    output = compiled(x)
+    assert output.dtype == torch.float32
+    torch.testing.assert_close(output, model(x), rtol=0, atol=0)
+
+
+def test_acosh(device: torch.device):
+    model = AcoshTestModel().to(device)
+    compiled = torch.compile(model, backend=luminal_backend)
+    x = torch.cat(
+        (
+            torch.linspace(1.0, 10.0, 257, device=device),
+            torch.tensor([0.0, 0.5, torch.inf, -torch.inf, torch.nan], device=device),
+        )
+    )
+    torch.testing.assert_close(
+        compiled(x), model(x), rtol=1e-5, atol=1e-5, equal_nan=True
+    )
+
+
+@pytest.mark.parametrize("dtype", (torch.bool, torch.int32, torch.int64))
+def test_acosh_promotes_integral_input(device: torch.device, dtype: torch.dtype):
+    model = AcoshTestModel().to(device)
+    compiled = torch.compile(model, backend=luminal_backend)
+    values = [False, True] if dtype == torch.bool else [1, 2, 4, 8]
+    x = torch.tensor(values, device=device, dtype=dtype)
+    output = compiled(x)
+    assert output.dtype == torch.float32
+    torch.testing.assert_close(output, model(x), rtol=1e-5, atol=1e-5, equal_nan=True)
 
 
 def test_transpose_2d(device: torch.device):

--- a/crates/luminal_python/tests/test_models.py
+++ b/crates/luminal_python/tests/test_models.py
@@ -89,6 +89,16 @@ class CosTestModel(torch.nn.Module):
         return torch.cos(x)
 
 
+class AcosTestModel(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.acos(x)
+
+
+class AcoshTestModel(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.acosh(x)
+
+
 class SubTestModel(torch.nn.Module):
     def __init__(self) -> None:
         super().__init__()

--- a/crates/luminal_python/tests/test_opinfo.py
+++ b/crates/luminal_python/tests/test_opinfo.py
@@ -1,0 +1,373 @@
+"""PyTorch OpInfo coverage for the Luminal ``torch.compile`` backend.
+
+This intentionally tests compiler-backend correctness, not PyTorch device-
+backend conformance. By default OpInfo creates CPU tensors, so eager PyTorch
+is compared with Luminal's reference backend. Setting
+``LUMINAL_TEST_DEVICE=cuda`` explicitly switches both sides to CUDA. Dynamo
+captures the public PyTorch operation, and Luminal compiles the resulting
+graph. Failures are intentionally unmarked so unsupported operations and dtype
+paths remain visible as ordinary test failures.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from contextlib import nullcontext
+from itertools import pairwise
+from types import FunctionType
+from typing import Any
+
+import pytest
+import torch
+from luminal import luminal_backend
+from torch.testing._internal.common_methods_invocations import op_db
+from torch.testing._internal.inductor_utils import clone_preserve_strides_offset
+from torch.testing._internal.opinfo.core import OpInfo, SampleInput
+from torch.testing._utils import freeze_rng_state, wrapper_set_seed
+from torch.utils import _pytree as pytree
+
+# PyTorch owns the complete operation inventory, metadata, and generated inputs
+# through ``op_db``. Every OpInfo is collected; unsupported Luminal paths should
+# be visible as test failures rather than filtered out by a capability allowlist.
+# Every CPU-supported dtype and every generated sample are exercised in this one
+# suite; there is no reduced smoke mode with a different coverage contract.
+_OPINFOS = tuple(op_db)
+
+_DTYPE_TOLERANCES = {
+    torch.float16: (1e-2, 1e-2),
+    torch.bfloat16: (3e-2, 2e-2),
+    torch.float32: (1e-5, 1e-5),
+    torch.float64: (1e-7, 1e-7),
+    torch.int32: (0.0, 0.0),
+    torch.int64: (0.0, 0.0),
+    torch.bool: (0.0, 0.0),
+}
+
+
+def _has_noncontiguous_tensor(sample: SampleInput) -> bool:
+    leaves = pytree.tree_leaves((sample.input, sample.args, sample.kwargs))
+    return any(
+        isinstance(value, torch.Tensor)
+        and value.layout is torch.strided
+        and not value.is_contiguous()
+        for value in leaves
+    )
+
+
+def _supports_noncontiguous_transform(sample: SampleInput) -> bool:
+    tensors = [
+        value
+        for value in pytree.tree_leaves((sample.input, sample.args, sample.kwargs))
+        if isinstance(value, torch.Tensor)
+    ]
+    return bool(tensors) and all(value.layout is torch.strided for value in tensors)
+
+
+def _opinfo_dtype_cases() -> tuple:
+    """Build lightweight cases for every CPU-supported OpInfo dtype."""
+
+    cases = []
+    for op in _OPINFOS:
+        for dtype in sorted(op.supported_dtypes("cpu"), key=str):
+            dtype_name = str(dtype).removeprefix("torch.")
+            cases.append(
+                pytest.param(
+                    op,
+                    dtype,
+                    id=f"{op.formatted_name}-{dtype_name}",
+                )
+            )
+    return tuple(cases)
+
+
+def _opinfo_shard_bounds(total: int, index: int, count: int) -> tuple[int, int]:
+    """Return one gap-free, near-even interval of the OpInfo parent cases."""
+
+    if count <= 0:
+        raise ValueError(f"LUMINAL_OPINFO_SHARD_COUNT must be positive, got {count}")
+    if not 0 <= index < count:
+        raise ValueError(
+            "LUMINAL_OPINFO_SHARD_INDEX must satisfy "
+            f"0 <= index < count, got index={index}, count={count}"
+        )
+    if count > total:
+        raise ValueError(
+            "LUMINAL_OPINFO_SHARD_COUNT cannot exceed the number of OpInfo "
+            f"parent cases, got count={count}, total={total}"
+        )
+    return total * index // count, total * (index + 1) // count
+
+
+def _shard_opinfo_dtype_cases(cases: tuple) -> tuple:
+    """Select this process's deterministic interval of the complete suite.
+
+    Sharding changes only how the parent cases are distributed across workers.
+    Each selected parent still exercises every PyTorch-generated sample and its
+    noncontiguous variant. With indices ``0..count-1``, the intervals are
+    disjoint and their union is the complete OpInfo x CPU-dtype inventory.
+    """
+
+    try:
+        count = int(os.environ.get("LUMINAL_OPINFO_SHARD_COUNT", "1"))
+        index = int(os.environ.get("LUMINAL_OPINFO_SHARD_INDEX", "0"))
+    except ValueError as error:
+        raise ValueError(
+            "LUMINAL_OPINFO_SHARD_INDEX and LUMINAL_OPINFO_SHARD_COUNT must be integers"
+        ) from error
+    start, end = _opinfo_shard_bounds(len(cases), index, count)
+    return cases[start:end]
+
+
+_ALL_OPINFO_DTYPE_CASES = _opinfo_dtype_cases()
+_OPINFO_DTYPE_CASES = _shard_opinfo_dtype_cases(_ALL_OPINFO_DTYPE_CASES)
+
+
+@pytest.mark.parametrize(("total", "count"), ((1, 1), (7, 3), (6121, 32)))
+def test_opinfo_shard_bounds_cover_inventory(total: int, count: int) -> None:
+    """Every shard count partitions its inventory without gaps or overlap."""
+
+    bounds = [_opinfo_shard_bounds(total, index, count) for index in range(count)]
+    assert bounds[0][0] == 0
+    assert bounds[-1][1] == total
+    assert all(left[1] == right[0] for left, right in pairwise(bounds))
+    assert sum(end - start for start, end in bounds) == total
+
+
+def _clone_sample(sample: SampleInput) -> SampleInput:
+    """Clone tensors so eager and compiled calls cannot affect each other."""
+
+    def clone(value: Any) -> Any:
+        if not isinstance(value, torch.Tensor):
+            return value
+        detached = value.detach()
+        if detached.layout is torch.strided:
+            return clone_preserve_strides_offset(detached)
+        return detached.clone()
+
+    return sample.transform(clone)
+
+
+def _call(op: Callable[..., Any], sample: SampleInput) -> Any:
+    return op(sample.input, *sample.args, **sample.kwargs)
+
+
+def _call_without_seed_wrapper(op: Callable[..., Any], *args, **kwargs) -> Any:
+    """The traceable body of PyTorch's ``wrapper_set_seed``."""
+
+    return op(*args, **kwargs)
+
+
+def _traceable_opinfo_callable(
+    op: Callable[..., Any],
+) -> tuple[Callable[..., Any], bool]:
+    """Remove only PyTorch's RNG test wrapper from an OpInfo callable.
+
+    Several OpInfos define their public callable as a lambda that invokes
+    ``wrapper_set_seed``. That wrapper enters internal C++ context managers to
+    save RNG state; Dynamo cannot trace their pybind constructors in a full
+    graph. Clone the callable with only that global replaced by its operation
+    body, then reproduce the wrapper's seed and state isolation outside the
+    compiled graph.
+    """
+
+    if not isinstance(op, FunctionType):
+        return op, False
+    if "wrapper_set_seed" not in op.__code__.co_names:
+        return op, False
+    if op.__globals__.get("wrapper_set_seed") is not wrapper_set_seed:
+        return op, False
+
+    traceable_globals = op.__globals__.copy()
+    traceable_globals["wrapper_set_seed"] = _call_without_seed_wrapper
+    traceable = FunctionType(
+        op.__code__,
+        traceable_globals,
+        name=op.__name__,
+        argdefs=op.__defaults__,
+        closure=op.__closure__,
+    )
+    traceable.__kwdefaults__ = op.__kwdefaults__
+    traceable.__annotations__ = op.__annotations__
+    return traceable, True
+
+
+def test_seed_wrapped_opinfos_are_made_traceable() -> None:
+    """Every PyTorch RNG wrapper is removed without changing other OpInfos."""
+
+    wrapper_backed = 0
+    for op in _OPINFOS:
+        op_callable = op.get_op()
+        traceable, changed = _traceable_opinfo_callable(op_callable)
+        is_wrapper_backed = (
+            isinstance(op_callable, FunctionType)
+            and "wrapper_set_seed" in op_callable.__code__.co_names
+            and op_callable.__globals__.get("wrapper_set_seed") is wrapper_set_seed
+        )
+        assert changed is is_wrapper_backed
+        if changed:
+            wrapper_backed += 1
+            assert traceable is not op_callable
+
+    assert wrapper_backed > 0
+
+
+def _assert_close(actual: Any, expected: Any, dtype: torch.dtype) -> None:
+    # Unary operations such as acos/acosh promote integral inputs to F32. Base
+    # tolerances on the reference output when it has one unambiguous tensor
+    # dtype; using the parametrized input dtype would incorrectly demand exact
+    # integer equality from a floating-point result.
+    expected_dtypes = {
+        value.dtype
+        for value in pytree.tree_leaves(expected)
+        if isinstance(value, torch.Tensor)
+    }
+    if len(expected_dtypes) == 1:
+        dtype = expected_dtypes.pop()
+
+    kwargs = {
+        "equal_nan": True,
+        "check_device": True,
+        "check_dtype": True,
+        "check_layout": True,
+        "check_stride": False,
+    }
+    if dtype in _DTYPE_TOLERANCES:
+        kwargs["rtol"], kwargs["atol"] = _DTYPE_TOLERANCES[dtype]
+    torch.testing.assert_close(actual, expected, **kwargs)
+
+
+def _assert_sample_state_close(
+    actual: SampleInput, expected: SampleInput, dtype: torch.dtype
+) -> None:
+    actual_leaves = pytree.tree_leaves((actual.input, actual.args, actual.kwargs))
+    expected_leaves = pytree.tree_leaves(
+        (expected.input, expected.args, expected.kwargs)
+    )
+    assert len(actual_leaves) == len(expected_leaves)
+    for actual_leaf, expected_leaf in zip(actual_leaves, expected_leaves):
+        if isinstance(expected_leaf, torch.Tensor):
+            assert isinstance(actual_leaf, torch.Tensor)
+            _assert_close(actual_leaf, expected_leaf, dtype)
+
+
+def _test_opinfo_sample(
+    device: torch.device,
+    op: OpInfo,
+    dtype: torch.dtype,
+    sample_index: int,
+    sample: SampleInput,
+    compiled_source: SampleInput,
+    input_layout: str,
+) -> None:
+    # Each sample/layout is an independent conformance case. Reset Dynamo so a
+    # different shape or stride cannot consume another case's recompile budget.
+    torch._dynamo.reset()
+    eager_sample = _clone_sample(sample)
+    compiled_sample = _clone_sample(compiled_source)
+    if input_layout == "noncontiguous":
+        assert _has_noncontiguous_tensor(compiled_sample)
+    op_callable, uses_seed_wrapper = _traceable_opinfo_callable(op.get_op())
+    rng_context = freeze_rng_state if uses_seed_wrapper else nullcontext
+    with rng_context():
+        torch.manual_seed(42 if uses_seed_wrapper else 0)
+        expected = _call(op_callable, eager_sample)
+
+    compile_count = 0
+
+    def counting_backend(gm, example_inputs, options=None):
+        nonlocal compile_count
+        compile_count += 1
+        return luminal_backend(
+            gm,
+            example_inputs,
+            options={"search_iterations": 1},
+        )
+
+    def fn(*args, **kwargs):
+        return op_callable(*args, **kwargs)
+
+    compiled = torch.compile(
+        fn,
+        backend=counting_backend,
+        fullgraph=True,
+        dynamic=False,
+    )
+    with rng_context():
+        torch.manual_seed(42 if uses_seed_wrapper else 0)
+        actual = _call(compiled, compiled_sample)
+
+    case_name = f"{op.full_name} {dtype} sample {sample_index} {input_layout}"
+    assert compile_count > 0, f"Luminal backend was not invoked for {case_name}"
+    _assert_close(actual, expected, dtype)
+    _assert_sample_state_close(compiled_sample, eager_sample, dtype)
+
+
+@pytest.mark.parametrize(("op", "dtype"), _OPINFO_DTYPE_CASES)
+def test_opinfo_forward_all_samples(
+    device: torch.device,
+    op: OpInfo,
+    dtype: torch.dtype,
+    subtests,
+) -> None:
+    """Compare every PyTorch sample with Luminal, reporting each separately."""
+
+    samples = tuple(op.sample_inputs("cpu", dtype, requires_grad=False))
+    exercised_samples = 0
+    for sample_index, sample in enumerate(samples):
+        if device.type != "cpu":
+            sample = sample.transform(
+                lambda value: (
+                    value.to(device) if isinstance(value, torch.Tensor) else value
+                )
+            )
+
+        layout_samples = [("contiguous", sample)]
+        if _supports_noncontiguous_transform(sample):
+            noncontiguous_sample = sample.noncontiguous()
+            if _has_noncontiguous_tensor(noncontiguous_sample):
+                layout_samples.append(("noncontiguous", noncontiguous_sample))
+
+        for input_layout, compiled_source in layout_samples:
+            exercised_samples += 1
+            with subtests.test(
+                sample_index=sample_index,
+                input_layout=input_layout,
+            ):
+                _test_opinfo_sample(
+                    device,
+                    op,
+                    dtype,
+                    sample_index,
+                    sample,
+                    compiled_source,
+                    input_layout,
+                )
+
+    assert exercised_samples > 0
+
+
+@pytest.mark.parametrize(
+    "dtype", (torch.float16, torch.bfloat16), ids=("float16", "bfloat16")
+)
+def test_empty_low_precision_output(device: torch.device, dtype: torch.dtype) -> None:
+    """Zero-sized half outputs must materialize without reading an empty buffer."""
+
+    def backend(gm, example_inputs, options=None):
+        return luminal_backend(
+            gm,
+            example_inputs,
+            options={"search_iterations": 1},
+        )
+
+    def fn(left, right):
+        return left + right
+
+    left = torch.empty((0, 1, 3), device=device, dtype=dtype)
+    right = torch.empty((0, 10, 3), device=device, dtype=dtype)
+    compiled = torch.compile(fn, backend=backend, fullgraph=True, dynamic=False)
+    actual = compiled(left, right)
+
+    assert actual.shape == (0, 10, 3)
+    assert actual.dtype == dtype
+    assert actual.device == device

--- a/crates/luminal_reference/src/kernels/mod.rs
+++ b/crates/luminal_reference/src/kernels/mod.rs
@@ -134,6 +134,11 @@ pub(crate) fn move_gathered(
                 dest[flat] = data[*index];
             }
         }
+        (TypedBuffer::F64(data), TypedBuffer::F64(dest)) => {
+            for (flat, index) in index_of.iter().enumerate() {
+                dest[flat] = data[*index];
+            }
+        }
         (TypedBuffer::I32(data), TypedBuffer::I32(dest)) => {
             for (flat, index) in index_of.iter().enumerate() {
                 dest[flat] = data[*index];

--- a/crates/luminal_reference/src/ops/exp/mod.rs
+++ b/crates/luminal_reference/src/ops/exp/mod.rs
@@ -138,5 +138,5 @@ pub(crate) fn kernel(
     _op: &dyn BufferTensorIrOp,
     ctx: &mut ReferenceKernelCtx,
 ) -> anyhow::Result<()> {
-    ctx.unary_elementwise(|x| x.exp())
+    ctx.unary_elementwise_typed(|x| x.exp(), |x| x.exp())
 }

--- a/crates/luminal_reference/src/ops/exp2/mod.rs
+++ b/crates/luminal_reference/src/ops/exp2/mod.rs
@@ -138,5 +138,5 @@ pub(crate) fn kernel(
     _op: &dyn BufferTensorIrOp,
     ctx: &mut ReferenceKernelCtx,
 ) -> anyhow::Result<()> {
-    ctx.unary_elementwise(|x| x.exp2())
+    ctx.unary_elementwise_typed(|x| x.exp2(), |x| x.exp2())
 }

--- a/crates/luminal_reference/src/ops/log2/mod.rs
+++ b/crates/luminal_reference/src/ops/log2/mod.rs
@@ -138,5 +138,5 @@ pub(crate) fn kernel(
     _op: &dyn BufferTensorIrOp,
     ctx: &mut ReferenceKernelCtx,
 ) -> anyhow::Result<()> {
-    ctx.unary_elementwise(|x| x.log2())
+    ctx.unary_elementwise_typed(|x| x.log2(), |x| x.log2())
 }

--- a/crates/luminal_reference/src/ops/recip/mod.rs
+++ b/crates/luminal_reference/src/ops/recip/mod.rs
@@ -138,5 +138,5 @@ pub(crate) fn kernel(
     _op: &dyn BufferTensorIrOp,
     ctx: &mut ReferenceKernelCtx,
 ) -> anyhow::Result<()> {
-    ctx.unary_elementwise(|x| x.recip())
+    ctx.unary_elementwise_typed(|x| x.recip(), |x| x.recip())
 }

--- a/crates/luminal_reference/src/ops/sin/mod.rs
+++ b/crates/luminal_reference/src/ops/sin/mod.rs
@@ -138,5 +138,5 @@ pub(crate) fn kernel(
     _op: &dyn BufferTensorIrOp,
     ctx: &mut ReferenceKernelCtx,
 ) -> anyhow::Result<()> {
-    ctx.unary_elementwise(|x| x.sin())
+    ctx.unary_elementwise_typed(|x| x.sin(), |x| x.sin())
 }

--- a/crates/luminal_reference/src/ops/sqrt/mod.rs
+++ b/crates/luminal_reference/src/ops/sqrt/mod.rs
@@ -138,5 +138,5 @@ pub(crate) fn kernel(
     _op: &dyn BufferTensorIrOp,
     ctx: &mut ReferenceKernelCtx,
 ) -> anyhow::Result<()> {
-    ctx.unary_elementwise(|x| x.sqrt())
+    ctx.unary_elementwise_typed(|x| x.sqrt(), |x| x.sqrt())
 }

--- a/crates/luminal_reference/src/runtime.rs
+++ b/crates/luminal_reference/src/runtime.rs
@@ -386,6 +386,13 @@ impl ReferenceRuntime {
                     TypedBuffer::F32(values.clone())
                 }
                 (PlanDtype::F32, None) => TypedBuffer::F32(vec![0.0; numel]),
+                // F64 is EXECUTABLE here (ruling 2026-09-02, main #398's
+                // f64 unary kernels re-expressed): a double-precision
+                // model runs in double precision, never on an F32 bridge.
+                (PlanDtype::F64, Some(TypedBuffer::F64(values))) => {
+                    TypedBuffer::F64(values.clone())
+                }
+                (PlanDtype::F64, None) => TypedBuffer::F64(vec![0.0; numel]),
                 (PlanDtype::Int, Some(TypedBuffer::I32(values))) => {
                     TypedBuffer::I32(values.clone())
                 }
@@ -415,7 +422,7 @@ impl ReferenceRuntime {
                 ),
                 (other, None) => anyhow::bail!(
                     "buffer {} has dtype {other:?}, which the reference \
-                     runtime cannot execute (f32, i32, i64, bool only)",
+                     runtime cannot execute (f32, f64, i32, i64, bool only)",
                     buffer.label
                 ),
             };
@@ -605,6 +612,13 @@ impl ReferenceRuntime {
     /// 0 or 1 — the two legal codes).
     pub fn get_bool8(&self, tensor: petgraph::graph::NodeIndex) -> Result<&Vec<u8>> {
         self.get_typed(self.output_buffer(tensor)?)?.as_bool8()
+    }
+
+    /// The f64 twin of [`Self::get_f32`] — native double-precision
+    /// output readback (ruling 2026-09-02: F64 executes, so it also
+    /// reads back as f64 and never through an f32 narrowing).
+    pub fn get_f64(&self, tensor: petgraph::graph::NodeIndex) -> Result<&Vec<f64>> {
+        self.get_typed(self.output_buffer(tensor)?)?.as_f64()
     }
 
     /// The i32 twin of [`Self::get_f32`] — native Int output readback
@@ -1699,6 +1713,48 @@ mod tests {
         let (cx2, x2, s2) = build();
         let ours = run_reference(&cx2, &[(x2.id, x_data.into())]);
         assert_close(ours.get_f32(s2.id).unwrap(), &expected);
+    }
+
+    /// F64 IS A REAL EXECUTABLE DTYPE (ruling 2026-09-02, main #398's
+    /// `f64_fn` unary kernels re-expressed). Main's
+    /// `reference_unary_ops_execute_f64_natively` rewritten against
+    /// this branch's runtime: an F64 input through `sqrt` on the real
+    /// search-and-execute ladder, read back as `f64`, BIT-EXACT
+    /// against `f64::sqrt`.
+    ///
+    /// The assertion is exact equality, not a tolerance, and `1e300`
+    /// is the load-bearing value: it has no f32 representation at all,
+    /// so any bridge through F32 anywhere in staging, execution or
+    /// readback turns it into an infinity and this test fails. `0.1`
+    /// covers the quieter direction — its f32 round trip differs from
+    /// its f64 value in the 9th significant digit.
+    #[test]
+    fn f64_unary_round_trips_exactly() {
+        let mut cx = luminal::graph::Graph::new();
+        let x = cx.tensor_dtyped(4, DType::F64);
+        let out = x.sqrt().output();
+
+        let values = vec![2.0f64, 3.0, 0.1, 1e300];
+        let rt = crate::harness::run_reference(&cx, &[(x.id, TypedBuffer::F64(values.clone()))]);
+
+        let expected: Vec<f64> = values.iter().map(|v| v.sqrt()).collect();
+        assert_eq!(
+            rt.get_f64(out.id).unwrap(),
+            &expected,
+            "F64 sqrt must be bit-exact double precision, never an f32 bridge"
+        );
+        assert!(
+            expected[3].is_finite(),
+            "sqrt(1e300) is finite in f64 and infinite in f32 — the whole point"
+        );
+        // And the readback is TYPED: asking for f32 refuses by name
+        // rather than narrowing.
+        let err = rt.get_f32(out.id).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("expected an f32 buffer, found f64"),
+            "typed readback must refuse, got: {err}"
+        );
     }
 
     /// TYPED-BUFFERS LANDING B PINS (2026-08-11).

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -31,7 +31,7 @@ Dispositions:
 | `7d2817fa` | — | luminal_python: search_iterations pass through more places | FILE-LEVEL | branch `merge/main-7d2817fa-search-iterations` | parked crate: re-point `search_iterations` at `ImplementationSearchOptions` when luminal_python is re-attached to the recorder |
 | `bea18ecf` | #389 | Sdpa gqa fixes | FILE-LEVEL | branch `merge/main-389-sdpa-gqa` | parked crate + non-gating `ci/`: RULED 2026-09-02 (ruling 1) — `ci/example_output.py` SYNCS main's numbers for now, by decision; the loosened gemma / gemma4_moe TPOT figures are main's HLIR cuda_lite draws and still have to be re-baselined against CL A100 draws before they gate anything here |
 | `499d0779` | #386 | Search: early-stop candidate profiling against the best-so-far metric | MIXED — RE-EXPRESSED (core: running mean + fifth positional cutoff + predicate) / FILE-LEVEL (parks, with a stubbed predicate) | branch `merge/main-386-early-stop` (two commits) | REQUIREMENT FOR CL (ruling 4): a device `PlanProfiler` that times candidates on device, mirroring `ReferenceProfiler`'s design, and then honours the cutoff — until then `StaticProfiler` accepts and ignores it; see **#386 early-stop profiling** below |
-| `6a5313f2` | #398 | Support for PyTorch OpInfo tests | MIXED — FILE-LEVEL (python + workflow) / RE-EXPRESSED (F64 becomes a real executable dtype) | branch `merge/main-398-opinfo` (two commits) | see **#398 OpInfo + F64** below |
+| `6a5313f2` | #398 | Support for PyTorch OpInfo tests | MIXED — FILE-LEVEL (python + workflow) / RE-EXPRESSED (`TypedBuffer::F64` + typed unary kernels) / DROPPED (`ConstantF64`, the empty-Vec fix) | branch `merge/main-398-opinfo` (two commits) | OpInfo harness, the arange-metadata and acos/acosh lowerings = M4 translator requirements; typed `LogicalConstant`; F32<->F64 cast policy; F64 on CL — see **#398 OpInfo + F64** below |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -303,6 +303,73 @@ deleted on this branch and were dropped from the pick. Of their content:
   constructor child or a `dtype-of` seed written by the recorder — and then
   `constant_float64` is a three-line frontend method. Until then a parked
   `scalar_constant` call to it stays dangling.
-- The **`f64_fn` arms** ARE re-expressed, in the next commit on this
-  branch — F64 becomes a real executable dtype (ruling 1 answered intent-row
-  question 2 in the affirmative).
+- The **`f64_fn` arms** ARE re-expressed; see below.
+
+**RE-EXPRESSED (commit 2): F64 as a real executable dtype.** Ruling 1
+answered intent-row question 2 in the affirmative, so main's five `f64_fn`
+kernel arms became a `TypedBuffer::F64(Vec<f64>)` variant and a typed unary
+dispatch. The pieces:
+
+- `TypedBuffer::F64(Vec<f64>)` in `src/buffer_tensor_ir.rs`, with `len`,
+  `type_name` (`"f64"`), `as_f64` / `as_f64_mut` and `zeroed_like`.
+  DELIBERATELY **no** `From<Vec<f64>>`, unlike F32/I32/I64: Rust's default
+  float type is f64, so the moment that impl exists the staging spelling
+  every test here uses — `vec![1.0, 2.0, 3.0].into()`, unsuffixed — silently
+  becomes an F64 buffer. Adding it turned 13 green tests red with
+  "BufferLit(0) is F32; staged f64 data is the wrong type", and that is the
+  BENIGN failure mode; the malignant one is an F64-annotated graph quietly
+  accepting the same literals. A dtype must never change because a literal
+  was unsuffixed, so F64 staging is spelled `TypedBuffer::F64(values)`, in
+  full. (Bool8 has no `From` either, for its own reason: caller bytes must
+  pass the validated two-legal-codes door.)
+- `ReferenceKernelCtx::unary_elementwise_typed(f32_fn, f64_fn)` — main's
+  `UnaryKernels` struct re-expressed. Main carried four fields (f32, f16,
+  bf16, f64); this branch has no f16/bf16 storage, so it carries two, and an
+  operand of any other type still refuses loudly by name. `unary_elementwise`
+  (F32-only) stays for callers that mean F32 only.
+- The six unary transcendental kernels take it: `sqrt`, `exp2`, `log2`,
+  `sin`, `recip` — main's exact five — plus `exp`, which is branch-only (main
+  spells it `exp2`) and is the same family, so leaving it F32-only would be
+  an arbitrary hole.
+- Storage and readback: the `PlanDtype::F64` arm in
+  `ReferenceRuntime::materialize` (staged F64 accepted, zeros otherwise) and
+  `ReferenceRuntime::get_f64`. The reference BINDING needed no change — it
+  emits `(bits-of (F64))` through the generic `{dtype:?}` arm, and the
+  preamble already sets that row to 64.
+- `crates/luminal_cuda_lite/src/device.rs` gains an F64 arm in
+  `typed_to_bytes` so its exhaustive match stays exhaustive. The arm is
+  `unreachable!`, not a transport path: `dtype_bytes` has no `PlanDtype::F64`
+  row, so CL refuses an F64 buffer by name before the bridge is ever reached.
+  Giving CL F64 *transport* without F64 *kernels* would be the half-done
+  version, so it is not done. **Owed:** F64 on CL, if it is ever wanted, is a
+  codegen question, not a storage one.
+
+**Not carried: F32 <-> F64 casts.** The cast kernel gains no F64 arm, so an
+F64 program must be F64 end to end. F32 -> F64 is an exact widening and would
+be uncontroversial; F64 -> F32 is a lossy NARROWING, and this branch's cast
+policy (2026-08-11) has a rule for float -> int (refuse) and for int -> float
+(checked-exact) but says nothing about float -> float narrowing. Rather than
+invent one in passing, both directions are left refusing by name at the
+kernel's catch-all. **Owed:** a float-narrowing cast policy, and then the two
+arms.
+
+**No proof gate.** F64 is a float, and the non-wrapping ruling of 2026-08-11
+gates Int and Int64 only — the ops' `match_functional.egg` non-Int arms are
+spelled `(!= ?value_dtype (Int)) (!= ?value_dtype (Int64))`, so F64 mints
+through them unchanged with no egglog edit at all.
+
+**Test.** `luminal_reference::runtime::tests::f64_unary_round_trips_exactly`
+is main's `reference_unary_ops_execute_f64_natively` re-expressed against the
+branch's runtime: an F64 input through `sqrt` on the real search-and-execute
+ladder, asserting BIT-EXACT equality against `f64::sqrt` on values whose f32
+round trip is provably lossier (`2.0`, `3.0`, `0.1`, `1e300`), plus the
+readback typed as `f64` via `get_f64`. `1e300` is the load-bearing one: it is
+not representable in f32 at all, so the assertion fails outright if anything
+in the path bridges through F32. The test also asserts that `get_f32` on
+that output REFUSES ("expected an f32 buffer, found f64") rather than
+narrowing.
+
+Main's other two Rust tests do not move: `f64_constant_to_egglog_round_trips_exactly`
+tests `ConstantF64`, which is superseded, and
+`empty_bytes_preserve_reference_dtype` tests a `from_raw_parts` hazard that
+does not exist here.

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -31,6 +31,7 @@ Dispositions:
 | `7d2817fa` | — | luminal_python: search_iterations pass through more places | FILE-LEVEL | branch `merge/main-7d2817fa-search-iterations` | parked crate: re-point `search_iterations` at `ImplementationSearchOptions` when luminal_python is re-attached to the recorder |
 | `bea18ecf` | #389 | Sdpa gqa fixes | FILE-LEVEL | branch `merge/main-389-sdpa-gqa` | parked crate + non-gating `ci/`: RULED 2026-09-02 (ruling 1) — `ci/example_output.py` SYNCS main's numbers for now, by decision; the loosened gemma / gemma4_moe TPOT figures are main's HLIR cuda_lite draws and still have to be re-baselined against CL A100 draws before they gate anything here |
 | `499d0779` | #386 | Search: early-stop candidate profiling against the best-so-far metric | MIXED — RE-EXPRESSED (core: running mean + fifth positional cutoff + predicate) / FILE-LEVEL (parks, with a stubbed predicate) | branch `merge/main-386-early-stop` (two commits) | REQUIREMENT FOR CL (ruling 4): a device `PlanProfiler` that times candidates on device, mirroring `ReferenceProfiler`'s design, and then honours the cutoff — until then `StaticProfiler` accepts and ignores it; see **#386 early-stop profiling** below |
+| `6a5313f2` | #398 | Support for PyTorch OpInfo tests | MIXED — FILE-LEVEL (python + workflow) / RE-EXPRESSED (F64 becomes a real executable dtype) | branch `merge/main-398-opinfo` (two commits) | see **#398 OpInfo + F64** below |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -242,3 +243,66 @@ profiler's design** — warmup, timed trials, a mean metric, and the same
 lower-bound cutoff — at which point `StaticProfiler`'s ignored argument becomes
 a real one. That is a larger question than the cutoff itself, and it is not in
 this batch.
+
+## #398 OpInfo + F64 — what landed, and what is owed
+
+RULED 2026-09-02 (ruling 1): *"this is good and should get its content
+merged"*. Split in two commits, because the commit is two things.
+
+**FILE-LEVEL (commit 1).** All 13 `crates/luminal_python/**` files plus
+`.github/workflows/test-python-native.yml` (the OpInfo shard job, committed
+commented-out) take main's diff. The crate is not a workspace member here, so
+none of it builds or runs; it is banked so the OpInfo harness — main's only
+broad conformance oracle, 373 lines of `tests/test_opinfo.py` — is not lost,
+and so the two genuine lowering fixes riding along are recorded as text:
+
+- **`translate_arange` trusts export's output metadata** instead of
+  recomputing `(end-start)/step`. The old code collected every *decodable*
+  positional argument with a `filter_map`, which silently dropped float and
+  bool values and shifted the survivors into the wrong start/end/step slots;
+  the rewrite resolves `start`/`step` by PT2 schema NAME and takes the length
+  from `output_meta_shape`, which is already correct for fractional and
+  negative steps (`arange(-1, 2, 2)`) and for empty ranges.
+- **`acos` / `acosh` lowerings** (Chebyshev-style polynomial + the
+  `1 - x` square-root fold, and `log(x + sqrt(x^2 - 1))`) in
+  `translator/unary.rs`.
+
+Both are REQUIREMENTS on the M4 re-attachment: when the translator is
+re-expressed against the recorder frontend they must not be silently
+re-broken.
+
+Four files conflicted and were resolved keeping this branch's spellings, never
+main's (the standing rule): `compiled_graph.rs` takes main's new
+`copy_host_bytes` helper but keeps the `IntExpr` doc comment;
+`translator/attention.rs` takes main's f64 default SDPA scale with the
+branch's `legacy_tracker_ref()` indentation; `translator/binary.rs` takes
+main's `scalar_constant` + alpha plumbing with `expand_rhs(a.dims())` for
+main's `expand_rhs(a.shape)`; `translator/tensor.rs` takes main's schema-name
+arange with `Expr(IntExpr)` for `Expr(Expression)` and `indices.dims()` for
+`indices.shape`. `main`'s new `Translator::scalar_constant` calls
+`Graph::constant_float64`, which this branch does not have — a DANGLING
+reference banked at main's spelling, the same standing cost as
+`early_stop_exceeded` in the #386 parks.
+
+**UNCARRIED.** `src/dyn_backend.rs` (+56) and `src/hlir.rs` (+240/-53) are
+deleted on this branch and were dropped from the pick. Of their content:
+
+- The **`bytes_to_reference_data` empty-Vec dtype fix** is DROPPED, not owed:
+  it repairs `ReferenceData::from_raw_parts` reinterpreting an empty byte
+  slice as F32 regardless of the declared dtype. `TypedBuffer` holds typed
+  `Vec`s and never reinterprets bytes, so the hazard cannot recur here.
+- **`ConstantF64`** is SUPERSEDED and deliberately NOT ported. Main's own
+  commit calls it temporary — *"should be removed ASAP once the SSA changeset
+  lands, by having Constant be typed"* — and typed constants ARE this
+  branch's design: `LogicalOp::Constant(f64)` already carries an f64 payload
+  and `LogicalGraph::op` already takes an explicit `DType`. What blocks
+  `Graph::constant_float64` today is one line of egglog, not an op:
+  `src/logical_op/constant/dtype.egg` sets `(dtype-of (LogicalConstant ?v))`
+  to `(F32)` UNCONDITIONALLY, so a constant cannot be minted at any other
+  dtype. **Owed:** give `LogicalConstant` a dtype — either a second
+  constructor child or a `dtype-of` seed written by the recorder — and then
+  `constant_float64` is a three-line frontend method. Until then a parked
+  `scalar_constant` call to it stays dangling.
+- The **`f64_fn` arms** ARE re-expressed, in the next commit on this
+  branch — F64 becomes a real executable dtype (ruling 1 answered intent-row
+  question 2 in the affirmative).

--- a/src/buffer_tensor_ir.rs
+++ b/src/buffer_tensor_ir.rs
@@ -65,7 +65,10 @@ impl<T: BufferTensorIrOp + Clone + 'static> CloneBufferTensorIrOp for T {
 /// Typed reference storage (rulings 2026-07-28, 2026-07-30, and the
 /// typed-buffers ruling 2026-08-11: NO value ever rides a buffer of
 /// another type — "no smuggling data in invalid types"). Floats live
-/// as f32; 32-bit integers as i32 and 64-bit as i64, NATIVE values
+/// as f32, or as f64 where the model asked for double precision
+/// (ruling 2026-09-02: F64 is a real executable dtype here, never an
+/// F32 bridge wearing an F64 tag); 32-bit integers as i32 and 64-bit
+/// as i64, NATIVE values
 /// (every bit pattern legal — total-code dtypes), which is what makes
 /// index arithmetic exact past f32's 2^24 ceiling; booleans live as
 /// Bool8 CODES — one u8 per element, exactly 0x00 or 0x01, every other
@@ -77,6 +80,11 @@ impl<T: BufferTensorIrOp + Clone + 'static> CloneBufferTensorIrOp for T {
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypedBuffer {
     F32(Vec<f32>),
+    /// Double-precision floats. A model that declares F64 executes in
+    /// F64: silently bridging through F32 would hide a precision
+    /// downgrade behind a dtype tag, which is the one thing the
+    /// deleted HLIR panic existed to refuse.
+    F64(Vec<f64>),
     I32(Vec<i32>),
     I64(Vec<i64>),
     Bool8(Vec<u8>),
@@ -107,6 +115,7 @@ impl TypedBuffer {
     pub fn len(&self) -> usize {
         match self {
             TypedBuffer::F32(values) => values.len(),
+            TypedBuffer::F64(values) => values.len(),
             TypedBuffer::I32(values) => values.len(),
             TypedBuffer::I64(values) => values.len(),
             TypedBuffer::Bool8(bits) => bits.len(),
@@ -121,6 +130,7 @@ impl TypedBuffer {
     pub fn type_name(&self) -> &'static str {
         match self {
             TypedBuffer::F32(_) => "f32",
+            TypedBuffer::F64(_) => "f64",
             TypedBuffer::I32(_) => "i32",
             TypedBuffer::I64(_) => "i64",
             TypedBuffer::Bool8(_) => "bool8",
@@ -139,6 +149,20 @@ impl TypedBuffer {
         match self {
             TypedBuffer::F32(values) => Ok(values),
             other => anyhow::bail!("expected an f32 buffer, found {}", other.type_name()),
+        }
+    }
+
+    pub fn as_f64(&self) -> Result<&Vec<f64>> {
+        match self {
+            TypedBuffer::F64(values) => Ok(values),
+            other => anyhow::bail!("expected an f64 buffer, found {}", other.type_name()),
+        }
+    }
+
+    pub fn as_f64_mut(&mut self) -> Result<&mut Vec<f64>> {
+        match self {
+            TypedBuffer::F64(values) => Ok(values),
+            other => anyhow::bail!("expected an f64 buffer, found {}", other.type_name()),
         }
     }
 
@@ -203,6 +227,7 @@ impl TypedBuffer {
     pub fn zeroed_like(&self) -> TypedBuffer {
         match self {
             TypedBuffer::F32(values) => TypedBuffer::F32(vec![0.0; values.len()]),
+            TypedBuffer::F64(values) => TypedBuffer::F64(vec![0.0; values.len()]),
             TypedBuffer::I32(values) => TypedBuffer::I32(vec![0; values.len()]),
             TypedBuffer::I64(values) => TypedBuffer::I64(vec![0; values.len()]),
             TypedBuffer::Bool8(bits) => TypedBuffer::Bool8(vec![0u8; bits.len()]),
@@ -217,6 +242,14 @@ impl TypedBuffer {
 // pattern is a legal value for these dtypes). Bool8 deliberately has NO
 // From impl — caller bytes must pass the validated [`TypedBuffer::bool8`]
 // constructor.
+//
+// F64 deliberately has no `From` impl either, for a different reason:
+// Rust's default float type is f64, so `vec![1.0, 2.0].into()` — the
+// spelling every staging site here uses — would SILENTLY become an F64
+// buffer the moment such an impl exists, and an F32 program would fail
+// at execute with a staging-variant refusal instead of running. A
+// dtype must never change because a literal was unsuffixed: F64
+// staging is spelled `TypedBuffer::F64(values)`, in full.
 impl From<Vec<f32>> for TypedBuffer {
     fn from(values: Vec<f32>) -> Self {
         TypedBuffer::F32(values)
@@ -261,6 +294,40 @@ impl ReferenceKernelCtx {
         anyhow::ensure!(input.len() == dest.len(), "unary kernel length mismatch");
         for (out, x) in dest.iter_mut().zip(input) {
             *out = f(*x);
+        }
+        Ok(())
+    }
+
+    /// dest0[i] = f64_fn(operand0[i]) over an F64 operand, or
+    /// f32_fn(operand0[i]) over an F32 one — main's `UnaryKernels`
+    /// struct (#398) re-expressed for this branch's storage. Main
+    /// carried four widths (f32/f16/bf16/f64); there is no f16 or
+    /// bf16 TypedBuffer here, so this carries two, and every other
+    /// variant refuses BY NAME rather than bridging through f32: a
+    /// caller who asked for double precision must not be handed
+    /// single-precision arithmetic behind an F64 tag.
+    pub fn unary_elementwise_typed(
+        &mut self,
+        f32_fn: impl Fn(f32) -> f32,
+        f64_fn: impl Fn(f64) -> f64,
+    ) -> Result<()> {
+        let double = match &self.operands[0] {
+            TypedBuffer::F32(_) => false,
+            TypedBuffer::F64(_) => true,
+            other => anyhow::bail!(
+                "unary transcendental has no {} arm (cast at the call site; \
+                 a silent bridge through f32 would hide a precision change)",
+                other.type_name()
+            ),
+        };
+        if !double {
+            return self.unary_elementwise(f32_fn);
+        }
+        let input = self.operands[0].as_f64()?;
+        let dest = self.dests[0].as_f64_mut()?;
+        anyhow::ensure!(input.len() == dest.len(), "unary kernel length mismatch");
+        for (out, x) in dest.iter_mut().zip(input) {
+            *out = f64_fn(*x);
         }
         Ok(())
     }


### PR DESCRIPTION
**Stack.** PR 1 of 8, batch 3 of the main rejoin (walking main's post-split commits chronologically). Base: `logical-ssa-project`. Merge in order; before merging, retarget to `logical-ssa-project` with `gh pr edit --base logical-ssa-project`.

**Summary.** Carries main `6a5313f2` (#398) per ruling 1. Commit 1: 13 `crates/luminal_python/**` files + `.github/workflows/test-python-native.yml` file-level — the OpInfo harness (`tests/test_opinfo.py`), the schema-name `arange` fix and acos/acosh lowerings are banked. Commit 2: main's five `f64_fn` unary kernels re-expressed as a real `TypedBuffer::F64`.

**What was re-expressed and why.** `TypedBuffer::F64(Vec<f64>)` with typed accessors and `ReferenceKernelCtx::unary_elementwise_typed(f32_fn, f64_fn)` — main's `UnaryKernels` at the two widths this branch stores; `sqrt/exp2/log2/sin/recip` (main's five) plus branch-only `exp` take it; `move_gathered`, `PlanDtype::F64` staging and `get_f64` close the path. No `From<Vec<f64>>`: the unsuffixed float literal is f64, so the impl would silently retype every `vec![1.0].into()` staging site. `ConstantF64` SUPERSEDED (main calls it temporary; typed constants are this branch's design — blocked only on `LogicalConstant`'s unconditional F32 dtype rule, owed). `bytes_to_reference_data` empty-Vec fix DROPPED (`TypedBuffer` never reinterprets bytes). CL `typed_to_bytes` gets an `unreachable!` arm; `dtype_bytes` refuses F64 by name first.

**Scope (reviewer).** F64 executes for the unary transcendental family, gather/materialize/copy, staging and readback. `add/mul/less_than/reduce_*/scatter/iota` have no F64 arm and refuse loudly by name; main had those pre-split via `ReferenceData::F64`. Owed together with the F32<->F64 cast policy (also not carried).

**Audit.** Diff-of-diffs vs `6a5313f2` on banked paths = five branch re-spellings only (`.shape`->`.dims()`, `Expression`->`IntExpr`, one `.clone()`); no rename reverted. Dangling reference banked at main's spelling: `Graph::constant_float64` (`translator/binary.rs:41`, `dispatch.rs:568`, `tensor.rs:103,110,111`). Test `f64_unary_round_trips_exactly` bit-exact over `[2.0, 3.0, 0.1, 1e300]` + `get_f32` refusal. luminal lib 245/0, luminal_reference lib 40/0, clippy + fmt clean.

**Not verified.** Parked crate does not build (non-member); the workflow's OpInfo job is committed commented-out; the "13 tests red with `From<Vec<f64>>`" claim not reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
