### PR TITLE
main rejoin: Narrow integer dtypes (#399): I8/U8/I16 execute, int abs fixed [carve-out to confirm]

### DIFF
--- a/crates/luminal_cuda_lite/src/device.rs
+++ b/crates/luminal_cuda_lite/src/device.rs
@@ -53,6 +53,11 @@ fn typed_to_bytes(data: &TypedBuffer) -> &[u8] {
         // representation, so `dtype_bytes` refuses it by name before a
         // buffer ever reaches this bridge.
         TypedBuffer::F64(_) => unreachable!("dtype_bytes refuses F64 first"),
+        // Likewise the narrow integers (ruling 2026-09-02): reference
+        // storage only, no CL kernel, no device representation.
+        TypedBuffer::I8(_) | TypedBuffer::U8(_) | TypedBuffer::I16(_) => {
+            unreachable!("dtype_bytes refuses narrow integers first")
+        }
     }
 }
 

--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -588,6 +588,39 @@ impl CompiledGraph {
         Ok(self.runtime.get_output_i64(*node_id))
     }
 
+    /// Read an output as i8 without widening.
+    fn get_output_i8(&self, name: &str) -> PyResult<Vec<i8>> {
+        let node_id = self.tensor_ids.get(name).ok_or_else(|| {
+            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
+                "Unknown output tensor: {}",
+                name
+            ))
+        })?;
+        Ok(self.runtime.get_output_i8(*node_id))
+    }
+
+    /// Read an output as u8 without widening.
+    fn get_output_u8(&self, name: &str) -> PyResult<Vec<u8>> {
+        let node_id = self.tensor_ids.get(name).ok_or_else(|| {
+            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
+                "Unknown output tensor: {}",
+                name
+            ))
+        })?;
+        Ok(self.runtime.get_output_u8(*node_id))
+    }
+
+    /// Read an output as i16 without widening.
+    fn get_output_i16(&self, name: &str) -> PyResult<Vec<i16>> {
+        let node_id = self.tensor_ids.get(name).ok_or_else(|| {
+            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
+                "Unknown output tensor: {}",
+                name
+            ))
+        })?;
+        Ok(self.runtime.get_output_i16(*node_id))
+    }
+
     /// Read an output as f64. Strict: the producer node must already
     /// be `DType::F64`; no widening at the read boundary.
     fn get_output_f64(&self, name: &str) -> PyResult<Vec<f64>> {

--- a/crates/luminal_python/rust/src/pt2_util.rs
+++ b/crates/luminal_python/rust/src/pt2_util.rs
@@ -210,30 +210,18 @@ pub fn resolve_neg1_dim_exprs(
 }
 
 /// Map a PT2 dtype code to luminal `DType`. Panics for variants the IR
-/// doesn't model as first-class types (narrow ints `Byte` / `Char` /
-/// `Short`, the complex family, the float8 family) and for unknown
-/// codes — better to fail loudly at the translator boundary than to
-/// silently widen and lie about the user's dtype.
+/// doesn't model as first-class types (the complex family, unsupported
+/// float8 variants, and uint16) and for unknown codes. The common narrow
+/// integers map to native-width HLIR dtypes without widening.
 pub fn torch_dtype_int_to_luminal(dtype: u32) -> DType {
     let t = crate::torch_dtype::TorchDType::from_code(dtype)
         .unwrap_or_else(|c| panic!("torch_dtype_int_to_luminal: unknown PT2 dtype code {c}"));
-    match t {
-        crate::torch_dtype::TorchDType::Byte
-        | crate::torch_dtype::TorchDType::Char
-        | crate::torch_dtype::TorchDType::Short => panic!(
-            "torch_dtype_int_to_luminal: PT2 dtype {} (code {}) isn't a first-class \
-             IR type yet — cast to torch.int32 at the call site, or wait for the \
-             narrower-int IR follow-up.",
-            t.name(),
-            t.code(),
-        ),
-        other => DType::try_from(other).unwrap_or_else(|t| {
-            panic!(
-                "torch_dtype_int_to_luminal: {} isn't a first-class luminal IR type",
-                t.name()
-            )
-        }),
-    }
+    DType::try_from(t).unwrap_or_else(|t| {
+        panic!(
+            "torch_dtype_int_to_luminal: {} isn't a first-class luminal IR type",
+            t.name()
+        )
+    })
 }
 
 

--- a/crates/luminal_python/rust/src/torch_dtype.rs
+++ b/crates/luminal_python/rust/src/torch_dtype.rs
@@ -113,17 +113,18 @@ impl TorchDType {
 }
 
 /// PyTorch dtype → luminal `DType`. `Err(self)` for variants luminal's IR
-/// doesn't model as first-class types — the narrow ints (`Byte` / `Char` /
-/// `Short`), the complex family, and the float8 NUZ variants. `DType::U8`,
-/// `DType::I8`, `DType::I16` exist on the luminal side but the IR has no
-/// kernels / codegen for them, so we refuse the conversion here rather
-/// than silently producing a buffer the kernels can't actually run.
+/// doesn't model as first-class types — uint16, the complex family, and the
+/// float8 NUZ variants. PyTorch's three common narrow integer storage dtypes
+/// map one-to-one to native luminal IR dtypes.
 /// Boundary code panics with the variant name on `Err`; cf.
 /// `typed_data::from_pytorch_bytes`, `pt2_util::torch_dtype_int_to_luminal`.
 impl TryFrom<TorchDType> for DType {
     type Error = TorchDType;
     fn try_from(t: TorchDType) -> Result<Self, Self::Error> {
         Ok(match t {
+            TorchDType::Byte => DType::U8,
+            TorchDType::Char => DType::I8,
+            TorchDType::Short => DType::I16,
             TorchDType::Int => DType::Int,
             TorchDType::Long => DType::I64,
             TorchDType::Half => DType::F16,
@@ -133,10 +134,7 @@ impl TryFrom<TorchDType> for DType {
             TorchDType::BFloat16 => DType::Bf16,
             TorchDType::Float8E4m3Fn => DType::F8E4M3,
             TorchDType::Float8E5m2 => DType::F8E5M2,
-            TorchDType::Byte
-            | TorchDType::Char
-            | TorchDType::Short
-            | TorchDType::Uint16
+            TorchDType::Uint16
             | TorchDType::Unknown
             | TorchDType::ComplexHalf
             | TorchDType::ComplexFloat
@@ -148,8 +146,8 @@ impl TryFrom<TorchDType> for DType {
 }
 
 /// luminal `DType` → PyTorch dtype. `Err(dtype)` for luminal-specific
-/// variants without a first-class PyTorch counterpart — the narrow ints
-/// (`U8` / `I8` / `I16` / `U16`), the sub-byte / exotic widths (`I4`,
+/// variants without a first-class PyTorch counterpart — `U16`, the sub-byte
+/// / exotic widths (`I4`,
 /// `U4`, `F6E2M3`, ...), and `TF32`.
 ///
 /// `TF32` is a compute-mode hint inside luminal, not a storage dtype on
@@ -167,6 +165,9 @@ impl TryFrom<DType> for TorchDType {
             DType::Bf16 => TorchDType::BFloat16,
             DType::Int => TorchDType::Int,
             DType::I64 => TorchDType::Long,
+            DType::I8 => TorchDType::Char,
+            DType::U8 => TorchDType::Byte,
+            DType::I16 => TorchDType::Short,
             DType::Bool => TorchDType::Bool,
             DType::F8E4M3 => TorchDType::Float8E4m3Fn,
             DType::F8E5M2 => TorchDType::Float8E5m2,
@@ -189,8 +190,8 @@ mod tests {
     #[test]
     fn supported_dtypes_roundtrip() {
         // Only the variants luminal's IR models as first-class can
-        // roundtrip cleanly. Narrow ints (`U8` / `I8` / `I16` / `U16`)
-        // are intentionally excluded — see the `TryFrom` impls.
+        // roundtrip cleanly. U16 remains intentionally excluded because its
+        // reference/runtime path is not native yet.
         for d in [
             DType::F32,
             DType::F64,
@@ -198,6 +199,9 @@ mod tests {
             DType::Bf16,
             DType::Int,
             DType::I64,
+            DType::I8,
+            DType::U8,
+            DType::I16,
             DType::Bool,
         ] {
             let t = TorchDType::try_from(d).expect("known DType");
@@ -207,17 +211,9 @@ mod tests {
     }
 
     #[test]
-    fn narrow_ints_refuse_conversion() {
-        // Forward (PyTorch → luminal) and reverse (luminal → PyTorch)
-        // both refuse the narrow-int variants; downstream sites translate
-        // the `Err` into a typed panic with the variant name.
-        for t in [TorchDType::Byte, TorchDType::Char, TorchDType::Short] {
-            assert!(DType::try_from(t).is_err(), "expected Err for {t:?}");
-        }
+    fn unsupported_storage_dtypes_refuse_conversion() {
+        assert!(DType::try_from(TorchDType::Uint16).is_err());
         for d in [
-            DType::U8,
-            DType::I8,
-            DType::I16,
             DType::U16,
             // TF32 is a luminal-internal compute-mode hint, not a PyTorch
             // storage dtype — refuse to silently alias it as `Float`.

--- a/crates/luminal_python/rust/src/translator/unary.rs
+++ b/crates/luminal_python/rust/src/translator/unary.rs
@@ -66,7 +66,9 @@ impl<'a> Translator<'a> {
     pub(crate) fn translate_acos(&mut self, node: &Node) -> Result<GraphTensor> {
         let input = self.get_input_tensor(node, 0)?;
         let input = match input.dtype {
-            DType::Bool | DType::Int | DType::I64 => input.cast(DType::F32),
+            DType::Bool | DType::Int | DType::I64 | DType::I8 | DType::U8 | DType::I16 => {
+                input.cast(DType::F32)
+            }
             _ => input,
         };
         let x = input.abs();
@@ -106,7 +108,9 @@ impl<'a> Translator<'a> {
     pub(crate) fn translate_acosh(&mut self, node: &Node) -> Result<GraphTensor> {
         let input = self.get_input_tensor(node, 0)?;
         let input = match input.dtype {
-            DType::Bool | DType::Int | DType::I64 => input.cast(DType::F32),
+            DType::Bool | DType::Int | DType::I64 | DType::I8 | DType::U8 | DType::I16 => {
+                input.cast(DType::F32)
+            }
             _ => input,
         };
         let reciprocal_squared = input.reciprocal().square();

--- a/crates/luminal_python/rust/src/typed_data.rs
+++ b/crates/luminal_python/rust/src/typed_data.rs
@@ -150,12 +150,8 @@ impl TypedData {
 
     /// Convert raw bytes from a PyTorch tensor (identified by PT2 dtype
     /// code) to `TypedData`. Supported dtypes preserve their raw bytes —
-    /// no width changes at the FFI boundary. Narrow integer widths
-    /// (`Byte` / `Char` / `Short`) panic: luminal's `ReferenceData` has no
-    /// narrower-integer variants yet, so the only way they could pass
-    /// through is via implicit widening to `i32`, which the no-implicit-
-    /// cast directive forbids. Cast at the call site
-    /// (`x.to(torch.int32)`) or wait for the narrower-int IR follow-up.
+    /// no width changes at the FFI boundary, including Byte/U8, Char/I8,
+    /// and Short/I16.
     pub fn from_pytorch_bytes(bytes: Vec<u8>, dtype_code: u32) -> Self {
         let t = crate::torch_dtype::TorchDType::from_code(dtype_code)
             .unwrap_or_else(|c| panic!("from_pytorch_bytes: unknown PT2 dtype code {c}"));
@@ -167,15 +163,9 @@ impl TypedData {
             crate::torch_dtype::TorchDType::Bool => Self::from_raw(bytes, DType::Bool),
             crate::torch_dtype::TorchDType::Long => Self::from_raw(bytes, DType::I64),
             crate::torch_dtype::TorchDType::Double => Self::from_raw(bytes, DType::F64),
-            crate::torch_dtype::TorchDType::Byte
-            | crate::torch_dtype::TorchDType::Char
-            | crate::torch_dtype::TorchDType::Short => panic!(
-                "from_pytorch_bytes: PT2 dtype {} (code {}) isn't a first-class \
-                 IR type yet — cast to torch.int32 at the call site, or wait \
-                 for the narrower-int IR follow-up.",
-                t.name(),
-                t.code(),
-            ),
+            crate::torch_dtype::TorchDType::Byte => Self::from_raw(bytes, DType::U8),
+            crate::torch_dtype::TorchDType::Char => Self::from_raw(bytes, DType::I8),
+            crate::torch_dtype::TorchDType::Short => Self::from_raw(bytes, DType::I16),
             other => panic!(
                 "from_pytorch_bytes: PT2 dtype {} (code {}) isn't a first-class \
                  IR type — no luminal mapping.",
@@ -282,22 +272,18 @@ impl From<TypedData> for ReferenceData {
                 let data: Vec<bool> = td.bytes.iter().map(|&b| b != 0).collect();
                 ReferenceData::Bool(data)
             }
-            // Integer types that map to ReferenceData::Int
             DType::I8 => {
-                let data: Vec<i32> = td.bytes.iter().map(|&b| b as i8 as i32).collect();
-                ReferenceData::Int(data)
+                let data: Vec<i8> = td.bytes.into_iter().map(|b| b as i8).collect();
+                ReferenceData::I8(data)
             }
-            DType::U8 => {
-                let data: Vec<i32> = td.bytes.iter().map(|&b| b as i32).collect();
-                ReferenceData::Int(data)
-            }
+            DType::U8 => ReferenceData::U8(td.bytes),
             DType::I16 => {
-                let data: Vec<i32> = td
+                let data: Vec<i16> = td
                     .bytes
                     .chunks_exact(2)
-                    .map(|b| i16::from_le_bytes([b[0], b[1]]) as i32)
+                    .map(|b| i16::from_le_bytes([b[0], b[1]]))
                     .collect();
-                ReferenceData::Int(data)
+                ReferenceData::I16(data)
             }
             DType::U16 => {
                 let data: Vec<i32> = td

--- a/crates/luminal_python/src/luminal/compiled_model.py
+++ b/crates/luminal_python/src/luminal/compiled_model.py
@@ -193,11 +193,6 @@ class CompiledModel:
         # `torch.frombuffer`. That's a reinterpret, not a numeric
         # cast — no precision change.
         #
-        # Narrow ints (`int8` / `int16` / `uint8`) are intentionally
-        # absent — luminal's IR refuses them at the FFI boundary (cf.
-        # `pt2_util::torch_dtype_int_to_luminal`,
-        # `typed_data::from_pytorch_bytes`), so a graph can never
-        # declare a narrow-int output that reaches this dispatch.
         _zero_copy_native_floats = (torch.float32, torch.float16, torch.bfloat16)
         _output_readers = {
             torch.float32: ("get_output", torch.float32),
@@ -206,6 +201,9 @@ class CompiledModel:
             torch.bfloat16: ("get_output_bf16", torch.bfloat16),
             torch.int64: ("get_output_i64", torch.int64),
             torch.int32: ("get_output_i32", torch.int32),
+            torch.int16: ("get_output_i16", torch.int16),
+            torch.int8: ("get_output_i8", torch.int8),
+            torch.uint8: ("get_output_u8", torch.uint8),
             torch.bool: ("get_output_bool", torch.bool),
         }
 
@@ -238,7 +236,7 @@ class CompiledModel:
                 if all(d != 0 for d in shape):
                     return None
                 return torch.empty(tuple(shape), dtype=out_dtype, device=input_device)
-            if out_dtype in (torch.float16, torch.bfloat16):
+            if out_dtype in (torch.float16, torch.bfloat16, torch.uint8):
                 # Getter returned an immutable `bytes` from Rust; wrap in
                 # `bytearray` to make the storage writable (suppresses
                 # the "non-writable buffer" warning), then bit-cast via

--- a/crates/luminal_python/tests/test_dtype_boundary.py
+++ b/crates/luminal_python/tests/test_dtype_boundary.py
@@ -15,6 +15,11 @@ class BoundaryNoopModel(torch.nn.Module):
         return x + torch.zeros((), dtype=x.dtype, device=x.device)
 
 
+class AbsModel(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.abs(x)
+
+
 class EmptyWeightModel(torch.nn.Module):
     def __init__(self) -> None:
         super().__init__()
@@ -190,14 +195,14 @@ def boundary_device(request) -> torch.device:
     return torch.device(device_name)
 
 
-# Dtypes that round-trip the BoundaryNoopModel without an explicit
-# `x.to(model.input_dtypes[0])` cast at the call site. Anything not in this
-# set is a narrow integer (uint8 / int8 / int16) that luminal collapses to
-# `DType::Int` internally — the hard-reject contract makes the boundary
-# refuse the mismatched dtype, and the test for those lives in
-# `test_input_dtype_mismatch_rejects` instead.
+# Dtypes that round-trip the BoundaryNoopModel without an explicit cast at the
+# call site. Each retains both its declared dtype and exact values across input
+# upload, reference execution, and output readback.
 _FIRST_CLASS_NOOP_DTYPES = {
     "bool",
+    "uint8",
+    "int8",
+    "int16",
     "int32",
     "int64_i32_range",
     "int64_outside_i32_range",
@@ -240,9 +245,32 @@ def test_boundary_noop_preserves_dtype_and_values(
 
 
 @pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(case, id=case.name)
+        for case in DTYPE_CASES
+        if case.name in {"uint8", "int8", "int16"}
+    ],
+)
+def test_narrow_integer_abs_preserves_wrapping_semantics(case: DTypeCase) -> None:
+    model = AbsModel()
+    compiled = torch.compile(model, backend=luminal_backend, fullgraph=True)
+    x = case.values()
+
+    expected = model(x)
+    actual = compiled(x)
+
+    assert actual.dtype == expected.dtype
+    assert torch.equal(actual, expected)
+
+
+@pytest.mark.parametrize(
     "dtype",
     [
         pytest.param(torch.bool, id="bool"),
+        pytest.param(torch.uint8, id="uint8"),
+        pytest.param(torch.int8, id="int8"),
+        pytest.param(torch.int16, id="int16"),
         pytest.param(torch.int32, id="int32"),
         pytest.param(torch.int64, id="int64"),
         pytest.param(torch.float16, id="float16"),
@@ -369,6 +397,9 @@ def test_item_returns_exact_python_scalar(
         pytest.param(False, True, True, torch.bfloat16, False, id="bool-scalars"),
         pytest.param(0, 3.1, 1, torch.float16, True, id="keyword-end"),
         pytest.param(1, 5, 2, torch.int64, False, id="int64-output"),
+        pytest.param(0, 6, 2, torch.uint8, False, id="uint8-output"),
+        pytest.param(-3, 4, 3, torch.int8, False, id="int8-output"),
+        pytest.param(-300, 301, 300, torch.int16, False, id="int16-output"),
         pytest.param(1.1, 1.1, -1.0, torch.float32, False, id="empty"),
     ],
 )
@@ -431,42 +462,12 @@ def test_nonempty_cpu_input_rejects_null_pointer() -> None:
     [
         pytest.param(case, id=case.name)
         for case in DTYPE_CASES
-        # Narrow integer widths (uint8 / int8 / int16) aren't first-class in
-        # luminal's IR — the translator refuses them outright. int64 /
-        # float64 are first-class and round-trip without rejection.
-        if case.name in {"uint8", "int8", "int16"}
-    ],
-)
-def test_input_dtype_mismatch_rejects(
-    boundary_device: torch.device,
-    case: DTypeCase,
-) -> None:
-    """Hard-reject contract: a graph whose declared input dtype is one of
-    the narrow ints (uint8 / int8 / int16) fails at compile time with a
-    clear panic from `torch_dtype_int_to_luminal`. Previously the
-    translator silently widened narrow ints to `Int` (i32), which left
-    the user's actual dtype invisible past the FFI boundary; today the
-    failure points at the missing IR support directly.
-    """
-    model = BoundaryNoopModel().to(boundary_device)
-    compiled = torch.compile(model, backend=luminal_backend)
-    x = case.values().to(boundary_device)
-
-    # `pyo3_runtime.PanicException` inherits from `BaseException` (not
-    # `Exception`), so `pytest.raises(Exception, ...)` would miss it.
-    # Match on the panic message text — stable across torch versions.
-    with pytest.raises(BaseException, match="isn't a first-class IR type yet"):
-        compiled(x)
-
-
-@pytest.mark.parametrize(
-    "case",
-    [
-        pytest.param(case, id=case.name)
-        for case in DTYPE_CASES
         if case.name
         in {
             "bool",
+            "uint8",
+            "int8",
+            "int16",
             "int32",
             "float16",
             "bfloat16",

--- a/crates/luminal_reference/src/kernels/mod.rs
+++ b/crates/luminal_reference/src/kernels/mod.rs
@@ -149,6 +149,21 @@ pub(crate) fn move_gathered(
                 dest[flat] = data[*index];
             }
         }
+        (TypedBuffer::I8(data), TypedBuffer::I8(dest)) => {
+            for (flat, index) in index_of.iter().enumerate() {
+                dest[flat] = data[*index];
+            }
+        }
+        (TypedBuffer::U8(data), TypedBuffer::U8(dest)) => {
+            for (flat, index) in index_of.iter().enumerate() {
+                dest[flat] = data[*index];
+            }
+        }
+        (TypedBuffer::I16(data), TypedBuffer::I16(dest)) => {
+            for (flat, index) in index_of.iter().enumerate() {
+                dest[flat] = data[*index];
+            }
+        }
         (TypedBuffer::Bool8(data), TypedBuffer::Bool8(dest)) => {
             for (flat, index) in index_of.iter().enumerate() {
                 dest[flat] = data[*index];

--- a/crates/luminal_reference/src/ops/add/mod.rs
+++ b/crates/luminal_reference/src/ops/add/mod.rs
@@ -157,6 +157,13 @@ pub(crate) fn kernel(
                 anyhow::anyhow!("i64 add overflow: {a} + {b} (ints are non-wrapping)")
             })
         }),
+        // NARROW INTS WRAP (carve-out 2026-09-02, main #399): torch
+        // semantics at 8 and 16 bits, and a defined result rather than
+        // an escaped error. I32/I64 above keep the checked, non-wrapping
+        // ruling of 2026-08-11.
+        TypedBuffer::I8(_) => ctx.binary_elementwise_i8(|a, b| Ok(a.wrapping_add(b))),
+        TypedBuffer::U8(_) => ctx.binary_elementwise_u8(|a, b| Ok(a.wrapping_add(b))),
+        TypedBuffer::I16(_) => ctx.binary_elementwise_i16(|a, b| Ok(a.wrapping_add(b))),
         other => anyhow::bail!("add has no {} arm", other.type_name()),
     }
 }

--- a/crates/luminal_reference/src/ops/cast/mod.rs
+++ b/crates/luminal_reference/src/ops/cast/mod.rs
@@ -139,7 +139,16 @@ pub(crate) fn kernel(
     // REFUSAL (a lossy read is an explicit op, never a cast — the
     // Bool8 projection rule generalized); bool -> number is the exact
     // 0/1 indicator bridge; number -> bool is always the refusal.
+    //
+    // NARROW INTEGERS (ruling 2026-09-02, main #399's carve-out): five
+    // integer widths would be 25 hand-written pair arms, so any cast
+    // TOUCHING I8/U8/I16 routes through `narrow_cast` below, which
+    // states the policy once. The wide arms in this match are
+    // untouched.
     const F32_EXACT_INT: i64 = 1 << 24;
+    if is_narrow(&ctx.operands[0]) || is_narrow(&ctx.dests[0]) {
+        return narrow_cast(ctx);
+    }
     match (&ctx.operands[0], &mut ctx.dests[0]) {
         // Same-type: value-preserving copies.
         (TypedBuffer::F32(input), TypedBuffer::F32(dest)) => {
@@ -272,6 +281,117 @@ pub(crate) fn kernel(
             input.type_name(),
             dest.type_name()
         ),
+    }
+    Ok(())
+}
+
+fn is_narrow(buffer: &TypedBuffer) -> bool {
+    matches!(
+        buffer,
+        TypedBuffer::I8(_) | TypedBuffer::U8(_) | TypedBuffer::I16(_)
+    )
+}
+
+/// Any integer buffer read as i64. LOSSLESS at every integer width this
+/// runtime has (I8/U8/I16/I32/I64 all fit in i64), so the reading never
+/// loses a value — only the write side can, and only where the policy
+/// below says it may.
+fn read_integer(buffer: &TypedBuffer) -> Option<Vec<i64>> {
+    Some(match buffer {
+        TypedBuffer::I8(values) => values.iter().map(|v| i64::from(*v)).collect(),
+        TypedBuffer::U8(values) => values.iter().map(|v| i64::from(*v)).collect(),
+        TypedBuffer::I16(values) => values.iter().map(|v| i64::from(*v)).collect(),
+        TypedBuffer::I32(values) => values.iter().map(|v| i64::from(*v)).collect(),
+        TypedBuffer::I64(values) => values.clone(),
+        _ => return None,
+    })
+}
+
+/// Every cast with a narrow integer on either side. The policy, stated
+/// once (carve-out 2026-09-02 — Austin to confirm at review):
+///
+/// * int -> NARROW int TRUNCATES (`as`), which is main #399's semantics
+///   and torch's: at 8 and 16 bits a narrowing conversion is a defined
+///   wrap, not an error.
+/// * int -> `Int` / `Int64` stays CHECKED — the non-wrapping ruling of
+///   2026-08-11 is untouched for the wide types, so `I64 -> I32` still
+///   refuses out of range.
+/// * NARROW int -> float is exact BY WIDTH (|v| <= 32767, far inside the
+///   f32 2^24 exactness bound), so it satisfies the checked-exact
+///   int -> float rule with nothing left to check.
+/// * `Bool8` -> narrow int is the exact 0/1 indicator bridge.
+/// * float -> NARROW int is REFUSED, exactly like every other
+///   float -> int. This is the ONE place main's unchecked `as` is not
+///   carried: the carve-out is about integer WIDTH semantics, and it is
+///   not a licence to make a lossy float read implicit (cast policy
+///   2026-08-11). A rounding or truncation stays an explicit op.
+/// * narrow int -> `Bool8` is REFUSED: `!= 0` is a projection, never a
+///   cast.
+fn narrow_cast(ctx: &mut ReferenceKernelCtx) -> anyhow::Result<()> {
+    let source_name = ctx.operands[0].type_name();
+    let dest_name = ctx.dests[0].type_name();
+    let values: Vec<i64> = match &ctx.operands[0] {
+        TypedBuffer::Bool8(codes) => {
+            let mut values = Vec::with_capacity(codes.len());
+            for code in codes {
+                anyhow::ensure!(*code <= 1, "Bool8 buffer holds ill-formed code {code}");
+                values.push(i64::from(*code));
+            }
+            values
+        }
+        other => read_integer(other).ok_or_else(|| {
+            anyhow::anyhow!(
+                "cast {source_name} -> {dest_name} is not a reinterpretation: \
+                 a rounding or truncation is a lossy read and must appear as \
+                 an explicit op in the model, never as a cast"
+            )
+        })?,
+    };
+    anyhow::ensure!(values.len() == ctx.dests[0].len(), "cast length mismatch");
+    match &mut ctx.dests[0] {
+        TypedBuffer::I8(dest) => {
+            for (out, value) in dest.iter_mut().zip(&values) {
+                *out = *value as i8;
+            }
+        }
+        TypedBuffer::U8(dest) => {
+            for (out, value) in dest.iter_mut().zip(&values) {
+                *out = *value as u8;
+            }
+        }
+        TypedBuffer::I16(dest) => {
+            for (out, value) in dest.iter_mut().zip(&values) {
+                *out = *value as i16;
+            }
+        }
+        TypedBuffer::I32(dest) => {
+            for (out, value) in dest.iter_mut().zip(&values) {
+                *out = i32::try_from(*value).map_err(|_| {
+                    anyhow::anyhow!("cast {source_name} -> i32 out of range at value {value}")
+                })?;
+            }
+        }
+        TypedBuffer::I64(dest) => {
+            for (out, value) in dest.iter_mut().zip(&values) {
+                *out = *value;
+            }
+        }
+        TypedBuffer::F32(dest) => {
+            for (out, value) in dest.iter_mut().zip(&values) {
+                *out = *value as f32;
+            }
+        }
+        TypedBuffer::F64(dest) => {
+            for (out, value) in dest.iter_mut().zip(&values) {
+                *out = *value as f64;
+            }
+        }
+        TypedBuffer::Bool8(_) => anyhow::bail!(
+            "cast {source_name} -> Bool8 is not a reinterpretation: the != 0 \
+             reading is a PROJECTION and must appear as an explicit \
+             comparison in the model (LessThan), never as a cast"
+        ),
+        dest => anyhow::bail!("cast has no ({source_name} -> {}) arm", dest.type_name()),
     }
     Ok(())
 }

--- a/crates/luminal_reference/src/ops/less_than/mod.rs
+++ b/crates/luminal_reference/src/ops/less_than/mod.rs
@@ -174,6 +174,43 @@ pub(crate) fn kernel(
                 *out = u8::from(lhs[index] < rhs[index]);
             }
         }
+        // Narrow ints compare NATIVELY: an i8 compared as i32 would be
+        // correct here but would need a widening the typed-buffer
+        // ruling forbids, and a u8 compared as i8 would not be correct
+        // at all.
+        (TypedBuffer::I8(lhs), TypedBuffer::I8(rhs)) => {
+            let (lhs, rhs) = (lhs.clone(), rhs.clone());
+            let dest = ctx.dests[0].as_bool8_mut()?;
+            anyhow::ensure!(
+                lhs.len() == rhs.len() && lhs.len() == dest.len(),
+                "less-than kernel length mismatch"
+            );
+            for (index, out) in dest.iter_mut().enumerate() {
+                *out = u8::from(lhs[index] < rhs[index]);
+            }
+        }
+        (TypedBuffer::U8(lhs), TypedBuffer::U8(rhs)) => {
+            let (lhs, rhs) = (lhs.clone(), rhs.clone());
+            let dest = ctx.dests[0].as_bool8_mut()?;
+            anyhow::ensure!(
+                lhs.len() == rhs.len() && lhs.len() == dest.len(),
+                "less-than kernel length mismatch"
+            );
+            for (index, out) in dest.iter_mut().enumerate() {
+                *out = u8::from(lhs[index] < rhs[index]);
+            }
+        }
+        (TypedBuffer::I16(lhs), TypedBuffer::I16(rhs)) => {
+            let (lhs, rhs) = (lhs.clone(), rhs.clone());
+            let dest = ctx.dests[0].as_bool8_mut()?;
+            anyhow::ensure!(
+                lhs.len() == rhs.len() && lhs.len() == dest.len(),
+                "less-than kernel length mismatch"
+            );
+            for (index, out) in dest.iter_mut().enumerate() {
+                *out = u8::from(lhs[index] < rhs[index]);
+            }
+        }
         (lhs, rhs) => anyhow::bail!(
             "less-than has no ({}, {}) arm (operands must share one dtype)",
             lhs.type_name(),

--- a/crates/luminal_reference/src/ops/mul/mod.rs
+++ b/crates/luminal_reference/src/ops/mul/mod.rs
@@ -157,6 +157,10 @@ pub(crate) fn kernel(
                 anyhow::anyhow!("i64 mul overflow: {a} * {b} (ints are non-wrapping)")
             })
         }),
+        // NARROW INTS WRAP — see the carve-out note in the add kernel.
+        TypedBuffer::I8(_) => ctx.binary_elementwise_i8(|a, b| Ok(a.wrapping_mul(b))),
+        TypedBuffer::U8(_) => ctx.binary_elementwise_u8(|a, b| Ok(a.wrapping_mul(b))),
+        TypedBuffer::I16(_) => ctx.binary_elementwise_i16(|a, b| Ok(a.wrapping_mul(b))),
         other => anyhow::bail!("mul has no {} arm", other.type_name()),
     }
 }

--- a/crates/luminal_reference/src/ops/reduce_max/mod.rs
+++ b/crates/luminal_reference/src/ops/reduce_max/mod.rs
@@ -151,6 +151,11 @@ pub(crate) fn kernel(
     match &ctx.operands[0] {
         TypedBuffer::F32(_) => ctx.reduce_axis(op.axis, f32::NEG_INFINITY, |acc, x| acc.max(x)),
         TypedBuffer::I32(_) => ctx.reduce_axis_i32(op.axis, i32::MIN, |acc, x| Ok(acc.max(x))),
+        // Max never leaves the operand range, so there is nothing to
+        // wrap and nothing to check at any width.
+        TypedBuffer::I8(_) => ctx.reduce_axis_i8(op.axis, i8::MIN, |acc, x| Ok(acc.max(x))),
+        TypedBuffer::U8(_) => ctx.reduce_axis_u8(op.axis, u8::MIN, |acc, x| Ok(acc.max(x))),
+        TypedBuffer::I16(_) => ctx.reduce_axis_i16(op.axis, i16::MIN, |acc, x| Ok(acc.max(x))),
         other => anyhow::bail!("reduce-max has no {} arm", other.type_name()),
     }
 }

--- a/crates/luminal_reference/src/ops/reduce_sum/mod.rs
+++ b/crates/luminal_reference/src/ops/reduce_sum/mod.rs
@@ -155,6 +155,11 @@ pub(crate) fn kernel(
             acc.checked_add(x)
                 .ok_or_else(|| anyhow::anyhow!("i32 reduce-sum overflow (ints are non-wrapping)"))
         }),
+        // NARROW INTS WRAP: main #399's `fold(0i8, i8::wrapping_add)`
+        // accumulators, re-expressed (carve-out 2026-09-02).
+        TypedBuffer::I8(_) => ctx.reduce_axis_i8(op.axis, 0, |acc, x| Ok(acc.wrapping_add(x))),
+        TypedBuffer::U8(_) => ctx.reduce_axis_u8(op.axis, 0, |acc, x| Ok(acc.wrapping_add(x))),
+        TypedBuffer::I16(_) => ctx.reduce_axis_i16(op.axis, 0, |acc, x| Ok(acc.wrapping_add(x))),
         other => anyhow::bail!("reduce-sum has no {} arm", other.type_name()),
     }
 }

--- a/crates/luminal_reference/src/ops/scatter/mod.rs
+++ b/crates/luminal_reference/src/ops/scatter/mod.rs
@@ -286,6 +286,24 @@ pub(crate) fn kernel(
                 dest[*target] = src[i];
             }
         }
+        (TypedBuffer::I8(init), TypedBuffer::I8(src), TypedBuffer::I8(dest)) => {
+            dest.copy_from_slice(init);
+            for (i, target) in target_of.iter().enumerate() {
+                dest[*target] = src[i];
+            }
+        }
+        (TypedBuffer::U8(init), TypedBuffer::U8(src), TypedBuffer::U8(dest)) => {
+            dest.copy_from_slice(init);
+            for (i, target) in target_of.iter().enumerate() {
+                dest[*target] = src[i];
+            }
+        }
+        (TypedBuffer::I16(init), TypedBuffer::I16(src), TypedBuffer::I16(dest)) => {
+            dest.copy_from_slice(init);
+            for (i, target) in target_of.iter().enumerate() {
+                dest[*target] = src[i];
+            }
+        }
         (TypedBuffer::Bool8(init), TypedBuffer::Bool8(src), TypedBuffer::Bool8(dest)) => {
             dest.copy_from_slice(init);
             for (i, target) in target_of.iter().enumerate() {

--- a/crates/luminal_reference/src/ops/trunc_div/mod.rs
+++ b/crates/luminal_reference/src/ops/trunc_div/mod.rs
@@ -139,6 +139,22 @@ pub(crate) fn kernel(
                 anyhow::anyhow!("i64 trunc-div refuses: {a} / {b} (zero divisor or MIN/-1)")
             })
         }),
+        // NARROW INTS WRAP at the MIN / -1 corner (carve-out
+        // 2026-09-02) — but a ZERO divisor is undefined at every width
+        // and still refuses loudly: wrapping is a defined result, a
+        // division by zero is not.
+        TypedBuffer::I8(_) => ctx.binary_elementwise_i8(|a, b| {
+            anyhow::ensure!(b != 0, "i8 trunc-div refuses: {a} / 0 (zero divisor)");
+            Ok(a.wrapping_div(b))
+        }),
+        TypedBuffer::U8(_) => ctx.binary_elementwise_u8(|a, b| {
+            anyhow::ensure!(b != 0, "u8 trunc-div refuses: {a} / 0 (zero divisor)");
+            Ok(a.wrapping_div(b))
+        }),
+        TypedBuffer::I16(_) => ctx.binary_elementwise_i16(|a, b| {
+            anyhow::ensure!(b != 0, "i16 trunc-div refuses: {a} / 0 (zero divisor)");
+            Ok(a.wrapping_div(b))
+        }),
         other => anyhow::bail!("trunc-div has no {} arm (Int only)", other.type_name()),
     }
 }

--- a/crates/luminal_reference/src/ops/trunc_rem/mod.rs
+++ b/crates/luminal_reference/src/ops/trunc_rem/mod.rs
@@ -138,6 +138,22 @@ pub(crate) fn kernel(
                 anyhow::anyhow!("i64 trunc-rem refuses: {a} % {b} (zero divisor or MIN/-1)")
             })
         }),
+        // Main #399 put `i8::wrapping_rem` / `u8: x % y` /
+        // `i16::wrapping_rem` on its `Mod` op; integer remainder is
+        // spelled TruncRem on this branch (Mod is the f32 op), so the
+        // arms land here. Zero divisor still refuses loudly.
+        TypedBuffer::I8(_) => ctx.binary_elementwise_i8(|a, b| {
+            anyhow::ensure!(b != 0, "i8 trunc-rem refuses: {a} % 0 (zero divisor)");
+            Ok(a.wrapping_rem(b))
+        }),
+        TypedBuffer::U8(_) => ctx.binary_elementwise_u8(|a, b| {
+            anyhow::ensure!(b != 0, "u8 trunc-rem refuses: {a} % 0 (zero divisor)");
+            Ok(a.wrapping_rem(b))
+        }),
+        TypedBuffer::I16(_) => ctx.binary_elementwise_i16(|a, b| {
+            anyhow::ensure!(b != 0, "i16 trunc-rem refuses: {a} % 0 (zero divisor)");
+            Ok(a.wrapping_rem(b))
+        }),
         other => anyhow::bail!("trunc-rem has no {} arm (Int only)", other.type_name()),
     }
 }

--- a/crates/luminal_reference/src/runtime.rs
+++ b/crates/luminal_reference/src/runtime.rs
@@ -401,6 +401,16 @@ impl ReferenceRuntime {
                     TypedBuffer::I64(values.clone())
                 }
                 (PlanDtype::Int64, None) => TypedBuffer::I64(vec![0; numel]),
+                // Narrow ints (ruling 2026-09-02, main #399): stored at
+                // their OWN width, never widened to i32 on the way in.
+                (PlanDtype::I8, Some(TypedBuffer::I8(values))) => TypedBuffer::I8(values.clone()),
+                (PlanDtype::I8, None) => TypedBuffer::I8(vec![0; numel]),
+                (PlanDtype::U8, Some(TypedBuffer::U8(values))) => TypedBuffer::U8(values.clone()),
+                (PlanDtype::U8, None) => TypedBuffer::U8(vec![0; numel]),
+                (PlanDtype::I16, Some(TypedBuffer::I16(values))) => {
+                    TypedBuffer::I16(values.clone())
+                }
+                (PlanDtype::I16, None) => TypedBuffer::I16(vec![0; numel]),
                 (PlanDtype::F8E4M3, Some(TypedBuffer::F8E4M3(codes))) => {
                     TypedBuffer::F8E4M3(codes.clone())
                 }
@@ -422,7 +432,8 @@ impl ReferenceRuntime {
                 ),
                 (other, None) => anyhow::bail!(
                     "buffer {} has dtype {other:?}, which the reference \
-                     runtime cannot execute (f32, f64, i32, i64, bool only)",
+                     runtime cannot execute (f32, f64, i8, u8, i16, i32, \
+                     i64, bool only)",
                     buffer.label
                 ),
             };
@@ -631,6 +642,28 @@ impl ReferenceRuntime {
     /// The i64 twin of [`Self::get_f32`].
     pub fn get_i64(&self, tensor: petgraph::graph::NodeIndex) -> Result<&Vec<i64>> {
         self.get_typed(self.output_buffer(tensor)?)?.as_i64()
+    }
+
+    /// The narrow-integer readers (ruling 2026-09-02, main #399's
+    /// `get_output_i8` / `get_output_u8` / `get_output_i16`). STRICTLY
+    /// NON-WIDENING, which is main's whole point and this branch's
+    /// typed-readback contract both: an I8 output reads back as `i8`,
+    /// and asking for it as `i32` refuses by name rather than quietly
+    /// promoting.
+    pub fn get_i8(&self, tensor: petgraph::graph::NodeIndex) -> Result<&Vec<i8>> {
+        self.get_typed(self.output_buffer(tensor)?)?.as_i8()
+    }
+
+    /// The u8 twin of [`Self::get_i8`]. Distinct from
+    /// [`Self::get_bool8`]: same storage width, different dtype, and a
+    /// U8 buffer has no two-legal-codes invariant.
+    pub fn get_u8(&self, tensor: petgraph::graph::NodeIndex) -> Result<&Vec<u8>> {
+        self.get_typed(self.output_buffer(tensor)?)?.as_u8()
+    }
+
+    /// The i16 twin of [`Self::get_i8`].
+    pub fn get_i16(&self, tensor: petgraph::graph::NodeIndex) -> Result<&Vec<i16>> {
+        self.get_typed(self.output_buffer(tensor)?)?.as_i16()
     }
 
     /// Buffer-id read for search internals.
@@ -1713,6 +1746,171 @@ mod tests {
         let (cx2, x2, s2) = build();
         let ours = run_reference(&cx2, &[(x2.id, x_data.into())]);
         assert_close(ours.get_f32(s2.id).unwrap(), &expected);
+    }
+
+    /// NARROW INTEGERS WRAP AT THEIR OWN WIDTH (carve-out 2026-09-02,
+    /// main #399's `reference_narrow_integer_add_wraps_in_declared_dtype`
+    /// re-expressed end to end). Main asserted this against a bare
+    /// `ReferenceData` op; here the same values go through the real
+    /// recorder / search / execute ladder and read back through the
+    /// STRICTLY NON-WIDENING getters, which is the other half of main's
+    /// claim: an I8 result is `i8`, not an i32 that happens to be small.
+    ///
+    /// This is the CARVE-OUT under review: I32 and I64 keep the
+    /// non-wrapping ruling of 2026-08-11 and would refuse these same
+    /// operands loudly.
+    #[test]
+    fn narrow_int_add_wraps_at_its_own_width() {
+        let mut cx = luminal::graph::Graph::new();
+        let a = cx.tensor_dtyped(2, DType::I8);
+        let b = cx.tensor_dtyped(2, DType::I8);
+        let out = (a + b).output();
+        let rt = crate::harness::run_reference(
+            &cx,
+            &[
+                (a.id, TypedBuffer::I8(vec![127, -128])),
+                (b.id, TypedBuffer::I8(vec![1, -1])),
+            ],
+        );
+        assert_eq!(rt.get_i8(out.id).unwrap(), &vec![-128i8, 127]);
+
+        let mut cx = luminal::graph::Graph::new();
+        let a = cx.tensor_dtyped(2, DType::U8);
+        let b = cx.tensor_dtyped(2, DType::U8);
+        let out = (a + b).output();
+        let rt = crate::harness::run_reference(
+            &cx,
+            &[
+                (a.id, TypedBuffer::U8(vec![255, 0])),
+                (b.id, TypedBuffer::U8(vec![1, 255])),
+            ],
+        );
+        assert_eq!(rt.get_u8(out.id).unwrap(), &vec![0u8, 255]);
+
+        let mut cx = luminal::graph::Graph::new();
+        let a = cx.tensor_dtyped(2, DType::I16);
+        let b = cx.tensor_dtyped(2, DType::I16);
+        let out = (a + b).output();
+        let rt = crate::harness::run_reference(
+            &cx,
+            &[
+                (a.id, TypedBuffer::I16(vec![32_767, -32_768])),
+                (b.id, TypedBuffer::I16(vec![1, -1])),
+            ],
+        );
+        assert_eq!(rt.get_i16(out.id).unwrap(), &vec![-32_768i16, 32_767]);
+    }
+
+    /// NARROW-INT CASTS TRUNCATE — main #399's
+    /// `reference_narrow_integer_casts_preserve_native_widths`, same
+    /// source values and the same expected results, through this
+    /// branch's cast kernel. The wide targets are NOT part of the
+    /// carve-out: `I64 -> I32` still refuses out of range, which the
+    /// last act pins.
+    #[test]
+    fn narrow_int_casts_truncate_and_wide_casts_stay_checked() {
+        let source = vec![-32_769i32, -129, -128, -1, 0, 127, 128, 255, 256];
+
+        let mut cx = luminal::graph::Graph::new();
+        let x = cx.tensor_dtyped(9, DType::Int);
+        let out = x.cast(DType::I8).output();
+        let rt = crate::harness::run_reference(&cx, &[(x.id, source.clone().into())]);
+        assert_eq!(
+            rt.get_i8(out.id).unwrap(),
+            &vec![-1i8, 127, -128, -1, 0, 127, -128, -1, 0]
+        );
+
+        let mut cx = luminal::graph::Graph::new();
+        let x = cx.tensor_dtyped(9, DType::Int);
+        let out = x.cast(DType::U8).output();
+        let rt = crate::harness::run_reference(&cx, &[(x.id, source.clone().into())]);
+        assert_eq!(
+            rt.get_u8(out.id).unwrap(),
+            &vec![255u8, 127, 128, 255, 0, 127, 128, 255, 0]
+        );
+
+        let mut cx = luminal::graph::Graph::new();
+        let x = cx.tensor_dtyped(9, DType::Int);
+        let out = x.cast(DType::I16).output();
+        let rt = crate::harness::run_reference(&cx, &[(x.id, source.clone().into())]);
+        assert_eq!(
+            rt.get_i16(out.id).unwrap(),
+            &vec![32_767i16, -129, -128, -1, 0, 127, 128, 255, 256]
+        );
+
+        // The wide half of the policy, unchanged by the carve-out.
+        let mut cx = luminal::graph::Graph::new();
+        let x = cx.tensor_dtyped(1, DType::I64);
+        let _out = x.cast(DType::Int).output();
+        let mut rt = ReferenceRuntime::load(&cx).expect("native load");
+        let mut data = FxHashMap::default();
+        data.insert(x.id, TypedBuffer::I64(vec![i64::from(i32::MAX) + 1]));
+        let err = rt
+            .search(&data, &luminal::test_support::harness_search_options())
+            .unwrap_err();
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("cast i64 -> i32 out of range at value 2147483648"),
+            "i64 -> i32 must stay CHECKED (ruling 2026-08-11), got: {message}"
+        );
+    }
+
+    /// INTEGER `abs()` EXECUTES (main #399's dtype-aware `abs`,
+    /// re-expressed). Before this, `abs()` on any integer went through
+    /// `relu` -> `maximum_f32` -> `constant_float(0.0).cast(Int)`, and
+    /// that F32 -> Int cast is REFUSED at authoring, so integer `abs`
+    /// panicked before it recorded anything. Now it is
+    /// `x * (1 - 2*(x < 0))` built from INT constants.
+    ///
+    /// At the signed minimum the result is the signed minimum: |i16::MIN|
+    /// is not representable in i16, and under the narrow-int carve-out
+    /// the multiplication wraps, which is exactly what torch reports.
+    #[test]
+    fn integer_abs_executes_and_wraps_at_the_signed_minimum() {
+        let mut cx = luminal::graph::Graph::new();
+        let x = cx.tensor_dtyped(4, DType::I16);
+        let out = x.abs().output();
+        let rt = crate::harness::run_reference(
+            &cx,
+            &[(x.id, TypedBuffer::I16(vec![-3, 0, 5, i16::MIN]))],
+        );
+        assert_eq!(rt.get_i16(out.id).unwrap(), &vec![3i16, 0, 5, i16::MIN]);
+
+        // Int stays proof-gated (2026-08-11), so the caller attests the
+        // range; inside it the answer is exact.
+        let mut cx = luminal::graph::Graph::new();
+        let x = cx.tensor_dtyped(4, DType::Int);
+        let out = x.abs().output();
+        let rt = crate::harness::run_reference_with_ranges(
+            &cx,
+            &[(x.id, vec![-3i32, 0, 5, -7].into())],
+            &[(x.id, -10, 10)],
+        );
+        assert_eq!(rt.get_i32(out.id).unwrap(), &vec![3i32, 0, 5, 7]);
+    }
+
+    /// A FLOAT -> NARROW-INT CAST IS STILL REFUSED. Main #399's
+    /// `to_i8_vec` family truncates from any source, floats included;
+    /// this branch does not carry that half. The carve-out is about
+    /// integer WIDTH, not about making a lossy float read implicit
+    /// (cast policy 2026-08-11), and the refusal is at AUTHORING so the
+    /// model's author sees it rather than the search.
+    #[test]
+    fn float_to_narrow_int_cast_is_refused_at_authoring() {
+        let refusal = std::panic::catch_unwind(|| {
+            let mut cx = luminal::graph::Graph::new();
+            let x = cx.tensor_dtyped(4, DType::F32);
+            let _ = x.cast(DType::I8);
+        })
+        .unwrap_err();
+        let message = refusal
+            .downcast_ref::<String>()
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            message.contains("F32") && message.contains("I8") && message.contains("refused"),
+            "expected the float -> int cast refusal, got: {message:?}"
+        );
     }
 
     /// F64 IS A REAL EXECUTABLE DTYPE (ruling 2026-09-02, main #398's

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -398,3 +398,99 @@ main's three trait methods become three `get_*` methods on the runtime and the
 trait. Main's two test hunks (`src/hlir.rs` `mod tests`, `src/dyn_backend.rs`)
 name deleted types and could not move as written; they are re-expressed as
 reference-runtime tests instead.
+
+**RE-EXPRESSED (commit 2): I8/U8/I16 become executable dtypes.** Ruling 2
+answered intent-row questions 1-4. `TypedBuffer` gains
+`I8(Vec<i8>) / U8(Vec<u8>) / I16(Vec<i16>)` with `len`, `type_name`, typed
+accessors, `zeroed_like`, `From<Vec<i8>>` and `From<Vec<i16>>` — but NOT
+`From<Vec<u8>>`, which is the payload type of both `U8` and `Bool8`, so an
+impl would have to guess which one caller bytes mean. Kernel arms land in
+`add`, `mul`, `less_than`, `scatter`, `reduce_sum`, `reduce_max`,
+`trunc_div`, `trunc_rem`, `cast` and (through `move_gathered`) `gather`,
+index-map materialize and the dense layout copy. `ReferenceRuntime` gains the
+three `PlanDtype` materialize arms and `get_i8` / `get_u8` / `get_i16`.
+
+> ### THE CARVE-OUT — Austin to confirm at review
+>
+> **I8, U8 and I16 arithmetic WRAPS at its own width, following main #399
+> and torch. I32 and I64 keep the non-wrapping ruling of 2026-08-11: a
+> checked overflow is a loud kernel error, discharged statically by the
+> value-bounds proof gate.**
+>
+> The two rules coexist without an egglog edit because each op's
+> `match_functional.egg` gate names `(Int)` and `(Int64)` and nothing else,
+> so a narrow-int op mints through the UNGATED arm and needs no proof. The
+> argument for the split is that a wrap is a DEFINED result at 8 and 16 bits
+> — it is what torch computes and what the OpInfo suite this feature exists
+> to serve compares against — whereas at 32 and 64 bits an overflow is an
+> escaped error that the bounds lattice can and does prove away. The
+> argument against is that it is two overflow semantics in one runtime,
+> distinguishable only by width. If ruled the other way, the change is
+> local: swap `Ok(a.wrapping_add(b))` for a `checked_add` in the six narrow
+> arms and add `(I8)/(U8)/(I16)` proof gates beside the `(Int)` ones.
+
+**Main's `as` casts: carried for integers, NOT for floats.** A cast touching
+a narrow int routes through one `narrow_cast` helper in
+`crates/luminal_reference/src/ops/cast/mod.rs` — five integer widths would
+otherwise be 25 hand-written pair arms. Policy, stated once there:
+int -> narrow int TRUNCATES (main's `as`); int -> `Int`/`Int64` stays CHECKED;
+narrow int -> float is exact by width (|v| <= 32767, well inside f32's 2^24
+bound), so the checked-exact rule has nothing left to check; `Bool8` -> narrow
+int is the 0/1 indicator bridge. The ONE place main's `as` is not carried is
+**float -> narrow int**, which stays a REFUSAL like every other float -> int:
+the carve-out is about integer WIDTH semantics, not a licence to make a lossy
+float read implicit. `GraphTensor::cast`'s authoring guard grows `I8|U8|I16`
+so the author sees that refusal, not the search. (`I4`/`U4`/`U16` are left out
+of the guard: they have no storage and no kernel, so a cast to them refuses at
+the plan instead.)
+
+**`Mod` vs `TruncRem`.** Main put its narrow arms on `Mod`. Integer remainder
+is spelled `TruncRem` here (`Mod` is the f32 op, and says so in its refusal),
+so `i8::wrapping_rem` / `u8: x % y` / `i16::wrapping_rem` land in
+`ops/trunc_rem/`. `ops/modulo/` is unchanged and still f32-only. `trunc_div`
+gets the matching `wrapping_div` arms, which main had no counterpart for. A
+ZERO divisor still refuses loudly at every width: wrapping is a defined
+result, division by zero is not.
+
+**LIVE frontend: `abs` and `neg`.** `GraphTensor::abs` takes main's
+dtype-aware body — identity for unsigned, `x * (1 - 2*(x < 0))` for signed —
+and this is a genuine bug fix, not a refinement. The old body was
+`self.relu() + (-self).relu()`, `relu` is `maximum_f32`, and `maximum_f32`
+builds its bound with `constant_float(0.0).cast(self.dtype)`; an F32 -> Int
+cast is REFUSED at authoring, so `abs()` on ANY integer PANICKED before it
+recorded anything. Main's body is rebuilt from `Graph::constant` (Int)
+instead of `constant_float` (F32) for the same reason. Landing it also
+exposed that `impl Neg for GraphTensor` was dtype-aware for `Int | I64` only;
+it now covers the whole integer family, and on an unsigned type the `-1`
+constant casts to that type's all-ones code so the wrapping multiply is
+two's-complement negation.
+
+**Tests** (all in `crates/luminal_reference/src/runtime.rs` unless noted).
+Main's two `src/hlir.rs` tests could not move — they name `ReferenceData` and
+call `.execute()` on a bare op — so both are re-expressed end to end, through
+the real recorder/search/execute ladder, which is strictly stronger:
+
+- `narrow_int_add_wraps_at_its_own_width` — main's
+  `reference_narrow_integer_add_wraps_in_declared_dtype`, same operands
+  (`127 + 1`, `-128 + -1` at i8; `255 + 1`, `0 + 255` at u8; the i16 pair) and
+  same expected wraps, read back through the non-widening getters.
+- `narrow_int_casts_truncate_and_wide_casts_stay_checked` — main's
+  `reference_narrow_integer_casts_preserve_native_widths`, the same
+  nine-element `Int` source and the same three expected result vectors,
+  plus a fourth act pinning that `I64 -> Int` still REFUSES out of range.
+- `float_to_narrow_int_cast_is_refused_at_authoring` — the one deliberate
+  divergence from main, pinned so it cannot drift back by accident.
+- `integer_abs_executes_and_wraps_at_the_signed_minimum` — `abs` on I16
+  (ungated) and on Int (attested range), with `abs(i16::MIN) == i16::MIN`,
+  which is both the wrap and what torch reports.
+- `luminal::frontend::unary::tests::unsigned_abs_is_the_identity` — `abs()`
+  on U4/U8/U16 records no op at all.
+
+Main's `src/dyn_backend.rs` test `narrow_integer_bytes_preserve_width_and_signedness`
+does not move: it tests `bytes_to_reference_data`, a byte-reinterpretation
+function with no counterpart under `TypedBuffer`.
+
+**Not carried.** `U16` stays unmapped, exactly as in main — the dtype tag
+exists, the storage does not. `crates/luminal_cuda_lite/src/device.rs` gets
+`unreachable!` arms only: `dtype_bytes` has no narrow-int row, so CL refuses
+them by name, and transport without kernels would be the half-done version.

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -32,6 +32,7 @@ Dispositions:
 | `bea18ecf` | #389 | Sdpa gqa fixes | FILE-LEVEL | branch `merge/main-389-sdpa-gqa` | parked crate + non-gating `ci/`: RULED 2026-09-02 (ruling 1) — `ci/example_output.py` SYNCS main's numbers for now, by decision; the loosened gemma / gemma4_moe TPOT figures are main's HLIR cuda_lite draws and still have to be re-baselined against CL A100 draws before they gate anything here |
 | `499d0779` | #386 | Search: early-stop candidate profiling against the best-so-far metric | MIXED — RE-EXPRESSED (core: running mean + fifth positional cutoff + predicate) / FILE-LEVEL (parks, with a stubbed predicate) | branch `merge/main-386-early-stop` (two commits) | REQUIREMENT FOR CL (ruling 4): a device `PlanProfiler` that times candidates on device, mirroring `ReferenceProfiler`'s design, and then honours the cutoff — until then `StaticProfiler` accepts and ignores it; see **#386 early-stop profiling** below |
 | `6a5313f2` | #398 | Support for PyTorch OpInfo tests | MIXED — FILE-LEVEL (python + workflow) / RE-EXPRESSED (`TypedBuffer::F64` + typed unary kernels) / DROPPED (`ConstantF64`, the empty-Vec fix) | branch `merge/main-398-opinfo` (two commits) | OpInfo harness, the arange-metadata and acos/acosh lowerings = M4 translator requirements; typed `LogicalConstant`; F32<->F64 cast policy; F64 on CL — see **#398 OpInfo + F64** below |
+| `db3c80fd` | #399 | Add native narrow integer HLIR dtypes | MIXED — FILE-LEVEL (python) / RE-EXPRESSED (I8/U8/I16 TypedBuffer + kernels, int-safe `abs`) | branch `merge/main-399-narrow-ints` (two commits) | **CARVE-OUT to confirm at review**: I8/U8/I16 wrap, I32/I64 stay checked — see **#399 narrow ints** below |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -373,3 +374,27 @@ Main's other two Rust tests do not move: `f64_constant_to_egglog_round_trips_exa
 tests `ConstantF64`, which is superseded, and
 `empty_bytes_preserve_reference_dtype` tests a `from_raw_parts` hazard that
 does not exist here.
+
+## #399 narrow ints — what landed, and the carve-out that needs confirming
+
+RULED 2026-09-02 (ruling 2): *"this is good and should get its content
+merged"*, with the narrow-int semantics flagged for Austin to object to at
+review. Two commits.
+
+**FILE-LEVEL (commit 1).** The seven `crates/luminal_python/**` files carry
+main's diff byte for byte (no conflicts, no re-spelling — the diff-of-diffs
+against `db3c80fd` is empty). `torch_dtype.rs` and `typed_data.rs` are the
+boundary dtype tables — the record of which torch dtype maps to which luminal
+one — and are worth having even inert. The crate is not a workspace member
+and `typed_data.rs` still names `luminal::hlir::ReferenceData`, so none of it
+builds; it is banked, not revived.
+
+**UNCARRIED.** `src/hlir.rs` (+350) and `src/dyn_backend.rs` (+87) are deleted
+here. Their content is re-expressed (below) except for the `DynBackend`
+`get_output_i8/u8/i16` trait defaults, which have no counterpart at all: this
+branch's outputs come back through `ReferenceRuntime`'s typed getters, so
+main's three trait methods become three `get_*` methods on the runtime and the
+`DynBackend`/pyo3/python reader-table plumbing around them is dropped with the
+trait. Main's two test hunks (`src/hlir.rs` `mod tests`, `src/dyn_backend.rs`)
+name deleted types and could not move as written; they are re-expressed as
+reference-runtime tests instead.

--- a/src/buffer_tensor_ir.rs
+++ b/src/buffer_tensor_ir.rs
@@ -70,7 +70,10 @@ impl<T: BufferTensorIrOp + Clone + 'static> CloneBufferTensorIrOp for T {
 /// F32 bridge wearing an F64 tag); 32-bit integers as i32 and 64-bit
 /// as i64, NATIVE values
 /// (every bit pattern legal — total-code dtypes), which is what makes
-/// index arithmetic exact past f32's 2^24 ceiling; booleans live as
+/// index arithmetic exact past f32's 2^24 ceiling; the NARROW integers
+/// I8/U8/I16 likewise store native, at their own width, never widened
+/// to i32 (ruling 2026-09-02, main #399) — see the carve-out note on
+/// [`ReferenceKernelCtx::binary_elementwise_i8`]; booleans live as
 /// Bool8 CODES — one u8 per element, exactly 0x00 or 0x01, every other
 /// pattern ill-formed (see the Bool8 contract in the preamble's Dtype
 /// declaration). The Bool8 variant serves both Bool8-typed buffers
@@ -87,12 +90,52 @@ pub enum TypedBuffer {
     F64(Vec<f64>),
     I32(Vec<i32>),
     I64(Vec<i64>),
+    /// Narrow signed byte integers. Stored at their OWN width: a
+    /// narrow value silently widened to i32 is exactly the smuggling
+    /// the typed-buffer ruling forbids, and it also loses the
+    /// wrap-at-8-bits arithmetic torch defines for them.
+    I8(Vec<i8>),
+    /// Narrow unsigned byte integers. Distinct from [`Self::Bool8`],
+    /// which is also byte-shaped but has only two legal codes.
+    U8(Vec<u8>),
+    /// Narrow signed 16-bit integers.
+    I16(Vec<i16>),
     Bool8(Vec<u8>),
     /// E4M3FN codes (the ML fp8: no infinities, saturate ±448, only
     /// 0x7F/0xFF NaN) — quantization is MODEL DEFINITION (ruling
     /// 2026-08-12), so checkpoint fp8 weights stage and store in their
     /// own dtype; arithmetic happens after an explicit widening cast.
     F8E4M3(Vec<float8::F8E4M3>),
+}
+
+/// The narrow-integer family (I8/U8/I16) is ONE implementation at three
+/// widths: typed accessors that refuse by name rather than coerce,
+/// exactly like the hand-written F32/I32/I64 pairs above. Written as a
+/// macro because three verbatim copies of a seven-line accessor is not
+/// three decisions — it is one, repeated. Anything that DIFFERS between
+/// the widths (there is nothing, today) belongs outside the macro.
+macro_rules! narrow_int_accessors {
+    ($variant:ident, $prim:ty, $get:ident, $get_mut:ident, $article:literal) => {
+        pub fn $get(&self) -> Result<&Vec<$prim>> {
+            match self {
+                TypedBuffer::$variant(values) => Ok(values),
+                other => anyhow::bail!(
+                    concat!("expected ", $article, " buffer, found {}"),
+                    other.type_name()
+                ),
+            }
+        }
+
+        pub fn $get_mut(&mut self) -> Result<&mut Vec<$prim>> {
+            match self {
+                TypedBuffer::$variant(values) => Ok(values),
+                other => anyhow::bail!(
+                    concat!("expected ", $article, " buffer, found {}"),
+                    other.type_name()
+                ),
+            }
+        }
+    };
 }
 
 impl TypedBuffer {
@@ -118,6 +161,9 @@ impl TypedBuffer {
             TypedBuffer::F64(values) => values.len(),
             TypedBuffer::I32(values) => values.len(),
             TypedBuffer::I64(values) => values.len(),
+            TypedBuffer::I8(values) => values.len(),
+            TypedBuffer::U8(values) => values.len(),
+            TypedBuffer::I16(values) => values.len(),
             TypedBuffer::Bool8(bits) => bits.len(),
             TypedBuffer::F8E4M3(codes) => codes.len(),
         }
@@ -133,6 +179,9 @@ impl TypedBuffer {
             TypedBuffer::F64(_) => "f64",
             TypedBuffer::I32(_) => "i32",
             TypedBuffer::I64(_) => "i64",
+            TypedBuffer::I8(_) => "i8",
+            TypedBuffer::U8(_) => "u8",
+            TypedBuffer::I16(_) => "i16",
             TypedBuffer::Bool8(_) => "bool8",
             TypedBuffer::F8E4M3(_) => "f8e4m3",
         }
@@ -194,6 +243,10 @@ impl TypedBuffer {
         }
     }
 
+    narrow_int_accessors!(I8, i8, as_i8, as_i8_mut, "an i8");
+    narrow_int_accessors!(U8, u8, as_u8, as_u8_mut, "a u8");
+    narrow_int_accessors!(I16, i16, as_i16, as_i16_mut, "an i16");
+
     pub fn as_f8e4m3(&self) -> Result<&Vec<float8::F8E4M3>> {
         match self {
             TypedBuffer::F8E4M3(codes) => Ok(codes),
@@ -230,6 +283,9 @@ impl TypedBuffer {
             TypedBuffer::F64(values) => TypedBuffer::F64(vec![0.0; values.len()]),
             TypedBuffer::I32(values) => TypedBuffer::I32(vec![0; values.len()]),
             TypedBuffer::I64(values) => TypedBuffer::I64(vec![0; values.len()]),
+            TypedBuffer::I8(values) => TypedBuffer::I8(vec![0; values.len()]),
+            TypedBuffer::U8(values) => TypedBuffer::U8(vec![0; values.len()]),
+            TypedBuffer::I16(values) => TypedBuffer::I16(vec![0; values.len()]),
             TypedBuffer::Bool8(bits) => TypedBuffer::Bool8(vec![0u8; bits.len()]),
             TypedBuffer::F8E4M3(codes) => {
                 TypedBuffer::F8E4M3(vec![float8::F8E4M3::from_bits(0); codes.len()])
@@ -265,6 +321,21 @@ impl From<Vec<i64>> for TypedBuffer {
         TypedBuffer::I64(values)
     }
 }
+impl From<Vec<i8>> for TypedBuffer {
+    fn from(values: Vec<i8>) -> Self {
+        TypedBuffer::I8(values)
+    }
+}
+impl From<Vec<i16>> for TypedBuffer {
+    fn from(values: Vec<i16>) -> Self {
+        TypedBuffer::I16(values)
+    }
+}
+// NOTE: `Vec<u8>` deliberately has NO `From`. It is the payload type of
+// BOTH `U8` and `Bool8`, so an impl would have to pick one, and either
+// choice is a silent reading of ambiguous caller bytes: Bool8 codes
+// must pass the validated door, and U8 data is spelled
+// `TypedBuffer::U8(values)`.
 impl From<Vec<float8::F8E4M3>> for TypedBuffer {
     fn from(codes: Vec<float8::F8E4M3>) -> Self {
         TypedBuffer::F8E4M3(codes)
@@ -284,6 +355,66 @@ pub struct ReferenceKernelCtx {
     pub operand_dims: Vec<Vec<usize>>,
     /// Result contents to fill, in result order (zero-initialized).
     pub dests: Vec<TypedBuffer>,
+}
+
+/// The elementwise-binary and axis-reduce helpers for one narrow integer
+/// width — the I8/U8/I16 twins of [`ReferenceKernelCtx::binary_elementwise_i32`]
+/// and [`ReferenceKernelCtx::reduce_axis_i32`], whose bodies are identical
+/// once the primitive type is fixed.
+macro_rules! narrow_int_kernel_helpers {
+    ($prim:ty, $get:ident, $get_mut:ident, $binary:ident, $reduce:ident) => {
+        /// dest0[i] = f(operand0[i], operand1[i]) at this narrow width.
+        pub fn $binary(&mut self, f: impl Fn($prim, $prim) -> Result<$prim>) -> Result<()> {
+            let lhs = self.operands[0].$get()?;
+            let rhs = self.operands[1].$get()?;
+            anyhow::ensure!(
+                lhs.len() == rhs.len() && lhs.len() == self.dests[0].len(),
+                "binary kernel length mismatch"
+            );
+            let (lhs, rhs) = (lhs.clone(), rhs.clone());
+            let dest = self.dests[0].$get_mut()?;
+            for (index, out) in dest.iter_mut().enumerate() {
+                *out = f(lhs[index], rhs[index])?;
+            }
+            Ok(())
+        }
+
+        /// Contiguous fold over one axis at this narrow width (axis
+        /// zero-based FROM THE END, the house convention).
+        pub fn $reduce(
+            &mut self,
+            axis_from_end: i64,
+            init: $prim,
+            fold: impl Fn($prim, $prim) -> Result<$prim>,
+        ) -> Result<()> {
+            let dims = &self.operand_dims[0];
+            let rank = dims.len();
+            anyhow::ensure!(
+                (axis_from_end as usize) < rank,
+                "reduce axis {axis_from_end} out of rank {rank}"
+            );
+            let axis = rank - 1 - axis_from_end as usize;
+            let reduced = dims[axis];
+            let inner: usize = dims[axis + 1..].iter().product();
+            let outer: usize = dims[..axis].iter().product();
+            let input = self.operands[0].$get()?.clone();
+            let dest = self.dests[0].$get_mut()?;
+            anyhow::ensure!(
+                dest.len() == outer * inner && input.len() == outer * reduced * inner,
+                "reduce kernel geometry mismatch"
+            );
+            for o in 0..outer {
+                for i in 0..inner {
+                    let mut acc = init;
+                    for r in 0..reduced {
+                        acc = fold(acc, input[o * reduced * inner + r * inner + i])?;
+                    }
+                    dest[o * inner + i] = acc;
+                }
+            }
+            Ok(())
+        }
+    };
 }
 
 impl ReferenceKernelCtx {
@@ -381,6 +512,34 @@ impl ReferenceKernelCtx {
         }
         Ok(())
     }
+
+    // ---- the narrow-integer family (ruling 2026-09-02, main #399) ----
+    //
+    // CARVE-OUT, to be confirmed at review. I8/U8/I16 follow TORCH's
+    // semantics, which main #399 adopted: arithmetic WRAPS at the type's
+    // own width. I32 and I64 keep the non-wrapping ruling of 2026-08-11
+    // — a checked overflow is a loud kernel error there, and the
+    // value-bounds proof gate in each op's `match_functional.egg` exists
+    // to discharge it statically. The two rules coexist because the
+    // egglog gate names `(Int)` and `(Int64)` and nothing else, so a
+    // narrow-int op mints through the UNGATED arm and needs no proof; a
+    // wrap is a defined result at these widths, not an escaped error.
+    //
+    // The closures still return `Result` — same shape as the i32/i64
+    // helpers — because wrapping is not the only failure mode: a
+    // zero divisor is undefined at every width, and the trunc-div and
+    // trunc-rem kernels refuse it loudly. What each op MEANS shows up at
+    // its call site (`Ok(a.wrapping_add(b))`), in its own folder, which
+    // is where this branch keeps op semantics.
+    narrow_int_kernel_helpers!(i8, as_i8, as_i8_mut, binary_elementwise_i8, reduce_axis_i8);
+    narrow_int_kernel_helpers!(u8, as_u8, as_u8_mut, binary_elementwise_u8, reduce_axis_u8);
+    narrow_int_kernel_helpers!(
+        i16,
+        as_i16,
+        as_i16_mut,
+        binary_elementwise_i16,
+        reduce_axis_i16
+    );
 
     /// Contiguous fold over one axis (zero-based FROM THE END — the house
     /// nth-from-end convention, matching the reduce ops' metadata).

--- a/src/frontend/other.rs
+++ b/src/frontend/other.rs
@@ -107,7 +107,16 @@ impl GraphTensor {
             self.dtype,
             DType::F32 | DType::F64 | DType::F16 | DType::Bf16 | DType::TF32
         );
-        let int_target = matches!(dtype, DType::Int | DType::I64);
+        // The narrow integers joined the executable set on 2026-09-02
+        // (main #399). Their carve-out is about integer WIDTH — a
+        // narrowing int -> int cast truncates — and NOT a licence to
+        // make a lossy float read implicit, so they are int targets
+        // here like every other integer. (I4/U4/U16 have no storage and
+        // no kernel, so a cast to them refuses at the plan instead.)
+        let int_target = matches!(
+            dtype,
+            DType::Int | DType::I64 | DType::I8 | DType::U8 | DType::I16
+        );
         assert!(
             !(float_source && int_target),
             "cast {:?} -> {:?} is refused: a float -> int conversion is a \

--- a/src/frontend/unary.rs
+++ b/src/frontend/unary.rs
@@ -50,11 +50,22 @@ impl Neg for GraphTensor {
     type Output = GraphTensor;
 
     fn neg(self) -> Self::Output {
-        // Dtype-aware: an Int tensor negates through an Int constant —
-        // the f32 literal would record a refused f32 -> Int cast
-        // (typed-buffers cast policy, 2026-08-11).
+        // Dtype-aware: an integer tensor negates through an Int
+        // constant — the f32 literal would record a refused f32 -> Int
+        // cast (typed-buffers cast policy, 2026-08-11). The narrow
+        // integers joined the executable set on 2026-09-02 (main #399)
+        // and take the same arm: on an unsigned type the -1 constant
+        // casts to that type's all-ones code and the wrapping multiply
+        // is two's-complement negation, which is what it means there.
         match self.dtype {
-            DType::Int | DType::I64 => self * IntExpr::from(-1),
+            DType::Int
+            | DType::I64
+            | DType::I4
+            | DType::U4
+            | DType::I8
+            | DType::U8
+            | DType::I16
+            | DType::U16 => self * IntExpr::from(-1),
             _ => self * -1.,
         }
     }
@@ -266,9 +277,41 @@ impl GraphTensor {
         self.var_options(axes, correction).sqrt()
     }
 
-    /// Take the absolute value
+    /// Take the absolute value.
+    ///
+    /// DTYPE-AWARE (main #399, re-expressed 2026-09-02). The float path
+    /// is unchanged: `relu(x) + relu(-x)`. Integers cannot take it —
+    /// `relu` is `maximum_f32`, which builds its bound with
+    /// `constant_float(0.0).cast(self.dtype)`, and an F32 -> Int cast is
+    /// REFUSED at authoring by the cast policy of 2026-08-11, so
+    /// `abs()` on an Int tensor used to panic before it recorded
+    /// anything. So:
+    ///
+    /// * UNSIGNED integers are already their own absolute value —
+    ///   identity, and no ops recorded at all.
+    /// * SIGNED integers use main's identity `x * (1 - 2*(x < 0))`,
+    ///   built from Int constants rather than float ones so no
+    ///   float -> int cast appears. This is also CORRECT at the signed
+    ///   minimum in the only sense available: `i32::MIN` has no
+    ///   representable absolute value, and the multiplication reports
+    ///   that as an overflow (the Int kernels are checked) instead of
+    ///   returning `MIN` as `relu` + `relu` would.
     pub fn abs(self) -> GraphTensor {
-        self.relu() + (-self).relu()
+        match self.dtype {
+            DType::U4 | DType::U8 | DType::U16 => self,
+            DType::I4 | DType::I8 | DType::I16 | DType::Int | DType::I64 => {
+                let dims = self.dims();
+                let zero = self
+                    .graph()
+                    .constant(0)
+                    .cast(self.dtype)
+                    .expand_rhs(dims.clone());
+                let one = self.graph().constant(1).cast(self.dtype).expand_rhs(dims);
+                let negative = self.lt(zero).cast(self.dtype);
+                self * (one - negative * 2)
+            }
+            _ => self.relu() + (-self).relu(),
+        }
     }
 
     /// Get the sign of each element, '1' for positive and '-1' for negative
@@ -490,6 +533,24 @@ pub(super) mod tests {
     use itertools::Itertools;
     use luminal::prelude::*;
     use proptest::prelude::*;
+
+    /// `abs()` ON AN UNSIGNED INTEGER RECORDS NOTHING (main #399's
+    /// `DType::U4 | U8 | U16 => self` arm). Not a performance nicety: a
+    /// recorded no-op would be a `lt` against zero, whose answer is
+    /// constant-false for an unsigned type, followed by arithmetic that
+    /// exists only to multiply by one.
+    #[test]
+    fn unsigned_abs_is_the_identity() {
+        let mut cx = Graph::new();
+        for dtype in [DType::U4, DType::U8, DType::U16] {
+            let x = cx.tensor_dtyped(4, dtype);
+            assert_eq!(
+                x.abs().id,
+                x.id,
+                "abs() on {dtype:?} must be the identity, not a recorded op"
+            );
+        }
+    }
 
     fn cummax_ref_2d(a: Tensor) -> Tensor {
         let v = a.to_vec2::<f32>().unwrap();


### PR DESCRIPTION
**Stack.** PR 2 of 8, batch 3 of the main rejoin (walking main's post-split commits chronologically). Base: `merge/main-398-opinfo`. Merge in order; before merging, retarget to `logical-ssa-project` with `gh pr edit --base logical-ssa-project`.

**Summary.** Carries main `db3c80fd` (#399) per ruling 2. Commit 1: seven `crates/luminal_python/**` boundary-table files file-level (diff-of-diffs empty). Commit 2: I8/U8/I16 as `TypedBuffer` variants + kernel arms with main's semantics, strictly non-widening readers, the live integer `abs`/`Neg` fix, and the cast authoring guard.

> **CARVE-OUT — Austin to confirm at review** (verbatim from the commit)
> I8, U8 and I16 arithmetic WRAPS at its own width, following main #399 and torch. I32 and I64 keep the non-wrapping ruling of 2026-08-11: an overflow is a loud checked error, discharged statically by the value-bounds proof gate.
> The two rules coexist with no egglog change at all, because each op's match_functional.egg gate names (Int) and (Int64) and nothing else — a narrow-int op mints through the UNGATED arm and needs no proof. The case for the split: at 8 and 16 bits a wrap is a DEFINED result, it is what torch computes, and matching torch is the entire reason this feature exists (main's number was OpInfo's first-100 slice going 39 -> 57 parent cases). At 32 and 64 bits an overflow is an escaped error the bounds lattice can prove away, which is what landing D built. The case against: two overflow semantics in one runtime, told apart only by width. If it is ruled the other way the change is local — six wrapping_* calls become checked_*, and (I8)/(U8)/(I16) proof gates go in beside the (Int) ones.

**Reviewer correction:** the wrapping call sites are FIFTEEN, not six — `add`, `mul`, `reduce_sum`, `trunc_div`, `trunc_rem` × three widths. Still local. Second flagged divergence: float -> narrow int stays REFUSED at authoring (main's `to_*_vec` truncated floats with `as`); pinned by `float_to_narrow_int_cast_is_refused_at_authoring`.

**What was re-expressed and why.** Main's `ReferenceData` arms → `TypedBuffer::{I8,U8,I16}` (macro-generated accessors + binary/reduce helpers); main's `Mod` arms land on `TruncRem` (integer remainder here); main's per-target casts → one `narrow_cast` policy helper (int->narrow truncates, ->Int/Int64 stays checked, narrow->float exact by width, Bool8->narrow 0/1, ->Bool8 refused); `DynBackend::get_output_*` → `ReferenceRuntime::get_i8/u8/i16` (refuse by name, never widen). `abs` rebuilt from Int constants because this branch refuses the F32->Int cast main's body relies on — the old `relu+relu` body PANICKED at authoring on every integer dtype. No `From<Vec<u8>>` (payload of both U8 and Bool8).

**Audit.** Kernel arms match main's op set exactly (Add/Mul/Mod/LessThan/Gather/Scatter/SumReduce/MaxReduce/Cast) plus `trunc_div`; cast test vectors identical to main's; `abs(i16::MIN) == i16::MIN` pinned; `I64 -> Int` still refuses. Live-file gates green (luminal lib 245/0, luminal_reference lib 40/0, clippy, fmt).

**Not verified.** `Neg` on U8/I8/I16 (two's-complement via the -1 constant) has no direct test; I4/U4/U16 remain storage-less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
