### PR TITLE
main rejoin: CUDA graph materialization (#394) into the HLIR park

### DIFF
--- a/crates/luminal_cuda_lite_hlir/src/dyn_backend.rs
+++ b/crates/luminal_cuda_lite_hlir/src/dyn_backend.rs
@@ -50,7 +50,6 @@ impl DynBackend for CudaLiteDynBackend {
     fn execute(&mut self, dyn_map: &FxHashMap<char, usize>) {
         self.runtime.execute(dyn_map);
     }
-
     fn supports_device_ptrs(&self) -> bool {
         true
     }
@@ -60,11 +59,18 @@ impl DynBackend for CudaLiteDynBackend {
     unsafe fn set_output_device_ptr(&mut self, node: NodeIndex, ptr: u64, n: usize) {
         unsafe { self.runtime.set_output_device_ptr(node, ptr, n) }
     }
+    fn clear_output_device_ptr(&mut self, node: NodeIndex) {
+        self.runtime.clear_output_device_ptr(node)
+    }
     fn output_is_zero_copy(&self, node: NodeIndex) -> bool {
         self.runtime.output_is_zero_copy(node)
     }
     unsafe fn copy_output_to_device_ptr(&self, node: NodeIndex, ptr: u64, n: usize) {
         unsafe { self.runtime.copy_output_to_device_ptr(node, ptr, n) }
+    }
+
+    unsafe fn copy_outputs_to_device_ptrs(&self, copies: &[(NodeIndex, u64, usize)]) {
+        unsafe { self.runtime.copy_outputs_to_device_ptrs(copies) }
     }
 }
 

--- a/crates/luminal_cuda_lite_hlir/src/host/flashinfer/mod.rs
+++ b/crates/luminal_cuda_lite_hlir/src/host/flashinfer/mod.rs
@@ -1114,6 +1114,13 @@ impl HostOp for FlashInferAttention {
         })
     }
 
+    fn resource_buffer_nodes(&self, inputs: &[NodeIndex]) -> Vec<NodeIndex> {
+        // device_resource_spec derives max_kv_pages from the logical lengths
+        // of K and V. Q, gather indices, and explicit indptr contents do not
+        // alter the allocation plan.
+        inputs.get(1..3).unwrap_or_default().to_vec()
+    }
+
     fn stats_name(&self) -> Option<&'static str> {
         Some("FlashInferAttention")
     }
@@ -1175,6 +1182,18 @@ unsafe fn cuda_pin_memory(ptr: *mut std::ffi::c_void, size: usize) -> i32 {
 mod resource_tests {
     use super::*;
     use itertools::Itertools;
+
+    #[test]
+    fn resource_signature_depends_only_on_kv_lengths() {
+        let attention = FlashInferAttention::default();
+        let inputs = (0..6).map(NodeIndex::new).collect_vec();
+
+        assert_eq!(
+            attention.resource_buffer_nodes(&inputs),
+            vec![inputs[1], inputs[2]]
+        );
+        assert!(attention.resource_buffer_nodes(&inputs[..2]).is_empty());
+    }
 
     #[test]
     fn device_resource_spec_is_pointer_free_and_capacity_adjusted() {

--- a/crates/luminal_cuda_lite_hlir/src/host/mod.rs
+++ b/crates/luminal_cuda_lite_hlir/src/host/mod.rs
@@ -203,6 +203,19 @@ pub trait HostOp: Debug + as_any::AsAny + EgglogOp {
         Ok(HostDeviceMemoryPlan::default())
     }
 
+    /// Graph-visible buffers whose logical byte lengths can change the result
+    /// of `device_memory_plan`.
+    ///
+    /// Pointer identity and payload contents are never resource facts. Most
+    /// HostOps derive their resource requirements entirely from `dyn_map` and
+    /// therefore return no nodes here. An op that consults `buffer_lengths`
+    /// must return exactly those inputs so the runtime can invalidate its
+    /// hard-resource validation cache when (and only when) their lengths
+    /// change.
+    fn resource_buffer_nodes(&self, _inputs: &[NodeIndex]) -> Vec<NodeIndex> {
+        vec![]
+    }
+
     /// Returns the name of this host op for stats reporting, or None if not reportable.
     fn stats_name(&self) -> Option<&'static str> {
         None

--- a/crates/luminal_cuda_lite_hlir/src/kernel/to_host.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/to_host.rs
@@ -489,6 +489,13 @@ impl CudaGraphOpState {
 pub struct CudaGraphOp {
     /// All nodes that this graph needs buffers for (kernels + their inputs)
     buffer_nodes: Vec<NodeIndex>,
+    buffer_node_set: FxHashSet<NodeIndex>,
+    /// Reverse dependency indices built once at graph construction. These let
+    /// pointer/dimension changes identify affected kernel nodes directly.
+    kernel_users_by_buffer: FxHashMap<NodeIndex, Vec<usize>>,
+    kernel_users_by_dyn_dim: FxHashMap<char, Vec<usize>>,
+    output_aliases: Vec<(NodeIndex, NodeIndex)>,
+    library_buffer_nodes: FxHashSet<NodeIndex>,
     /// Buffer size requirements for extra nodes (node -> size in elements)
     buffer_sizes: FxHashMap<NodeIndex, IntExpr>,
     /// Dynamic dimensions used by this graph (sorted alphabetically)
@@ -510,8 +517,43 @@ impl CudaGraphOp {
         capture_stream: Option<Arc<CudaStream>>,
         state: CudaGraphOpState,
     ) -> Self {
+        let mut kernel_users_by_buffer: FxHashMap<NodeIndex, Vec<usize>> = FxHashMap::default();
+        let mut kernel_users_by_dyn_dim: FxHashMap<char, Vec<usize>> = FxHashMap::default();
+        let mut output_aliases = Vec::new();
+        let mut library_buffer_nodes = FxHashSet::default();
+        // Build reverse dependency indexes once so materialization can update only the kernels
+        // affected by changed buffer bindings or dynamic dimensions.
+        for (idx, kernel) in state.kernels.iter().enumerate() {
+            kernel_users_by_buffer
+                .entry(kernel.node)
+                .or_default()
+                .push(idx);
+            for input in &kernel.inputs {
+                kernel_users_by_buffer.entry(*input).or_default().push(idx);
+            }
+            for dim in &kernel.dyn_vars {
+                kernel_users_by_dyn_dim.entry(*dim).or_default().push(idx);
+            }
+            if let Some(input_idx) = kernel.kernel_op.output_aliases_input() {
+                output_aliases.push((kernel.inputs[input_idx], kernel.node));
+            }
+        }
+        for op in &state.cublaslt_ops {
+            library_buffer_nodes.insert(op.node);
+            library_buffer_nodes.extend(op.inputs.iter().copied());
+        }
+        for op in &state.flashinfer_ops {
+            library_buffer_nodes.insert(op.node);
+            library_buffer_nodes.extend(op.inputs.iter().copied());
+        }
+        let buffer_node_set = buffer_nodes.iter().copied().collect();
         Self {
             buffer_nodes,
+            buffer_node_set,
+            kernel_users_by_buffer,
+            kernel_users_by_dyn_dim,
+            output_aliases,
+            library_buffer_nodes,
             buffer_sizes,
             dyn_dims_order,
             stream,
@@ -840,6 +882,19 @@ impl HostOp for CudaGraphOp {
         dyn_map: &FxHashMap<char, usize>,
     ) -> Result<HostDeviceMemoryPlan, ResourceViolation> {
         self.host_device_memory_plan(buffer_lengths, dyn_map)
+    }
+
+    fn resource_buffer_nodes(&self, _inputs: &[NodeIndex]) -> Vec<NodeIndex> {
+        // CudaGraphOp absorbs HostOps, so its graph-visible `inputs` argument
+        // does not describe the internal FlashInfer inputs. Preserve the
+        // dependency explicitly from the compiled island metadata.
+        let state = self.state.borrow();
+        state
+            .flashinfer_ops
+            .iter()
+            .flat_map(|op| op.inputs.get(1..3).unwrap_or_default().iter().copied())
+            .unique()
+            .collect()
     }
 
     fn extra_buffer_nodes(&self) -> Vec<NodeIndex> {
@@ -1303,6 +1358,189 @@ impl CudaGraphOp {
         }
     }
 
+    pub(crate) fn uses_buffer(&self, node: NodeIndex) -> bool {
+        self.buffer_node_set.contains(&node)
+    }
+
+    /// Patch a CUDA graph from an exact set of changed bindings without
+    /// rebuilding or comparing its complete pointer table. Returns `false`
+    /// when a full materialization is required (first use, dynamic-dimension
+    /// changes or an affected captured library island).
+    pub(crate) fn materialize_changed_bindings(
+        &self,
+        stream: &Arc<CudaStream>,
+        changed_buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
+        dyn_map: &FxHashMap<char, usize>,
+    ) -> anyhow::Result<bool> {
+        let mut state = self.state.borrow_mut();
+        if state.cuda_graph.is_none() || state.cuda_graph_exec.is_none() {
+            return Ok(false);
+        }
+        let dyn_map_changed = dyn_map.len() != state.last_dyn_values.len()
+            || dyn_map
+                .iter()
+                .any(|(dim, value)| state.last_dyn_values.get(dim) != Some(value));
+        if dyn_map_changed {
+            return Ok(false);
+        }
+
+        let mut changed = changed_buffers.clone();
+        // Output aliases always inherit their input pointer, even when the
+        // caller attempted to register a distinct output allocation.
+        for &(input, output) in &self.output_aliases {
+            if !changed.contains_key(&input) && !changed.contains_key(&output) {
+                continue;
+            }
+            let input_buffer = changed.get(&input).copied().or_else(|| {
+                let ptr = state.last_buffer_ptrs.get(&input).copied()?;
+                let len = changed.get(&output).map(|buffer| buffer.len()).unwrap_or(0);
+                Some(DeviceBuffer::new(ptr, len))
+            });
+            if let Some(input_buffer) = input_buffer {
+                changed.insert(output, input_buffer);
+            }
+        }
+
+        if changed
+            .keys()
+            .any(|node| self.library_buffer_nodes.contains(node))
+        {
+            return Ok(false);
+        }
+
+        let mut current_buffer_ptrs = state.last_buffer_ptrs.clone();
+        current_buffer_ptrs.extend(changed.iter().map(|(&node, buffer)| (node, buffer.ptr())));
+        for kernel in &mut state.kernels {
+            kernel.kernel_op.pre_execute(
+                stream,
+                &mut kernel.internal_bufs,
+                &mut kernel.constants,
+                &current_buffer_ptrs,
+                dyn_map,
+            );
+        }
+
+        let mut dirty_kernel_set = FxHashSet::default();
+        for node in changed.keys() {
+            if let Some(users) = self.kernel_users_by_buffer.get(node) {
+                dirty_kernel_set.extend(users.iter().copied());
+            }
+        }
+        let mut dirty_kernels = dirty_kernel_set.into_iter().collect_vec();
+        dirty_kernels.sort_unstable();
+
+        let dyn_dims_ptr = state
+            .dyn_dims_buffer
+            .as_ref()
+            .map(|buf| buf.device_ptr(stream).0)
+            .unwrap_or(0);
+        for &idx in &dirty_kernels {
+            let kernel = &state.kernels[idx];
+            let output_ptr = changed
+                .get(&kernel.node)
+                .map(|buffer| buffer.ptr())
+                .or_else(|| state.last_buffer_ptrs.get(&kernel.node).copied())
+                .unwrap_or(0);
+            let input_ptrs = kernel
+                .inputs
+                .iter()
+                .map(|input| {
+                    changed
+                        .get(input)
+                        .map(|buffer| buffer.ptr())
+                        .or_else(|| state.last_buffer_ptrs.get(input).copied())
+                        .unwrap_or(0)
+                })
+                .collect_vec();
+            Self::validate_kernel_pointers(kernel, output_ptr, &input_ptrs, dyn_map)?;
+            let kernel_dyn_dims_ptr = if kernel.has_dyn_dims_param {
+                dyn_dims_ptr
+            } else {
+                0
+            };
+            let param_values = kernel.kernel_op.build_params(
+                stream,
+                output_ptr,
+                &input_ptrs,
+                &kernel.internal_bufs,
+                kernel_dyn_dims_ptr,
+            );
+            state.kernel_params[idx] = UnifiedKernelParams::new(param_values);
+        }
+
+        for &idx in &dirty_kernels {
+            let kernel = &state.kernels[idx];
+            let graph_node = state.node_to_graph_node[&kernel.node];
+            let grid_dim = (
+                kernel.grid.0.exec(dyn_map).unwrap() as u32,
+                kernel.grid.1.exec(dyn_map).unwrap() as u32,
+                kernel.grid.2.exec(dyn_map).unwrap() as u32,
+            );
+            let block_dim = (
+                kernel.block.0.exec(dyn_map).unwrap() as u32,
+                kernel.block.1.exec(dyn_map).unwrap() as u32,
+                kernel.block.2.exec(dyn_map).unwrap() as u32,
+            );
+            if grid_dim.0 == 0
+                || grid_dim.1 == 0
+                || grid_dim.2 == 0
+                || block_dim.0 == 0
+                || block_dim.1 == 0
+                || block_dim.2 == 0
+            {
+                anyhow::bail!(
+                    "invalid CUDA launch dimensions for kernel {} at LLIR node {:?}: grid={grid_dim:?} block={block_dim:?}",
+                    kernel.kernel_name,
+                    kernel.node,
+                );
+            }
+            let shared_mem = kernel.shared_mem.exec(dyn_map).unwrap() as u32;
+            let cu_func = unsafe { kernel.function.raw_function() };
+            let params_ptr = state.kernel_params[idx].as_cuda_params();
+            let graph = state.cuda_graph.as_mut().unwrap();
+            unsafe {
+                graph.set_kernel_node_params(
+                    graph_node, cu_func, grid_dim, block_dim, shared_mem, params_ptr,
+                )?;
+            }
+        }
+
+        state
+            .cuda_graph_exec
+            .as_ref()
+            .unwrap()
+            .ctx
+            .bind_to_thread()?;
+        for &idx in &dirty_kernels {
+            let kernel = &state.kernels[idx];
+            let graph_node = state.node_to_graph_node[&kernel.node];
+            let grid_dim = (
+                kernel.grid.0.exec(dyn_map).unwrap() as u32,
+                kernel.grid.1.exec(dyn_map).unwrap() as u32,
+                kernel.grid.2.exec(dyn_map).unwrap() as u32,
+            );
+            let block_dim = (
+                kernel.block.0.exec(dyn_map).unwrap() as u32,
+                kernel.block.1.exec(dyn_map).unwrap() as u32,
+                kernel.block.2.exec(dyn_map).unwrap() as u32,
+            );
+            let shared_mem = kernel.shared_mem.exec(dyn_map).unwrap() as u32;
+            let cu_func = unsafe { kernel.function.raw_function() };
+            let params_ptr = state.kernel_params[idx].as_cuda_params();
+            let exec = state.cuda_graph_exec.as_mut().unwrap();
+            unsafe {
+                exec.update_kernel_node(
+                    graph_node, cu_func, grid_dim, block_dim, shared_mem, params_ptr,
+                )?;
+            }
+        }
+
+        for (node, buffer) in changed {
+            state.last_buffer_ptrs.insert(node, buffer.ptr());
+        }
+        Ok(true)
+    }
+
     /// Ensure the mutable and executable CUDA graphs reflect the given buffers
     /// and dynamic dimensions. This may build the graph once, patch kernel node
     /// params, and surgically recapture cuBLASLt islands, but it does not launch.
@@ -1395,27 +1633,30 @@ impl CudaGraphOp {
         // Collect current buffer pointers
         let timer = Instant::now();
         let mut current_buffer_ptrs: FxHashMap<NodeIndex, u64> = FxHashMap::default();
+        let mut changed_buffer_nodes = FxHashSet::default();
         for &node in &self.buffer_nodes {
             if let Some(buf) = buffers.get(&node) {
                 current_buffer_ptrs.insert(node, buf.ptr());
+                if state.last_buffer_ptrs.get(&node) != Some(&buf.ptr()) {
+                    changed_buffer_nodes.insert(node);
+                }
             }
         }
 
         // Apply output-aliases-input
-        for kernel in state.kernels.iter() {
-            if let Some(input_idx) = kernel.kernel_op.output_aliases_input()
-                && let Some(&input_ptr) = current_buffer_ptrs.get(&kernel.inputs[input_idx])
-            {
-                current_buffer_ptrs.insert(kernel.node, input_ptr);
+        for &(input, output) in &self.output_aliases {
+            if let Some(&input_ptr) = current_buffer_ptrs.get(&input) {
+                current_buffer_ptrs.insert(output, input_ptr);
+                if state.last_buffer_ptrs.get(&output) != Some(&input_ptr) {
+                    changed_buffer_nodes.insert(output);
+                }
             }
         }
         profile.collect_buffer_ptrs += timer.elapsed();
 
-        // Always call pre_execute for each kernel to reset internal state
-        // (e.g., MegakernelOps need work queue, head, barriers, lock reset every execution)
+        // Reset any per-invocation kernel state before updating the graph.
         let timer = Instant::now();
-        for idx in 0..state.kernels.len() {
-            let kernel = &mut state.kernels[idx];
+        for kernel in &mut state.kernels {
             kernel.kernel_op.pre_execute(
                 stream,
                 &mut kernel.internal_bufs,
@@ -1431,18 +1672,19 @@ impl CudaGraphOp {
         let needs_update = dyn_map_changed || buffer_ptrs_changed;
 
         if needs_update {
-            let kernel_dirty = (0..state.kernels.len())
-                .map(|idx| {
-                    let kernel = &state.kernels[idx];
-                    let output_ptr_changed = current_buffer_ptrs.get(&kernel.node)
-                        != state.last_buffer_ptrs.get(&kernel.node);
-                    let input_ptr_changed = kernel.inputs.iter().any(|input| {
-                        current_buffer_ptrs.get(input) != state.last_buffer_ptrs.get(input)
-                    });
-                    let dyn_changed = !changed_dyn_vars.is_disjoint(&kernel.dyn_vars);
-                    output_ptr_changed || input_ptr_changed || dyn_changed
-                })
-                .collect_vec();
+            let mut dirty_kernel_set = FxHashSet::default();
+            for node in &changed_buffer_nodes {
+                if let Some(users) = self.kernel_users_by_buffer.get(node) {
+                    dirty_kernel_set.extend(users.iter().copied());
+                }
+            }
+            for dim in &changed_dyn_vars {
+                if let Some(users) = self.kernel_users_by_dyn_dim.get(dim) {
+                    dirty_kernel_set.extend(users.iter().copied());
+                }
+            }
+            let mut dirty_kernels = dirty_kernel_set.into_iter().collect_vec();
+            dirty_kernels.sort_unstable();
 
             // Update kernel params
             let dyn_dims_ptr = state
@@ -1452,12 +1694,8 @@ impl CudaGraphOp {
                 .unwrap_or(0);
 
             // Build params for each kernel first
-            let num_kernels = state.kernels.len();
             let timer = Instant::now();
-            for (idx, dirty) in kernel_dirty.iter().enumerate().take(num_kernels) {
-                if !dirty {
-                    continue;
-                }
+            for &idx in &dirty_kernels {
                 let kernel = &state.kernels[idx];
                 let output_ptr = current_buffer_ptrs.get(&kernel.node).copied().unwrap_or(0);
                 let input_ptrs: Vec<u64> = kernel
@@ -1502,10 +1740,7 @@ impl CudaGraphOp {
             // is recaptured below, cuGraphExecUpdate will refresh the executable
             // from these source-node params.
             let timer = Instant::now();
-            for (idx, dirty) in kernel_dirty.iter().enumerate().take(num_kernels) {
-                if !dirty {
-                    continue;
-                }
+            for &idx in &dirty_kernels {
                 let kernel = &state.kernels[idx];
                 let graph_node = state.node_to_graph_node[&kernel.node];
 
@@ -1826,10 +2061,7 @@ impl CudaGraphOp {
                     .bind_to_thread()?;
 
                 let timer = Instant::now();
-                for (idx, dirty) in kernel_dirty.iter().enumerate().take(num_kernels) {
-                    if !dirty {
-                        continue;
-                    }
+                for &idx in &dirty_kernels {
                     let kernel = &state.kernels[idx];
                     let graph_node = state.node_to_graph_node[&kernel.node];
 

--- a/crates/luminal_cuda_lite_hlir/src/runtime.rs
+++ b/crates/luminal_cuda_lite_hlir/src/runtime.rs
@@ -66,14 +66,24 @@ pub enum CudaInput {
 /// Input facts that can change hard-resource accounting. Payload bytes and
 /// pointer identity are deliberately excluded: replacing data or a pointer at
 /// the same logical length/capacity only requires refreshing launch bindings.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct ResourceInputFootprint {
-    logical_bytes: usize,
+    logical_bytes: Option<usize>,
     owned_capacity_bytes: Option<usize>,
 }
 
+/// Complete hard-resource state covered by one successful validation. Keeping
+/// more than the most recent signature matters for decode workloads: context
+/// lengths repeat across requests, and revisiting an already validated shape
+/// must not rebuild the same aggregate resource plan.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ResourceValidationSignature {
+    allocation_dyn_maps: Vec<Vec<(char, usize)>>,
+    input_footprints: Vec<(usize, ResourceInputFootprint)>,
+}
+
 impl ResourceInputFootprint {
-    fn owned(logical_bytes: usize, capacity_bytes: usize) -> Self {
+    fn owned(capacity_bytes: usize, logical_bytes: Option<usize>) -> Self {
         Self {
             logical_bytes,
             owned_capacity_bytes: Some(capacity_bytes),
@@ -82,21 +92,32 @@ impl ResourceInputFootprint {
 
     fn external(logical_bytes: usize) -> Self {
         Self {
-            logical_bytes,
+            logical_bytes: Some(logical_bytes),
             owned_capacity_bytes: None,
         }
     }
 }
 
-fn resource_input_signature_changed(
-    previous: &FxHashMap<NodeIndex, ResourceInputFootprint>,
-    current_input_count: usize,
-    mut changed_inputs: impl Iterator<Item = (NodeIndex, Option<ResourceInputFootprint>)>,
+fn device_pointer_binding_matches(
+    current_ptr: Option<u64>,
+    current_bytes: Option<usize>,
+    device_ptr: u64,
+    n_bytes: usize,
 ) -> bool {
-    if previous.len() != current_input_count {
-        return true;
+    current_ptr == Some(device_ptr) && current_bytes == Some(n_bytes)
+}
+
+fn device_ranges_overlap(a_ptr: u64, a_bytes: usize, b_ptr: u64, b_bytes: usize) -> bool {
+    if a_bytes == 0 || b_bytes == 0 {
+        return false;
     }
-    changed_inputs.any(|(node, current)| previous.get(&node).copied() != current)
+    let a_end = a_ptr.saturating_add(a_bytes as u64);
+    let b_end = b_ptr.saturating_add(b_bytes as u64);
+    a_ptr < b_end && b_ptr < a_end
+}
+
+fn should_consume_hlir_input(is_external_pointer: bool, preserved_for_output: bool) -> bool {
+    !preserved_for_output && !is_external_pointer
 }
 
 impl CudaInput {
@@ -179,6 +200,34 @@ pub(crate) struct NonFiniteBufferReport {
     pub(crate) value: f32,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ResolvedOutputRegistration {
+    /// The compiled producer writes directly into an external allocation.
+    External { data_node: NodeIndex },
+    /// The selected graph aliases the output to an HLIR input. A differing
+    /// destination requires the recorded copy on every execution.
+    Alias {
+        hlir_input: NodeIndex,
+        input_ptr: u64,
+        input_bytes: usize,
+        destination_ptr: u64,
+        copy_bytes: usize,
+    },
+    /// The requested destination overlaps a graph input, but the selected
+    /// producer does not explicitly alias that input. Binding it directly
+    /// would introduce a hidden dependency, so compute into the planned
+    /// output buffer and copy after graph execution.
+    Copy {
+        data_node: NodeIndex,
+        source_ptr: u64,
+        source_bytes: usize,
+        destination_ptr: u64,
+        copy_bytes: usize,
+    },
+    /// This retained bucket does not contain the registered HLIR output.
+    Missing,
+}
+
 /// Per-bucket compiled state. Each bucket holds its own executable graph,
 /// explicit runtime metadata, intermediate buffers, and node mappings.
 /// Weights (hlir_buffers) are shared.
@@ -204,6 +253,7 @@ pub(crate) struct CompiledBucket {
     buffer_spec_nodes_by_dyn_var: FxHashMap<char, Vec<NodeIndex>>,
     pub(crate) llir_to_hlir: FxHashMap<NodeIndex, NodeIndex>,
     pub(crate) hlir_to_llir: FxHashMap<NodeIndex, NodeIndex>,
+    pub(crate) hlir_to_all_llir: FxHashMap<NodeIndex, Vec<NodeIndex>>,
     pub(crate) output_producers: FxHashMap<NodeIndex, NodeIndex>,
     pub(crate) output_alias_map: FxHashMap<NodeIndex, NodeIndex>,
     pub(crate) output_data_map: FxHashMap<NodeIndex, NodeIndex>,
@@ -228,6 +278,12 @@ pub(crate) struct CompiledBucket {
     /// Keep intermediate offsets and base allocation stable across shape growth
     /// when captured library graph nodes embed intermediate pointers.
     stabilize_intermediate_pointers: bool,
+    /// Exact bindings whose effective pointer or logical length changed since
+    /// the previous successful CUDA-graph materialization.
+    materialization_dirty_nodes: FxHashSet<NodeIndex>,
+    /// Arena relocation, candidate replacement, and first use invalidate the
+    /// complete buffer map instead of attempting incremental repair.
+    materialization_fully_dirty: bool,
 }
 
 impl CompiledBucket {
@@ -250,6 +306,7 @@ impl CompiledBucket {
             buffer_spec_nodes_by_dyn_var: FxHashMap::default(),
             llir_to_hlir: FxHashMap::default(),
             hlir_to_llir: FxHashMap::default(),
+            hlir_to_all_llir: FxHashMap::default(),
             output_producers: FxHashMap::default(),
             output_alias_map: FxHashMap::default(),
             output_data_map: FxHashMap::default(),
@@ -265,6 +322,8 @@ impl CompiledBucket {
             hlir_synced: false,
             preserve_intermediate_buffers_for_debug: false,
             stabilize_intermediate_pointers: false,
+            materialization_dirty_nodes: FxHashSet::default(),
+            materialization_fully_dirty: true,
         }
     }
 }
@@ -315,7 +374,14 @@ pub struct CudaRuntime {
     /// Resource-relevant input state covered by the most recent aggregate
     /// retained-bucket validation.
     last_resource_input_signature: FxHashMap<NodeIndex, ResourceInputFootprint>,
-
+    /// Boundary inputs whose logical byte length is read by a HostOp resource
+    /// plan. External inputs not in this set cannot change hard-resource
+    /// accounting, regardless of pointer or logical-size churn.
+    resource_length_sensitive_hlir: FxHashSet<NodeIndex>,
+    /// Successful validations for the currently loaded retained-bucket set.
+    /// Cleared whenever the executable graph or a configured hard limit
+    /// changes.
+    validated_resource_signatures: FxHashSet<ResourceValidationSignature>,
     // Per-bucket compiled state
     compiled_buckets: Vec<CompiledBucket>,
     active_bucket: usize,
@@ -329,6 +395,11 @@ pub struct CudaRuntime {
     /// Pending output pointer registrations: HLIR output id -> (device_ptr, n_bytes)
     /// Set by python before execute(), consumed at start of execute()
     output_ptr_registrations: FxHashMap<NodeIndex, (u64, usize)>,
+    /// Registrations whose pointer/size changed or whose LLIR resolution was
+    /// invalidated by loading/switching executable buckets.
+    dirty_output_ptr_registrations: FxHashSet<NodeIndex>,
+    resolved_output_registrations: FxHashMap<NodeIndex, ResolvedOutputRegistration>,
+    resolved_output_bucket: Option<usize>,
     /// (src_ptr, dst_ptr, bytes) device copies enqueued at the end of each
     /// execute: in-place-elected outputs whose registered buffer differs
     /// from the aliased input's (user-managed double buffering).
@@ -382,6 +453,7 @@ impl CudaRuntime {
     /// remains subject to the CUDA device limit when this is `None`.
     pub fn set_max_memory_bytes(&mut self, max_memory_bytes: Option<usize>) {
         self.max_intermediate_memory_bytes = max_memory_bytes;
+        self.validated_resource_signatures.clear();
         for bucket in &mut self.compiled_buckets {
             bucket.resource_validation_complete = false;
         }
@@ -406,6 +478,7 @@ impl CudaRuntime {
 
     pub fn set_max_kernel_source_bytes(&mut self, max_kernel_source_bytes: Option<usize>) {
         self.max_kernel_source_bytes = max_kernel_source_bytes;
+        self.validated_resource_signatures.clear();
         for bucket in &mut self.compiled_buckets {
             bucket.resource_validation_complete = false;
         }
@@ -502,6 +575,31 @@ impl CudaRuntime {
         let len = *bucket.logical_buffer_bytes.get(logical_node)?;
         let ptr = arena.device_ptr(stream).0.checked_add(offset as u64)?;
         Some(DeviceBuffer::new(ptr, len))
+    }
+
+    fn cache_bucket_device_buffer(
+        bucket: &mut CompiledBucket,
+        node: NodeIndex,
+        buffer: DeviceBuffer,
+    ) {
+        let changed = bucket.cached_buffer_ptrs.get(&node) != Some(&buffer.ptr())
+            || bucket
+                .cached_device_buffers
+                .get(&node)
+                .is_none_or(|old| old.len() != buffer.len());
+        if changed {
+            bucket.materialization_dirty_nodes.insert(node);
+        }
+        bucket.cached_buffer_ptrs.insert(node, buffer.ptr());
+        bucket.cached_device_buffers.insert(node, buffer);
+    }
+
+    fn remove_cached_bucket_device_buffer(bucket: &mut CompiledBucket, node: NodeIndex) {
+        if bucket.cached_buffer_ptrs.remove(&node).is_some()
+            || bucket.cached_device_buffers.remove(&node).is_some()
+        {
+            bucket.materialization_dirty_nodes.insert(node);
+        }
     }
 
     fn copy_device_buffer_to_new_slice(
@@ -601,6 +699,8 @@ impl CudaRuntime {
             bucket.logical_buffer_capacity_bytes.clear();
             bucket.cached_buffer_ptrs.clear();
             bucket.cached_device_buffers.clear();
+            bucket.materialization_dirty_nodes.clear();
+            bucket.materialization_fully_dirty = true;
             bucket.hlir_synced = false;
             Self::take_bucket_arena(bucket, &mut releases);
             bucket.arena_bytes = 0;
@@ -758,6 +858,14 @@ impl CudaRuntime {
     pub unsafe fn set_device_ptr(&mut self, id: impl ToId, device_ptr: u64, n_bytes: usize) {
         debug_assert!(device_ptr != 0, "set_device_ptr called with null pointer");
         let id = id.to_id();
+        let current_ptr = match self.hlir_buffers.get(&id) {
+            Some(CudaInput::Ptr(ptr)) => Some(*ptr),
+            _ => None,
+        };
+        let current_bytes = self.external_buffers.get(&id).map(|buffer| buffer.len());
+        if device_pointer_binding_matches(current_ptr, current_bytes, device_ptr, n_bytes) {
+            return;
+        }
         // Create CudaSlice view via cudarc's upgrade_device_ptr.
         // ManuallyDrop prevents cuMemFree on drop (external allocator owns this memory).
         let slice = unsafe {
@@ -783,8 +891,22 @@ impl CudaRuntime {
             device_ptr != 0,
             "set_output_device_ptr called with null pointer"
         );
+        let id = id.to_id();
+        if self.output_ptr_registrations.get(&id) == Some(&(device_ptr, n_bytes)) {
+            return;
+        }
         self.output_ptr_registrations
-            .insert(id.to_id(), (device_ptr, n_bytes));
+            .insert(id, (device_ptr, n_bytes));
+        self.dirty_output_ptr_registrations.insert(id);
+    }
+
+    /// Remove a durable external output registration. The next execution
+    /// restores the runtime-managed output buffer for this node.
+    pub fn clear_output_device_ptr(&mut self, id: impl ToId) {
+        let id = id.to_id();
+        if self.output_ptr_registrations.remove(&id).is_some() {
+            self.dirty_output_ptr_registrations.insert(id);
+        }
     }
 
     // alias_state is GONE (ruling 2026-07-30): the in-place
@@ -952,110 +1074,241 @@ impl CudaRuntime {
     /// # Safety
     /// The dest_ptr must be a valid CUDA device allocation with at least n_bytes available.
     pub unsafe fn copy_output_to_device_ptr(&self, id: impl ToId, dest_ptr: u64, n_bytes: usize) {
-        debug_assert!(
-            dest_ptr != 0,
-            "copy_output_to_device_ptr called with null pointer"
-        );
-        let src = self.resolve_output_buffer(id);
-        let copy_bytes = n_bytes.min(src.len());
-        unsafe {
-            result::memcpy_dtod_async(
-                dest_ptr,
-                src.ptr(),
-                copy_bytes,
-                self.cuda_stream.cu_stream(),
-            )
-            .expect("cuMemcpyDtoDAsync failed");
+        unsafe { self.copy_outputs_to_device_ptrs(&[(id.to_id(), dest_ptr, n_bytes)]) };
+    }
+
+    /// Copy several output tensors to external CUDA device pointers and wait once.
+    ///
+    /// Resolving every source before submitting any work makes the operation
+    /// all-or-nothing with respect to runtime lookup failures. More importantly,
+    /// callers which need to commit many functionalized mutations (for example
+    /// every K/V tensor in a StaticCache) do not pay one stream synchronization
+    /// per tensor.
+    ///
+    /// # Safety
+    /// Every destination pointer must name a live CUDA allocation with at least
+    /// the corresponding byte count available for the duration of this call.
+    pub unsafe fn copy_outputs_to_device_ptrs(&self, copies: &[(NodeIndex, u64, usize)]) {
+        let resolved = copies
+            .iter()
+            .map(|(id, dest_ptr, n_bytes)| {
+                assert!(
+                    *dest_ptr != 0,
+                    "copy_outputs_to_device_ptrs called with null pointer"
+                );
+                let src = self.resolve_output_buffer(*id);
+                (src, *dest_ptr, *n_bytes)
+            })
+            .collect_vec();
+
+        for (src, dest_ptr, n_bytes) in resolved {
+            let copy_bytes = n_bytes.min(src.len());
+            if copy_bytes == 0 || src.ptr() == dest_ptr {
+                continue;
+            }
+            unsafe {
+                result::memcpy_dtod_async(
+                    dest_ptr,
+                    src.ptr(),
+                    copy_bytes,
+                    self.cuda_stream.cu_stream(),
+                )
+                .expect("cuMemcpyDtoDAsync failed");
+            }
         }
         self.cuda_stream.synchronize().unwrap();
     }
 
-    /// Resolve pending output pointer registrations into external_output_buffers.
-    /// Called at the start of execute(), after buffer allocation and HLIR sync.
-    fn apply_output_ptr_registrations(&mut self) {
-        // clear stale external output buffers from previous execution
-        let stale_output_nodes = self.external_output_buffers.keys().copied().collect_vec();
-        self.external_output_buffers.clear();
-        for data_node in stale_output_nodes {
-            if let Some(buf) = Self::bucket_buffer(self.active(), &self.cuda_stream, &data_node) {
-                let bucket = self.active_mut();
-                bucket.cached_buffer_ptrs.insert(data_node, buf.ptr());
-                bucket.cached_device_buffers.insert(data_node, buf);
-            } else {
-                let bucket = self.active_mut();
-                bucket.cached_buffer_ptrs.remove(&data_node);
-                bucket.cached_device_buffers.remove(&data_node);
-            }
+    fn restore_external_output_node(&mut self, data_node: NodeIndex) {
+        self.external_output_buffers.remove(&data_node);
+        if let Some(buf) = Self::bucket_buffer(self.active(), &self.cuda_stream, &data_node) {
+            Self::cache_bucket_device_buffer(self.active_mut(), data_node, buf);
+        } else {
+            Self::remove_cached_bucket_device_buffer(self.active_mut(), data_node);
         }
+    }
 
-        self.pending_output_copies.clear();
-        if self.output_ptr_registrations.is_empty() {
+    fn remove_resolved_output_registration(&mut self, hlir_id: NodeIndex) {
+        let Some(old) = self.resolved_output_registrations.remove(&hlir_id) else {
             return;
+        };
+        let ResolvedOutputRegistration::External { data_node } = old else {
+            return;
+        };
+        let still_used = self.resolved_output_registrations.values().any(|resolved| {
+            matches!(
+                resolved,
+                ResolvedOutputRegistration::External { data_node: other } if *other == data_node
+            )
+        });
+        if !still_used {
+            self.restore_external_output_node(data_node);
+        }
+    }
+
+    fn invalidate_output_registration_resolution(&mut self) {
+        self.external_output_buffers.clear();
+        self.resolved_output_registrations.clear();
+        self.dirty_output_ptr_registrations
+            .extend(self.output_ptr_registrations.keys().copied());
+        self.resolved_output_bucket = None;
+        self.pending_output_copies.clear();
+    }
+
+    fn current_hlir_device_binding(&self, hlir_input: NodeIndex) -> Option<(u64, usize)> {
+        match self.hlir_buffers.get(&hlir_input) {
+            Some(CudaInput::Buffer { buf, len }) => {
+                Some((buf.device_ptr(&self.cuda_stream).0, *len))
+            }
+            Some(CudaInput::Ptr(ptr)) => self
+                .external_buffers
+                .get(&hlir_input)
+                .map(|buffer| (*ptr, buffer.len())),
+            None => None,
+        }
+    }
+
+    /// Incrementally resolve durable output registrations. Stable cache
+    /// destinations keep their LLIR resolution and external CudaSlice views;
+    /// only changed registrations (normally the fresh logits output) cross
+    /// this path on steady decode.
+    fn apply_output_ptr_registrations(&mut self) {
+        if self.resolved_output_bucket != Some(self.active_bucket) {
+            self.invalidate_output_registration_resolution();
+            self.resolved_output_bucket = Some(self.active_bucket);
         }
 
-        // Registrations are durable: outputs are re-resolved against the
-        // active bucket every execute (producers and alias structure differ
-        // per bucket and per loaded candidate).
-        let registrations: Vec<_> = self
-            .output_ptr_registrations
+        // Copy registrations depend on their source buffer, and aliases depend
+        // on their input binding. Re-resolve only registrations whose source moved.
+        let changed_sources = self
+            .resolved_output_registrations
             .iter()
-            .map(|(k, v)| (*k, *v))
-            .collect();
+            .filter_map(|(hlir_output, resolved)| {
+                let changed = match resolved {
+                    ResolvedOutputRegistration::Alias {
+                        hlir_input,
+                        input_ptr,
+                        input_bytes,
+                        ..
+                    } => {
+                        self.current_hlir_device_binding(*hlir_input)
+                            != Some((*input_ptr, *input_bytes))
+                    }
+                    ResolvedOutputRegistration::Copy {
+                        data_node,
+                        source_ptr,
+                        source_bytes,
+                        ..
+                    } => Self::cached_device_buffer_for_node(self.active(), *data_node).is_none_or(
+                        |source| source.ptr() != *source_ptr || source.len() != *source_bytes,
+                    ),
+                    _ => false,
+                };
+                changed.then_some(*hlir_output)
+            })
+            .collect_vec();
+        self.dirty_output_ptr_registrations.extend(changed_sources);
 
-        for (hlir_id, (device_ptr, n_bytes)) in registrations {
-            // Resolve HLIR output id -> LLIR producer -> follow aliases -> data node.
-            // Registrations are durable and may reference outputs absent from
-            // the active bucket (stale profiling-scratch ids, other-bucket
-            // outputs) — skip those.
+        let dirty = std::mem::take(&mut self.dirty_output_ptr_registrations);
+        for hlir_id in dirty {
+            self.remove_resolved_output_registration(hlir_id);
+            let Some(&(device_ptr, n_bytes)) = self.output_ptr_registrations.get(&hlir_id) else {
+                continue;
+            };
             let Some(&producer) = self.active().output_producers.get(&hlir_id) else {
+                self.resolved_output_registrations
+                    .insert(hlir_id, ResolvedOutputRegistration::Missing);
                 continue;
             };
             let data_node = self.follow_aliases(producer);
 
-            // In-place elected output: the data lands in the aliased HLIR
-            // input's buffer. If the user registered that same buffer, the
-            // write is already in place; otherwise honor the registration
-            // with an epilogue copy (manual double-buffering support).
-            if let Some(&hlir_input) = self.compiled_buckets[self.active_bucket]
-                .llir_to_hlir
-                .get(&data_node)
-            {
-                let input_buf = match self.hlir_buffers.get(&hlir_input) {
-                    Some(CudaInput::Buffer { buf, len }) => {
-                        Some((buf.device_ptr(&self.cuda_stream).0, *len))
-                    }
-                    Some(CudaInput::Ptr(p)) => Some((*p, n_bytes)),
-                    None => None,
+            if let Some(&hlir_input) = self.active().llir_to_hlir.get(&data_node) {
+                let Some((input_ptr, input_len)) = self.current_hlir_device_binding(hlir_input)
+                else {
+                    self.resolved_output_registrations
+                        .insert(hlir_id, ResolvedOutputRegistration::Missing);
+                    continue;
                 };
-                if let Some((input_ptr, input_len)) = input_buf
-                    && input_ptr != device_ptr
-                {
-                    self.pending_output_copies.push((
+                self.resolved_output_registrations.insert(
+                    hlir_id,
+                    ResolvedOutputRegistration::Alias {
+                        hlir_input,
                         input_ptr,
-                        device_ptr,
-                        n_bytes.min(input_len),
-                    ));
-                }
+                        input_bytes: input_len,
+                        destination_ptr: device_ptr,
+                        copy_bytes: n_bytes.min(input_len),
+                    },
+                );
                 continue;
             }
 
-            // Create non-owning CudaSlice view of PyTorch's buffer
+            let destination_overlaps_input = self.hlir_buffers.keys().copied().any(|hlir_input| {
+                self.current_hlir_device_binding(hlir_input).is_some_and(
+                    |(input_ptr, input_bytes)| {
+                        device_ranges_overlap(device_ptr, n_bytes, input_ptr, input_bytes)
+                    },
+                )
+            });
+            if destination_overlaps_input {
+                let Some(source) = Self::cached_device_buffer_for_node(self.active(), data_node)
+                else {
+                    self.resolved_output_registrations
+                        .insert(hlir_id, ResolvedOutputRegistration::Missing);
+                    continue;
+                };
+                self.resolved_output_registrations.insert(
+                    hlir_id,
+                    ResolvedOutputRegistration::Copy {
+                        data_node,
+                        source_ptr: source.ptr(),
+                        source_bytes: source.len(),
+                        destination_ptr: device_ptr,
+                        copy_bytes: n_bytes.min(source.len()),
+                    },
+                );
+                continue;
+            }
+
             let slice = unsafe {
                 self.cuda_stream
                     .upgrade_device_ptr::<u8>(device_ptr, n_bytes)
             };
-
             self.external_output_buffers
                 .insert(data_node, std::mem::ManuallyDrop::new(slice));
-
-            // Update cached_buffer_ptrs so CudaGraphOp picks up the new pointer
-            self.compiled_buckets[self.active_bucket]
-                .cached_buffer_ptrs
-                .insert(data_node, device_ptr);
-            self.compiled_buckets[self.active_bucket]
-                .cached_device_buffers
-                .insert(data_node, DeviceBuffer::new(device_ptr, n_bytes));
+            Self::cache_bucket_device_buffer(
+                self.active_mut(),
+                data_node,
+                DeviceBuffer::new(device_ptr, n_bytes),
+            );
+            self.resolved_output_registrations
+                .insert(hlir_id, ResolvedOutputRegistration::External { data_node });
         }
+
+        self.pending_output_copies.clear();
+        self.pending_output_copies
+            .extend(
+                self.resolved_output_registrations.values().filter_map(
+                    |resolved| match *resolved {
+                        ResolvedOutputRegistration::Alias {
+                            input_ptr,
+                            destination_ptr,
+                            copy_bytes,
+                            ..
+                        } => (input_ptr != destination_ptr).then_some((
+                            input_ptr,
+                            destination_ptr,
+                            copy_bytes,
+                        )),
+                        ResolvedOutputRegistration::Copy {
+                            source_ptr,
+                            destination_ptr,
+                            copy_bytes,
+                            ..
+                        } => Some((source_ptr, destination_ptr, copy_bytes)),
+                        _ => None,
+                    },
+                ),
+            );
     }
 
     pub fn get_f32(&self, id: impl ToId) -> Vec<f32> {
@@ -1254,12 +1507,10 @@ impl CudaRuntime {
             .output_producers
             .get(&output_id)
             .expect("Cannot find output node for swap!");
-
-        // Get the LLIR node for the input
-        let input_llir_node = *bucket
-            .hlir_to_llir
-            .get(&input_id)
-            .expect("Cannot find input in LLIR mapping!");
+        assert!(
+            bucket.hlir_to_all_llir.contains_key(&input_id),
+            "Cannot find input in LLIR mapping!"
+        );
 
         let src = Self::bucket_buffer(
             &self.compiled_buckets[bi],
@@ -1278,17 +1529,9 @@ impl CudaRuntime {
         );
         self.changed_hlir.insert(input_id);
 
-        // Update cached pointer for the input
-        let ptr = match &self.hlir_buffers[&input_id] {
-            CudaInput::Buffer { buf, .. } => buf.device_ptr(&self.cuda_stream).0,
-            CudaInput::Ptr(p) => *p,
-        };
-        self.compiled_buckets[bi]
-            .cached_buffer_ptrs
-            .insert(input_llir_node, ptr);
-        self.compiled_buckets[bi]
-            .cached_device_buffers
-            .insert(input_llir_node, DeviceBuffer::new(ptr, len));
+        // `changed_hlir` is the single source of truth for binding changes.
+        // The next prepare pass updates every LLIR copy and marks CUDA graph
+        // nodes dirty before the old input pointer can be launched again.
     }
 
     /// Free all intermediate buffers to reclaim GPU memory.
@@ -1299,6 +1542,8 @@ impl CudaRuntime {
             Self::take_bucket_arena(bucket, &mut releases);
             bucket.cached_buffer_ptrs.clear();
             bucket.cached_device_buffers.clear();
+            bucket.materialization_dirty_nodes.clear();
+            bucket.materialization_fully_dirty = true;
             bucket.hlir_synced = false;
         }
         Self::finish_arena_releases(&self.cuda_stream, releases)
@@ -1364,6 +1609,8 @@ impl CudaRuntime {
             }
             bucket.cached_buffer_ptrs.clear();
             bucket.cached_device_buffers.clear();
+            bucket.materialization_dirty_nodes.clear();
+            bucket.materialization_fully_dirty = true;
             if profile_alloc {
                 eprintln!(
                     "CUDA_ALLOC_PROFILE total_ms={:.3} needs_new_plan={} sync_ms={:.3} plan_ms={:.3} refresh_ms={:.3} cuda_alloc_ms={:.3} cache_ptrs_ms={:.3} allocated_new_arena=false old_arena_len={} new_arena_len=0 old_arena_bytes={} new_arena_bytes=0 allocation_bytes=0 cached_ptrs=0 logical_offsets=0",
@@ -1430,17 +1677,21 @@ impl CudaRuntime {
         }
 
         let timer = std::time::Instant::now();
+        if allocated_new_arena {
+            bucket.materialization_fully_dirty = true;
+        }
         let arena_ptr = bucket.arena.as_ref().unwrap().device_ptr(stream).0;
-        for (logical_node, &offset) in &bucket.logical_buffer_offsets {
-            let Some(&len) = bucket.logical_buffer_bytes.get(logical_node) else {
-                continue;
-            };
-            if let Some(ptr) = arena_ptr.checked_add(offset as u64) {
-                bucket.cached_buffer_ptrs.insert(*logical_node, ptr);
-                bucket
-                    .cached_device_buffers
-                    .insert(*logical_node, DeviceBuffer::new(ptr, len));
-            }
+        let buffer_updates = bucket
+            .logical_buffer_offsets
+            .iter()
+            .filter_map(|(logical_node, offset)| {
+                let len = bucket.logical_buffer_bytes.get(logical_node).copied()?;
+                let ptr = arena_ptr.checked_add(*offset as u64)?;
+                Some((*logical_node, DeviceBuffer::new(ptr, len)))
+            })
+            .collect_vec();
+        for (logical_node, buffer) in buffer_updates {
+            Self::cache_bucket_device_buffer(bucket, logical_node, buffer);
         }
         cache_ptrs_time += timer.elapsed();
         if profile_alloc {
@@ -1492,17 +1743,28 @@ impl CudaRuntime {
         dyn_dims: &FxHashMap<char, usize>,
     ) {
         bucket.logical_buffer_bytes.clear();
-        for (node, spec) in &bucket.buffer_specs {
-            let bytes = spec.bytes.exec(dyn_dims).unwrap();
+        let buffer_lengths = bucket
+            .buffer_specs
+            .iter()
+            .map(|(node, spec)| (*node, spec.bytes.exec(dyn_dims).unwrap()))
+            .collect_vec();
+        for (node, bytes) in buffer_lengths {
             if bytes > 0 {
-                bucket.logical_buffer_bytes.insert(*node, bytes);
-                if let Some(ptr) = bucket.cached_buffer_ptrs.get(node).copied() {
+                bucket.logical_buffer_bytes.insert(node, bytes);
+                if let Some(ptr) = bucket.cached_buffer_ptrs.get(&node).copied() {
+                    if bucket
+                        .cached_device_buffers
+                        .get(&node)
+                        .is_none_or(|old| old.len() != bytes)
+                    {
+                        bucket.materialization_dirty_nodes.insert(node);
+                    }
                     bucket
                         .cached_device_buffers
-                        .insert(*node, DeviceBuffer::new(ptr, bytes));
+                        .insert(node, DeviceBuffer::new(ptr, bytes));
                 }
             } else {
-                bucket.cached_device_buffers.remove(node);
+                Self::remove_cached_bucket_device_buffer(bucket, node);
             }
         }
         bucket.last_dyn_map = dyn_dims.clone();
@@ -1563,13 +1825,20 @@ impl CudaRuntime {
             if bytes > 0 {
                 bucket.logical_buffer_bytes.insert(node, bytes);
                 if let Some(ptr) = bucket.cached_buffer_ptrs.get(&node).copied() {
+                    if bucket
+                        .cached_device_buffers
+                        .get(&node)
+                        .is_none_or(|old| old.len() != bytes)
+                    {
+                        bucket.materialization_dirty_nodes.insert(node);
+                    }
                     bucket
                         .cached_device_buffers
                         .insert(node, DeviceBuffer::new(ptr, bytes));
                 }
             } else {
                 bucket.logical_buffer_bytes.remove(&node);
-                bucket.cached_device_buffers.remove(&node);
+                Self::remove_cached_bucket_device_buffer(bucket, node);
             }
         }
         bucket.last_dyn_map = dyn_dims.clone();
@@ -1858,6 +2127,8 @@ impl CudaRuntime {
         bucket.intermediate_buffer_dims.clear();
         bucket.cached_buffer_ptrs.clear();
         bucket.cached_device_buffers.clear();
+        bucket.materialization_dirty_nodes.clear();
+        bucket.materialization_fully_dirty = true;
         bucket.last_dyn_map = dyn_dims.clone();
 
         let mut logical_bytes = FxHashMap::default();
@@ -2141,18 +2412,33 @@ impl CudaRuntime {
         let timer = std::time::Instant::now();
         let allocation_dyn_map = self.bucket_capacity_dyn_map(bucket_idx, dyn_map);
         let allocation_dyn_map_time = timer.elapsed();
-        let resource_inputs_changed = self.resource_inputs_changed_since_validation();
+        let resource_validation_signature =
+            self.resource_validation_signature(bucket_idx, &allocation_dyn_map);
+        let resource_validation_cache_miss = !self
+            .validated_resource_signatures
+            .contains(&resource_validation_signature);
         let needs_resource_validation = {
             let bucket = &self.compiled_buckets[bucket_idx];
-            !bucket.resource_validation_complete
-                || bucket.last_resource_validation_dyn_map != allocation_dyn_map
-                || resource_inputs_changed
+            !bucket.resource_validation_complete || resource_validation_cache_miss
         };
         if needs_resource_validation
             && let Err(violation) =
                 self.validate_compiled_bucket_resources(bucket_idx, &allocation_dyn_map)
         {
             panic!("compiled CUDA plan violates a hard resource limit: {violation}");
+        }
+        if needs_resource_validation {
+            self.validated_resource_signatures
+                .insert(resource_validation_signature);
+        } else {
+            // A non-consecutive cache hit is now the active proof. Advance the
+            // "last" state as if validation had just run so later bucket
+            // switches build aggregate signatures from the state actually in
+            // use, not from whichever shape happened to validate most recently.
+            let bucket = &mut self.compiled_buckets[bucket_idx];
+            bucket.last_resource_validation_dyn_map = allocation_dyn_map.clone();
+            bucket.resource_validation_complete = true;
+            self.last_resource_input_signature = self.current_resource_input_signature();
         }
         let (
             stabilize_intermediate_pointers,
@@ -2251,7 +2537,7 @@ impl CudaRuntime {
             let to_process: Vec<(NodeIndex, u64, usize)> = hlir_nodes
                 .iter()
                 .filter_map(|hlir_node| {
-                    let llir_node = bucket.hlir_to_llir.get(hlir_node)?;
+                    bucket.hlir_to_all_llir.get(hlir_node)?;
                     let input = self.hlir_buffers.get(hlir_node)?;
                     let (ptr, len) = match input {
                         CudaInput::Buffer { buf, len } => {
@@ -2266,7 +2552,7 @@ impl CudaRuntime {
                             (*p, len)
                         }
                     };
-                    Some((*llir_node, ptr, len))
+                    Some((*hlir_node, ptr, len))
                 })
                 .collect();
             (
@@ -2280,11 +2566,15 @@ impl CudaRuntime {
         let timer = std::time::Instant::now();
         let bucket = &mut self.compiled_buckets[bucket_idx];
         let to_process_count = to_process.len();
-        for (llir_node, ptr, len) in to_process {
-            bucket.cached_buffer_ptrs.insert(llir_node, ptr);
-            bucket
-                .cached_device_buffers
-                .insert(llir_node, DeviceBuffer::new(ptr, len));
+        for (hlir_node, ptr, len) in to_process {
+            let llir_nodes = bucket
+                .hlir_to_all_llir
+                .get(&hlir_node)
+                .cloned()
+                .unwrap_or_default();
+            for llir_node in llir_nodes {
+                Self::cache_bucket_device_buffer(bucket, llir_node, DeviceBuffer::new(ptr, len));
+            }
         }
         bucket.hlir_synced = true;
         let cached_ptrs_final = bucket.cached_buffer_ptrs.len();
@@ -2465,23 +2755,68 @@ impl CudaRuntime {
     }
 
     fn materialize_bucket_cuda_graphs(
-        &self,
+        &mut self,
         bucket_idx: usize,
         dyn_map: &FxHashMap<char, usize>,
         allow_missing_inputs: bool,
     ) -> anyhow::Result<()> {
+        let fully_dirty = self.compiled_buckets[bucket_idx].materialization_fully_dirty;
+        let dirty_nodes = self.compiled_buckets[bucket_idx]
+            .materialization_dirty_nodes
+            .clone();
         let bucket = &self.compiled_buckets[bucket_idx];
         for exec_node in toposort(&bucket.exec_graph, None).unwrap() {
             let exec_op = &bucket.exec_graph[exec_node];
             let Some(cuda_graph) = exec_op.internal.as_any().downcast_ref::<CudaGraphOp>() else {
                 continue;
             };
+            if !fully_dirty {
+                let mut changed_buffers = FxHashMap::default();
+                for node in dirty_nodes
+                    .iter()
+                    .copied()
+                    .filter(|node| cuda_graph.uses_buffer(*node))
+                {
+                    let buffer = Self::cached_device_buffer_for_node(bucket, node).or_else(|| {
+                        Self::resolve_runtime_buffer(
+                            bucket,
+                            &self.cuda_stream,
+                            &self.hlir_buffers,
+                            &self.external_buffers,
+                            &self.external_output_buffers,
+                            node,
+                        )
+                    });
+                    let Some(buffer) = buffer else {
+                        if allow_missing_inputs {
+                            continue;
+                        }
+                        anyhow::bail!(
+                            "missing dirty buffer for CUDA graph materialization: LLIR node {:?}",
+                            node
+                        );
+                    };
+                    changed_buffers.insert(node, buffer);
+                }
+                if cuda_graph.materialize_changed_bindings(
+                    &exec_op.stream,
+                    &changed_buffers,
+                    dyn_map,
+                )? {
+                    continue;
+                }
+            }
             let Some(buffer_map) =
                 self.buffer_map_for_cuda_graph(bucket, cuda_graph, allow_missing_inputs)?
             else {
                 continue;
             };
             cuda_graph.materialize(&exec_op.stream, &buffer_map, dyn_map)?;
+        }
+        if !allow_missing_inputs {
+            let bucket = &mut self.compiled_buckets[bucket_idx];
+            bucket.materialization_dirty_nodes.clear();
+            bucket.materialization_fully_dirty = false;
         }
         Ok(())
     }
@@ -2613,42 +2948,102 @@ impl CudaRuntime {
         &self,
         node: NodeIndex,
         input: &CudaInput,
-    ) -> ResourceInputFootprint {
+    ) -> Option<ResourceInputFootprint> {
+        let length_sensitive = self.resource_length_sensitive_hlir.contains(&node);
         match input {
-            CudaInput::Buffer { buf, len } => ResourceInputFootprint::owned(*len, buf.num_bytes()),
-            CudaInput::Ptr(_) => ResourceInputFootprint::external(
+            // Runtime-owned allocation capacity always contributes to the
+            // device-memory limit. Its logical length matters only when an
+            // attached HostOp explicitly consumes it during planning.
+            CudaInput::Buffer { buf, len } => Some(ResourceInputFootprint::owned(
+                buf.num_bytes(),
+                length_sensitive.then_some(*len),
+            )),
+            // External allocations are intentionally excluded from aggregate
+            // device-memory accounting: aliases/views could otherwise be
+            // counted repeatedly. Retain only logical lengths that a HostOp
+            // resource plan actually reads.
+            CudaInput::Ptr(_) if length_sensitive => Some(ResourceInputFootprint::external(
                 self.external_buffers
                     .get(&node)
                     .map(|buffer| buffer.len())
                     .unwrap_or(0),
-            ),
+            )),
+            CudaInput::Ptr(_) => None,
         }
     }
 
     fn current_resource_input_signature(&self) -> FxHashMap<NodeIndex, ResourceInputFootprint> {
         self.hlir_buffers
             .iter()
-            .map(|(&node, input)| (node, self.resource_input_footprint(node, input)))
+            .filter_map(|(&node, input)| {
+                self.resource_input_footprint(node, input)
+                    .map(|footprint| (node, footprint))
+            })
             .collect()
     }
 
-    fn resource_inputs_changed_since_validation(&self) -> bool {
-        // All supported input mutation paths add the affected node to
-        // changed_hlir. Restrict the potentially large signature comparison to
-        // that set so a token update does not rescan every model weight. A
-        // removal without a replacement is caught by the map-length check; a
-        // replacement/addition is itself in changed_hlir.
-        resource_input_signature_changed(
-            &self.last_resource_input_signature,
-            self.hlir_buffers.len(),
-            self.changed_hlir.iter().map(|&node| {
-                let current = self
-                    .hlir_buffers
-                    .get(&node)
-                    .map(|input| self.resource_input_footprint(node, input));
-                (node, current)
-            }),
-        )
+    fn retained_bucket_allocation_dyn_maps(
+        &self,
+        bucket_idx: usize,
+        allocation_dyn_map: &FxHashMap<char, usize>,
+    ) -> Vec<FxHashMap<char, usize>> {
+        self.compiled_buckets
+            .iter()
+            .enumerate()
+            .map(|(idx, bucket)| {
+                if idx == bucket_idx {
+                    allocation_dyn_map.clone()
+                } else if !bucket.last_resource_validation_dyn_map.is_empty() {
+                    bucket.last_resource_validation_dyn_map.clone()
+                } else {
+                    Self::complete_resource_dyn_map(bucket, bucket.last_dyn_map.clone())
+                }
+            })
+            .collect()
+    }
+
+    fn resource_validation_signature(
+        &self,
+        bucket_idx: usize,
+        allocation_dyn_map: &FxHashMap<char, usize>,
+    ) -> ResourceValidationSignature {
+        let allocation_dyn_maps = self
+            .retained_bucket_allocation_dyn_maps(bucket_idx, allocation_dyn_map)
+            .into_iter()
+            .map(|map| {
+                let mut entries = map.into_iter().collect_vec();
+                entries.sort_unstable_by_key(|(name, _)| *name);
+                entries
+            })
+            .collect();
+        let mut input_footprints = self
+            .current_resource_input_signature()
+            .into_iter()
+            .map(|(node, footprint)| (node.index(), footprint))
+            .collect_vec();
+        input_footprints.sort_unstable_by_key(|(node, _)| *node);
+        ResourceValidationSignature {
+            allocation_dyn_maps,
+            input_footprints,
+        }
+    }
+
+    fn resource_length_sensitive_hlir_inputs(buckets: &[CompiledBucket]) -> FxHashSet<NodeIndex> {
+        buckets
+            .iter()
+            .flat_map(|bucket| {
+                bucket
+                    .exec_graph
+                    .node_weights()
+                    .flat_map(move |executable| {
+                        executable
+                            .internal
+                            .resource_buffer_nodes(&executable.inputs)
+                            .into_iter()
+                            .filter_map(|llir_node| bucket.llir_to_hlir.get(&llir_node).copied())
+                    })
+            })
+            .collect()
     }
 
     /// Loading can preflight an LLIR before its graph inputs are installed.
@@ -2840,20 +3235,8 @@ impl CudaRuntime {
         };
         let device = self.candidate_device_resource_limits();
         let hlir_buffer_lengths = self.hlir_resource_buffer_lengths();
-        let allocation_dyn_maps = self
-            .compiled_buckets
-            .iter()
-            .enumerate()
-            .map(|(idx, bucket)| {
-                if idx == bucket_idx {
-                    allocation_dyn_map.clone()
-                } else if !bucket.last_resource_validation_dyn_map.is_empty() {
-                    bucket.last_resource_validation_dyn_map.clone()
-                } else {
-                    Self::complete_resource_dyn_map(bucket, bucket.last_dyn_map.clone())
-                }
-            })
-            .collect_vec();
+        let allocation_dyn_maps =
+            self.retained_bucket_allocation_dyn_maps(bucket_idx, allocation_dyn_map);
         let plan = Self::retained_bucket_resource_plan(
             &mut self.compiled_buckets,
             &allocation_dyn_maps,
@@ -3260,7 +3643,11 @@ impl CudaRuntime {
         }
         self.compiled_buckets = vec![bucket];
         self.active_bucket = 0;
+        self.invalidate_output_registration_resolution();
         self.dim_buckets.clear();
+        self.validated_resource_signatures.clear();
+        self.resource_length_sensitive_hlir =
+            Self::resource_length_sensitive_hlir_inputs(&self.compiled_buckets);
         Self::finish_arena_releases(&self.cuda_stream, releases)?;
         // Reclaim search-profiling residue from the async allocator pool before
         // the stitched-graph arena allocates (see try_load_llir_buckets).
@@ -3270,6 +3657,13 @@ impl CudaRuntime {
         } else {
             FxHashMap::default()
         };
+        if input_lengths_complete {
+            let validated_dyn_map = self.compiled_buckets[0]
+                .last_resource_validation_dyn_map
+                .clone();
+            let signature = self.resource_validation_signature(0, &validated_dyn_map);
+            self.validated_resource_signatures.insert(signature);
+        }
 
         // Mark all HLIR inputs as changed so their pointers get re-cached in execute
         self.changed_hlir.extend(self.hlir_buffers.keys().copied());
@@ -3304,6 +3698,10 @@ impl CudaRuntime {
         }
         self.dim_buckets = dim_buckets.clone();
         self.compiled_buckets = compiled_buckets;
+        self.invalidate_output_registration_resolution();
+        self.validated_resource_signatures.clear();
+        self.resource_length_sensitive_hlir =
+            Self::resource_length_sensitive_hlir_inputs(&self.compiled_buckets);
         // The first real execution for model workloads is usually prefill, which
         // lands in the largest/range bucket rather than the singleton decode
         // bucket. Select it before prebuilding so only that active bucket gets an
@@ -3315,6 +3713,14 @@ impl CudaRuntime {
         } else {
             FxHashMap::default()
         };
+        if input_lengths_complete {
+            let validated_dyn_map = self.compiled_buckets[self.active_bucket]
+                .last_resource_validation_dyn_map
+                .clone();
+            let signature =
+                self.resource_validation_signature(self.active_bucket, &validated_dyn_map);
+            self.validated_resource_signatures.insert(signature);
+        }
 
         // Reclaim what search profiling left resident in the async allocator
         // pool before allocating the stitched-graph arenas. This load runs
@@ -3506,10 +3912,15 @@ impl Runtime for CudaRuntime {
             max_kernel_source_bytes: Some(DEFAULT_MAX_KERNEL_SOURCE_BYTES),
             device_resource_limits,
             last_resource_input_signature: FxHashMap::default(),
+            resource_length_sensitive_hlir: FxHashSet::default(),
+            validated_resource_signatures: FxHashSet::default(),
             compiled_buckets: vec![CompiledBucket::new()],
             active_bucket: 0,
             dim_buckets: FxHashMap::default(),
             output_ptr_registrations: FxHashMap::default(),
+            dirty_output_ptr_registrations: FxHashSet::default(),
+            resolved_output_registrations: FxHashMap::default(),
+            resolved_output_bucket: None,
             pending_output_copies: Vec::new(),
             external_output_buffers: FxHashMap::default(),
             external_buffers: FxHashMap::default(),
@@ -3553,6 +3964,8 @@ impl Runtime for CudaRuntime {
             Self::take_bucket_arena(bucket, &mut releases);
             bucket.cached_buffer_ptrs.clear();
             bucket.cached_device_buffers.clear();
+            bucket.materialization_dirty_nodes.clear();
+            bucket.materialization_fully_dirty = true;
             bucket.hlir_synced = false;
         }
         Self::finish_arena_releases(&self.cuda_stream, releases)
@@ -3693,6 +4106,10 @@ impl Runtime for CudaRuntime {
                 Self::take_bucket_arena(&mut self.compiled_buckets[old], &mut releases);
                 self.compiled_buckets[old].cached_buffer_ptrs.clear();
                 self.compiled_buckets[old].cached_device_buffers.clear();
+                self.compiled_buckets[old]
+                    .materialization_dirty_nodes
+                    .clear();
+                self.compiled_buckets[old].materialization_fully_dirty = true;
                 Self::finish_arena_releases(&self.cuda_stream, releases)
                     .expect("failed to release the previous CUDA bucket arena");
                 self.active_bucket = idx;
@@ -3719,7 +4136,6 @@ impl Runtime for CudaRuntime {
         self.materialize_bucket_cuda_graphs(self.active_bucket, dyn_map, false)
             .unwrap_or_else(|e| panic!("CUDA graph materialization failed: {e}"));
         materialize_time += timer.elapsed();
-
         let total_start = std::time::Instant::now();
         let bucket = &self.compiled_buckets[self.active_bucket];
 
@@ -3831,7 +4247,12 @@ impl Runtime for CudaRuntime {
         }
         stats_time += timer.elapsed();
 
-        // Consume input buffers
+        // Consume runtime-owned one-shot input buffers. External pointers are
+        // caller-owned persistent bindings: set_device_ptr's safety contract
+        // requires them to remain valid for the runtime lifetime, and dropping
+        // their metadata here would force every repeated invocation to
+        // reinstall lifted weights. A later changed set_device_ptr call safely
+        // replaces the retained non-owning view.
         if self.profiling {
             return;
         }
@@ -3852,18 +4273,27 @@ impl Runtime for CudaRuntime {
 
         let to_consume: Vec<NodeIndex> = self
             .hlir_buffers
-            .keys()
-            .filter(|hlir_node| !inputs_with_outputs.contains(hlir_node))
-            .copied()
+            .iter()
+            .filter_map(|(&hlir_node, input)| {
+                should_consume_hlir_input(
+                    matches!(input, CudaInput::Ptr(_)),
+                    inputs_with_outputs.contains(&hlir_node),
+                )
+                .then_some(hlir_node)
+            })
             .collect();
 
         for hlir_node in to_consume {
             self.hlir_buffers.remove(&hlir_node);
             self.external_buffers.remove(&hlir_node);
             let bucket = &mut self.compiled_buckets[self.active_bucket];
-            if let Some(llir_node) = bucket.hlir_to_llir.get(&hlir_node) {
-                bucket.cached_buffer_ptrs.remove(llir_node);
-                bucket.cached_device_buffers.remove(llir_node);
+            let llir_nodes = bucket
+                .hlir_to_all_llir
+                .get(&hlir_node)
+                .cloned()
+                .unwrap_or_default();
+            for llir_node in llir_nodes {
+                Self::remove_cached_bucket_device_buffer(bucket, llir_node);
             }
         }
         consume_time += timer.elapsed();
@@ -3987,8 +4417,14 @@ impl CudaRuntime {
                 node: hlir_node, ..
             }) = llir_graph[node].to_op::<Input>()
             {
-                bucket.llir_to_hlir.insert(node, NodeIndex::new(*hlir_node));
-                bucket.hlir_to_llir.insert(NodeIndex::new(*hlir_node), node);
+                let hlir_node = NodeIndex::new(*hlir_node);
+                bucket.llir_to_hlir.insert(node, hlir_node);
+                bucket.hlir_to_llir.insert(hlir_node, node);
+                bucket
+                    .hlir_to_all_llir
+                    .entry(hlir_node)
+                    .or_default()
+                    .push(node);
                 continue;
             }
 
@@ -4673,10 +5109,11 @@ mod arena_plan_tests {
 
     #[test]
     fn resource_input_footprint_tracks_lengths_and_owned_capacity_only() {
-        let owned = ResourceInputFootprint::owned(8, 64);
-        assert_eq!(owned, ResourceInputFootprint::owned(8, 64));
-        assert_ne!(owned, ResourceInputFootprint::owned(16, 64));
-        assert_ne!(owned, ResourceInputFootprint::owned(8, 128));
+        let owned = ResourceInputFootprint::owned(64, Some(8));
+        assert_eq!(owned, ResourceInputFootprint::owned(64, Some(8)));
+        assert_ne!(owned, ResourceInputFootprint::owned(64, Some(16)));
+        assert_ne!(owned, ResourceInputFootprint::owned(128, Some(8)));
+        assert_ne!(owned, ResourceInputFootprint::owned(64, None));
         assert_ne!(owned, ResourceInputFootprint::external(8));
 
         // External pointer identity and payload contents are intentionally not
@@ -4693,40 +5130,162 @@ mod arena_plan_tests {
     }
 
     #[test]
-    fn resource_signature_checks_only_changed_inputs_after_count_guard() {
-        let a = NodeIndex::new(1);
-        let b = NodeIndex::new(2);
-        let c = NodeIndex::new(3);
-        let previous = FxHashMap::from_iter([
-            (a, ResourceInputFootprint::owned(8, 64)),
-            (b, ResourceInputFootprint::external(32)),
-        ]);
+    fn identical_external_pointer_binding_is_a_noop() {
+        assert!(device_pointer_binding_matches(
+            Some(0x1000),
+            Some(64),
+            0x1000,
+            64
+        ));
+        assert!(!device_pointer_binding_matches(
+            Some(0x2000),
+            Some(64),
+            0x1000,
+            64
+        ));
+        assert!(!device_pointer_binding_matches(
+            Some(0x1000),
+            Some(32),
+            0x1000,
+            64
+        ));
+        assert!(!device_pointer_binding_matches(None, None, 0x1000, 64));
+    }
 
-        assert!(!resource_input_signature_changed(
-            &previous,
-            2,
-            [(a, Some(ResourceInputFootprint::owned(8, 64)))].into_iter(),
-        ));
-        assert!(resource_input_signature_changed(
-            &previous,
-            2,
-            [(a, Some(ResourceInputFootprint::owned(16, 64)))].into_iter(),
-        ));
-        assert!(resource_input_signature_changed(
-            &previous,
-            1,
-            std::iter::empty(),
-        ));
-        assert!(resource_input_signature_changed(
-            &previous,
-            2,
-            [(c, Some(ResourceInputFootprint::external(32)))].into_iter(),
-        ));
-        assert!(resource_input_signature_changed(
-            &previous,
-            2,
-            [(b, None)].into_iter(),
-        ));
+    #[test]
+    fn set_device_ptr_dirties_only_changed_external_bindings() {
+        let mut rt = CudaRuntime::new().unwrap();
+        let input = NodeIndex::new(125);
+        let allocation = rt.cuda_stream.alloc_zeros::<u8>(64).unwrap();
+        let ptr = allocation.device_ptr(&rt.cuda_stream).0;
+
+        unsafe { rt.set_device_ptr(input, ptr, 64) };
+        assert_eq!(rt.changed_hlir, FxHashSet::from_iter([input]));
+
+        rt.changed_hlir.clear();
+        unsafe { rt.set_device_ptr(input, ptr, 64) };
+        assert!(rt.changed_hlir.is_empty());
+
+        unsafe { rt.set_device_ptr(input, ptr, 32) };
+        assert_eq!(rt.changed_hlir, FxHashSet::from_iter([input]));
+    }
+
+    #[test]
+    fn set_output_device_ptr_dirties_only_changed_registrations() {
+        let mut rt = CudaRuntime::new().unwrap();
+        let output = NodeIndex::new(126);
+        let allocation = rt.cuda_stream.alloc_zeros::<u8>(64).unwrap();
+        let ptr = allocation.device_ptr(&rt.cuda_stream).0;
+
+        unsafe { rt.set_output_device_ptr(output, ptr, 64) };
+        assert_eq!(
+            rt.dirty_output_ptr_registrations,
+            FxHashSet::from_iter([output])
+        );
+
+        rt.dirty_output_ptr_registrations.clear();
+        unsafe { rt.set_output_device_ptr(output, ptr, 64) };
+        assert!(rt.dirty_output_ptr_registrations.is_empty());
+
+        unsafe { rt.set_output_device_ptr(output, ptr, 32) };
+        assert_eq!(
+            rt.dirty_output_ptr_registrations,
+            FxHashSet::from_iter([output])
+        );
+
+        rt.dirty_output_ptr_registrations.clear();
+        rt.clear_output_device_ptr(output);
+        assert!(!rt.output_ptr_registrations.contains_key(&output));
+        assert_eq!(
+            rt.dirty_output_ptr_registrations,
+            FxHashSet::from_iter([output])
+        );
+    }
+
+    #[test]
+    fn cached_device_buffer_tracks_exact_materialization_changes() {
+        let mut bucket = CompiledBucket::new();
+        let node = NodeIndex::new(7);
+
+        bucket.materialization_fully_dirty = false;
+        CudaRuntime::cache_bucket_device_buffer(&mut bucket, node, DeviceBuffer::new(0x1000, 64));
+        assert_eq!(
+            bucket.materialization_dirty_nodes,
+            FxHashSet::from_iter([node])
+        );
+
+        bucket.materialization_dirty_nodes.clear();
+        CudaRuntime::cache_bucket_device_buffer(&mut bucket, node, DeviceBuffer::new(0x1000, 64));
+        assert!(bucket.materialization_dirty_nodes.is_empty());
+
+        CudaRuntime::cache_bucket_device_buffer(&mut bucket, node, DeviceBuffer::new(0x1000, 32));
+        assert_eq!(
+            bucket.materialization_dirty_nodes,
+            FxHashSet::from_iter([node])
+        );
+    }
+
+    #[test]
+    fn external_pointer_inputs_are_persistent_but_owned_inputs_remain_consumable() {
+        assert!(!should_consume_hlir_input(true, false));
+        assert!(!should_consume_hlir_input(true, true));
+        assert!(should_consume_hlir_input(false, false));
+        assert!(!should_consume_hlir_input(false, true));
+    }
+
+    #[test]
+    fn device_range_overlap_detects_hidden_output_input_aliases() {
+        assert!(device_ranges_overlap(0x1000, 64, 0x1000, 64));
+        assert!(device_ranges_overlap(0x1000, 64, 0x1020, 64));
+        assert!(!device_ranges_overlap(0x1000, 64, 0x1040, 64));
+        assert!(!device_ranges_overlap(0x1000, 0, 0x1000, 64));
+    }
+
+    #[test]
+    fn resource_validation_cache_reuses_nonconsecutive_exact_signatures() {
+        let signature = |a, bytes| ResourceValidationSignature {
+            allocation_dyn_maps: vec![vec![('a', a)]],
+            input_footprints: vec![(7, ResourceInputFootprint::external(bytes))],
+        };
+        let a17 = signature(17, 64);
+        let a18 = signature(18, 64);
+        let a17_larger_input = signature(17, 128);
+        let mut validated = FxHashSet::default();
+
+        assert!(validated.insert(a17.clone()));
+        assert!(validated.insert(a18));
+        assert!(validated.contains(&a17));
+        assert!(!validated.contains(&a17_larger_input));
+    }
+
+    #[test]
+    fn external_lengths_only_enter_signature_for_resource_sensitive_inputs() {
+        let mut rt = CudaRuntime::new().unwrap();
+        let ordinary = NodeIndex::new(126);
+        let resource_sensitive = NodeIndex::new(127);
+        let allocation = rt.cuda_stream.alloc_zeros::<u8>(128).unwrap();
+        let ptr = allocation.device_ptr(&rt.cuda_stream).0;
+
+        unsafe {
+            rt.set_device_ptr(ordinary, ptr, 32);
+            rt.set_device_ptr(resource_sensitive, ptr, 64);
+        }
+        rt.resource_length_sensitive_hlir.insert(resource_sensitive);
+
+        let signature = rt.current_resource_input_signature();
+        assert!(!signature.contains_key(&ordinary));
+        assert_eq!(
+            signature.get(&resource_sensitive),
+            Some(&ResourceInputFootprint::external(64))
+        );
+
+        let original_signature = signature;
+        rt.changed_hlir.clear();
+        unsafe { rt.set_device_ptr(ordinary, ptr, 16) };
+        assert_eq!(rt.current_resource_input_signature(), original_signature);
+
+        unsafe { rt.set_device_ptr(resource_sensitive, ptr, 32) };
+        assert_ne!(rt.current_resource_input_signature(), original_signature);
     }
 
     #[test]

--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -111,6 +111,9 @@ pub struct GraphTranslation {
     pub tensor_ids: HashMap<String, NodeIndex>,
     pub input_names: Vec<String>,
     pub output_names: Vec<String>,
+    /// Output node identities in exactly the same order as `output_names`.
+    /// Names are not unique when a functionalized mutation is also returned.
+    pub output_ids: Vec<NodeIndex>,
     pub output_shape_exprs: Vec<Vec<IntExpr>>,
     /// Output dtypes as PT2 dtype codes (e.g. 5 = int64, 7 = float32).
     /// Stored as PT2 codes (rather than luminal `DType`) so we can preserve
@@ -144,6 +147,7 @@ pub struct CompiledGraph {
     label_map: HashMap<String, NodeIndex>,
     pub input_names: Vec<String>,
     pub output_names: Vec<String>,
+    pub output_ids: Vec<NodeIndex>,
     pub output_shapes: Vec<Vec<usize>>,
     pub output_shape_exprs: Vec<Vec<IntExpr>>,
     /// Output dtypes as PT2 dtype codes (preserves int64 / int32 distinction
@@ -172,6 +176,7 @@ impl CompiledGraph {
             tensor_ids,
             input_names,
             output_names,
+            output_ids,
             output_shape_exprs,
             output_dtypes,
             input_shape_exprs,
@@ -214,6 +219,7 @@ impl CompiledGraph {
             label_map,
             input_names,
             output_names,
+            output_ids,
             output_shapes,
             output_shape_exprs,
             output_dtypes,
@@ -221,6 +227,34 @@ impl CompiledGraph {
             dim_param_map,
             writeback_outputs,
         })
+    }
+
+    fn output_node_at(&self, position: usize) -> PyResult<NodeIndex> {
+        self.output_ids.get(position).copied().ok_or_else(|| {
+            pyo3::exceptions::PyIndexError::new_err(format!(
+                "output position {position} is out of range for {} outputs",
+                self.output_ids.len()
+            ))
+        })
+    }
+
+    fn output_node_by_name(&self, name: &str) -> PyResult<NodeIndex> {
+        let mut matches = self
+            .output_names
+            .iter()
+            .zip(self.output_ids.iter().copied())
+            .filter_map(|(candidate, node)| (candidate == name).then_some(node));
+        let Some(node) = matches.next() else {
+            return Err(pyo3::exceptions::PyKeyError::new_err(format!(
+                "Unknown output tensor: {name}"
+            )));
+        };
+        if matches.next().is_some() {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "Output tensor name '{name}' is ambiguous; use the positional output API"
+            )));
+        }
+        Ok(node)
     }
 }
 
@@ -454,16 +488,43 @@ impl CompiledGraph {
                 "set_output_device_ptr requires a GPU backend",
             ));
         }
-        let node_id = self.tensor_ids.get(name).ok_or_else(|| {
-            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
-                "Unknown output tensor: {}",
-                name
-            ))
-        })?;
+        let node_id = self.output_node_by_name(name)?;
         unsafe {
             self.runtime
-                .set_output_device_ptr(*node_id, device_ptr, n_bytes)
+                .set_output_device_ptr(node_id, device_ptr, n_bytes)
         };
+        Ok(())
+    }
+
+    /// Positional variant of `set_output_device_ptr`; unlike output names,
+    /// output positions are unique for functionalized mutation outputs.
+    fn set_output_device_ptr_at(
+        &mut self,
+        position: usize,
+        device_ptr: u64,
+        n_bytes: usize,
+    ) -> PyResult<()> {
+        if !self.runtime.supports_device_ptrs() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "set_output_device_ptr_at requires a GPU backend",
+            ));
+        }
+        let node_id = self.output_node_at(position)?;
+        unsafe {
+            self.runtime
+                .set_output_device_ptr(node_id, device_ptr, n_bytes)
+        };
+        Ok(())
+    }
+
+    fn clear_output_device_ptr_at(&mut self, position: usize) -> PyResult<()> {
+        if !self.runtime.supports_device_ptrs() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "clear_output_device_ptr_at requires a GPU backend",
+            ));
+        }
+        let node_id = self.output_node_at(position)?;
+        self.runtime.clear_output_device_ptr(node_id);
         Ok(())
     }
 
@@ -471,13 +532,13 @@ impl CompiledGraph {
     /// Returns false for aliased outputs that need a fallback DtoD copy, or if no GPU backend.
     /// Must be called after run().
     fn output_is_zero_copy(&self, name: &str) -> PyResult<bool> {
-        let node_id = self.tensor_ids.get(name).ok_or_else(|| {
-            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
-                "Unknown output tensor: {}",
-                name
-            ))
-        })?;
-        Ok(self.runtime.output_is_zero_copy(*node_id))
+        let node_id = self.output_node_by_name(name)?;
+        Ok(self.runtime.output_is_zero_copy(node_id))
+    }
+
+    fn output_is_zero_copy_at(&self, position: usize) -> PyResult<bool> {
+        let node_id = self.output_node_at(position)?;
+        Ok(self.runtime.output_is_zero_copy(node_id))
     }
 
     /// Register a weight tensor from a CPU host pointer, matching by Input node label (dtype-aware).
@@ -521,24 +582,20 @@ impl CompiledGraph {
 
     /// Get output tensor data by name as f32 (copies to host).
     fn get_output(&self, name: &str) -> PyResult<Vec<f32>> {
-        let node_id = self.tensor_ids.get(name).ok_or_else(|| {
-            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
-                "Unknown output tensor: {}",
-                name
-            ))
-        })?;
-        Ok(self.runtime.get_output_f32(*node_id))
+        Ok(self.runtime.get_output_f32(self.output_node_by_name(name)?))
+    }
+
+    fn get_output_at(&self, position: usize) -> PyResult<Vec<f32>> {
+        Ok(self.runtime.get_output_f32(self.output_node_at(position)?))
     }
 
     /// Get output tensor data by name as i32 (copies to host).
     fn get_output_i32(&self, name: &str) -> PyResult<Vec<i32>> {
-        let node_id = self.tensor_ids.get(name).ok_or_else(|| {
-            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
-                "Unknown output tensor: {}",
-                name
-            ))
-        })?;
-        Ok(self.runtime.get_output_i32(*node_id))
+        Ok(self.runtime.get_output_i32(self.output_node_by_name(name)?))
+    }
+
+    fn get_output_i32_at(&self, position: usize) -> PyResult<Vec<i32>> {
+        Ok(self.runtime.get_output_i32(self.output_node_at(position)?))
     }
 
     /// Read an output as f16 (returned as raw little-endian bytes —
@@ -547,13 +604,18 @@ impl CompiledGraph {
     /// producer node must already be `DType::F16`; no widening at
     /// the read boundary.
     fn get_output_f16<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyBytes>> {
-        let node_id = self.tensor_ids.get(name).ok_or_else(|| {
-            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
-                "Unknown output tensor: {}",
-                name
-            ))
-        })?;
-        let data = self.runtime.get_output_f16(*node_id);
+        let data = self.runtime.get_output_f16(self.output_node_by_name(name)?);
+        let bytes: &[u8] =
+            unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 2) };
+        Ok(PyBytes::new(py, bytes))
+    }
+
+    fn get_output_f16_at<'py>(
+        &self,
+        py: Python<'py>,
+        position: usize,
+    ) -> PyResult<Bound<'py, PyBytes>> {
+        let data = self.runtime.get_output_f16(self.output_node_at(position)?);
         let bytes: &[u8] =
             unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 2) };
         Ok(PyBytes::new(py, bytes))
@@ -564,13 +626,20 @@ impl CompiledGraph {
     /// bfloat16)`). Strict: the producer node must already be
     /// `DType::Bf16`; no widening at the read boundary.
     fn get_output_bf16<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyBytes>> {
-        let node_id = self.tensor_ids.get(name).ok_or_else(|| {
-            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
-                "Unknown output tensor: {}",
-                name
-            ))
-        })?;
-        let data = self.runtime.get_output_bf16(*node_id);
+        let data = self
+            .runtime
+            .get_output_bf16(self.output_node_by_name(name)?);
+        let bytes: &[u8] =
+            unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 2) };
+        Ok(PyBytes::new(py, bytes))
+    }
+
+    fn get_output_bf16_at<'py>(
+        &self,
+        py: Python<'py>,
+        position: usize,
+    ) -> PyResult<Bound<'py, PyBytes>> {
+        let data = self.runtime.get_output_bf16(self.output_node_at(position)?);
         let bytes: &[u8] =
             unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 2) };
         Ok(PyBytes::new(py, bytes))
@@ -579,13 +648,11 @@ impl CompiledGraph {
     /// Read an output as i64. Strict: the producer node must already
     /// be `DType::I64`; no widening at the read boundary.
     fn get_output_i64(&self, name: &str) -> PyResult<Vec<i64>> {
-        let node_id = self.tensor_ids.get(name).ok_or_else(|| {
-            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
-                "Unknown output tensor: {}",
-                name
-            ))
-        })?;
-        Ok(self.runtime.get_output_i64(*node_id))
+        Ok(self.runtime.get_output_i64(self.output_node_by_name(name)?))
+    }
+
+    fn get_output_i64_at(&self, position: usize) -> PyResult<Vec<i64>> {
+        Ok(self.runtime.get_output_i64(self.output_node_at(position)?))
     }
 
     /// Read an output as i8 without widening.
@@ -624,24 +691,22 @@ impl CompiledGraph {
     /// Read an output as f64. Strict: the producer node must already
     /// be `DType::F64`; no widening at the read boundary.
     fn get_output_f64(&self, name: &str) -> PyResult<Vec<f64>> {
-        let node_id = self.tensor_ids.get(name).ok_or_else(|| {
-            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
-                "Unknown output tensor: {}",
-                name
-            ))
-        })?;
-        Ok(self.runtime.get_output_f64(*node_id))
+        Ok(self.runtime.get_output_f64(self.output_node_by_name(name)?))
+    }
+
+    fn get_output_f64_at(&self, position: usize) -> PyResult<Vec<f64>> {
+        Ok(self.runtime.get_output_f64(self.output_node_at(position)?))
     }
 
     /// Get output tensor data by name as bool (copies to host).
     fn get_output_bool(&self, name: &str) -> PyResult<Vec<bool>> {
-        let node_id = self.tensor_ids.get(name).ok_or_else(|| {
-            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
-                "Unknown output tensor: {}",
-                name
-            ))
-        })?;
-        Ok(self.runtime.get_output_bool(*node_id))
+        Ok(self
+            .runtime
+            .get_output_bool(self.output_node_by_name(name)?))
+    }
+
+    fn get_output_bool_at(&self, position: usize) -> PyResult<Vec<bool>> {
+        Ok(self.runtime.get_output_bool(self.output_node_at(position)?))
     }
 
     /// Copy output tensor data directly to a device pointer (DtoD).
@@ -653,16 +718,66 @@ impl CompiledGraph {
                 "copy_output_to_device_ptr requires a GPU backend",
             ));
         }
-        let node_id = self.tensor_ids.get(name).ok_or_else(|| {
-            PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!(
-                "Unknown output tensor: {}",
-                name
-            ))
-        })?;
+        let node_id = self.output_node_by_name(name)?;
         unsafe {
             self.runtime
-                .copy_output_to_device_ptr(*node_id, dest_ptr, n_bytes)
+                .copy_output_to_device_ptr(node_id, dest_ptr, n_bytes)
         };
+        Ok(())
+    }
+
+    fn copy_output_to_device_ptr_at(
+        &self,
+        position: usize,
+        dest_ptr: u64,
+        n_bytes: usize,
+    ) -> PyResult<()> {
+        if !self.runtime.supports_device_ptrs() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "copy_output_to_device_ptr_at requires a GPU backend",
+            ));
+        }
+        let node_id = self.output_node_at(position)?;
+        unsafe {
+            self.runtime
+                .copy_output_to_device_ptr(node_id, dest_ptr, n_bytes)
+        };
+        Ok(())
+    }
+
+    /// Copy several outputs directly to CUDA device pointers, synchronizing
+    /// only after the entire batch has been enqueued.
+    fn copy_outputs_to_device_ptrs(&self, copies: Vec<(String, u64, usize)>) -> PyResult<()> {
+        if !self.runtime.supports_device_ptrs() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "copy_outputs_to_device_ptrs requires a GPU backend",
+            ));
+        }
+        let resolved = copies
+            .into_iter()
+            .map(|(name, dest_ptr, n_bytes)| {
+                self.output_node_by_name(&name)
+                    .map(|node_id| (node_id, dest_ptr, n_bytes))
+            })
+            .collect::<PyResult<Vec<_>>>()?;
+        unsafe { self.runtime.copy_outputs_to_device_ptrs(&resolved) };
+        Ok(())
+    }
+
+    fn copy_outputs_to_device_ptrs_at(&self, copies: Vec<(usize, u64, usize)>) -> PyResult<()> {
+        if !self.runtime.supports_device_ptrs() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "copy_outputs_to_device_ptrs_at requires a GPU backend",
+            ));
+        }
+        let resolved = copies
+            .into_iter()
+            .map(|(position, dest_ptr, n_bytes)| {
+                self.output_node_at(position)
+                    .map(|node_id| (node_id, dest_ptr, n_bytes))
+            })
+            .collect::<PyResult<Vec<_>>>()?;
+        unsafe { self.runtime.copy_outputs_to_device_ptrs(&resolved) };
         Ok(())
     }
 }

--- a/crates/luminal_python/rust/src/pt2_compiled_model.rs
+++ b/crates/luminal_python/rust/src/pt2_compiled_model.rs
@@ -173,6 +173,7 @@ pub fn translate_pt2(
         .iter()
         .map(|(name, _)| name.clone())
         .collect();
+    let output_ids: Vec<NodeIndex> = translated.output_ids.iter().map(|(_, id)| *id).collect();
 
     let input_shape_exprs: Vec<Vec<IntExpr>> = translated
         .user_input_ids
@@ -257,6 +258,7 @@ pub fn translate_pt2(
         tensor_ids,
         input_names,
         output_names,
+        output_ids,
         output_dtypes,
         output_shape_exprs,
         input_shape_exprs,

--- a/crates/luminal_python/src/luminal/compiled_model.py
+++ b/crates/luminal_python/src/luminal/compiled_model.py
@@ -1,11 +1,21 @@
 """CompiledModel wrapper for the Rust CompiledGraph."""
 
-from typing import List
+import math
 
 import torch
 
 from .dtype_util import code_to_torch_dtype
 from .dtype_util import torch_dtype_code as _torch_dtype_code
+
+
+def _cuda_input_binding_signature(tensor, n_bytes: int) -> tuple:
+    """Return the metadata that determines an external CUDA binding.
+
+    Tensor contents are deliberately absent from the signature. A producer may
+    update the same allocation between invocations without changing anything
+    about the compiled graph's pointer binding.
+    """
+    return (tensor.device, tensor.data_ptr(), n_bytes, tensor.dtype)
 
 
 class DTypeBoundaryError(TypeError):
@@ -51,6 +61,11 @@ class CompiledModel:
         # mutations. Keyed by position, not name: a model that mutates an
         # input and also returns it yields two same-named outputs.
         self._writeback_by_pos = dict(graph_result.writeback_outputs)
+        input_positions = {name: pos for pos, name in enumerate(self._input_names)}
+        self._writeback_input_pos = {
+            output_pos: input_positions[input_name]
+            for output_pos, input_name in self._writeback_by_pos.items()
+        }
         self._output_shapes = graph_result.output_shapes
         self._has_dynamic_dims = getattr(graph_result, "has_dynamic_dims", False)
         self._weight_refs = weight_refs or []
@@ -61,6 +76,15 @@ class CompiledModel:
         self._supports_device_ptrs = getattr(
             graph_result, "supports_device_ptrs", False
         )
+        # name -> (device, pointer, required bytes, dtype, strong tensor ref).
+        # CUDA bindings are persistent in the runtime; only changed metadata
+        # needs to cross PyO3 on subsequent calls.
+        self._cuda_input_bindings = {}
+        # output position -> (device, pointer, required bytes, dtype, strong tensor ref).
+        # Functionalized mutation outputs normally target long-lived state
+        # tensors, so their durable registrations cross PyO3 only when the
+        # actual storage changes.
+        self._cuda_writeback_bindings = {}
         # Expected input dtypes from graph. Every declared input MUST
         # have a dtype code — refuse to silently default to float32 if
         # the Rust side returned a shorter list than `input_names`.
@@ -92,10 +116,10 @@ class CompiledModel:
         return self._has_dynamic_dims
 
     @property
-    def dim_params(self) -> List[str]:
+    def dim_params(self) -> list[str]:
         return self._graph.dim_params
 
-    def __call__(self, *inputs: torch.Tensor) -> List[torch.Tensor]:
+    def __call__(self, *inputs: torch.Tensor) -> list[torch.Tensor]:
         """Execute the compiled model with PyTorch tensor inputs.
 
         Args:
@@ -150,9 +174,20 @@ class CompiledModel:
                     "bugs and burnt cycles on per-call allocation+copy."
                 )
             if self._supports_device_ptrs and tensor.is_cuda:
-                t = tensor.detach().contiguous()
+                # A contiguous caller tensor is already a valid read-only
+                # boundary input; making a detached view for every lifted
+                # weight adds hundreds of Python objects per invocation.
+                t = tensor if tensor.is_contiguous() else tensor.detach().contiguous()
                 n_bytes = t.numel() * t.element_size()
-                self._graph.set_input_device_ptr(name, t.data_ptr(), n_bytes)
+                signature = _cuda_input_binding_signature(t, n_bytes)
+                previous = self._cuda_input_bindings.get(name)
+                if previous is None or previous[:4] != signature:
+                    self._graph.set_input_device_ptr(name, t.data_ptr(), n_bytes)
+                # Commit only after a changed registration succeeds. Retaining
+                # the tensor prevents allocator reuse while Rust holds its
+                # non-owning pointer; `previous` keeps the old allocation alive
+                # until the replacement has crossed the boundary.
+                self._cuda_input_bindings[name] = (*signature, t)
                 _input_refs.append(t)
             else:
                 t = tensor.detach().cpu().contiguous()
@@ -207,7 +242,9 @@ class CompiledModel:
             torch.bool: ("get_output_bool", torch.bool),
         }
 
-        def _read_typed_output(name: str, shape, out_dtype) -> torch.Tensor:
+        def _read_typed_output(
+            position: int, name: str, shape, out_dtype
+        ) -> torch.Tensor:
             """Pull one output back from the runtime at the right dtype.
 
             Strict: any `out_dtype` not in `_output_readers` raises
@@ -231,7 +268,7 @@ class CompiledModel:
                     f"the output to a supported dtype upstream."
                 )
             getter_name, read_dtype = entry
-            data = getattr(self._graph, getter_name)(name)
+            data = getattr(self._graph, f"{getter_name}_at")(position)
             if len(data) == 0:
                 if all(d != 0 for d in shape):
                     return None
@@ -258,43 +295,89 @@ class CompiledModel:
         # device buffer to register against.
         _use_zero_copy = self._supports_device_ptrs
         output_tensors = []
+        direct_writebacks = set()
         if _use_zero_copy:
             for i, (name, shape) in enumerate(zip(self._output_names, output_shapes)):
                 out_dtype = output_torch_dtypes[i]
                 if i in self._writeback_by_pos:
-                    # Write-backs land in the caller's input tensor below, not
-                    # in a fresh output buffer.
+                    # Point functionalized mutation outputs at the caller's
+                    # state tensor up front. The CUDA runtime either writes
+                    # there directly or schedules its required epilogue D2D
+                    # copy on the graph stream before the one terminal wait.
+                    target = user_inputs[self._writeback_input_pos[i]]
+                    expected_numel = math.prod(shape)
+                    if (
+                        target.is_cuda
+                        and target.is_contiguous()
+                        and target.dtype == out_dtype
+                        and target.numel() == expected_numel
+                    ):
+                        n_bytes = target.numel() * target.element_size()
+                        signature = _cuda_input_binding_signature(target, n_bytes)
+                        previous = self._cuda_writeback_bindings.get(i)
+                        if previous is None or previous[:4] != signature:
+                            self._graph.set_output_device_ptr_at(
+                                i, target.data_ptr(), n_bytes
+                            )
+                        self._cuda_writeback_bindings[i] = (*signature, target)
+                        direct_writebacks.add(i)
+                    elif i in self._cuda_writeback_bindings:
+                        self._graph.clear_output_device_ptr_at(i)
+                        del self._cuda_writeback_bindings[i]
                     output_tensors.append(None)
                     continue
                 out = torch.empty(shape, dtype=out_dtype, device=input_device)
                 if out_dtype in _zero_copy_native_floats:
-                    self._graph.set_output_device_ptr(
-                        name, out.data_ptr(), out.numel() * out.element_size()
+                    self._graph.set_output_device_ptr_at(
+                        i, out.data_ptr(), out.numel() * out.element_size()
                     )
                 output_tensors.append(out)
 
         self._graph.run()
 
         outputs = []
+        gpu_writebacks = []
         for i, (name, shape) in enumerate(zip(self._output_names, output_shapes)):
             out_dtype = output_torch_dtypes[i]
             if i in self._writeback_by_pos:
                 # In-place input mutation: copy the computed state back into
                 # the caller's tensor (the same object the model would have
                 # mutated eagerly); it is not part of the returned tuple.
-                input_name = self._writeback_by_pos[i]
-                target = user_inputs[self._input_names.index(input_name)]
-                target.copy_(_read_typed_output(name, shape, out_dtype))
+                target = user_inputs[self._writeback_input_pos[i]]
+                if i in direct_writebacks:
+                    continue
+                expected_numel = math.prod(shape)
+                can_copy_on_device = (
+                    self._supports_device_ptrs
+                    and hasattr(self._graph, "copy_outputs_to_device_ptrs_at")
+                    and target.is_cuda
+                    and target.is_contiguous()
+                    and target.dtype == out_dtype
+                    and target.numel() == expected_numel
+                )
+                if can_copy_on_device:
+                    gpu_writebacks.append(
+                        (
+                            i,
+                            target.data_ptr(),
+                            target.numel() * target.element_size(),
+                        )
+                    )
+                else:
+                    target.copy_(_read_typed_output(i, name, shape, out_dtype))
                 continue
             if _use_zero_copy and out_dtype in _zero_copy_native_floats:
                 out = output_tensors[i]
-                if not self._graph.output_is_zero_copy(name):
-                    self._graph.copy_output_to_device_ptr(
-                        name, out.data_ptr(), out.numel() * out.element_size()
+                if not self._graph.output_is_zero_copy_at(i):
+                    self._graph.copy_output_to_device_ptr_at(
+                        i, out.data_ptr(), out.numel() * out.element_size()
                     )
             else:
-                out = _read_typed_output(name, shape, out_dtype)
+                out = _read_typed_output(i, name, shape, out_dtype)
             outputs.append(out)
+
+        if gpu_writebacks:
+            self._graph.copy_outputs_to_device_ptrs_at(gpu_writebacks)
 
         return tuple(
             output.item() if i in self._scalar_output_positions else output

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -33,6 +33,7 @@ Dispositions:
 | `499d0779` | #386 | Search: early-stop candidate profiling against the best-so-far metric | MIXED — RE-EXPRESSED (core: running mean + fifth positional cutoff + predicate) / FILE-LEVEL (parks, with a stubbed predicate) | branch `merge/main-386-early-stop` (two commits) | REQUIREMENT FOR CL (ruling 4): a device `PlanProfiler` that times candidates on device, mirroring `ReferenceProfiler`'s design, and then honours the cutoff — until then `StaticProfiler` accepts and ignores it; see **#386 early-stop profiling** below |
 | `6a5313f2` | #398 | Support for PyTorch OpInfo tests | MIXED — FILE-LEVEL (python + workflow) / RE-EXPRESSED (`TypedBuffer::F64` + typed unary kernels) / DROPPED (`ConstantF64`, the empty-Vec fix) | branch `merge/main-398-opinfo` (two commits) | OpInfo harness, the arange-metadata and acos/acosh lowerings = M4 translator requirements; typed `LogicalConstant`; F32<->F64 cast policy; F64 on CL — see **#398 OpInfo + F64** below |
 | `db3c80fd` | #399 | Add native narrow integer HLIR dtypes | MIXED — FILE-LEVEL (python) / RE-EXPRESSED (I8/U8/I16 TypedBuffer + kernels, int-safe `abs`) | branch `merge/main-399-narrow-ints` (two commits) | **CARVE-OUT to confirm at review**: I8/U8/I16 wrap, I32/I64 stay checked — see **#399 narrow ints** below |
+| `727918cd` | #394 | Optimize CUDA graph materialization and StaticCache writebacks | FILE-LEVEL (parks) + INTENT-ONLY (core) | branch `merge/main-394-cuda-graph-park` | REQUIREMENT FOR THE CL EXECUTOR: durable external device-pointer registration, exact binding-delta graph patching, cached reverse indexes, resource-signature reuse — see **#394 CL executor persistence** below |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -494,3 +495,71 @@ function with no counterpart under `TypedBuffer`.
 exists, the storage does not. `crates/luminal_cuda_lite/src/device.rs` gets
 `unreachable!` arms only: `dtype_bytes` has no narrow-int row, so CL refuses
 them by name, and transport without kernels would be the half-done version.
+
+## #394 CL executor persistence — the requirement main paid for
+
+RULED 2026-09-02 (ruling 3): *"merge this into hlir version of cl and we'll
+figure it out later"*.
+
+**FILE-LEVEL.** The five `crates/luminal_cuda_lite/` files
+(`runtime.rs` +989/-338, `kernel/to_host.rs` +300, `host/mod.rs`,
+`host/flashinfer/mod.rs`, `dyn_backend.rs`) are path-rewritten into
+`crates/luminal_cuda_lite_hlir/` per the standing park policy — the park
+TRACKS main so the target CL must eventually reach keeps moving. Every hunk
+applied cleanly over the park's existing drift; there were no rejects. The
+three `crates/luminal_python/**` files come along; `compiled_graph.rs`
+conflicted only on the branch's `Expression` -> `IntExpr` rename in the
+context around main's new `output_ids` field, and the branch spelling is
+kept. Nothing here builds: neither crate is a workspace member.
+
+**UNCARRIED — `src/dyn_backend.rs` (+14).** The file is deleted on this
+branch. Its two additions, `DynBackend::clear_output_device_ptr` and a
+default `copy_outputs_to_device_ptrs`, are the core seam of a capability CL
+does not have at all, so they are recorded here as intent rather than code.
+
+**THE REQUIREMENT, for whenever CL grows a persistent executor.** CL today is
+single-shot: `crates/luminal_cuda_lite/src/device.rs` `execute_plan`
+allocates every buffer, uploads, launches, synchronizes, downloads, and drops
+the storage — strictly worse per invocation than main's runtime even BEFORE
+this commit. What #394 is worth, in the order it would have to be rebuilt:
+
+1. **Durable external pointer registration.** A caller-owned device pointer
+   (a torch allocation) binds once; an identical re-registration is a NO-OP,
+   not a rebuild of the pointer table.
+2. **Exact binding deltas.** Track which HLIR/LLIR bindings actually changed
+   and patch only the affected graph nodes, rather than re-materializing the
+   whole captured graph per call.
+3. **Reverse indexes built once** at construction: buffer -> kernel,
+   dyn-dim -> kernel, output aliases, library buffer nodes.
+4. **Resource-signature caching.** Validate hard resources by an aggregate
+   signature so a repeated (even non-consecutive) shape configuration reuses
+   the previous validation. Main's `HostOp::resource_buffer_nodes` exists so
+   that ONLY inputs whose logical length a plan actually reads enter that
+   signature; the branch analogue would live in the bufferizer if CL ever
+   caches a device-memory plan.
+5. **One terminal synchronize** for a batch of output writebacks
+   (`copy_outputs_to_device_ptrs`), not one per output.
+
+Two correctness rules from main's tests are worth having in writing NOW,
+because they are the kind of thing a re-implementation gets wrong once each:
+
+- An external output destination that **overlaps** a graph input but is not
+  an explicit alias of it must be computed into the PLANNED buffer and copied
+  afterwards, never bound directly (`device_ranges_overlap`, saturating
+  arithmetic, zero-length is never an overlap).
+- External-pointer inputs must **not** be consumed as one-shot buffers while
+  runtime-owned ones are
+  (`should_consume(is_external, preserved_for_output) = !preserved &&
+  !is_external`), or a second invocation re-installs lifted weights.
+
+**SUPERSEDED, do not port.** The positional-output half (`output_node_at`,
+`set_output_device_ptr_at`, `get_output_*_at`) fixes duplicated output NAMES
+losing identity. This branch's outputs are already a positional
+`Vec<OutputSlot>` reached through `output_named`, so that defect is
+structurally absent.
+
+Main's eight `mod arena_plan_tests` unit tests cannot move — every field they
+poke (`CudaRuntime`, `CompiledBucket`) is absent here. The two pure helpers
+`device_ranges_overlap` and `should_consume_hlir_input` are ~15 lines and are
+the only directly liftable fragments; copy them when the CL executor needs
+them.


### PR DESCRIPTION
**Stack.** PR 3 of 8, batch 3 of the main rejoin (walking main's post-split commits chronologically). Base: `merge/main-399-narrow-ints`. Merge in order; before merging, retarget to `logical-ssa-project` with `gh pr edit --base logical-ssa-project`.

**Summary.** Carries main `727918cd` (#394) per ruling 3 ("merge this into hlir version of cl"). Five `crates/luminal_cuda_lite/` files path-rewritten into `crates/luminal_cuda_lite_hlir/` (runtime.rs +989/-338, kernel/to_host.rs +300, host/mod.rs, host/flashinfer/mod.rs, dyn_backend.rs) and three `crates/luminal_python/**` files file-level.

**What was re-expressed and why.** Nothing in code — parks only. `src/dyn_backend.rs` (+14: `DynBackend::clear_output_device_ptr`, default `copy_outputs_to_device_ptrs`) is deleted on this branch; recorded in the ledger as the CL-executor requirement (durable external pointer registration, binding-delta patching, reverse indexes, resource-signature caching, one terminal synchronize) with the two overlap/consume correctness rules from main's tests written out. Positional-output half noted SUPERSEDED (this branch's outputs are already positional).

**Audit.** Path-rewrite diff-of-diffs vs `727918cd` empty; python diff-of-diffs empty (the `compiled_graph.rs` conflict was `IntExpr` context only); zero files touched under the live `crates/luminal_cuda_lite/`.

**Not verified.** The park does not compile (non-member); nothing built or ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
