### PR TITLE
main rejoin: Symbol dim names (#396): parks file-level, core landed-by-equivalent

### DIFF
--- a/crates/luminal_bench/benches/patterns.rs
+++ b/crates/luminal_bench/benches/patterns.rs
@@ -35,7 +35,7 @@ use rand::Rng;
 #[cfg(feature = "metal")]
 struct PreparedBench {
     rt: MetalRuntime,
-    dyn_map: luminal::prelude::FxHashMap<char, usize>,
+    dyn_map: luminal::prelude::DynMap,
     metrics: Option<BenchMetrics>,
 }
 

--- a/crates/luminal_cuda_lite_hlir/src/dyn_backend.rs
+++ b/crates/luminal_cuda_lite_hlir/src/dyn_backend.rs
@@ -47,7 +47,7 @@ impl DynBackend for CudaLiteDynBackend {
     fn get_output_bool(&self, node: NodeIndex) -> Vec<bool> {
         self.runtime.get_bool(node)
     }
-    fn execute(&mut self, dyn_map: &FxHashMap<char, usize>) {
+    fn execute(&mut self, dyn_map: &DynMap) {
         self.runtime.execute(dyn_map);
     }
     fn supports_device_ptrs(&self) -> bool {

--- a/crates/luminal_cuda_lite_hlir/src/host/cublaslt/mod.rs
+++ b/crates/luminal_cuda_lite_hlir/src/host/cublaslt/mod.rs
@@ -1441,10 +1441,7 @@ impl CuBlasLt {
     /// CUDA-graph preparation, and ordinary host execution. Keeping dimension,
     /// layout, dtype, and scalar resolution here prevents those paths from
     /// silently preparing different descriptors for the same extracted op.
-    fn resolve_matmul_spec(
-        &self,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> anyhow::Result<LtMatmulSpec> {
+    fn resolve_matmul_spec(&self, dyn_map: &DynMap) -> anyhow::Result<LtMatmulSpec> {
         let resolve = |expression: &IntExpr, name: &str| -> anyhow::Result<usize> {
             expression
                 .substitute('z', IntExpr::from(1))
@@ -1560,7 +1557,7 @@ impl CuBlasLt {
         self.n_inputs()
     }
 
-    pub(crate) fn graph_spec_dyn_vars(&self) -> FxHashSet<char> {
+    pub(crate) fn graph_spec_dyn_vars(&self) -> FxHashSet<Symbol> {
         [
             &self.m,
             &self.n,
@@ -1585,7 +1582,7 @@ impl CuBlasLt {
     /// allocation preflight before any arena exists.
     pub(crate) fn prepare_key_for_resources(
         &self,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<CuBlasLtPrepareKey> {
         Ok(CuBlasLtPrepareKey {
             spec: self.resolve_matmul_spec(dyn_map)?,
@@ -1597,7 +1594,7 @@ impl CuBlasLt {
         self_node: NodeIndex,
         inputs: &[NodeIndex],
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<CuBlasLtResolvedGraphCall> {
         let spec = self.resolve_matmul_spec(dyn_map)?;
         let ptrs = resolve_cublaslt_pointers(
@@ -1704,7 +1701,7 @@ impl HostOp for CuBlasLt {
         self_node: NodeIndex,
         inputs: &[NodeIndex],
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         let spec = self.resolve_matmul_spec(dyn_map)?;
         let ptrs = resolve_cublaslt_pointers(
@@ -1760,7 +1757,7 @@ impl HostOp for CuBlasLt {
         _self_node: NodeIndex,
         _inputs: &[NodeIndex],
         _buffer_lengths: &FxHashMap<NodeIndex, usize>,
-        _dyn_map: &FxHashMap<char, usize>,
+        _dyn_map: &DynMap,
     ) -> Result<HostDeviceMemoryPlan, ResourceViolation> {
         let scale_bytes = [self.a_dtype, self.b_dtype, self.c_dtype, self.d_dtype]
             .into_iter()
@@ -1792,7 +1789,7 @@ mod tests {
             ldd: IntExpr::from(1),
             ..Default::default()
         };
-        let dyn_map = FxHashMap::from_iter([('m', 3)]);
+        let dyn_map = FxHashMap::from_iter([(Symbol::from('m'), 3)]);
 
         let spec = op.resolve_matmul_spec(&dyn_map).unwrap();
         let prepare_key = op.prepare_key_for_resources(&dyn_map).unwrap();

--- a/crates/luminal_cuda_lite_hlir/src/host/flashinfer/flashinfer_attention.egg
+++ b/crates/luminal_cuda_lite_hlir/src/host/flashinfer/flashinfer_attention.egg
@@ -17,7 +17,6 @@
 ; gather_idx input from the lowered flat gather index.
 ;
 ; Shape dimensions are egglog variables, not pinned constants.
-; Dynamic dims "s" (batch/seq) and "c" (context) stay pinned as MVar.
 
 (relation flashinfer_cache_pair (IR IR))
 
@@ -107,7 +106,7 @@
         ; softmax internals connect the mask chain to the second matmul —
         ; without this the two halves join as a cross-product across the
         ; distinct layer instances of rolled multi-layer bodies.
-        (= ?smax (Op (Max ?smax_shape (MVar "c") ?smax_in ?smax_iter ?smax_out)
+        (= ?smax (Op (Max ?smax_shape ?context_tokens ?smax_in ?smax_iter ?smax_out)
             (ICons ?masked (INil))))
         (= ?negmax (Op (Mul ?nm_shape ?nm_a ?nm_b ?nm_o)
             (ICons ?smax (ICons ?nm_negone (INil)))))
@@ -117,14 +116,14 @@
             (ICons ?shifted (ICons ?sc_log2e (INil)))))
         (const_like ?sc_log2e 1.442695)
         (= ?sexp (Op (Exp2 ?se_shape ?se_in ?se_out) (ICons ?sc (INil))))
-        (= ?sexpsum (Op (Sum ?ss_shape (MVar "c") ?ss_in ?ss_iter ?ss_out)
+        (= ?sexpsum (Op (Sum ?ss_shape ?context_tokens ?ss_in ?ss_iter ?ss_out)
             (ICons ?sexp (INil))))
         (= ?srecip (Op (Recip ?sr_shape ?sr_in ?sr_out) (ICons ?sexpsum (INil))))
         (= ?soft (Op (Mul ?sf_shape ?sf_a ?sf_b ?sf_o)
             (ICons ?sexp (ICons ?srecip (INil)))))
 
         (= ?mul2 (Op (Mul
-            (ECons ?nheads (ECons (MVar "s") (ECons ?hdim (ECons (MVar "c") (ENil)))))
+            (ECons ?nheads (ECons ?input_tokens (ECons ?hdim (ECons ?context_tokens (ENil)))))
             ?mul2_a_strides
             ?mul2_b_strides
             ?mul2_out_strides)
@@ -133,8 +132,8 @@
         ; ── Second matmul: Sum (reduction over c) → output ──
         ; Shape: (nheads, s, hdim) — reduces c
         (= ?output (Op (Sum
-            (ECons ?nheads2 (ECons (MVar "s") (ECons ?hdim2 (ENil))))
-            (MVar "c")
+            (ECons ?nheads2 (ECons ?input_tokens (ECons ?hdim2 (ENil))))
+            ?context_tokens
             ?out_in_strides
             (MIter)
             ?out_out_strides)
@@ -144,7 +143,7 @@
         ; Shape: (nheads, c, hdim) — 3D
         (const_like ?v_gqa_const 1.000000)
         (= ?v_gqa (Op (Mul
-            (ECons ?nheads3 (ECons (MVar "c") (ECons ?hdim3 (ENil))))
+            (ECons ?nheads3 (ECons ?context_tokens (ECons ?hdim3 (ENil))))
             ?v_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?v_gqa_out_strides)
@@ -153,7 +152,7 @@
         ; ── V Gather: rows from V_cache (2D) ──
         ; Shape: (c, kvdim), Source: (num_slots, kvdim)
         (= ?v_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim (ENil)))
             ?v_gather_strides
             (ECons ?num_slots_v (ECons ?kvdim2 (ENil)))
             ?v_src_strides)
@@ -162,7 +161,7 @@
         ; ── First matmul: Mul(Q, K_gqa) ──
         ; Shape: (nheads, s, c, hdim) — 4D
         (= ?mul1 (Op (Mul
-            (ECons ?nheads4 (ECons (MVar "s") (ECons (MVar "c") (ECons ?hdim4 (ENil)))))
+            (ECons ?nheads4 (ECons ?input_tokens (ECons ?context_tokens (ECons ?hdim4 (ENil)))))
             ?mul1_a_strides
             ?mul1_b_strides
             ?mul1_out_strides)
@@ -171,7 +170,7 @@
         ; ── First matmul: Sum (reduction over hdim) → QK scores ──
         ; Shape: (nheads, s, c) — reduces hdim
         (= ?qk (Op (Sum
-            (ECons ?nheads5 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads5 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?hdim5
             ?qk_in_strides
             (MIter)
@@ -182,7 +181,7 @@
         ; Shape: (nheads, s, c) — 3D
         ; Mask is broadcast from (s, c) via zero-stride in first dim (nheads).
         (= ?masked (Op (Add
-            (ECons ?nheads8 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads8 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?mask_add_a_strides
             (ECons (MNum 0) ?mask_rest_strides)
             ?mask_add_out_strides)
@@ -208,7 +207,7 @@
         ; Shape: (nheads, hdim, c) — 3D
         (const_like ?k_gqa_const 1.000000)
         (= ?k_gqa (Op (Mul
-            (ECons ?nheads6 (ECons ?hdim6 (ECons (MVar "c") (ENil))))
+            (ECons ?nheads6 (ECons ?hdim6 (ECons ?context_tokens (ENil))))
             ?k_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?k_gqa_out_strides)
@@ -217,7 +216,7 @@
         ; ── K Gather: rows from K_cache (2D) ──
         ; Shape: (c, kvdim), Source: (num_slots, kvdim)
         (= ?k_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim3 (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim3 (ENil)))
             ?k_gather_strides
             (ECons ?num_slots_k (ECons ?kvdim4 (ENil)))
             ?k_src_strides)
@@ -232,7 +231,7 @@
     )
     (
         (let ?fi (Op (FlashInferAttention
-            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) (MVar "s") ?dt ?sq_scale_val -1.0)
+            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) ?input_tokens ?context_tokens ?dt ?sq_scale_val -1.0)
             (ICons ?q (ICons ?k_cache (ICons ?v_cache (ICons ?k_idx (ICons ?mask (INil))))))))
         (union ?output ?fi)
         (set (dtype ?fi) ?dt)
@@ -250,15 +249,15 @@
         ; This spelling currently lowers to the fp32 batch-decode runtime path,
         ; not prefill. It is only valid when the active dynamic-dim bucket proves
         ; s == 1.
-        (= ?s_lower (lower (MVar "s")))
-        (= ?s_upper (upper (MVar "s")))
+        (= ?s_lower (lower ?input_tokens))
+        (= ?s_upper (upper ?input_tokens))
         (> ?s_lower 0)
         (< ?s_upper 2)
 
         ; softmax internals connect the mask chain to the second matmul —
         ; without this the two halves join as a cross-product across the
         ; distinct layer instances of rolled multi-layer bodies.
-        (= ?smax (Op (Max ?smax_shape (MVar "c") ?smax_in ?smax_iter ?smax_out)
+        (= ?smax (Op (Max ?smax_shape ?context_tokens ?smax_in ?smax_iter ?smax_out)
             (ICons ?masked (INil))))
         (= ?negmax (Op (Mul ?nm_shape ?nm_a ?nm_b ?nm_o)
             (ICons ?smax (ICons ?nm_negone (INil)))))
@@ -268,22 +267,22 @@
             (ICons ?shifted (ICons ?sc_log2e (INil)))))
         (const_like ?sc_log2e 1.442695)
         (= ?sexp (Op (Exp2 ?se_shape ?se_in ?se_out) (ICons ?sc (INil))))
-        (= ?sexpsum (Op (Sum ?ss_shape (MVar "c") ?ss_in ?ss_iter ?ss_out)
+        (= ?sexpsum (Op (Sum ?ss_shape ?context_tokens ?ss_in ?ss_iter ?ss_out)
             (ICons ?sexp (INil))))
         (= ?srecip (Op (Recip ?sr_shape ?sr_in ?sr_out) (ICons ?sexpsum (INil))))
         (= ?soft (Op (Mul ?sf_shape ?sf_a ?sf_b ?sf_o)
             (ICons ?sexp (ICons ?srecip (INil)))))
 
         (= ?mul2 (Op (Mul
-            (ECons ?nheads (ECons (MVar "s") (ECons ?hdim (ECons (MVar "c") (ENil)))))
+            (ECons ?nheads (ECons ?input_tokens (ECons ?hdim (ECons ?context_tokens (ENil)))))
             ?mul2_a_strides
             ?mul2_b_strides
             ?mul2_out_strides)
             (ICons ?soft (ICons ?v_gqa (INil)))))
 
         (= ?output (Op (Sum
-            (ECons ?nheads2 (ECons (MVar "s") (ECons ?hdim2 (ENil))))
-            (MVar "c")
+            (ECons ?nheads2 (ECons ?input_tokens (ECons ?hdim2 (ENil))))
+            ?context_tokens
             ?out_in_strides
             (MIter)
             ?out_out_strides)
@@ -291,28 +290,28 @@
 
         (const_like ?v_gqa_const 1.000000)
         (= ?v_gqa (Op (Mul
-            (ECons ?nheads3 (ECons (MVar "c") (ECons ?hdim3 (ENil))))
+            (ECons ?nheads3 (ECons ?context_tokens (ECons ?hdim3 (ENil))))
             ?v_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?v_gqa_out_strides)
             (ICons ?v_gathered (ICons ?v_gqa_const (INil)))))
 
         (= ?v_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim (ENil)))
             ?v_gather_strides
             (ECons ?num_slots_v (ECons ?kvdim2 (ENil)))
             ?v_src_strides)
             (ICons ?k_idx (ICons ?v_cache (INil)))))
 
         (= ?mul1 (Op (Mul
-            (ECons ?nheads4 (ECons (MVar "s") (ECons (MVar "c") (ECons ?hdim4 (ENil)))))
+            (ECons ?nheads4 (ECons ?input_tokens (ECons ?context_tokens (ECons ?hdim4 (ENil)))))
             ?mul1_a_strides
             ?mul1_b_strides
             ?mul1_out_strides)
             (ICons ?q (ICons ?k_gqa (INil)))))
 
         (= ?qk (Op (Sum
-            (ECons ?nheads5 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads5 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?hdim5
             ?qk_in_strides
             (MIter)
@@ -320,7 +319,7 @@
             (ICons ?mul1 (INil))))
 
         (= ?masked (Op (Add
-            (ECons ?nheads8 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads8 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?mask_add_a_strides
             (ECons (MNum 0) ?mask_rest_strides)
             ?mask_add_out_strides)
@@ -342,14 +341,14 @@
 
         (const_like ?k_gqa_const 1.000000)
         (= ?k_gqa (Op (Mul
-            (ECons ?nheads6 (ECons ?hdim6 (ECons (MVar "c") (ENil))))
+            (ECons ?nheads6 (ECons ?hdim6 (ECons ?context_tokens (ENil))))
             ?k_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?k_gqa_out_strides)
             (ICons ?k_gathered (ICons ?k_gqa_const (INil)))))
 
         (= ?k_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim3 (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim3 (ENil)))
             ?k_gather_strides
             (ECons ?num_slots_k (ECons ?kvdim4 (ENil)))
             ?k_src_strides)
@@ -363,7 +362,7 @@
     )
     (
         (let ?fi (Op (FlashInferAttention
-            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) (MVar "s") ?dt ?sq_scale_val -1.0)
+            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) ?input_tokens ?context_tokens ?dt ?sq_scale_val -1.0)
             (ICons ?q (ICons ?k_cache (ICons ?v_cache (ICons ?k_idx (ICons ?mask (INil))))))))
         (union ?output ?fi)
         (set (dtype ?fi) ?dt)
@@ -383,15 +382,15 @@
         ;
         ; Like the direct causal spelling, this is decode-only until the fp32
         ; prefill runtime exists. The active bucket must prove s == 1.
-        (= ?s_lower (lower (MVar "s")))
-        (= ?s_upper (upper (MVar "s")))
+        (= ?s_lower (lower ?input_tokens))
+        (= ?s_upper (upper ?input_tokens))
         (> ?s_lower 0)
         (< ?s_upper 2)
 
         ; softmax internals connect the mask chain to the second matmul —
         ; without this the two halves join as a cross-product across the
         ; distinct layer instances of rolled multi-layer bodies.
-        (= ?smax (Op (Max ?smax_shape (MVar "c") ?smax_in ?smax_iter ?smax_out)
+        (= ?smax (Op (Max ?smax_shape ?context_tokens ?smax_in ?smax_iter ?smax_out)
             (ICons ?masked (INil))))
         (= ?negmax (Op (Mul ?nm_shape ?nm_a ?nm_b ?nm_o)
             (ICons ?smax (ICons ?nm_negone (INil)))))
@@ -401,22 +400,22 @@
             (ICons ?shifted (ICons ?sc_log2e (INil)))))
         (const_like ?sc_log2e 1.442695)
         (= ?sexp (Op (Exp2 ?se_shape ?se_in ?se_out) (ICons ?sc (INil))))
-        (= ?sexpsum (Op (Sum ?ss_shape (MVar "c") ?ss_in ?ss_iter ?ss_out)
+        (= ?sexpsum (Op (Sum ?ss_shape ?context_tokens ?ss_in ?ss_iter ?ss_out)
             (ICons ?sexp (INil))))
         (= ?srecip (Op (Recip ?sr_shape ?sr_in ?sr_out) (ICons ?sexpsum (INil))))
         (= ?soft (Op (Mul ?sf_shape ?sf_a ?sf_b ?sf_o)
             (ICons ?sexp (ICons ?srecip (INil)))))
 
         (= ?mul2 (Op (Mul
-            (ECons ?nheads (ECons (MVar "s") (ECons ?hdim (ECons (MVar "c") (ENil)))))
+            (ECons ?nheads (ECons ?input_tokens (ECons ?hdim (ECons ?context_tokens (ENil)))))
             ?mul2_a_strides
             ?mul2_b_strides
             ?mul2_out_strides)
             (ICons ?soft (ICons ?v_gqa (INil)))))
 
         (= ?output (Op (Sum
-            (ECons ?nheads2 (ECons (MVar "s") (ECons ?hdim2 (ENil))))
-            (MVar "c")
+            (ECons ?nheads2 (ECons ?input_tokens (ECons ?hdim2 (ENil))))
+            ?context_tokens
             ?out_in_strides
             (MIter)
             ?out_out_strides)
@@ -424,28 +423,28 @@
 
         (const_like ?v_gqa_const 1.000000)
         (= ?v_gqa (Op (Mul
-            (ECons ?nheads3 (ECons (MVar "c") (ECons ?hdim3 (ENil))))
+            (ECons ?nheads3 (ECons ?context_tokens (ECons ?hdim3 (ENil))))
             ?v_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?v_gqa_out_strides)
             (ICons ?v_gathered (ICons ?v_gqa_const (INil)))))
 
         (= ?v_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim (ENil)))
             ?v_gather_strides
             (ECons ?num_slots_v (ECons ?kvdim2 (ENil)))
             ?v_src_strides)
             (ICons ?k_idx (ICons ?v_cache (INil)))))
 
         (= ?mul1 (Op (Mul
-            (ECons ?nheads4 (ECons (MVar "s") (ECons (MVar "c") (ECons ?hdim4 (ENil)))))
+            (ECons ?nheads4 (ECons ?input_tokens (ECons ?context_tokens (ECons ?hdim4 (ENil)))))
             ?mul1_a_strides
             ?mul1_b_strides
             ?mul1_out_strides)
             (ICons ?q (ICons ?k_gqa (INil)))))
 
         (= ?qk (Op (Sum
-            (ECons ?nheads5 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads5 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?hdim5
             ?qk_in_strides
             (MIter)
@@ -453,7 +452,7 @@
             (ICons ?mul1 (INil))))
 
         (= ?masked (Op (Add
-            (ECons ?nheads8 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads8 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?mask_add_a_strides
             (ECons (MNum 0) ?mask_rest_strides)
             ?mask_add_out_strides)
@@ -479,14 +478,14 @@
 
         (const_like ?k_gqa_const 1.000000)
         (= ?k_gqa (Op (Mul
-            (ECons ?nheads6 (ECons ?hdim6 (ECons (MVar "c") (ENil))))
+            (ECons ?nheads6 (ECons ?hdim6 (ECons ?context_tokens (ENil))))
             ?k_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?k_gqa_out_strides)
             (ICons ?k_gathered (ICons ?k_gqa_const (INil)))))
 
         (= ?k_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim3 (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim3 (ENil)))
             ?k_gather_strides
             (ECons ?num_slots_k (ECons ?kvdim4 (ENil)))
             ?k_src_strides)
@@ -500,7 +499,7 @@
     )
     (
         (let ?fi (Op (FlashInferAttention
-            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) (MVar "s") ?dt ?sq_scale_val -1.0)
+            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) ?input_tokens ?context_tokens ?dt ?sq_scale_val -1.0)
             (ICons ?q (ICons ?k_cache (ICons ?v_cache (ICons ?k_idx (ICons ?mask (INil))))))))
         (union ?output ?fi)
         (set (dtype ?fi) ?dt)
@@ -526,7 +525,7 @@
         ; softmax internals connect the mask chain to the second matmul —
         ; without this the two halves join as a cross-product across the
         ; distinct layer instances of rolled multi-layer bodies.
-        (= ?smax (Op (Max ?smax_shape (MVar "c") ?smax_in ?smax_iter ?smax_out)
+        (= ?smax (Op (Max ?smax_shape ?context_tokens ?smax_in ?smax_iter ?smax_out)
             (ICons ?masked (INil))))
         (= ?negmax (Op (Mul ?nm_shape ?nm_a ?nm_b ?nm_o)
             (ICons ?smax (ICons ?nm_negone (INil)))))
@@ -536,22 +535,22 @@
             (ICons ?shifted (ICons ?sc_log2e (INil)))))
         (const_like ?sc_log2e 1.442695)
         (= ?sexp (Op (Exp2 ?se_shape ?se_in ?se_out) (ICons ?sc (INil))))
-        (= ?sexpsum (Op (Sum ?ss_shape (MVar "c") ?ss_in ?ss_iter ?ss_out)
+        (= ?sexpsum (Op (Sum ?ss_shape ?context_tokens ?ss_in ?ss_iter ?ss_out)
             (ICons ?sexp (INil))))
         (= ?srecip (Op (Recip ?sr_shape ?sr_in ?sr_out) (ICons ?sexpsum (INil))))
         (= ?soft (Op (Mul ?sf_shape ?sf_a ?sf_b ?sf_o)
             (ICons ?sexp (ICons ?srecip (INil)))))
 
         (= ?mul2 (Op (Mul
-            (ECons ?nheads (ECons (MVar "s") (ECons ?hdim (ECons (MVar "c") (ENil)))))
+            (ECons ?nheads (ECons ?input_tokens (ECons ?hdim (ECons ?context_tokens (ENil)))))
             ?mul2_a_strides
             ?mul2_b_strides
             ?mul2_out_strides)
             (ICons ?soft (ICons ?v_gqa (INil)))))
 
         (= ?output (Op (Sum
-            (ECons ?nheads2 (ECons (MVar "s") (ECons ?hdim2 (ENil))))
-            (MVar "c")
+            (ECons ?nheads2 (ECons ?input_tokens (ECons ?hdim2 (ENil))))
+            ?context_tokens
             ?out_in_strides
             (MIter)
             ?out_out_strides)
@@ -559,28 +558,28 @@
 
         (const_like ?v_gqa_const 1.000000)
         (= ?v_gqa (Op (Mul
-            (ECons ?nheads3 (ECons (MVar "c") (ECons ?hdim3 (ENil))))
+            (ECons ?nheads3 (ECons ?context_tokens (ECons ?hdim3 (ENil))))
             ?v_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?v_gqa_out_strides)
             (ICons ?v_gathered (ICons ?v_gqa_const (INil)))))
 
         (= ?v_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim (ENil)))
             ?v_gather_strides
             (ECons ?num_slots_v (ECons ?kvdim2 (ENil)))
             ?v_src_strides)
             (ICons ?k_idx (ICons ?v_cache (INil)))))
 
         (= ?mul1 (Op (Mul
-            (ECons ?nheads4 (ECons (MVar "s") (ECons (MVar "c") (ECons ?hdim4 (ENil)))))
+            (ECons ?nheads4 (ECons ?input_tokens (ECons ?context_tokens (ECons ?hdim4 (ENil)))))
             ?mul1_a_strides
             ?mul1_b_strides
             ?mul1_out_strides)
             (ICons ?q (ICons ?k_gqa (INil)))))
 
         (= ?qk (Op (Sum
-            (ECons ?nheads5 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads5 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?hdim5
             ?qk_in_strides
             (MIter)
@@ -588,7 +587,7 @@
             (ICons ?mul1 (INil))))
 
         (= ?masked (Op (Add
-            (ECons ?nheads8 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads8 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?mask_add_a_strides
             (ECons (MNum 0) ?mask_rest_strides)
             ?mask_add_out_strides)
@@ -614,14 +613,14 @@
 
         (const_like ?k_gqa_const 1.000000)
         (= ?k_gqa (Op (Mul
-            (ECons ?nheads6 (ECons ?hdim6 (ECons (MVar "c") (ENil))))
+            (ECons ?nheads6 (ECons ?hdim6 (ECons ?context_tokens (ENil))))
             ?k_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?k_gqa_out_strides)
             (ICons ?k_gathered (ICons ?k_gqa_const (INil)))))
 
         (= ?k_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim3 (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim3 (ENil)))
             ?k_gather_strides
             (ECons ?num_slots_k (ECons ?kvdim4 (ENil)))
             ?k_src_strides)
@@ -635,7 +634,7 @@
     )
     (
         (let ?fi (Op (FlashInferAttention
-            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) (MVar "s") ?dt ?sq_scale_val -1.0)
+            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) ?input_tokens ?context_tokens ?dt ?sq_scale_val -1.0)
             (ICons ?q (ICons ?k_cache (ICons ?v_cache (ICons ?k_idx (ICons ?mask (INil))))))))
         (union ?output ?fi)
         (set (dtype ?fi) ?dt)
@@ -656,28 +655,28 @@
 (rule
     (
         (= ?cmask (Op (Gather
-            (ECons (MVar "s") (ECons (MVar "c") (ENil)))
+            (ECons ?input_tokens (ECons ?context_tokens (ENil)))
             ?mask_idx_strides
-            (ECons (MVar "c") (ECons (MVar "c") (ENil)))
+            (ECons ?context_tokens (ECons ?context_tokens (ENil)))
             ?mask_src_strides)
             (ICons ?mask_indices (ICons ?scaled_blocked (INil)))))
         (= ?mask_indices (Op (Add
-            (ECons (MVar "s") (ECons (MVar "c") (ENil)))
+            (ECons ?input_tokens (ECons ?context_tokens (ENil)))
             ?row_idx_strides
             ?col_idx_strides
             ?mask_idx_out_strides)
             (ICons ?row_offsets (ICons ?col_offsets (INil)))))
-        (= ?col_offsets (Op (Iota (MIter) (MVar "c")) (INil)))
+        (= ?col_offsets (Op (Iota (MIter) ?context_tokens) (INil)))
         (= ?row_offsets (Op (Mul
-            (ECons (MVar "s") (ENil))
+            (ECons ?input_tokens (ENil))
             ?q_pos_strides
             ?ctx_scalar_strides
             ?row_offsets_out_strides)
             (ICons ?q_pos (ICons ?ctx_scalar (INil)))))
-        (= ?ctx_scalar (Op (Iota (MVar "c") (MNum 1)) (INil)))
+        (= ?ctx_scalar (Op (Iota ?context_tokens (MNum 1)) (INil)))
 
         (= ?scaled_blocked (Op (Mul
-            (ECons (MVar "c") (ECons (MVar "c") (ENil)))
+            (ECons ?context_tokens (ECons ?context_tokens (ENil)))
             ?blocked_strides
             ?neg_scale_strides
             ?scaled_blocked_strides)
@@ -688,19 +687,19 @@
         (= ?blocked_f32 (Op (Cast ?blocked_cast_size ?blocked_cast_dt)
             (ICons ?blocked_bool (INil))))
         (= ?blocked_bool (Op (LessThan
-            (ECons (MVar "c") (ECons (MVar "c") (ENil)))
+            (ECons ?context_tokens (ECons ?context_tokens (ENil)))
             ?tri_row_strides
             ?tri_col_strides
             ?blocked_out_strides)
             (ICons ?tri_iota_f32 (ICons ?tri_iota_minus_zero (INil)))))
         (= ?tri_iota_minus_zero (Op (Add
-            (ECons (MVar "c") (ECons (MVar "c") (ENil)))
+            (ECons ?context_tokens (ECons ?context_tokens (ENil)))
             ?tri_minus_zero_a_strides
             ?tri_minus_zero_b_strides
             ?tri_minus_zero_out_strides)
             (ICons ?tri_iota_f32 (ICons ?zero_offset (INil)))))
         (= ?zero_offset (Op (Mul
-            (ECons (MVar "c") (ECons (MVar "c") (ENil)))
+            (ECons ?context_tokens (ECons ?context_tokens (ENil)))
             ?zero_offset_a_strides
             ?zero_offset_b_strides
             ?zero_offset_out_strides)
@@ -709,7 +708,7 @@
         (= ?neg_one_const (Op (Constant -1.000000) (INil)))
         (= ?tri_iota_f32 (Op (Cast ?tri_iota_cast_size (F32))
             (ICons ?tri_iota (INil))))
-        (= ?tri_iota (Op (Iota (MIter) (MVar "c")) (INil)))
+        (= ?tri_iota (Op (Iota (MIter) ?context_tokens) (INil)))
     )
     (
         (fi_triu_mask ?cmask ?q_pos)
@@ -743,7 +742,7 @@
         ;   (q_pos[:, None] < arange(c)[None, :]).cast(F32) * -1e10
         ; The "direct causal attention" island rule anchors at this fact.
         (= ?mask (Op (Mul
-            (ECons (MVar "s") (ECons (MVar "c") (ENil)))
+            (ECons ?input_tokens (ECons ?context_tokens (ENil)))
             ?blocked_strides
             ?neg_scale_strides
             ?mask_out_strides)
@@ -754,12 +753,12 @@
         (= ?blocked_f32 (Op (Cast ?blocked_cast_size ?blocked_cast_dt)
             (ICons ?blocked_bool (INil))))
         (= ?blocked_bool (Op (LessThan
-            (ECons (MVar "s") (ECons (MVar "c") (ENil)))
+            (ECons ?input_tokens (ECons ?context_tokens (ENil)))
             ?q_pos_cmp_strides
             ?col_cmp_strides
             ?blocked_out_strides)
             (ICons ?q_pos (ICons ?col_offsets (INil)))))
-        (= ?col_offsets (Op (Iota (MIter) (MVar "c")) (INil)))
+        (= ?col_offsets (Op (Iota (MIter) ?context_tokens) (INil)))
     )
     (
         (fi_direct_causal_mask ?mask ?q_pos)
@@ -773,7 +772,7 @@
         ; window term: (col < q_pos - (W-1)) cast * -1e10; the constant W-1
         ; is FlashInfer's window_left.
         (= ?wterm (Op (Mul
-            (ECons (MVar "s") (ECons (MVar "c") (ENil)))
+            (ECons ?input_tokens (ECons ?context_tokens (ENil)))
             ?wt_a_strides
             ?wt_b_strides
             ?wt_out_strides)
@@ -784,22 +783,22 @@
         (= ?w_bool_cast (Op (Cast ?w_cast_size ?w_cast_dt)
             (ICons ?w_lt (INil))))
         (= ?w_lt (Op (LessThan
-            (ECons (MVar "s") (ECons (MVar "c") (ENil)))
+            (ECons ?input_tokens (ECons ?context_tokens (ENil)))
             (ECons (MNum 0) (ECons (MIter) (ENil)))
             (ECons (MIter) (ECons (MNum 0) (ENil)))
             ?w_lt_out_strides)
             (ICons ?w_col_f (ICons ?w_lo (INil)))))
         (= ?w_col_f (Op (Cast ?w_col_cast_size (F32)) (ICons ?w_col_iota (INil))))
-        (= ?w_col_iota (Op (Iota (MIter) (MVar "c")) (INil)))
+        (= ?w_col_iota (Op (Iota (MIter) ?context_tokens) (INil)))
         (= ?w_lo (Op (Add
-            (ECons (MVar "s") (ENil))
+            (ECons ?input_tokens (ENil))
             ?w_lo_a_strides
             ?w_lo_b_strides
             ?w_lo_out_strides)
             (ICons ?w_qpos_f (ICons ?w_neg (INil)))))
         (= ?w_qpos_f (Op (Cast ?w_qpos_cast_size (F32)) (ICons ?w_qpos (INil))))
         (= ?w_neg (Op (Mul
-            (ECons (MVar "s") (ENil))
+            (ECons ?input_tokens (ENil))
             (ECons (MNum 0) (ENil))
             (ECons (MNum 0) (ENil))
             ?w_neg_out_strides)
@@ -819,8 +818,8 @@
         ; Gemma-4 full attention: scale-free, causal triu-gather mask.
         ; 16-bit only (covers head_dim 512); no s==1 guard — the tensor-core
         ; prefill runtime handles s>1.
-        (= ?s_lower (lower (MVar "s")))
-        (= ?s_upper (upper (MVar "s")))
+        (= ?s_lower (lower ?input_tokens))
+        (= ?s_upper (upper ?input_tokens))
         (> ?s_lower 0)
         (< ?s_upper 2)
 
@@ -828,12 +827,12 @@
         (fi_triu_mask ?mask ?q_pos)
         ; mask Add → softmax internals → second matmul: one connected chain.
         (= ?masked (Op (Add
-            (ECons ?nheads8 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads8 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?mask_add_a_strides
             (ECons (MNum 0) ?mask_rest_strides)
             ?mask_add_out_strides)
             (ICons ?qk (ICons ?mask (INil)))))
-        (= ?smax (Op (Max ?smax_shape (MVar "c") ?smax_in ?smax_iter ?smax_out)
+        (= ?smax (Op (Max ?smax_shape ?context_tokens ?smax_in ?smax_iter ?smax_out)
             (ICons ?masked (INil))))
         (= ?negmax (Op (Mul ?nm_shape ?nm_a ?nm_b ?nm_o)
             (ICons ?smax (ICons ?nm_negone (INil)))))
@@ -843,22 +842,22 @@
             (ICons ?shifted (ICons ?sc_log2e (INil)))))
         (const_like ?sc_log2e 1.442695)
         (= ?sexp (Op (Exp2 ?se_shape ?se_in ?se_out) (ICons ?sc (INil))))
-        (= ?sexpsum (Op (Sum ?ss_shape (MVar "c") ?ss_in ?ss_iter ?ss_out)
+        (= ?sexpsum (Op (Sum ?ss_shape ?context_tokens ?ss_in ?ss_iter ?ss_out)
             (ICons ?sexp (INil))))
         (= ?srecip (Op (Recip ?sr_shape ?sr_in ?sr_out) (ICons ?sexpsum (INil))))
         (= ?soft (Op (Mul ?sf_shape ?sf_a ?sf_b ?sf_o)
             (ICons ?sexp (ICons ?srecip (INil)))))
 
         (= ?mul2 (Op (Mul
-            (ECons ?nheads (ECons (MVar "s") (ECons ?hdim (ECons (MVar "c") (ENil)))))
+            (ECons ?nheads (ECons ?input_tokens (ECons ?hdim (ECons ?context_tokens (ENil)))))
             ?mul2_a_strides
             ?mul2_b_strides
             ?mul2_out_strides)
             (ICons ?soft (ICons ?v_gqa (INil)))))
 
         (= ?output (Op (Sum
-            (ECons ?nheads2 (ECons (MVar "s") (ECons ?hdim2 (ENil))))
-            (MVar "c")
+            (ECons ?nheads2 (ECons ?input_tokens (ECons ?hdim2 (ENil))))
+            ?context_tokens
             ?out_in_strides
             (MIter)
             ?out_out_strides)
@@ -866,14 +865,14 @@
 
         (const_like ?v_gqa_const 1.000000)
         (= ?v_gqa (Op (Mul
-            (ECons ?nheads3 (ECons (MVar "c") (ECons ?hdim3 (ENil))))
+            (ECons ?nheads3 (ECons ?context_tokens (ECons ?hdim3 (ENil))))
             ?v_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?v_gqa_out_strides)
             (ICons ?v_gathered (ICons ?v_gqa_const (INil)))))
 
         (= ?v_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim (ENil)))
             ?v_gather_strides
             (ECons ?num_slots_v (ECons ?kvdim2 (ENil)))
             ?v_src_strides)
@@ -881,28 +880,28 @@
 
         ; SCALE-FREE: ?qk (the raw QK Sum) feeds the mask Add directly.
         (= ?qk (Op (Sum
-            (ECons ?nheads5 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads5 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?hdim5
             ?qk_in_strides
             (MIter)
             ?qk_out_strides)
             (ICons ?mul1 (INil))))
         (= ?mul1 (Op (Mul
-            (ECons ?nheads4 (ECons (MVar "s") (ECons (MVar "c") (ECons ?hdim4 (ENil)))))
+            (ECons ?nheads4 (ECons ?input_tokens (ECons ?context_tokens (ECons ?hdim4 (ENil)))))
             ?mul1_a_strides
             ?mul1_b_strides
             ?mul1_out_strides)
             (ICons ?q (ICons ?k_gqa (INil)))))
         (const_like ?k_gqa_const 1.000000)
         (= ?k_gqa (Op (Mul
-            (ECons ?nheads6 (ECons ?hdim6 (ECons (MVar "c") (ENil))))
+            (ECons ?nheads6 (ECons ?hdim6 (ECons ?context_tokens (ENil))))
             ?k_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?k_gqa_out_strides)
             (ICons ?k_gathered (ICons ?k_gqa_const (INil)))))
 
         (= ?k_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim3 (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim3 (ENil)))
             ?k_gather_strides
             (ECons ?num_slots_k (ECons ?kvdim4 (ENil)))
             ?k_src_strides)
@@ -916,7 +915,7 @@
     )
     (
         (let ?fi (Op (FlashInferAttention
-            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) (MVar "s") ?dt 1.0 -1.0)
+            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) ?input_tokens ?context_tokens ?dt 1.0 -1.0)
             (ICons ?q (ICons ?k_cache (ICons ?v_cache (ICons ?k_idx (ICons ?mask (INil))))))))
         (union ?output ?fi)
         (set (dtype ?fi) ?dt)
@@ -929,14 +928,14 @@
     (
         ; Gemma-4 sliding-window attention: scale-free, causal triu-gather
         ; mask + window term; window_left carried onto the op.
-        (= ?s_lower (lower (MVar "s")))
-        (= ?s_upper (upper (MVar "s")))
+        (= ?s_lower (lower ?input_tokens))
+        (= ?s_upper (upper ?input_tokens))
         (> ?s_lower 0)
         (< ?s_upper 2)
 
         (flashinfer_prefill_dt ?dt)
         (= ?mask (Op (Add
-            (ECons (MVar "s") (ECons (MVar "c") (ENil)))
+            (ECons ?input_tokens (ECons ?context_tokens (ENil)))
             ?wm_a_strides
             ?wm_b_strides
             ?wm_out_strides)
@@ -946,12 +945,12 @@
         (= ?q_pos ?q_pos2)
         ; mask Add → softmax internals → second matmul: one connected chain.
         (= ?masked (Op (Add
-            (ECons ?nheads8 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads8 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?mask_add_a_strides
             (ECons (MNum 0) ?mask_rest_strides)
             ?mask_add_out_strides)
             (ICons ?qk (ICons ?mask (INil)))))
-        (= ?smax (Op (Max ?smax_shape (MVar "c") ?smax_in ?smax_iter ?smax_out)
+        (= ?smax (Op (Max ?smax_shape ?context_tokens ?smax_in ?smax_iter ?smax_out)
             (ICons ?masked (INil))))
         (= ?negmax (Op (Mul ?nm_shape ?nm_a ?nm_b ?nm_o)
             (ICons ?smax (ICons ?nm_negone (INil)))))
@@ -961,22 +960,22 @@
             (ICons ?shifted (ICons ?sc_log2e (INil)))))
         (const_like ?sc_log2e 1.442695)
         (= ?sexp (Op (Exp2 ?se_shape ?se_in ?se_out) (ICons ?sc (INil))))
-        (= ?sexpsum (Op (Sum ?ss_shape (MVar "c") ?ss_in ?ss_iter ?ss_out)
+        (= ?sexpsum (Op (Sum ?ss_shape ?context_tokens ?ss_in ?ss_iter ?ss_out)
             (ICons ?sexp (INil))))
         (= ?srecip (Op (Recip ?sr_shape ?sr_in ?sr_out) (ICons ?sexpsum (INil))))
         (= ?soft (Op (Mul ?sf_shape ?sf_a ?sf_b ?sf_o)
             (ICons ?sexp (ICons ?srecip (INil)))))
 
         (= ?mul2 (Op (Mul
-            (ECons ?nheads (ECons (MVar "s") (ECons ?hdim (ECons (MVar "c") (ENil)))))
+            (ECons ?nheads (ECons ?input_tokens (ECons ?hdim (ECons ?context_tokens (ENil)))))
             ?mul2_a_strides
             ?mul2_b_strides
             ?mul2_out_strides)
             (ICons ?soft (ICons ?v_gqa (INil)))))
 
         (= ?output (Op (Sum
-            (ECons ?nheads2 (ECons (MVar "s") (ECons ?hdim2 (ENil))))
-            (MVar "c")
+            (ECons ?nheads2 (ECons ?input_tokens (ECons ?hdim2 (ENil))))
+            ?context_tokens
             ?out_in_strides
             (MIter)
             ?out_out_strides)
@@ -984,14 +983,14 @@
 
         (const_like ?v_gqa_const 1.000000)
         (= ?v_gqa (Op (Mul
-            (ECons ?nheads3 (ECons (MVar "c") (ECons ?hdim3 (ENil))))
+            (ECons ?nheads3 (ECons ?context_tokens (ECons ?hdim3 (ENil))))
             ?v_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?v_gqa_out_strides)
             (ICons ?v_gathered (ICons ?v_gqa_const (INil)))))
 
         (= ?v_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim (ENil)))
             ?v_gather_strides
             (ECons ?num_slots_v (ECons ?kvdim2 (ENil)))
             ?v_src_strides)
@@ -999,28 +998,28 @@
 
         ; SCALE-FREE: ?qk (the raw QK Sum) feeds the mask Add directly.
         (= ?qk (Op (Sum
-            (ECons ?nheads5 (ECons (MVar "s") (ECons (MVar "c") (ENil))))
+            (ECons ?nheads5 (ECons ?input_tokens (ECons ?context_tokens (ENil))))
             ?hdim5
             ?qk_in_strides
             (MIter)
             ?qk_out_strides)
             (ICons ?mul1 (INil))))
         (= ?mul1 (Op (Mul
-            (ECons ?nheads4 (ECons (MVar "s") (ECons (MVar "c") (ECons ?hdim4 (ENil)))))
+            (ECons ?nheads4 (ECons ?input_tokens (ECons ?context_tokens (ECons ?hdim4 (ENil)))))
             ?mul1_a_strides
             ?mul1_b_strides
             ?mul1_out_strides)
             (ICons ?q (ICons ?k_gqa (INil)))))
         (const_like ?k_gqa_const 1.000000)
         (= ?k_gqa (Op (Mul
-            (ECons ?nheads6 (ECons ?hdim6 (ECons (MVar "c") (ENil))))
+            (ECons ?nheads6 (ECons ?hdim6 (ECons ?context_tokens (ENil))))
             ?k_gqa_a_strides
             (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
             ?k_gqa_out_strides)
             (ICons ?k_gathered (ICons ?k_gqa_const (INil)))))
 
         (= ?k_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim3 (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim3 (ENil)))
             ?k_gather_strides
             (ECons ?num_slots_k (ECons ?kvdim4 (ENil)))
             ?k_src_strides)
@@ -1034,7 +1033,7 @@
     )
     (
         (let ?fi (Op (FlashInferAttention
-            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) (MVar "s") ?dt 1.0 ?window_left)
+            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MNum 1) ?input_tokens ?context_tokens ?dt 1.0 ?window_left)
             (ICons ?q (ICons ?k_cache (ICons ?v_cache (ICons ?k_idx (ICons ?mask (INil))))))))
         (union ?output ?fi)
         (set (dtype ?fi) ?dt)

--- a/crates/luminal_cuda_lite_hlir/src/host/flashinfer/mod.rs
+++ b/crates/luminal_cuda_lite_hlir/src/host/flashinfer/mod.rs
@@ -44,6 +44,9 @@ pub struct FlashInferAttention {
     pub head_dim: usize,
     pub page_size: usize,
     pub batch_dim: IntExpr,
+    /// Total tokens attended over. Captured from the matched shape by the
+    /// rules, so it does not depend on what the graph calls this dim.
+    pub context_dim: IntExpr,
     pub dtype: DType,
     /// Softmax scale; 0.0 = default `1/sqrt(head_dim)`.
     pub sm_scale: f64,
@@ -197,6 +200,19 @@ fn prepared_device_bytes(
         })
 }
 
+/// Rows in a CSR index pointer, from the buffer's length.
+fn indptr_rows(
+    buffer_lengths: &FxHashMap<NodeIndex, usize>,
+    node: NodeIndex,
+) -> Result<usize, ResourceViolation> {
+    buffer_lengths
+        .get(&node)
+        .map(|bytes| bytes / std::mem::size_of::<i32>())
+        .ok_or(ResourceViolation::HostResourcePlanning {
+            name: "FlashInfer indptr length",
+        })
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct FlashInferResolvedDecode {
     spec: FlashInferDecodeSpec,
@@ -332,6 +348,7 @@ impl Default for FlashInferAttention {
             head_dim: 0,
             page_size: 0,
             batch_dim: IntExpr::default(),
+            context_dim: IntExpr::default(),
             dtype: DType::F32,
             sm_scale: 0.0,
             window_left: -1,
@@ -351,6 +368,7 @@ impl EgglogOp for FlashInferAttention {
                 ("head_dim", EXPRESSION),
                 ("page_size", EXPRESSION),
                 ("batch_dim", EXPRESSION),
+                ("context_dim", EXPRESSION),
                 ("dtype", DTYPE),
                 ("sm_scale", F64),
                 ("window_left", F64),
@@ -404,13 +422,14 @@ impl EgglogOp for FlashInferAttention {
             .exec(&FxHashMap::default())
             .unwrap();
         let batch_dim = extract_expr(egraph, kind_children[4], expr_cache).unwrap();
-        let dtype = extract_dtype(egraph, kind_children[5]);
-        let sm_scale: f64 = egraph.enodes[kind_children[6]]
+        let context_dim = extract_expr(egraph, kind_children[5], expr_cache).unwrap();
+        let dtype = extract_dtype(egraph, kind_children[6]);
+        let sm_scale: f64 = egraph.enodes[kind_children[7]]
             .0
             .replace('"', "")
             .parse()
             .unwrap();
-        let window_left = egraph.enodes[kind_children[7]]
+        let window_left = egraph.enodes[kind_children[8]]
             .0
             .replace('"', "")
             .parse::<f64>()
@@ -427,6 +446,7 @@ impl EgglogOp for FlashInferAttention {
             head_dim,
             page_size,
             batch_dim,
+            context_dim,
             dtype,
             sm_scale,
             window_left,
@@ -470,7 +490,7 @@ impl FlashInferAttention {
         &self,
         inputs: &[NodeIndex],
         buffer_lengths: &FxHashMap<NodeIndex, usize>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         enable_cuda_graph: bool,
     ) -> Result<FlashInferDeviceResourceSpec, ResourceViolation> {
         let total_q_tokens =
@@ -479,9 +499,9 @@ impl FlashInferAttention {
                 .ok_or(ResourceViolation::UnresolvedExpression {
                     resource: "FlashInfer total query tokens",
                 })?;
-        let c = dyn_map
-            .get(&'c')
-            .copied()
+        let c = self
+            .context_dim
+            .exec(dyn_map)
             .ok_or(ResourceViolation::UnresolvedExpression {
                 resource: "FlashInfer context length",
             })?;
@@ -523,13 +543,11 @@ impl FlashInferAttention {
             .unwrap_or(c);
         let explicit_indptr = inputs.len() == 6;
         let batch_size = if explicit_indptr {
-            dyn_map
-                .get(&'r')
-                .copied()
-                .ok_or(ResourceViolation::UnresolvedExpression {
-                    resource: "FlashInfer indptr rows",
-                })?
-                .saturating_sub(1)
+            // A CSR index pointer has one entry per sequence plus a terminator,
+            // so the row count is the buffer's own length. Asking dyn_map for it
+            // by name meant the caller had to declare a dim describing an input
+            // the op is already holding.
+            indptr_rows(buffer_lengths, inputs[5])?.saturating_sub(1)
         } else if total_q_tokens > 1 && dtype.supports_prefill() {
             1
         } else {
@@ -575,15 +593,16 @@ impl FlashInferAttention {
         self_node: NodeIndex,
         inputs: &[NodeIndex],
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<FlashInferResolvedDecode> {
         let total_q_tokens = self
             .batch_dim
             .exec(dyn_map)
             .ok_or_else(|| anyhow::anyhow!("FlashInferAttention batch_dim is unresolved"))?;
-        let c = *dyn_map
-            .get(&'c')
-            .ok_or_else(|| anyhow::anyhow!("FlashInferAttention requires dynamic dim 'c'"))?;
+        let c = self
+            .context_dim
+            .exec(dyn_map)
+            .ok_or_else(|| anyhow::anyhow!("FlashInferAttention context_dim is unresolved"))?;
         if inputs.len() != 4 && inputs.len() != 6 {
             anyhow::bail!(
                 "FlashInferAttention expects 4 inputs (derived causal decode) or 6 inputs (explicit indptrs), got {}",
@@ -619,11 +638,14 @@ impl FlashInferAttention {
             .unwrap_or(c);
         let (kv_indptr_host, batch_size, explicit_qo_indptr, explicit_kv_indptr) =
             if inputs.len() >= 6 {
-                let r = *dyn_map.get(&'r').ok_or_else(|| {
-                    anyhow::anyhow!("FlashInferAttention requires dynamic dim 'r'")
-                })?;
                 let qo_indptr_buf = get_buf("qo_indptr", inputs[4])?;
                 let kv_indptr_buf = get_buf("kv_indptr", inputs[5])?;
+                let r = kv_indptr_buf.len() / std::mem::size_of::<i32>();
+                anyhow::ensure!(
+                    r >= 2,
+                    "FlashInferAttention: kv_indptr holds {r} rows, need at least 2 \
+                 (one per sequence plus a terminator)"
+                );
                 // Host contents are read during prepare, where stream synchronization
                 // is allowed. The pointers are part of the capture signature.
                 (
@@ -1072,7 +1094,7 @@ impl HostOp for FlashInferAttention {
         self_node: NodeIndex,
         inputs: &[NodeIndex],
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         let resolved = self.resolve_for_graph(self_node, inputs, buffers, dyn_map)?;
         let ptrs = resolved.ptrs;
@@ -1104,7 +1126,7 @@ impl HostOp for FlashInferAttention {
         _self_node: NodeIndex,
         inputs: &[NodeIndex],
         buffer_lengths: &FxHashMap<NodeIndex, usize>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> Result<HostDeviceMemoryPlan, ResourceViolation> {
         let resource_spec = self.device_resource_spec(inputs, buffer_lengths, dyn_map, false)?;
         Ok(HostDeviceMemoryPlan {
@@ -1203,6 +1225,7 @@ mod resource_tests {
             head_dim: 64,
             page_size: 1,
             batch_dim: 1.into(),
+            context_dim: IntExpr::from('c'),
             dtype: DType::F16,
             sm_scale: 0.0,
             window_left: -1,
@@ -1214,7 +1237,7 @@ mod resource_tests {
             (inputs[1], 4096 * kv_row_bytes),
             (inputs[2], 4096 * kv_row_bytes),
         ]);
-        let dyn_map = FxHashMap::from_iter([('c', 100)]);
+        let dyn_map = FxHashMap::from_iter([(Symbol::from('c'), 100)]);
         let resident_before = resident_shared_device_memory_allocations();
 
         let spec = attention
@@ -1243,13 +1266,14 @@ mod resource_tests {
             head_dim: 64,
             page_size: 1,
             batch_dim: 1.into(),
+            context_dim: IntExpr::from('c'),
             dtype: DType::F16,
             sm_scale: 0.0,
             window_left: -1,
             plan_info: Mutex::new(Vec::new()),
         };
         let inputs = (0..4).map(NodeIndex::new).collect_vec();
-        let dyn_map = FxHashMap::from_iter([('c', 100)]);
+        let dyn_map = FxHashMap::from_iter([(Symbol::from('c'), 100)]);
         let uninstalled_lengths = FxHashMap::from_iter([(inputs[1], 0), (inputs[2], 0)]);
 
         let spec = attention
@@ -1277,6 +1301,7 @@ mod resource_tests {
             head_dim: 64,
             page_size: 1,
             batch_dim: 2.into(),
+            context_dim: IntExpr::from('c'),
             dtype: DType::F16,
             sm_scale: 0.0,
             window_left: -1,
@@ -1287,8 +1312,11 @@ mod resource_tests {
         let lengths = FxHashMap::from_iter([
             (inputs[1], 4096 * kv_row_bytes),
             (inputs[2], 4096 * kv_row_bytes),
+            // 3 CSR rows -> batch of 2. Supplied as the buffer's length, which
+            // is where the op reads it from.
+            (inputs[5], 3 * std::mem::size_of::<i32>()),
         ]);
-        let dyn_map = FxHashMap::from_iter([('c', 100), ('r', 3)]);
+        let dyn_map = FxHashMap::from_iter([(Symbol::from('c'), 100)]);
 
         let spec = attention
             .device_resource_spec(&inputs, &lengths, &dyn_map, true)

--- a/crates/luminal_cuda_lite_hlir/src/host/flashinfer/sink_attention.egg
+++ b/crates/luminal_cuda_lite_hlir/src/host/flashinfer/sink_attention.egg
@@ -75,7 +75,7 @@
 
 ; (out, q_bf16, k_pool, v_pool, flat_gather_idx, sinks_f32,
 ;  nheads, kvdim, hdim, scale, window_left)
-(relation sa_island (IR IR IR IR IR IR Expression Expression Expression f64 f64))
+(relation sa_island (IR IR IR IR IR IR Expression Expression Expression Expression f64 f64))
 
 (rule
     (
@@ -87,14 +87,14 @@
 
         ; ── Context gathers from both pools via ONE flat gather index ──
         (= ?k_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim (ENil)))
             ?kg_a
             (ECons ?nslots (ECons ?kvdim2 (ENil)))
             ?kg_b)
             (ICons ?flat_gidx (ICons ?k_pool (INil)))))
         (= ?k_ctx (Op (Cast ?kc_sz (F32)) (ICons ?k_gathered (INil))))
         (= ?v_gathered (Op (Gather
-            (ECons (MVar "c") (ECons ?kvdim3 (ENil)))
+            (ECons ?context_tokens (ECons ?kvdim3 (ENil)))
             ?vg_a
             (ECons ?nslots2 (ECons ?kvdim4 (ENil)))
             ?vg_b)
@@ -107,7 +107,7 @@
 
         ; ── Q·K^T: (nheads, s, c, hd) mul + reduce over hd ──
         (= ?qk (Op (Mul
-            (ECons ?nheads (ECons (MVar "s") (ECons (MVar "c") (ECons ?hdim (ENil)))))
+            (ECons ?nheads (ECons ?input_tokens (ECons ?context_tokens (ECons ?hdim (ENil)))))
             ?qk_a ?qk_b ?qk_o)
             (ICons ?q_f (ICons ?k_ctx (INil)))))
         (= ?scores (Op (Sum ?ss_shape ?hdim ?ss_in ?ss_iter ?ss_out)
@@ -118,7 +118,7 @@
         (sa_masked ?masked ?scores ?scale_val ?window_val)
 
         ; ── Row max, then max(row_max, sink) in the lt-select spelling ──
-        (= ?rmax (Op (Max ?rm_shape (MVar "c") ?rm_in ?rm_iter ?rm_out)
+        (= ?rmax (Op (Max ?rm_shape ?context_tokens ?rm_in ?rm_iter ?rm_out)
             (ICons ?masked (INil))))
         (= ?sinks_f (Op (Cast ?sk_sz (F32)) (ICons ?sinks_w (INil))))
         (= ?lt (Op (LessThan ?lt_s ?lt_a ?lt_b ?lt_o)
@@ -149,7 +149,7 @@
             (ICons ?shifted (ICons ?log2e_a (INil)))))
         (const_like ?log2e_a 1.442695)
         (= ?num (Op (Exp2 ?ex_s ?ex_in ?ex_out) (ICons ?sc2 (INil))))
-        (= ?numsum (Op (Sum ?ns_shape (MVar "c") ?ns_in ?ns_iter ?ns_out)
+        (= ?numsum (Op (Sum ?ns_shape ?context_tokens ?ns_in ?ns_iter ?ns_out)
             (ICons ?num (INil))))
 
         ; ── The sink joins the DENOMINATOR only ──
@@ -170,15 +170,15 @@
 
         ; ── P·V: (nheads, s, hd, c) mul + reduce over c → output point ──
         (= ?pv (Op (Mul
-            (ECons ?nheads2 (ECons (MVar "s") (ECons ?hdim2 (ECons (MVar "c") (ENil)))))
+            (ECons ?nheads2 (ECons ?input_tokens (ECons ?hdim2 (ECons ?context_tokens (ENil)))))
             ?pv_a ?pv_b ?pv_o)
             (ICons ?probs (ICons ?v_ctx (INil)))))
-        (= ?out (Op (Sum ?o_shape (MVar "c") ?o_in ?o_iter ?o_out)
+        (= ?out (Op (Sum ?o_shape ?context_tokens ?o_in ?o_iter ?o_out)
             (ICons ?pv (INil))))
     )
     (
         (sa_island ?out ?q_bf ?k_pool ?v_pool ?flat_gidx ?sinks_f
-            ?nheads ?kvdim ?hdim ?scale_val ?window_val)
+            ?nheads ?kvdim ?hdim ?input_tokens ?scale_val ?window_val)
     )
     :ruleset kernel_fuse_late
     :name "SinkAttention island fact"
@@ -188,13 +188,13 @@
 
 (rule
     (
-        (sa_island ?out ?q ?kp ?vp ?g ?s ?nheads ?kvdim ?hdim ?scale_val ?window_val)
+        (sa_island ?out ?q ?kp ?vp ?g ?s ?nheads ?kvdim ?hdim ?input_tokens ?scale_val ?window_val)
         (= ?qoi (Input ?qo_idx "qo_indptr" (Int)))
         (= ?kvi (Input ?kv_idx "kv_indptr" (Int)))
     )
     (
         (let ?fi (Op (SinkAttention
-            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MVar "s") ?scale_val ?window_val)
+            ?nheads (MDiv ?kvdim ?hdim) ?hdim ?input_tokens ?scale_val ?window_val)
             (ICons ?q (ICons ?kp (ICons ?vp (ICons ?g
                 (ICons ?qoi (ICons ?kvi (ICons ?s (INil))))))))))
         (union ?out ?fi)

--- a/crates/luminal_cuda_lite_hlir/src/host/flashinfer/sink_attention.rs
+++ b/crates/luminal_cuda_lite_hlir/src/host/flashinfer/sink_attention.rs
@@ -174,7 +174,7 @@ impl HostOp for SinkAttention {
         self_node: NodeIndex,
         inputs: &[NodeIndex],
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        _dyn_map: &FxHashMap<char, usize>,
+        _dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         anyhow::ensure!(
             inputs.len() == 7,

--- a/crates/luminal_cuda_lite_hlir/src/host/mod.rs
+++ b/crates/luminal_cuda_lite_hlir/src/host/mod.rs
@@ -144,7 +144,7 @@ pub trait HostOp: Debug + as_any::AsAny + EgglogOp {
         self_node: NodeIndex,
         inputs: &[NodeIndex],
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()>;
 
     /// Returns the output buffer size in elements.
@@ -198,7 +198,7 @@ pub trait HostOp: Debug + as_any::AsAny + EgglogOp {
         _self_node: NodeIndex,
         _inputs: &[NodeIndex],
         _buffer_lengths: &FxHashMap<NodeIndex, usize>,
-        _dyn_map: &FxHashMap<char, usize>,
+        _dyn_map: &DynMap,
     ) -> Result<HostDeviceMemoryPlan, ResourceViolation> {
         Ok(HostDeviceMemoryPlan::default())
     }

--- a/crates/luminal_cuda_lite_hlir/src/host/moe/fused.rs
+++ b/crates/luminal_cuda_lite_hlir/src/host/moe/fused.rs
@@ -147,7 +147,7 @@ impl HostOp for FusedMoE {
         self_node: NodeIndex,
         inputs: &[NodeIndex],
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         if inputs.len() < 9 {
             anyhow::bail!("FusedMoE expected 9 inputs, got {}", inputs.len());

--- a/crates/luminal_cuda_lite_hlir/src/host/moe/mod.rs
+++ b/crates/luminal_cuda_lite_hlir/src/host/moe/mod.rs
@@ -301,7 +301,7 @@ impl HostOp for GLUMoE {
         self_node: NodeIndex,
         inputs: &[NodeIndex],
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         if inputs.len() < 6 {
             anyhow::bail!("GLUMoE expected at least 6 inputs, got {}", inputs.len());
@@ -681,7 +681,7 @@ impl HostOp for GLUMoE {
         _self_node: NodeIndex,
         _inputs: &[NodeIndex],
         _buffer_lengths: &FxHashMap<NodeIndex, usize>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> Result<HostDeviceMemoryPlan, ResourceViolation> {
         let x_bf16 = eval_resource_expression(
             IntExpr::from('s') * self.gu_matmul_k * 2,

--- a/crates/luminal_cuda_lite_hlir/src/kernel/argmax.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/argmax.rs
@@ -146,7 +146,7 @@ impl KernelOp for KernelArgmax {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .out_shape

--- a/crates/luminal_cuda_lite_hlir/src/kernel/conv2d.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/conv2d.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use cudarc::driver::{CudaFunction, CudaModule, CudaSlice, CudaStream};
-use luminal::prelude::FxHashMap;
+use luminal::prelude::{FxHashMap, Symbol};
 use luminal::{
     dtype::DType,
     egglog_utils::{
@@ -717,11 +717,11 @@ impl KernelOp for KernelConv2D {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         assert_eq!(self.dtype, DType::F32, "KernelConv2D currently emits F32");
 
-        let vars: FxHashSet<char> = self
+        let vars: FxHashSet<Symbol> = self
             .out_shape
             .iter()
             .chain(&self.input_shape)
@@ -779,8 +779,7 @@ impl KernelOp for KernelConv2D {
         let pad_w = self.pad_w.to_kernel();
         let out_idx = flatten_strides(&self.out_shape, &self.out_stride).to_kernel();
         let input_idx = flatten_strides(&self.input_shape, &self.input_stride)
-            .to_kernel()
-            .replace("const_z", "input_linear");
+            .to_kernel_with_index("input_linear");
         let n_outputs: IntExpr = self.out_shape.iter().copied().product();
 
         let kernel = format!(
@@ -867,7 +866,7 @@ extern \"C\" {{
         self.out_shape.iter().copied().product()
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.out_shape
             .iter()
             .chain(&self.input_shape)

--- a/crates/luminal_cuda_lite_hlir/src/kernel/fusion/elementwise.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/fusion/elementwise.rs
@@ -30,7 +30,7 @@ type CompileOut = (
     (IntExpr, IntExpr, IntExpr),
     (IntExpr, IntExpr, IntExpr),
     IntExpr,
-    FxHashMap<char, CudaSlice<u8>>,
+    FxHashMap<Symbol, CudaSlice<u8>>,
 );
 
 fn extract_string_label(egraph: &SerializedEGraph, node: &ENodeId) -> String {

--- a/crates/luminal_cuda_lite_hlir/src/kernel/fusion/markers.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/fusion/markers.rs
@@ -38,7 +38,7 @@ type CompileOut = (
     (IntExpr, IntExpr, IntExpr),
     (IntExpr, IntExpr, IntExpr),
     IntExpr,
-    FxHashMap<char, CudaSlice<u8>>,
+    FxHashMap<Symbol, CudaSlice<u8>>,
 );
 
 // =========================================================================

--- a/crates/luminal_cuda_lite_hlir/src/kernel/fusion/region_codegen.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/fusion/region_codegen.rs
@@ -170,7 +170,7 @@ struct FusionValidationCache {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 enum CanonicalSemanticExpression {
     Number(i64),
-    Variable(char),
+    Variable(Symbol),
     Binary(u8, Box<Self>, Box<Self>),
     AssociativeCommutative(u8, Vec<Self>),
 }
@@ -345,7 +345,7 @@ fn fusion_unary_dtype_supported(op: &str, dtype: DType) -> bool {
 fn expression_relation(
     lhs: IntExpr,
     rhs: IntExpr,
-    dyn_map: Option<&FxHashMap<char, usize>>,
+    dyn_map: Option<&DynMap>,
     z_witnesses: &[usize],
     exhaustive: bool,
     cache: &mut FusionValidationCache,
@@ -423,7 +423,7 @@ fn expression_relation(
         let mut different = false;
         for &z in z_witnesses {
             let mut values = concrete_map.clone();
-            values.insert('z', z);
+            values.insert(Symbol::reserved_index(), z);
             match (
                 eval_expression(lhs_simplified, &values),
                 eval_expression(rhs_simplified, &values),
@@ -462,7 +462,7 @@ fn expression_relation(
     relation
 }
 
-fn eval_expression(expression: IntExpr, values: &FxHashMap<char, usize>) -> Option<usize> {
+fn eval_expression(expression: IntExpr, values: &DynMap) -> Option<usize> {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| expression.exec(values)))
         .ok()
         .flatten()
@@ -471,7 +471,7 @@ fn eval_expression(expression: IntExpr, values: &FxHashMap<char, usize>) -> Opti
 fn layout_relation(
     lhs: FusionLayout<'_>,
     rhs: FusionLayout<'_>,
-    dyn_map: Option<&FxHashMap<char, usize>>,
+    dyn_map: Option<&DynMap>,
     cache: &mut FusionValidationCache,
 ) -> SemanticRelation {
     debug_assert_eq!(lhs.shape.len(), lhs.strides.len());
@@ -544,7 +544,7 @@ fn require_layout_compatible(
     input_slot: usize,
     produced: FusionLayout<'_>,
     expected: FusionLayout<'_>,
-    dyn_map: Option<&FxHashMap<char, usize>>,
+    dyn_map: Option<&DynMap>,
     cache: &mut FusionValidationCache,
 ) -> Result<(), FusionValidationError> {
     match layout_relation(produced, expected, dyn_map, cache) {
@@ -586,7 +586,7 @@ fn incoming_nodes(llir: &LLIRGraph, node: NodeIndex) -> Vec<NodeIndex> {
 /// rejected as an unsupported layout because codegen erases that metadata.
 pub(crate) fn validate_fusion_regions(
     llir: &LLIRGraph,
-    dyn_map: Option<&FxHashMap<char, usize>>,
+    dyn_map: Option<&DynMap>,
 ) -> Result<(), FusionValidationError> {
     let mut validation_cache = FusionValidationCache::default();
     for node in llir.node_indices() {
@@ -1429,7 +1429,7 @@ pub(crate) struct CompiledRegion {
     pub grid: (IntExpr, IntExpr, IntExpr),
     pub block: (IntExpr, IntExpr, IntExpr),
     pub shared_mem: IntExpr,
-    pub constants: FxHashMap<char, CudaSlice<u8>>,
+    pub constants: FxHashMap<Symbol, CudaSlice<u8>>,
 }
 
 /// Generate the fused kernel source plus launch geometry for a region.
@@ -1454,7 +1454,7 @@ pub(crate) fn region_kernel_source(
     // Aggregate all dynamic vars used anywhere in the region (FS strides,
     // FE strides and elementwise shapes.
     // own strides are likewise relevant for any future stride-affine ops).
-    let mut all_vars: FxHashSet<char> = FxHashSet::default();
+    let mut all_vars: FxHashSet<Symbol> = FxHashSet::default();
     all_vars.extend(out_shape.iter().flat_map(|e| e.dyn_vars()));
     all_vars.extend(out_strides.iter().flat_map(|e| e.dyn_vars()));
     for &fs_idx in &region.fs_nodes {
@@ -1815,7 +1815,13 @@ mod tests {
         llir.add_edge(fs, sin, ());
         llir.add_edge(sin, fe, ());
 
-        let dims = [('a', 2), ('b', 3), ('c', 4)].into_iter().collect();
+        let dims = [
+            (Symbol::from('a'), 2),
+            (Symbol::from('b'), 3),
+            (Symbol::from('c'), 4),
+        ]
+        .into_iter()
+        .collect();
         validate_fusion_regions(&llir, Some(&dims)).unwrap();
     }
 
@@ -1852,7 +1858,9 @@ mod tests {
         llir.add_edge(fs, sin, ());
         llir.add_edge(sin, fe, ());
 
-        let representative = [('a', 16), ('b', 16)].into_iter().collect();
+        let representative = [(Symbol::from('a'), 16), (Symbol::from('b'), 16)]
+            .into_iter()
+            .collect();
         let error = validate_fusion_regions(&llir, Some(&representative)).unwrap_err();
         assert!(error.reason.contains("could not be proved"));
     }

--- a/crates/luminal_cuda_lite_hlir/src/kernel/gemv.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/gemv.rs
@@ -168,7 +168,7 @@ impl KernelOp for KernelGemv {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .n
@@ -479,7 +479,7 @@ impl KernelOp for KernelGemvF8 {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .n

--- a/crates/luminal_cuda_lite_hlir/src/kernel/generic_matmul.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/generic_matmul.rs
@@ -316,7 +316,7 @@ impl KernelOp for GenericMatmul {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self.all_dyn_vars();
         let dtype = cuda_dtype(self.dtype);
@@ -330,13 +330,11 @@ impl KernelOp for GenericMatmul {
 
         let n_outputs = self.output_size();
         let sum_base_idx = flatten_strides(&self.out_shape, &self.sum_input_strides).to_kernel();
-        let iter_offset = self.sum_iter_stride.to_kernel().replace("const_z", "i");
-        let lhs_idx = flatten_strides(&self.mul_shape, &self.lhs_strides)
-            .to_kernel()
-            .replace("const_z", "mul_idx");
-        let rhs_idx = flatten_strides(&self.mul_shape, &self.rhs_strides)
-            .to_kernel()
-            .replace("const_z", "mul_idx");
+        let iter_offset = self.sum_iter_stride.to_kernel_with_index("i");
+        let lhs_idx =
+            flatten_strides(&self.mul_shape, &self.lhs_strides).to_kernel_with_index("mul_idx");
+        let rhs_idx =
+            flatten_strides(&self.mul_shape, &self.rhs_strides).to_kernel_with_index("mul_idx");
         let out_idx = flatten_strides(&self.out_shape, &self.out_strides).to_kernel();
         let k = self.k.to_kernel();
 
@@ -421,7 +419,7 @@ extern \"C\" {{
             .max(IntExpr::from(1))
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.out_shape
             .iter()
             .flat_map(|e| e.dyn_vars())

--- a/crates/luminal_cuda_lite_hlir/src/kernel/hlir.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/hlir.rs
@@ -153,7 +153,7 @@ impl KernelOp for KernelMaxReduce {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .out_shape
@@ -188,7 +188,7 @@ impl KernelOp for KernelMaxReduce {
             ", const int* dyn_dims"
         };
 
-        let iter_stride_of_i = self.iter_stride.to_kernel().replace("const_z", "i");
+        let iter_stride_of_i = self.iter_stride.to_kernel_with_index("i");
         let load_value = if low_precision_storage {
             format!("static_cast<float>(in[in_start + {iter_stride_of_i}])")
         } else {
@@ -385,7 +385,7 @@ impl KernelOp for KernelSumReduce {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .out_shape
@@ -416,7 +416,7 @@ impl KernelOp for KernelSumReduce {
             ", const int* dyn_dims"
         };
 
-        let iter_stride_of_i = self.iter_stride.to_kernel().replace("const_z", "i");
+        let iter_stride_of_i = self.iter_stride.to_kernel_with_index("i");
         let load_value = if uses_fp8_storage {
             format!("static_cast<float>(in_data[in_start + {iter_stride_of_i}])")
         } else {
@@ -643,7 +643,7 @@ impl KernelOp for KernelCastSumReduce {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .out_shape
@@ -666,7 +666,7 @@ impl KernelOp for KernelCastSumReduce {
             ", const int* dyn_dims"
         };
 
-        let iter_stride_of_i = self.iter_stride.to_kernel().replace("const_z", "i");
+        let iter_stride_of_i = self.iter_stride.to_kernel_with_index("i");
 
         let kernel = format!(
             "{includes}
@@ -903,7 +903,7 @@ impl KernelOp for KernelGather {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .out_shape
@@ -969,7 +969,7 @@ extern \"C\" {{
         self.out_shape.iter().copied().product()
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.out_shape
             .iter()
             .flat_map(|e| e.dyn_vars())
@@ -1144,9 +1144,9 @@ impl KernelOp for KernelScatter {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
-        let all_vars: FxHashSet<char> = self
+        let all_vars: FxHashSet<Symbol> = self
             .dest_shape
             .iter()
             .flat_map(|e| e.dyn_vars())
@@ -1235,7 +1235,7 @@ extern \"C\" {{
         self.dest_shape.iter().copied().product()
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.dest_shape
             .iter()
             .flat_map(|e| e.dyn_vars())
@@ -1387,7 +1387,7 @@ impl KernelOp for KernelIota {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let mut vars = self.expr.dyn_vars().into_iter().collect::<FxHashSet<_>>();
         vars.extend(self.range.dyn_vars());
@@ -1533,7 +1533,7 @@ impl KernelOp for KernelMod {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .out_shape
@@ -1711,7 +1711,7 @@ impl KernelOp for KernelLessThan {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .out_shape
@@ -1894,7 +1894,7 @@ impl KernelOp for KernelConstant {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let value_str = if self.value.is_nan() {
             "__int_as_float(0x7fc00000)".to_string()
@@ -2042,7 +2042,7 @@ impl KernelOp for KernelCast {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let out_dtype = cuda_dtype(self.out_dtype);
         let includes = dtype_includes(&[self.in_dtype, self.out_dtype]);
@@ -2147,11 +2147,11 @@ extern \"C\" {{
 /// This ensures all kernels in a CudaGraphOp use consistent indices into the shared
 /// dyn_dims buffer.
 thread_local! {
-    static GLOBAL_DYN_DIMS: std::cell::RefCell<Option<Vec<char>>> = const { std::cell::RefCell::new(None) };
+    static GLOBAL_DYN_DIMS: std::cell::RefCell<Option<Vec<Symbol>>> = const { std::cell::RefCell::new(None) };
 }
 
 /// Set the global dyn dims ordering for subsequent kernel compilations.
-pub fn set_global_dyn_dims(dims: Vec<char>) {
+pub fn set_global_dyn_dims(dims: Vec<Symbol>) {
     GLOBAL_DYN_DIMS.with(|g| *g.borrow_mut() = Some(dims));
 }
 
@@ -2161,7 +2161,7 @@ pub fn clear_global_dyn_dims() {
 }
 
 /// Get the current global dyn dims ordering.
-pub fn get_global_dyn_dims() -> Option<Vec<char>> {
+pub fn get_global_dyn_dims() -> Option<Vec<Symbol>> {
     GLOBAL_DYN_DIMS.with(|g| g.borrow().clone())
 }
 
@@ -2171,7 +2171,7 @@ pub fn get_global_dyn_dims() -> Option<Vec<char>> {
 ///
 /// When a global dyn dims ordering is set (via `set_global_dyn_dims`), indices are based
 /// on the global ordering to ensure consistency across kernels sharing a dyn_dims buffer.
-pub fn generate_dyn_dims_defines(vars: &FxHashSet<char>) -> (String, Vec<char>) {
+pub fn generate_dyn_dims_defines(vars: &FxHashSet<Symbol>) -> (String, Vec<Symbol>) {
     if vars.is_empty() {
         return (String::new(), Vec::new());
     }
@@ -2200,28 +2200,22 @@ pub fn generate_dyn_dims_defines(vars: &FxHashSet<char>) -> (String, Vec<char>) 
                     .iter()
                     .position(|d| d == dim)
                     .expect("Dim must be in global ordering after extension");
-                format!("#define const_{dim} dyn_dims[{idx}]")
+                format!("#define {} dyn_dims[{idx}]", kernel_const_name(dim))
             })
             .collect::<Vec<_>>()
             .join("\n");
         return (defines, global_order);
     }
     // Default: local ordering
-    let mut sorted_dims: Vec<char> = vars.iter().copied().collect();
+    let mut sorted_dims: Vec<Symbol> = vars.iter().copied().collect();
     sorted_dims.sort();
     let defines = sorted_dims
         .iter()
         .enumerate()
-        .map(|(idx, dim)| format!("#define const_{dim} dyn_dims[{idx}]"))
+        .map(|(idx, dim)| format!("#define {} dyn_dims[{idx}]", kernel_const_name(dim)))
         .collect::<Vec<_>>()
         .join("\n");
     (defines, sorted_dims)
-}
-
-/// Get the offset for a dynamic dimension in the shared dyn_dims buffer.
-/// Returns None if the dim is not in the set.
-pub fn get_dyn_dim_offset(dim: char, sorted_dims: &[char]) -> Option<usize> {
-    sorted_dims.iter().position(|&d| d == dim)
 }
 
 #[derive(Default, Debug, Clone)]
@@ -2486,7 +2480,7 @@ impl KernelOp for KernelEmbed {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let batch_size = self
             .batch_shape

--- a/crates/luminal_cuda_lite_hlir/src/kernel/matmul2d.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/matmul2d.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 use cudarc::driver::{CudaFunction, CudaModule, CudaSlice, CudaStream};
 use luminal::{
     dtype::DType, op::CustomOp, op::LLIROp, prelude::FxHashMap, prelude::GraphTensor,
-    shape::IntExpr,
+    prelude::Symbol, shape::IntExpr,
 };
 
 use crate::compile_module_image_for_current_device;
@@ -79,7 +79,7 @@ impl KernelOp for Matmul2DKernel {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let bias_param = if self.has_bias {
             ", const float* __restrict__ bias"

--- a/crates/luminal_cuda_lite_hlir/src/kernel/mod.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/mod.rs
@@ -211,7 +211,7 @@ pub trait KernelOp: std::fmt::Debug + as_any::AsAny {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     );
 
     /// Returns the output buffer size in elements.
@@ -220,7 +220,7 @@ pub trait KernelOp: std::fmt::Debug + as_any::AsAny {
     /// Returns all dynamic variables used by this kernel (for grid dims, strides, etc).
     /// Default: returns dyn vars from output_size(). Override if the kernel has dyn vars
     /// in expressions not captured by output_size (e.g., KernelScatter's index_shape).
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.output_size().dyn_vars().into_iter().collect()
     }
 
@@ -259,7 +259,7 @@ pub trait KernelOp: std::fmt::Debug + as_any::AsAny {
     fn allocate_internal_buffers(
         &self,
         _stream: &Arc<CudaStream>,
-        _dyn_map: &FxHashMap<char, usize>,
+        _dyn_map: &DynMap,
     ) -> Vec<CudaSlice<u8>> {
         vec![]
     }
@@ -267,7 +267,7 @@ pub trait KernelOp: std::fmt::Debug + as_any::AsAny {
     /// Returns the set of dynamic dimensions that affect internal buffer sizes.
     /// When any of these dimensions change, internal buffers should be reallocated.
     /// Default: empty set (no dimensions affect internal buffers).
-    fn internal_buffer_dyn_dims(&self) -> FxHashSet<char> {
+    fn internal_buffer_dyn_dims(&self) -> FxHashSet<Symbol> {
         FxHashSet::default()
     }
 
@@ -310,9 +310,9 @@ pub trait KernelOp: std::fmt::Debug + as_any::AsAny {
         &self,
         _stream: &Arc<CudaStream>,
         _internal_bufs: &mut [CudaSlice<u8>],
-        _constants: &mut FxHashMap<char, CudaSlice<u8>>,
+        _constants: &mut FxHashMap<Symbol, CudaSlice<u8>>,
         _all_buffer_ptrs: &FxHashMap<NodeIndex, u64>,
-        _dyn_map: &FxHashMap<char, usize>,
+        _dyn_map: &DynMap,
     ) {
     }
 

--- a/crates/luminal_cuda_lite_hlir/src/kernel/moe_gemv.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/moe_gemv.rs
@@ -215,12 +215,12 @@ impl KernelOp for KernelMoEGemv {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let (s, k, o, d, e, xs_s, xs_k, ts_s, ts_k) = self.dims();
         let includes = dtype_includes(&[DType::Bf16]);
 
-        let vars: FxHashSet<char> = s.dyn_vars().into_iter().collect();
+        let vars: FxHashSet<Symbol> = s.dyn_vars().into_iter().collect();
         let (dyn_defines, _sorted) = generate_dyn_dims_defines(&vars);
         let dyn_dims_param = if vars.is_empty() {
             ""
@@ -332,7 +332,7 @@ extern \"C\" {{
         DType::F32
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.out_shape[0].dyn_vars().into_iter().collect()
     }
 

--- a/crates/luminal_cuda_lite_hlir/src/kernel/other_ops.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/other_ops.rs
@@ -105,7 +105,7 @@ impl KernelOp for KernelMeanReduce {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self
             .out_shape
@@ -386,9 +386,9 @@ impl KernelOp for KernelScatterNoCopy {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
-        let all_vars: FxHashSet<char> = self
+        let all_vars: FxHashSet<Symbol> = self
             .dest_shape
             .iter()
             .flat_map(|e| e.dyn_vars())
@@ -461,7 +461,7 @@ extern \"C\" {{
         self.dest_shape.iter().copied().product()
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.dest_shape
             .iter()
             .flat_map(|e| e.dyn_vars())

--- a/crates/luminal_cuda_lite_hlir/src/kernel/quant_f8.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/quant_f8.rs
@@ -102,7 +102,7 @@ impl KernelOp for KernelQuantF8 {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let vars = self.size.dyn_vars().into_iter().collect::<FxHashSet<_>>();
         let includes = dtype_includes(&[DType::Bf16, DType::F8E4M3]);

--- a/crates/luminal_cuda_lite_hlir/src/kernel/rms_norm.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/rms_norm.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use cudarc::driver::{CudaFunction, CudaModule, CudaSlice, CudaStream};
 use luminal::{
     dtype::DType, op::CustomOp, op::LLIROp, prelude::FxHashMap, prelude::GraphTensor,
-    shape::IntExpr,
+    prelude::Symbol, shape::IntExpr,
 };
 
 use crate::compile_module_image_for_current_device;
@@ -44,7 +44,7 @@ impl KernelOp for RMSNormKernel {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let cols = self.cols;
         let eps = self.eps;
@@ -248,7 +248,7 @@ impl KernelOp for RMSNormQuantKernel {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let cols = self.cols;
         let eps = self.eps;

--- a/crates/luminal_cuda_lite_hlir/src/kernel/rope.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/rope.rs
@@ -19,7 +19,7 @@ use luminal::{
     dtype::DType,
     egglog_utils::list_to_egglog,
     op::{CustomOp, HLIROp, LLIROp},
-    prelude::{FxHashMap, FxHashSet, GraphTensor, NodeIndex, ShapeTracker},
+    prelude::{DynMap, FxHashMap, FxHashSet, GraphTensor, NodeIndex, ShapeTracker, Symbol},
     shape::IntExpr,
 };
 
@@ -47,7 +47,7 @@ impl KernelOp for RoPEKernel {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let s = self.s;
         let h = self.h;
@@ -341,7 +341,7 @@ impl KernelOp for RoPEHalfKernel {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let h = self.h;
         let d = self.d;
@@ -648,7 +648,7 @@ impl KernelOp for RoPEScatterKernel {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let h = self.rope.h;
         let d = self.rope.d;
@@ -658,7 +658,7 @@ impl KernelOp for RoPEScatterKernel {
         let ty = crate::cuda_dtype(self.rope.dtype);
         let includes = crate::kernel::hlir::dtype_includes(&[self.rope.dtype]);
 
-        let vars: FxHashSet<char> = self
+        let vars: FxHashSet<Symbol> = self
             .idx_flat
             .dyn_vars()
             .into_iter()
@@ -780,7 +780,7 @@ extern "C" __global__ void rope_scatter_kernel(
         true
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.idx_flat
             .dyn_vars()
             .into_iter()
@@ -1117,7 +1117,7 @@ impl KernelOp for KernelRoPE {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let heads = self.out_shape[0].to_usize().expect("RoPE heads is static");
         let seq = self.out_shape[1];
@@ -1129,7 +1129,7 @@ impl KernelOp for KernelRoPE {
         let lnt = self.ln_theta as f32;
         let inv_hd = self.inv_hd as f32;
 
-        let vars: FxHashSet<char> = seq.dyn_vars().into_iter().collect();
+        let vars: FxHashSet<Symbol> = seq.dyn_vars().into_iter().collect();
         let (dyn_defines, _sorted) = crate::kernel::hlir::generate_dyn_dims_defines(&vars);
         let dyn_dims_param = if vars.is_empty() {
             ""
@@ -1219,7 +1219,7 @@ extern \"C\" {{
         DType::Bf16
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.out_shape[1].dyn_vars().into_iter().collect()
     }
 
@@ -1393,7 +1393,7 @@ impl KernelOp for KernelRoPEScatterFused {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let heads = self.rope.out_shape[0]
             .to_usize()
@@ -1408,7 +1408,7 @@ impl KernelOp for KernelRoPEScatterFused {
         let inv_hd = self.rope.inv_hd as f32;
         let kvd = heads * hd;
 
-        let vars: FxHashSet<char> = self.all_dyn_vars();
+        let vars: FxHashSet<Symbol> = self.all_dyn_vars();
         let (dyn_defines, _sorted) = crate::kernel::hlir::generate_dyn_dims_defines(&vars);
         let dyn_dims_param = if vars.is_empty() {
             ""
@@ -1514,7 +1514,7 @@ extern \"C\" {{
         true
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.idx_flat
             .dyn_vars()
             .into_iter()

--- a/crates/luminal_cuda_lite_hlir/src/kernel/swiglu.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/swiglu.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use cudarc::driver::{CudaFunction, CudaModule, CudaSlice, CudaStream};
 use luminal::{
     dtype::DType, op::CustomOp, op::LLIROp, prelude::FxHashMap, prelude::GraphTensor,
-    shape::IntExpr,
+    prelude::Symbol, shape::IntExpr,
 };
 
 use crate::compile_module_image_for_current_device;
@@ -39,7 +39,7 @@ impl KernelOp for SwigluKernel {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let i = self.intermediate;
         let ty = crate::cuda_dtype(self.dtype);
@@ -190,7 +190,7 @@ impl KernelOp for SwigluQuantKernel {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let i = self.intermediate;
         let ty = crate::cuda_dtype(self.dtype);

--- a/crates/luminal_cuda_lite_hlir/src/kernel/to_host.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/to_host.rs
@@ -87,11 +87,11 @@ struct CompiledKernel {
     /// Whether this compiled CUDA function has a trailing dyn_dims parameter.
     has_dyn_dims_param: bool,
     /// Dynamic dimensions that can affect launch dimensions, params, or code.
-    dyn_vars: FxHashSet<char>,
+    dyn_vars: FxHashSet<Symbol>,
     /// Internal buffers allocated for this kernel
     internal_bufs: Vec<CudaSlice<u8>>,
     /// Device constants from compile()
-    constants: FxHashMap<char, CudaSlice<u8>>,
+    constants: FxHashMap<Symbol, CudaSlice<u8>>,
     /// Graph node handle (set after graph is built)
     graph_node: Option<CUgraphNode>,
     /// Kernel name for profiling
@@ -231,7 +231,7 @@ impl RecaptureProfile {
         duration.as_secs_f64() * 1e3
     }
 
-    fn print(&self, dyn_map: &FxHashMap<char, usize>, kernels: usize, cublaslt: usize) {
+    fn print(&self, dyn_map: &DynMap, kernels: usize, cublaslt: usize) {
         if !self.enabled || (self.pending_count == 0 && self.materialize_total.is_zero()) {
             return;
         }
@@ -350,7 +350,7 @@ impl CompiledKernel {
         input_labels: Vec<String>,
         kernel_op: Arc<Box<dyn KernelOp>>,
         has_dyn_dims_param: bool,
-        constants: FxHashMap<char, CudaSlice<u8>>,
+        constants: FxHashMap<Symbol, CudaSlice<u8>>,
         kernel_name: &'static str,
         source_bytes: Option<usize>,
     ) -> Self {
@@ -441,7 +441,7 @@ struct CudaGraphOpState {
     /// Kernel params for each kernel
     kernel_params: Vec<UnifiedKernelParams>,
     /// Last dynamic dimension values (for change detection)
-    last_dyn_values: FxHashMap<char, usize>,
+    last_dyn_values: DynMap,
     /// Last buffer pointers (for change detection)
     last_buffer_ptrs: FxHashMap<NodeIndex, u64>,
     /// Timing events for profiling
@@ -499,7 +499,7 @@ pub struct CudaGraphOp {
     /// Buffer size requirements for extra nodes (node -> size in elements)
     buffer_sizes: FxHashMap<NodeIndex, IntExpr>,
     /// Dynamic dimensions used by this graph (sorted alphabetically)
-    dyn_dims_order: Vec<char>,
+    dyn_dims_order: Vec<Symbol>,
     /// The CUDA stream (needed for operations)
     stream: Arc<CudaStream>,
     /// Nonblocking stream used only for narrow cuBLASLt graph captures.
@@ -512,7 +512,7 @@ impl CudaGraphOp {
     fn new(
         buffer_nodes: Vec<NodeIndex>,
         buffer_sizes: FxHashMap<NodeIndex, IntExpr>,
-        dyn_dims_order: Vec<char>,
+        dyn_dims_order: Vec<Symbol>,
         stream: Arc<CudaStream>,
         capture_stream: Option<Arc<CudaStream>>,
         state: CudaGraphOpState,
@@ -604,7 +604,7 @@ impl CudaGraphOp {
     /// not consume search trials. It does not assign a cost to legal kernels.
     pub(crate) fn resource_plans(
         &self,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> Result<Vec<KernelResourcePlan>, ResourceViolation> {
         self.state
             .borrow()
@@ -661,14 +661,14 @@ impl CudaGraphOp {
             .collect()
     }
 
-    pub(crate) fn resource_dyn_dims(&self) -> &[char] {
+    pub(crate) fn resource_dyn_dims(&self) -> &[Symbol] {
         &self.dyn_dims_order
     }
 
     fn host_device_memory_plan(
         &self,
         buffer_lengths: &FxHashMap<NodeIndex, usize>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> Result<HostDeviceMemoryPlan, ResourceViolation> {
         let state = self.state.borrow();
         let mut persistent_bytes = self
@@ -859,7 +859,7 @@ impl HostOp for CudaGraphOp {
         _self_node: NodeIndex,
         _inputs: &[NodeIndex],
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         self.execute_internal(stream, buffers, dyn_map)
     }
@@ -879,7 +879,7 @@ impl HostOp for CudaGraphOp {
         _self_node: NodeIndex,
         _inputs: &[NodeIndex],
         buffer_lengths: &FxHashMap<NodeIndex, usize>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> Result<HostDeviceMemoryPlan, ResourceViolation> {
         self.host_device_memory_plan(buffer_lengths, dyn_map)
     }
@@ -1293,10 +1293,7 @@ impl CudaGraphOp {
         }
     }
 
-    fn kernel_requires_output_buffer(
-        kernel: &CompiledKernel,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> bool {
+    fn kernel_requires_output_buffer(kernel: &CompiledKernel, dyn_map: &DynMap) -> bool {
         kernel.kernel_op.output_size().exec(dyn_map).unwrap_or(1) != 0
             && kernel.kernel_op.output_aliases_input().is_none()
     }
@@ -1305,7 +1302,7 @@ impl CudaGraphOp {
         kernel: &CompiledKernel,
         output_ptr: u64,
         input_ptrs: &[u64],
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         if Self::kernel_requires_output_buffer(kernel, dyn_map) && output_ptr == 0 {
             anyhow::bail!(
@@ -1342,7 +1339,7 @@ impl CudaGraphOp {
     /// untouched — a dim change does not dirty it. (The process-global
     /// cuBLASLt heuristic cache is deliberately kept: purging it would fight
     /// autotune and its query is not the dominant transition cost.)
-    pub(crate) fn assume_dyn_dims_stale(&self, stale_dims: &[char]) {
+    pub(crate) fn assume_dyn_dims_stale(&self, stale_dims: &[Symbol]) {
         let mut state = self.state.borrow_mut();
         for dim in stale_dims {
             state.last_dyn_values.remove(dim);
@@ -1548,7 +1545,7 @@ impl CudaGraphOp {
         &self,
         stream: &Arc<CudaStream>,
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         let materialize_start = Instant::now();
         let mut profile = RecaptureProfile::new();
@@ -2116,7 +2113,7 @@ impl CudaGraphOp {
         &self,
         stream: &Arc<CudaStream>,
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         self.materialize(stream, buffers, dyn_map)?;
 
@@ -2548,7 +2545,7 @@ impl CudaGraphOp {
         state: &mut std::cell::RefMut<'_, CudaGraphOpState>,
         stream: &Arc<CudaStream>,
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         let ctx = stream.context().clone();
         let mut graph = CudaGraphHandle::new(ctx.clone())?;
@@ -3032,7 +3029,7 @@ pub fn kernel_to_host(
         }
 
         // Set global dyn dims ordering so compiles use consistent indices
-        let mut global_dyn_dims: Vec<char> = all_dyn_dims.iter().copied().collect();
+        let mut global_dyn_dims: Vec<Symbol> = all_dyn_dims.iter().copied().collect();
         global_dyn_dims.sort();
         set_global_dyn_dims(global_dyn_dims.clone());
 
@@ -3296,10 +3293,10 @@ pub fn kernel_to_host(
         clear_global_dyn_dims();
 
         // Use the final global ordering if it was extended during compilation
-        let mut dyn_dims_order: Vec<char> = if let Some(final_order) = final_global {
+        let mut dyn_dims_order: Vec<Symbol> = if let Some(final_order) = final_global {
             final_order
         } else {
-            let mut dims: Vec<char> = all_dyn_dims.into_iter().collect();
+            let mut dims: Vec<Symbol> = all_dyn_dims.into_iter().collect();
             dims.sort();
             dims
         };

--- a/crates/luminal_cuda_lite_hlir/src/kernel/topk.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/topk.rs
@@ -200,13 +200,13 @@ impl KernelOp for KernelStableSortIdx {
         (IntExpr, IntExpr, IntExpr),
         (IntExpr, IntExpr, IntExpr),
         IntExpr,
-        FxHashMap<char, CudaSlice<u8>>,
+        FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
         let rows = self.out_shape[0];
         let e = self.out_shape[1].to_usize().expect("ranks E is static");
         assert!(e <= 1024, "stable ranks kernel supports E <= 1024");
 
-        let vars: FxHashSet<char> = rows.dyn_vars().into_iter().collect();
+        let vars: FxHashSet<Symbol> = rows.dyn_vars().into_iter().collect();
         let (dyn_defines, _sorted) = generate_dyn_dims_defines(&vars);
         let dyn_dims_param = if vars.is_empty() {
             ""
@@ -285,7 +285,7 @@ extern \"C\" {{
         DType::Int
     }
 
-    fn all_dyn_vars(&self) -> FxHashSet<char> {
+    fn all_dyn_vars(&self) -> FxHashSet<Symbol> {
         self.out_shape[0].dyn_vars().into_iter().collect()
     }
 

--- a/crates/luminal_cuda_lite_hlir/src/resource.rs
+++ b/crates/luminal_cuda_lite_hlir/src/resource.rs
@@ -23,7 +23,7 @@ use luminal::{
     graph::LLIRGraph,
     hlir::Output,
     prelude::{
-        FxHashMap, FxHashSet, IntExpr, NodeIndex,
+        DynMap, IntExpr, FxHashMap, FxHashSet, NodeIndex,
         petgraph::{
             Direction,
             algo::toposort,
@@ -521,7 +521,7 @@ where
 
 pub(crate) fn eval_resource_expression(
     expr: IntExpr,
-    dyn_map: &FxHashMap<char, usize>,
+    dyn_map: &DynMap,
     resource: &'static str,
 ) -> Result<usize, ResourceViolation> {
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| expr.exec(dyn_map))) {
@@ -753,7 +753,7 @@ pub(crate) fn validate_static_llir_semantics(llir: &LLIRGraph) -> Result<(), Res
 /// because non-overlapping buffers are individually large.
 pub(crate) fn plan_static_llir_resources(
     llir: &LLIRGraph,
-    dyn_map: &FxHashMap<char, usize>,
+    dyn_map: &DynMap,
 ) -> Result<CandidateResourcePlan, ResourceViolation> {
     let (topo, aliases) = validated_topology_and_aliases(llir)?;
     region_codegen::validate_fusion_regions(llir, Some(dyn_map)).map_err(|violation| {
@@ -874,6 +874,8 @@ pub(crate) fn plan_static_llir_resources(
 
 #[cfg(test)]
 mod tests {
+    use luminal::prelude::Symbol;
+
     use super::*;
 
     fn test_device(total_memory_bytes: usize) -> CudaDeviceResourceLimits {
@@ -1158,7 +1160,7 @@ mod tests {
             (IntExpr, IntExpr, IntExpr),
             (IntExpr, IntExpr, IntExpr),
             IntExpr,
-            FxHashMap<char, cudarc::driver::CudaSlice<u8>>,
+            FxHashMap<Symbol, cudarc::driver::CudaSlice<u8>>,
         ) {
             unreachable!("static resource planning must not compile test kernels")
         }
@@ -1203,7 +1205,7 @@ mod tests {
         llir.add_edge(input, first, ());
         llir.add_edge(first, second, ());
 
-        let dyn_map = FxHashMap::from_iter([('s', 16)]);
+        let dyn_map = FxHashMap::from_iter([(Symbol::from('s'), 16)]);
         let plan = plan_static_llir_resources(&llir, &dyn_map).unwrap();
 
         // The first output is 64 B and must coexist with the second's 128 B

--- a/crates/luminal_cuda_lite_hlir/src/runtime.rs
+++ b/crates/luminal_cuda_lite_hlir/src/runtime.rs
@@ -249,8 +249,8 @@ pub(crate) struct CompiledBucket {
     arena_conflicts: FxHashSet<(NodeIndex, NodeIndex)>,
     pub(crate) cached_buffer_ptrs: FxHashMap<NodeIndex, u64>,
     pub(crate) buffer_specs: FxHashMap<NodeIndex, BufferSpec>,
-    buffer_spec_dyn_vars: FxHashMap<NodeIndex, Vec<char>>,
-    buffer_spec_nodes_by_dyn_var: FxHashMap<char, Vec<NodeIndex>>,
+    buffer_spec_dyn_vars: FxHashMap<NodeIndex, Vec<Symbol>>,
+    buffer_spec_nodes_by_dyn_var: FxHashMap<Symbol, Vec<NodeIndex>>,
     pub(crate) llir_to_hlir: FxHashMap<NodeIndex, NodeIndex>,
     pub(crate) hlir_to_llir: FxHashMap<NodeIndex, NodeIndex>,
     pub(crate) hlir_to_all_llir: FxHashMap<NodeIndex, Vec<NodeIndex>>,
@@ -259,17 +259,17 @@ pub(crate) struct CompiledBucket {
     pub(crate) output_data_map: FxHashMap<NodeIndex, NodeIndex>,
     pub(crate) preserved_hlir_inputs: FxHashSet<NodeIndex>,
     pub(crate) kernel_names: Vec<&'static str>,
-    pub(crate) last_dyn_map: FxHashMap<char, usize>,
-    pub(crate) last_allocation_dyn_map: FxHashMap<char, usize>,
+    pub(crate) last_dyn_map: DynMap,
+    pub(crate) last_allocation_dyn_map: DynMap,
     /// Bucket-capacity dimensions used by the most recent hard-resource
     /// validation. Kept separate from allocation state so validation cannot
     /// accidentally suppress a required arena refresh.
-    last_resource_validation_dyn_map: FxHashMap<char, usize>,
+    last_resource_validation_dyn_map: DynMap,
     resource_validation_complete: bool,
-    pub(crate) intermediate_buffer_dims: FxHashSet<char>,
+    pub(crate) intermediate_buffer_dims: FxHashSet<Symbol>,
     pub(crate) cached_device_buffers: FxHashMap<NodeIndex, DeviceBuffer>,
     /// Which bucket index per dim this compilation targets
-    pub(crate) bucket_indices: FxHashMap<char, usize>,
+    pub(crate) bucket_indices: DynMap,
     /// Whether HLIR pointers have been synced into this bucket's cached_buffer_ptrs
     pub(crate) hlir_synced: bool,
     /// Test/debug mode: give every intermediate a distinct arena range so
@@ -336,7 +336,7 @@ struct ArenaReleasePlan {
 
 struct ValidatedBucketSet {
     compiled_buckets: Vec<CompiledBucket>,
-    representative_dyn_maps: Vec<FxHashMap<char, usize>>,
+    representative_dyn_maps: Vec<DynMap>,
     input_lengths_complete: bool,
 }
 
@@ -386,7 +386,7 @@ pub struct CudaRuntime {
     compiled_buckets: Vec<CompiledBucket>,
     active_bucket: usize,
     /// Bucket definitions per dimension (empty = single-bucket mode)
-    dim_buckets: FxHashMap<char, Vec<DimBucket>>,
+    dim_buckets: FxHashMap<Symbol, Vec<DimBucket>>,
 
     /// Non-owning CudaSlice wrappers for external device pointers.
     /// ManuallyDrop prevents cuMemFree — the external allocator (e.g. PyTorch) owns the memory.
@@ -1554,7 +1554,7 @@ impl CudaRuntime {
     fn allocate_intermediate_buffers(
         bucket: &mut CompiledBucket,
         stream: &Arc<CudaStream>,
-        dyn_dims: &FxHashMap<char, usize>,
+        dyn_dims: &DynMap,
     ) {
         let profile_alloc = std::env::var_os("LUMINAL_CUDA_PROFILE_RECAPTURE").is_some();
         let alloc_profile_start = std::time::Instant::now();
@@ -1716,7 +1716,7 @@ impl CudaRuntime {
         }
     }
 
-    fn buffer_plan_matches(bucket: &CompiledBucket, dyn_dims: &FxHashMap<char, usize>) -> bool {
+    fn buffer_plan_matches(bucket: &CompiledBucket, dyn_dims: &DynMap) -> bool {
         if bucket.buffer_specs.is_empty() {
             return true;
         }
@@ -1738,10 +1738,7 @@ impl CudaRuntime {
         })
     }
 
-    fn refresh_intermediate_buffer_lengths(
-        bucket: &mut CompiledBucket,
-        dyn_dims: &FxHashMap<char, usize>,
-    ) {
+    fn refresh_intermediate_buffer_lengths(bucket: &mut CompiledBucket, dyn_dims: &DynMap) {
         bucket.logical_buffer_bytes.clear();
         let buffer_lengths = bucket
             .buffer_specs
@@ -1792,7 +1789,7 @@ impl CudaRuntime {
 
     fn refresh_intermediate_buffer_lengths_for_changed_dims(
         bucket: &mut CompiledBucket,
-        dyn_dims: &FxHashMap<char, usize>,
+        dyn_dims: &DynMap,
     ) {
         if bucket.last_dyn_map.is_empty() {
             Self::refresh_intermediate_buffer_lengths(bucket, dyn_dims);
@@ -1844,10 +1841,7 @@ impl CudaRuntime {
         bucket.last_dyn_map = dyn_dims.clone();
     }
 
-    fn initialize_fixed_intermediate_buffer_plan(
-        bucket: &mut CompiledBucket,
-        dyn_dims: &FxHashMap<char, usize>,
-    ) {
+    fn initialize_fixed_intermediate_buffer_plan(bucket: &mut CompiledBucket, dyn_dims: &DynMap) {
         bucket.arena_slots.clear();
         bucket.logical_buffer_slots.clear();
 
@@ -1915,10 +1909,7 @@ impl CudaRuntime {
         }
     }
 
-    fn refresh_fixed_intermediate_buffer_plan(
-        bucket: &mut CompiledBucket,
-        dyn_dims: &FxHashMap<char, usize>,
-    ) {
+    fn refresh_fixed_intermediate_buffer_plan(bucket: &mut CompiledBucket, dyn_dims: &DynMap) {
         bucket.logical_buffer_offsets.clear();
         bucket.logical_buffer_bytes.clear();
         bucket.logical_buffer_capacity_bytes.clear();
@@ -1972,7 +1963,7 @@ impl CudaRuntime {
 
     fn planned_intermediate_buffers(
         bucket: &mut CompiledBucket,
-        dyn_dims: &FxHashMap<char, usize>,
+        dyn_dims: &DynMap,
         include_zero_sized: bool,
     ) -> Vec<PlannedBuffer> {
         bucket.intermediate_buffer_dims.clear();
@@ -2116,7 +2107,7 @@ impl CudaRuntime {
             .collect_vec()
     }
 
-    fn plan_intermediate_buffers(bucket: &mut CompiledBucket, dyn_dims: &FxHashMap<char, usize>) {
+    fn plan_intermediate_buffers(bucket: &mut CompiledBucket, dyn_dims: &DynMap) {
         let old_offsets = bucket.logical_buffer_offsets.clone();
         let old_bytes = bucket.logical_buffer_bytes.clone();
         let old_capacity_bytes = bucket.logical_buffer_capacity_bytes.clone();
@@ -2398,7 +2389,7 @@ impl CudaRuntime {
         }
     }
 
-    fn prepare_bucket_buffers(&mut self, bucket_idx: usize, dyn_map: &FxHashMap<char, usize>) {
+    fn prepare_bucket_buffers(&mut self, bucket_idx: usize, dyn_map: &DynMap) {
         debug_assert!(
             self.compiled_buckets
                 .iter()
@@ -2729,10 +2720,7 @@ impl CudaRuntime {
     /// Post-mortem aid for sticky CUDA errors during search: keep the most
     /// recent candidate's LLIR on disk so a crash identifies the genome that
     /// was executing. Gated on LUMINAL_SEARCH_DUMP_LAST_LLIR.
-    fn dump_candidate_llir_for_postmortem(
-        llir_graph: &LLIRGraph,
-        dyn_map: &FxHashMap<char, usize>,
-    ) {
+    fn dump_candidate_llir_for_postmortem(llir_graph: &LLIRGraph, dyn_map: &DynMap) {
         if std::env::var_os("LUMINAL_SEARCH_DUMP_LAST_LLIR").is_none() {
             return;
         }
@@ -2757,7 +2745,7 @@ impl CudaRuntime {
     fn materialize_bucket_cuda_graphs(
         &mut self,
         bucket_idx: usize,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         allow_missing_inputs: bool,
     ) -> anyhow::Result<()> {
         let fully_dirty = self.compiled_buckets[bucket_idx].materialization_fully_dirty;
@@ -2821,11 +2809,7 @@ impl CudaRuntime {
         Ok(())
     }
 
-    fn bucket_capacity_dyn_map(
-        &self,
-        bucket_idx: usize,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> FxHashMap<char, usize> {
+    fn bucket_capacity_dyn_map(&self, bucket_idx: usize, dyn_map: &DynMap) -> DynMap {
         let mut capacity_dyn_map = dyn_map.clone();
         let Some(bucket) = self.compiled_buckets.get(bucket_idx) else {
             return capacity_dyn_map;
@@ -2840,10 +2824,10 @@ impl CudaRuntime {
     }
 
     fn bucket_capacity_dyn_map_from_context(
-        dyn_map: &FxHashMap<char, usize>,
-        bucket_indices: &FxHashMap<char, usize>,
-        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
-    ) -> FxHashMap<char, usize> {
+        dyn_map: &DynMap,
+        bucket_indices: &DynMap,
+        dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
+    ) -> DynMap {
         let mut capacity_dyn_map = dyn_map.clone();
         for (dim, buckets) in dim_buckets {
             let bucket_idx = bucket_indices.get(dim).copied().unwrap_or(0);
@@ -2854,10 +2838,7 @@ impl CudaRuntime {
         capacity_dyn_map
     }
 
-    fn dry_plan_intermediate_buffers(
-        bucket: &mut CompiledBucket,
-        dyn_dims: &FxHashMap<char, usize>,
-    ) {
+    fn dry_plan_intermediate_buffers(bucket: &mut CompiledBucket, dyn_dims: &DynMap) {
         let needs_new_plan =
             bucket.logical_buffer_slots.is_empty() && !bucket.buffer_specs.is_empty();
         if needs_new_plan {
@@ -2883,9 +2864,7 @@ impl CudaRuntime {
         }
     }
 
-    fn candidate_allocation_dyn_map(
-        context: luminal::op::CandidateFilterContext<'_>,
-    ) -> FxHashMap<char, usize> {
+    fn candidate_allocation_dyn_map(context: luminal::op::CandidateFilterContext<'_>) -> DynMap {
         if let Some(bucket_context) = context.bucket_context {
             Self::bucket_capacity_dyn_map_from_context(
                 context.dyn_map,
@@ -2899,7 +2878,7 @@ impl CudaRuntime {
 
     fn compiled_kernel_resource_plans(
         bucket: &CompiledBucket,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> Result<Vec<KernelResourcePlan>, ResourceViolation> {
         let mut plans = Vec::new();
         for executable in bucket.exec_graph.node_weights() {
@@ -2910,10 +2889,7 @@ impl CudaRuntime {
         Ok(plans)
     }
 
-    fn complete_resource_dyn_map(
-        bucket: &CompiledBucket,
-        mut dyn_map: FxHashMap<char, usize>,
-    ) -> FxHashMap<char, usize> {
+    fn complete_resource_dyn_map(bucket: &CompiledBucket, mut dyn_map: DynMap) -> DynMap {
         for dim in bucket
             .buffer_specs
             .values()
@@ -3106,7 +3082,7 @@ impl CudaRuntime {
 
     fn compiled_host_device_memory_plans(
         bucket: &CompiledBucket,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         buffer_lengths: &FxHashMap<NodeIndex, usize>,
     ) -> Result<Vec<HostDeviceMemoryPlan>, ResourceViolation> {
         bucket
@@ -3193,7 +3169,7 @@ impl CudaRuntime {
     /// rejected before replacing the working runtime.
     fn retained_bucket_resource_plan(
         buckets: &mut [CompiledBucket],
-        allocation_dyn_maps: &[FxHashMap<char, usize>],
+        allocation_dyn_maps: &[DynMap],
         hlir_buffer_lengths: &FxHashMap<NodeIndex, usize>,
     ) -> Result<CandidateResourcePlan, ResourceViolation> {
         assert_eq!(buckets.len(), allocation_dyn_maps.len());
@@ -3227,7 +3203,7 @@ impl CudaRuntime {
     fn validate_compiled_bucket_resources(
         &mut self,
         bucket_idx: usize,
-        allocation_dyn_map: &FxHashMap<char, usize>,
+        allocation_dyn_map: &DynMap,
     ) -> Result<(), ResourceViolation> {
         let caps = CandidateResourceCaps {
             max_intermediate_bytes: self.max_intermediate_memory_bytes,
@@ -3277,11 +3253,11 @@ impl CudaRuntime {
     /// Pre-allocate buffers and materialize CUDA graphs with the given dynamic
     /// dimension values when all required input buffers are already available.
     #[tracing::instrument(skip_all)]
-    pub fn prebuild_graphs(&mut self, dyn_map: &FxHashMap<char, usize>) {
+    pub fn prebuild_graphs(&mut self, dyn_map: &DynMap) {
         self.try_prebuild_graphs(dyn_map).unwrap();
     }
 
-    fn try_prebuild_graphs(&mut self, dyn_map: &FxHashMap<char, usize>) -> anyhow::Result<()> {
+    fn try_prebuild_graphs(&mut self, dyn_map: &DynMap) -> anyhow::Result<()> {
         let bucket_idx = self.active_bucket;
         self.prepare_bucket_buffers(bucket_idx, dyn_map);
         self.materialize_bucket_cuda_graphs(bucket_idx, dyn_map, true)
@@ -3454,7 +3430,7 @@ impl CudaRuntime {
             // trip-difference terms by a constant per body (~3x observed on
             // gemma4_moe) regardless of the candidate's true dim
             // sensitivity.
-            let stale_dims: Vec<char> = {
+            let stale_dims: Vec<Symbol> = {
                 let bucket = &self.compiled_buckets[bucket_idx];
                 bucket
                     .last_dyn_map
@@ -3495,7 +3471,7 @@ impl CudaRuntime {
     fn profile_loaded_llir(
         &mut self,
         llir_graph: &LLIRGraph,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         trials: usize,
         timeout: Option<std::time::Duration>,
         early_stop: Option<(Duration, f64)>,
@@ -3679,7 +3655,7 @@ impl CudaRuntime {
 
     fn try_load_llir_buckets(
         &mut self,
-        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
+        dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
         bucket_llirs: &[BucketLLIR],
     ) -> anyhow::Result<()> {
         let bucket_llir_refs = bucket_llirs.iter().map(BucketLLIRRef::from).collect_vec();
@@ -3747,7 +3723,7 @@ impl CudaRuntime {
     /// load time.
     fn compile_and_validate_bucket_set(
         &mut self,
-        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
+        dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
         bucket_llirs: &[BucketLLIRRef<'_>],
     ) -> anyhow::Result<ValidatedBucketSet> {
         // Validate the entire stitched candidate before mutating the currently
@@ -3882,7 +3858,7 @@ impl Runtime for CudaRuntime {
 
     fn filter_llir_bucket_set(
         &mut self,
-        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
+        dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
         bucket_llirs: &[BucketLLIRRef<'_>],
         _search_options: &CompileOptions,
     ) -> luminal::op::CandidateFilterResult {
@@ -3979,7 +3955,7 @@ impl Runtime for CudaRuntime {
             .sum()
     }
 
-    fn has_nan_outputs(&self, _llir_graph: &LLIRGraph, _dyn_map: &FxHashMap<char, usize>) -> bool {
+    fn has_nan_outputs(&self, _llir_graph: &LLIRGraph, _dyn_map: &DynMap) -> bool {
         let _ = self.cuda_stream.synchronize();
         let bucket = self.active();
         let mut checked = FxHashSet::default();
@@ -4027,7 +4003,7 @@ impl Runtime for CudaRuntime {
     fn profile(
         &mut self,
         llir_graph: &LLIRGraph,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         trials: usize,
         timeout: Option<std::time::Duration>,
         early_stop: Option<(Self::ProfileMetric, f64)>,
@@ -4049,7 +4025,7 @@ impl Runtime for CudaRuntime {
     fn profile_with_bucket_context(
         &mut self,
         llir_graph: &LLIRGraph,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         trials: usize,
         timeout: Option<std::time::Duration>,
         early_stop: Option<(Self::ProfileMetric, f64)>,
@@ -4079,7 +4055,7 @@ impl Runtime for CudaRuntime {
     }
 
     #[tracing::instrument(skip_all)]
-    fn execute(&mut self, dyn_map: &FxHashMap<char, usize>) -> Self::ExecReturn {
+    fn execute(&mut self, dyn_map: &DynMap) -> Self::ExecReturn {
         let profile_runtime = std::env::var_os("LUMINAL_CUDA_PROFILE_RECAPTURE").is_some();
         let runtime_profile_start = std::time::Instant::now();
         let mut bucket_dispatch_time = Duration::ZERO;
@@ -4330,7 +4306,7 @@ impl Runtime for CudaRuntime {
 
     fn load_llir_buckets(
         &mut self,
-        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
+        dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
         bucket_llirs: &[BucketLLIR],
     ) {
         self.try_load_llir_buckets(dim_buckets, bucket_llirs)
@@ -4626,7 +4602,7 @@ impl CudaRuntime {
     }
 
     /// Resolve which bucket matches the current dyn_map values.
-    fn resolve_bucket(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn resolve_bucket(&self, dyn_map: &DynMap) -> usize {
         self.compiled_buckets
             .iter()
             .position(|bucket| {
@@ -5378,7 +5354,7 @@ mod arena_plan_tests {
     fn bucket_memory_dry_plan_uses_bucket_capacity_dims() {
         let data = NodeIndex::new(1);
         let mut bucket = CompiledBucket::new();
-        bucket.bucket_indices.insert('s', 1);
+        bucket.bucket_indices.insert(Symbol::from('s'), 1);
         bucket.buffer_specs.insert(
             data,
             BufferSpec {
@@ -5389,10 +5365,13 @@ mod arena_plan_tests {
         bucket.output_producers.insert(NodeIndex::new(99), data);
 
         let mut dim_buckets = FxHashMap::default();
-        dim_buckets.insert('s', vec![DimBucket::new(1, 1), DimBucket::new(2, 64)]);
+        dim_buckets.insert(
+            Symbol::from('s'),
+            vec![DimBucket::new(1, 1), DimBucket::new(2, 64)],
+        );
 
         let mut representative_dyn_map = FxHashMap::default();
-        representative_dyn_map.insert('s', 16);
+        representative_dyn_map.insert(Symbol::from('s'), 16);
         let capacity_dyn_map = CudaRuntime::bucket_capacity_dyn_map_from_context(
             &representative_dyn_map,
             &bucket.bucket_indices,
@@ -5401,7 +5380,7 @@ mod arena_plan_tests {
 
         CudaRuntime::dry_plan_intermediate_buffers(&mut bucket, &capacity_dyn_map);
 
-        assert_eq!(capacity_dyn_map[&'s'], 64);
+        assert_eq!(capacity_dyn_map[&Symbol::from('s')], 64);
         assert_eq!(bucket.arena_bytes, align_up(64 * 4, ARENA_ALIGNMENT));
         assert_eq!(
             CudaRuntime::planned_allocation_bytes(&bucket),
@@ -5571,13 +5550,13 @@ mod arena_plan_tests {
         });
 
         let mut dyn_map = FxHashMap::default();
-        dyn_map.insert('s', 4);
+        dyn_map.insert(Symbol::from('s'), 4);
         CudaRuntime::refresh_fixed_intermediate_buffer_plan(&mut bucket, &dyn_map);
         let first_offset_a = bucket.logical_buffer_offsets[&a];
         let first_offset_b = bucket.logical_buffer_offsets[&b];
         let first_arena_bytes = bucket.arena_bytes;
 
-        dyn_map.insert('s', 32);
+        dyn_map.insert(Symbol::from('s'), 32);
         CudaRuntime::refresh_fixed_intermediate_buffer_plan(&mut bucket, &dyn_map);
 
         assert_eq!(bucket.logical_buffer_slots[&a], 0);

--- a/crates/luminal_cuda_lite_hlir/src/tests/cublaslt_rewrite_tests.rs
+++ b/crates/luminal_cuda_lite_hlir/src/tests/cublaslt_rewrite_tests.rs
@@ -1068,18 +1068,21 @@ fn bucket_range_and_singleton_cublaslt_buckets_are_captured() {
     let llir =
         extract_forced_cublaslt_llir_where(&mut cx, "bucketed s cuBLASLt graph capture", |_| true);
 
-    let dim_buckets = [('s', vec![DimBucket::new(1, 1), DimBucket::new(2, 4)])]
-        .into_iter()
-        .collect();
+    let dim_buckets = [(
+        Symbol::from('s'),
+        vec![DimBucket::new(1, 1), DimBucket::new(2, 4)],
+    )]
+    .into_iter()
+    .collect();
     let bucket_llirs = vec![
         (
-            [('s', 0usize)].into_iter().collect(),
-            [('s', 1usize)].into_iter().collect(),
+            [(Symbol::from('s'), 0usize)].into_iter().collect(),
+            [(Symbol::from('s'), 1usize)].into_iter().collect(),
             llir.clone(),
         ),
         (
-            [('s', 1usize)].into_iter().collect(),
-            [('s', 3usize)].into_iter().collect(),
+            [(Symbol::from('s'), 1usize)].into_iter().collect(),
+            [(Symbol::from('s'), 3usize)].into_iter().collect(),
             llir,
         ),
     ];

--- a/crates/luminal_cuda_lite_hlir/src/tests/flashinfer.rs
+++ b/crates/luminal_cuda_lite_hlir/src/tests/flashinfer.rs
@@ -152,6 +152,7 @@ fn run_flashinfer(
         head_dim: HEAD_DIM,
         page_size: 1,
         batch_dim: IntExpr::from('s'),
+        context_dim: IntExpr::from('c'),
         dtype: luminal::dtype::DType::F32,
         sm_scale: 0.0,
         window_left: -1,
@@ -183,9 +184,9 @@ fn run_flashinfer(
     let inputs = [q_n, k_n, v_n, idx_n, qo_n, kv_n];
 
     let mut dyn_map = FxHashMap::default();
-    dyn_map.insert('s', batch_size);
-    dyn_map.insert('c', kv_indices.len());
-    dyn_map.insert('r', kv_indptr.len());
+    dyn_map.insert(Symbol::from('s'), batch_size);
+    dyn_map.insert(Symbol::from('c'), kv_indices.len());
+    dyn_map.insert(Symbol::from('r'), kv_indptr.len());
 
     fi.execute(stream, out_n, &inputs, &buffers, &dyn_map)
         .expect("FlashInferAttention execute failed");
@@ -226,6 +227,7 @@ fn run_flashinfer_with_compact_decode_indices(
         head_dim: HEAD_DIM,
         page_size: 1,
         batch_dim: IntExpr::from('s'),
+        context_dim: IntExpr::from('c'),
         dtype: luminal::dtype::DType::F32,
         sm_scale: 0.0,
         window_left: -1,
@@ -250,8 +252,8 @@ fn run_flashinfer_with_compact_decode_indices(
     let inputs = [q_n, k_n, v_n, idx_n];
 
     let mut dyn_map = FxHashMap::default();
-    dyn_map.insert('s', batch_size);
-    dyn_map.insert('c', kv_indices.len());
+    dyn_map.insert(Symbol::from('s'), batch_size);
+    dyn_map.insert(Symbol::from('c'), kv_indices.len());
 
     fi.execute(stream, out_n, &inputs, &buffers, &dyn_map)
         .expect("FlashInferAttention compact-index execute failed");
@@ -281,6 +283,7 @@ fn resolve_flashinfer_decode_for_signature_test(
         head_dim: HEAD_DIM,
         page_size: 1,
         batch_dim: IntExpr::from('s'),
+        context_dim: IntExpr::from('c'),
         dtype: luminal::dtype::DType::F32,
         sm_scale: 0.0,
         window_left: -1,
@@ -296,8 +299,8 @@ fn resolve_flashinfer_decode_for_signature_test(
     buffers.insert(out_n, DeviceBuffer::new(0x6000, HIDDEN * 4));
 
     let mut dyn_map = FxHashMap::default();
-    dyn_map.insert('s', 1);
-    dyn_map.insert('c', context_len);
+    dyn_map.insert(Symbol::from('s'), 1);
+    dyn_map.insert(Symbol::from('c'), context_len);
     fi.resolve_for_graph(out_n, &[q_n, k_n, v_n, idx_n], &buffers, &dyn_map)
         .unwrap()
 }
@@ -721,23 +724,50 @@ fn build_paged_attention_graph_with_mask_and_cache_provenance(
     k_provenance: TestCacheProvenance,
     v_provenance: TestCacheProvenance,
 ) -> (Graph, PagedAttnHandles) {
+    build_paged_attention_graph_with_token_dim(
+        n_heads,
+        n_kv_heads,
+        head_dim,
+        mask_kind,
+        k_provenance,
+        v_provenance,
+        's',
+        'c',
+    )
+}
+
+/// `token_dim` and `context_dim` name the per-forward-pass token dimension and
+/// the total attended context. The rules bind both as pattern variables, so any
+/// names work; the parameters exist so a test can prove that rather than assert
+/// it.
+#[allow(clippy::too_many_arguments)] // test builder; the two dims are the point
+fn build_paged_attention_graph_with_token_dim(
+    n_heads: usize,
+    n_kv_heads: usize,
+    head_dim: usize,
+    mask_kind: TestMaskKind,
+    k_provenance: TestCacheProvenance,
+    v_provenance: TestCacheProvenance,
+    token_dim: char,
+    context_dim: char,
+) -> (Graph, PagedAttnHandles) {
     let kv_groups = n_heads / n_kv_heads;
     let kv_dim = n_kv_heads * head_dim;
     let hidden = n_heads * head_dim;
 
     let mut cx = Graph::default();
 
-    let q_rope = cx.named_tensor("q_rope", ('s', hidden));
-    let k_rope = cx.named_tensor("k_rope", ('s', kv_dim));
-    let v_new = cx.named_tensor("v_new", ('s', kv_dim));
+    let q_rope = cx.named_tensor("q_rope", (token_dim, hidden));
+    let k_rope = cx.named_tensor("k_rope", (token_dim, kv_dim));
+    let v_new = cx.named_tensor("v_new", (token_dim, kv_dim));
     let k_cache = cx.named_tensor("k_cache", (2048, kv_dim)).persist();
     let v_cache = cx.named_tensor("v_cache", (2048, kv_dim)).persist();
     let scatter_idx = cx
-        .named_tensor_dtyped("scatter_idx", 's', luminal::dtype::DType::Int);
+        .named_tensor_dtyped("scatter_idx", token_dim, luminal::dtype::DType::Int);
     let gather_idx = cx
-        .named_tensor_dtyped("gather_idx", 'c', luminal::dtype::DType::Int);
+        .named_tensor_dtyped("gather_idx", context_dim, luminal::dtype::DType::Int);
     let q_pos = cx
-        .named_tensor_dtyped("q_pos", 's', luminal::dtype::DType::Int);
+        .named_tensor_dtyped("q_pos", token_dim, luminal::dtype::DType::Int);
     let qo_indptr = cx
         .named_tensor_dtyped("qo_indptr", 'r', luminal::dtype::DType::Int);
     let kv_indptr = cx
@@ -752,7 +782,7 @@ fn build_paged_attention_graph_with_mask_and_cache_provenance(
     let k = gather_rows(k_cache_out, gather_idx, kv_dim);
     let v_ctx = gather_rows(v_cache_out, gather_idx, kv_dim);
 
-    let c: IntExpr = 'c'.into();
+    let c: IntExpr = context_dim.into();
     let attn_mask = match mask_kind {
         TestMaskKind::Indptr => test_compute_attn_mask(&mut cx, q_pos, qo_indptr, kv_indptr, c),
         TestMaskKind::TriuGather => test_compute_triu_gather_mask(&mut cx, q_pos, c),
@@ -824,7 +854,10 @@ fn saturate_and_has_flashinfer_inner(
     // whether downstream extraction would have pruned it.
     let egraph = if let Some((s_min, s_max)) = s_interval {
         let mut intervals = luminal::prelude::FxHashMap::default();
-        intervals.insert('s', luminal::shape::DimInterval::new(s_min, s_max));
+        intervals.insert(
+            Symbol::from('s'),
+            luminal::shape::DimInterval::new(s_min, s_max),
+        );
         let interval_facts = luminal::egglog_utils::base::interval_facts_egglog(&intervals, []);
         let program = format!("{interval_facts}\n{program}");
         run_egglog_with_late_passes_and_interval_analysis(&program, &root, &ops, false, &[], true)
@@ -1254,6 +1287,35 @@ fn flashinfer_rule_fires_on_non_llama_dims() {
 }
 
 #[test]
+fn flashinfer_rule_fires_regardless_of_dim_names() {
+    if !crate::tests::utilities::gpu_supports_flashinfer() {
+        return;
+    }
+    // The rules bind both dynamic dims as pattern variables rather than matching
+    // literal names, so an identical graph must be recognised under any names.
+    // Before that change this graph produced no FlashInferAttention at all -- it
+    // silently fell back to the HLIR chain, which is why PT2-imported models
+    // (dims named s77/u0) never hit this path.
+    let (cx, _) = build_paged_attention_graph_with_token_dim(
+        8,
+        8,
+        64,
+        TestMaskKind::Indptr,
+        TestCacheProvenance::Raw,
+        TestCacheProvenance::Raw,
+        'w',
+        'x',
+    );
+    let (has_flashinfer, op_kinds) = saturate_and_has_flashinfer(&cx);
+    assert!(
+        has_flashinfer,
+        "FlashInferAttention was NOT found for a graph whose dims are named \
+         'w'/'x' instead of 's'/'c'. The rules are still name-coupled. \
+         OpKinds: {op_kinds:?}"
+    );
+}
+
+#[test]
 fn flashinfer_rule_fires_on_mha() {
     if !crate::tests::utilities::gpu_supports_flashinfer() {
         return;
@@ -1432,6 +1494,7 @@ fn run_flashinfer_bf16(
         head_dim: HEAD_DIM,
         page_size: 1,
         batch_dim: IntExpr::from('s'),
+        context_dim: IntExpr::from('c'),
         dtype: luminal::dtype::DType::Bf16,
         sm_scale: 0.0,
         window_left: -1,
@@ -1467,8 +1530,8 @@ fn run_flashinfer_bf16(
     );
 
     let mut dyn_map = FxHashMap::default();
-    dyn_map.insert('s', total_q_tokens);
-    dyn_map.insert('c', kv_indices.len());
+    dyn_map.insert(Symbol::from('s'), total_q_tokens);
+    dyn_map.insert(Symbol::from('c'), kv_indices.len());
 
     let _qo_buf;
     let _kv_buf;
@@ -1485,7 +1548,7 @@ fn run_flashinfer_bf16(
             kv_n,
             DeviceBuffer::new(_kv_buf.device_ptr(stream).0, kv_indptr.len() * 4),
         );
-        dyn_map.insert('r', kv_indptr.len());
+        dyn_map.insert(Symbol::from('r'), kv_indptr.len());
         vec![q_n, k_n, v_n, idx_n, qo_n, kv_n]
     } else {
         vec![q_n, k_n, v_n, idx_n]

--- a/crates/luminal_metal/src/dyn_backend.rs
+++ b/crates/luminal_metal/src/dyn_backend.rs
@@ -28,7 +28,7 @@ impl DynBackend for MetalDynBackend {
     fn get_output_f32(&self, node: NodeIndex) -> Vec<f32> {
         self.runtime.get_f32(node)
     }
-    fn execute(&mut self, dyn_map: &FxHashMap<char, usize>) {
+    fn execute(&mut self, dyn_map: &DynMap) {
         self.runtime.execute(dyn_map);
     }
 }

--- a/crates/luminal_metal/src/kernel/mod.rs
+++ b/crates/luminal_metal/src/kernel/mod.rs
@@ -15,7 +15,40 @@ use objc::runtime::Object;
 use objc::{class, msg_send, sel, sel_impl};
 use std::cell::RefCell;
 
-pub const DYN_SLOT_COUNT: usize = 26;
+thread_local! {
+    /// Layout of the shared `dyn[]` buffer: slot `i` holds the size of
+    /// `DYN_DIMS_ORDER[i]`. Codegen bakes these indices into generated source
+    /// and the runtime uploads in the same order, so both must read one list.
+    /// Built by `dyn_slot` as compilation reaches each dim.
+    static DYN_DIMS_ORDER: RefCell<Vec<Symbol>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Drop the previous graph's layout. Must run before compiling, or slots
+/// carry over and the buffer is sized for dims this graph never reads.
+pub(crate) fn clear_dyn_dims_order() {
+    DYN_DIMS_ORDER.with(|order| order.borrow_mut().clear());
+}
+
+/// The current `dyn[]` buffer layout.
+pub(crate) fn dyn_dims_order() -> Vec<Symbol> {
+    DYN_DIMS_ORDER.with(|order| order.borrow().clone())
+}
+
+/// This dim's slot, assigning the next one if it has not been seen.
+///
+/// Appends, never inserts, so a slot already baked into emitted source keeps
+/// its meaning. The runtime re-reads the layout after compiling and sizes the
+/// buffer to match.
+pub(crate) fn dyn_slot(symbol: &Symbol) -> usize {
+    DYN_DIMS_ORDER.with(|order| {
+        if let Some(slot) = order.borrow().iter().position(|d| d == symbol) {
+            return slot;
+        }
+        let mut order = order.borrow_mut();
+        order.push(*symbol);
+        order.len() - 1
+    })
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct MpsMatrixDescriptorKey {
@@ -163,7 +196,7 @@ pub trait MetalKernelOp: EgglogOp {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     );
 
     #[allow(clippy::too_many_arguments)]
@@ -173,7 +206,7 @@ pub trait MetalKernelOp: EgglogOp {
         pipeline: Option<&ComputePipelineState>,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         _input_dtypes: &[DType],
         _output_dtype: DType,
     ) {
@@ -189,15 +222,15 @@ pub trait MetalKernelOp: EgglogOp {
     // Performance Metrics for MBU/MFU Calculation
     // ========================================================================
 
-    fn bytes_loaded(&self, _dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_loaded(&self, _dyn_map: &DynMap) -> usize {
         0
     }
 
-    fn bytes_stored(&self, _dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_stored(&self, _dyn_map: &DynMap) -> usize {
         0
     }
 
-    fn flops(&self, _dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn flops(&self, _dyn_map: &DynMap) -> usize {
         0
     }
 

--- a/crates/luminal_metal/src/kernel/ops.rs
+++ b/crates/luminal_metal/src/kernel/ops.rs
@@ -72,19 +72,10 @@ fn compile_shader(device: &Device, source: &str, function_name: &str) -> Compute
         })
 }
 
-fn lower_dynamic_consts(mut code: String) -> String {
-    for c in b'a'..=b'y' {
-        let symbol = c as char;
-        code = code.replace(
-            &format!("const_{symbol}"),
-            &format!("dyn[{}]", (c - b'a') as usize),
-        );
-    }
-    code
-}
-
 pub(crate) fn lower_expression_for_metal(expr: &IntExpr, index_var: &str) -> String {
-    lower_dynamic_consts(expr.to_kernel().replace("const_z", index_var))
+    expr.to_kernel_with(index_var, &|symbol| {
+        format!("dyn[{}]", super::dyn_slot(symbol))
+    })
 }
 
 fn metal_buffer_type(dtype: DType) -> &'static str {
@@ -179,17 +170,17 @@ fn binary_dtype_rewrite(hlir_sort: &SortDef, metal_sort: &SortDef) -> Rule {
 /// Generate metrics methods for unary ops: 1 input read, 1 output write, 1 flop per element
 macro_rules! impl_unary_metrics {
     ($self:ident, $dyn_map:ident) => {
-        fn bytes_loaded(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+        fn bytes_loaded(&$self, $dyn_map: &DynMap) -> usize {
             let n = $self.output_size().exec($dyn_map).unwrap_or(0);
             n * std::mem::size_of::<f32>()
         }
 
-        fn bytes_stored(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+        fn bytes_stored(&$self, $dyn_map: &DynMap) -> usize {
             let n = $self.output_size().exec($dyn_map).unwrap_or(0);
             n * std::mem::size_of::<f32>()
         }
 
-        fn flops(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+        fn flops(&$self, $dyn_map: &DynMap) -> usize {
             $self.output_size().exec($dyn_map).unwrap_or(0)
         }
     };
@@ -198,17 +189,17 @@ macro_rules! impl_unary_metrics {
 /// Generate metrics methods for binary ops: 2 inputs read, 1 output write, flops_per_elem per element
 macro_rules! impl_binary_metrics {
     ($self:ident, $dyn_map:ident, $flops_per_elem:expr) => {
-        fn bytes_loaded(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+        fn bytes_loaded(&$self, $dyn_map: &DynMap) -> usize {
             let n = $self.output_size().exec($dyn_map).unwrap_or(0);
             n * 2 * std::mem::size_of::<f32>()
         }
 
-        fn bytes_stored(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+        fn bytes_stored(&$self, $dyn_map: &DynMap) -> usize {
             let n = $self.output_size().exec($dyn_map).unwrap_or(0);
             n * std::mem::size_of::<f32>()
         }
 
-        fn flops(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+        fn flops(&$self, $dyn_map: &DynMap) -> usize {
             $self.output_size().exec($dyn_map).unwrap_or(0) * $flops_per_elem
         }
     };
@@ -217,18 +208,18 @@ macro_rules! impl_binary_metrics {
 /// Generate metrics methods for reduce ops
 macro_rules! impl_reduce_metrics {
     ($self:ident, $dyn_map:ident) => {
-        fn bytes_loaded(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+        fn bytes_loaded(&$self, $dyn_map: &DynMap) -> usize {
             let n_outputs = $self.output_size().exec($dyn_map).unwrap_or(0);
             let iters = $self.iters.exec($dyn_map).unwrap_or(0);
             n_outputs * iters * std::mem::size_of::<f32>()
         }
 
-        fn bytes_stored(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+        fn bytes_stored(&$self, $dyn_map: &DynMap) -> usize {
             let n = $self.output_size().exec($dyn_map).unwrap_or(0);
             n * std::mem::size_of::<f32>()
         }
 
-        fn flops(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+        fn flops(&$self, $dyn_map: &DynMap) -> usize {
             let n_outputs = $self.output_size().exec($dyn_map).unwrap_or(0);
             let iters = $self.iters.exec($dyn_map).unwrap_or(0);
             n_outputs * iters
@@ -355,7 +346,7 @@ macro_rules! metal_unary_op {
                 pipeline: &ComputePipelineState,
                 inputs: &[&Buffer],
                 output: &Buffer,
-                dyn_map: &FxHashMap<char, usize>,
+                dyn_map: &DynMap,
             ) {
                 let n_elements = self.output_size().exec(dyn_map).unwrap() as u32;
 
@@ -508,7 +499,7 @@ impl MetalKernelOp for MetalAdd {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_elements = self.output_size().exec(dyn_map).unwrap() as u32;
 
@@ -640,7 +631,7 @@ impl MetalKernelOp for MetalMul {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_elements = self.output_size().exec(dyn_map).unwrap() as u32;
 
@@ -787,7 +778,7 @@ impl MetalKernelOp for MetalMod {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_elements = self.output_size().exec(dyn_map).unwrap() as u32;
 
@@ -932,7 +923,7 @@ impl MetalKernelOp for MetalLessThan {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_elements = self.output_size().exec(dyn_map).unwrap() as u32;
 
@@ -1098,7 +1089,7 @@ impl MetalKernelOp for MetalSumReduce {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_outputs = self.output_size().exec(dyn_map).unwrap() as u32;
 
@@ -1270,7 +1261,7 @@ impl MetalKernelOp for MetalMaxReduce {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_outputs = self.output_size().exec(dyn_map).unwrap() as u32;
 
@@ -1501,7 +1492,7 @@ impl EgglogOp for MPSMatmul {
 }
 
 impl MPSMatmul {
-    fn row_bytes(row_stride: IntExpr, dtype: DType, dyn_map: &FxHashMap<char, usize>) -> u64 {
+    fn row_bytes(row_stride: IntExpr, dtype: DType, dyn_map: &DynMap) -> u64 {
         let elems = row_stride
             .substitute('z', IntExpr::from(1))
             .exec(dyn_map)
@@ -1557,7 +1548,7 @@ impl MetalKernelOp for MPSMatmul {
         _pipeline: &ComputePipelineState,
         _inputs: &[&Buffer],
         _output: &Buffer,
-        _dyn_map: &FxHashMap<char, usize>,
+        _dyn_map: &DynMap,
     ) {
         panic!("MPSMatmul encodes directly onto the command buffer")
     }
@@ -1568,7 +1559,7 @@ impl MetalKernelOp for MPSMatmul {
         _pipeline: Option<&ComputePipelineState>,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         input_dtypes: &[DType],
         output_dtype: DType,
     ) {
@@ -1636,20 +1627,20 @@ impl MetalKernelOp for MPSMatmul {
         }
     }
 
-    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_loaded(&self, dyn_map: &DynMap) -> usize {
         let m = self.m.exec(dyn_map).unwrap_or(0);
         let n = self.n.exec(dyn_map).unwrap_or(0);
         let k = self.k.exec(dyn_map).unwrap_or(0);
         2 * m * n * k * std::mem::size_of::<f32>()
     }
 
-    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_stored(&self, dyn_map: &DynMap) -> usize {
         let m = self.m.exec(dyn_map).unwrap_or(0);
         let n = self.n.exec(dyn_map).unwrap_or(0);
         m * n * std::mem::size_of::<f32>()
     }
 
-    fn flops(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn flops(&self, dyn_map: &DynMap) -> usize {
         let m = self.m.exec(dyn_map).unwrap_or(0);
         let n = self.n.exec(dyn_map).unwrap_or(0);
         let k = self.k.exec(dyn_map).unwrap_or(0);
@@ -1940,7 +1931,7 @@ impl MetalKernelOp for MPSBatchedMatmul {
         _pipeline: &ComputePipelineState,
         _inputs: &[&Buffer],
         _output: &Buffer,
-        _dyn_map: &FxHashMap<char, usize>,
+        _dyn_map: &DynMap,
     ) {
         panic!("MPSBatchedMatmul encodes directly onto the command buffer")
     }
@@ -1951,7 +1942,7 @@ impl MetalKernelOp for MPSBatchedMatmul {
         _pipeline: Option<&ComputePipelineState>,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         input_dtypes: &[DType],
         output_dtype: DType,
     ) {
@@ -2033,7 +2024,7 @@ impl MetalKernelOp for MPSBatchedMatmul {
         }
     }
 
-    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_loaded(&self, dyn_map: &DynMap) -> usize {
         let batch = self.batch.exec(dyn_map).unwrap_or(0);
         let m = self.m.exec(dyn_map).unwrap_or(0);
         let n = self.n.exec(dyn_map).unwrap_or(0);
@@ -2041,14 +2032,14 @@ impl MetalKernelOp for MPSBatchedMatmul {
         2 * batch * m * n * k * std::mem::size_of::<f32>()
     }
 
-    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_stored(&self, dyn_map: &DynMap) -> usize {
         let batch = self.batch.exec(dyn_map).unwrap_or(0);
         let m = self.m.exec(dyn_map).unwrap_or(0);
         let n = self.n.exec(dyn_map).unwrap_or(0);
         batch * m * n * std::mem::size_of::<f32>()
     }
 
-    fn flops(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn flops(&self, dyn_map: &DynMap) -> usize {
         let batch = self.batch.exec(dyn_map).unwrap_or(0);
         let m = self.m.exec(dyn_map).unwrap_or(0);
         let n = self.n.exec(dyn_map).unwrap_or(0);
@@ -2304,7 +2295,7 @@ impl MetalKernelOp for GenericMatmul {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_outputs = self.output_size().exec(dyn_map).unwrap() as u32;
 
@@ -2323,17 +2314,17 @@ impl MetalKernelOp for GenericMatmul {
         encoder.dispatch_thread_groups(thread_groups, thread_group_size);
     }
 
-    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_loaded(&self, dyn_map: &DynMap) -> usize {
         let n_outputs = self.output_size().exec(dyn_map).unwrap_or(0);
         let k = self.k.exec(dyn_map).unwrap_or(0);
         2 * n_outputs * k * std::mem::size_of::<f32>()
     }
 
-    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_stored(&self, dyn_map: &DynMap) -> usize {
         self.output_size().exec(dyn_map).unwrap_or(0) * std::mem::size_of::<f32>()
     }
 
-    fn flops(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn flops(&self, dyn_map: &DynMap) -> usize {
         let n_outputs = self.output_size().exec(dyn_map).unwrap_or(0);
         let k = self.k.exec(dyn_map).unwrap_or(0);
         2 * n_outputs * k
@@ -2444,7 +2435,7 @@ impl MetalKernelOp for MetalConstant {
         pipeline: &ComputePipelineState,
         _inputs: &[&Buffer],
         output: &Buffer,
-        _dyn_map: &FxHashMap<char, usize>,
+        _dyn_map: &DynMap,
     ) {
         encoder.set_compute_pipeline_state(pipeline);
         encoder.set_buffer(0, Some(output), 0);
@@ -2552,7 +2543,7 @@ impl MetalKernelOp for MetalIota {
         pipeline: &ComputePipelineState,
         _inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_elements = self.range.exec(dyn_map).unwrap() as u32;
 
@@ -2725,7 +2716,7 @@ impl MetalKernelOp for MetalGather {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_elements = self.output_size().exec(dyn_map).unwrap() as u32;
 
@@ -2745,19 +2736,19 @@ impl MetalKernelOp for MetalGather {
     }
 
     // Gather metrics: read indices + read gathered data + write output
-    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_loaded(&self, dyn_map: &DynMap) -> usize {
         let n = self.output_size().exec(dyn_map).unwrap_or(0);
         // Read n indices (i32 = 4 bytes) + n data elements (f32 = 4 bytes)
         n * std::mem::size_of::<i32>() + n * std::mem::size_of::<f32>()
     }
 
-    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_stored(&self, dyn_map: &DynMap) -> usize {
         let n = self.output_size().exec(dyn_map).unwrap_or(0);
         // Write n output elements (f32)
         n * std::mem::size_of::<f32>()
     }
 
-    fn flops(&self, _dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn flops(&self, _dyn_map: &DynMap) -> usize {
         // Gather is memory-bound, no significant FLOPs
         0
     }
@@ -2975,7 +2966,7 @@ impl MetalKernelOp for MetalScatter {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_dest = self
             .dest_shape
@@ -3027,7 +3018,7 @@ impl MetalKernelOp for MetalScatter {
         );
     }
 
-    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_loaded(&self, dyn_map: &DynMap) -> usize {
         let n_dest = self.output_size().exec(dyn_map).unwrap_or(0);
         let n_src = self
             .index_shape
@@ -3041,12 +3032,12 @@ impl MetalKernelOp for MetalScatter {
             + n_src * std::mem::size_of::<f32>()
     }
 
-    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_stored(&self, dyn_map: &DynMap) -> usize {
         let n = self.output_size().exec(dyn_map).unwrap_or(0);
         n * std::mem::size_of::<f32>()
     }
 
-    fn flops(&self, _dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn flops(&self, _dyn_map: &DynMap) -> usize {
         0
     }
 }
@@ -3255,7 +3246,7 @@ impl MetalKernelOp for MetalScatterNoCopy {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_src = self
             .index_shape
@@ -3281,7 +3272,7 @@ impl MetalKernelOp for MetalScatterNoCopy {
         );
     }
 
-    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_loaded(&self, dyn_map: &DynMap) -> usize {
         let n_src = self
             .index_shape
             .iter()
@@ -3292,7 +3283,7 @@ impl MetalKernelOp for MetalScatterNoCopy {
         n_src * std::mem::size_of::<i32>() + n_src * std::mem::size_of::<f32>()
     }
 
-    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_stored(&self, dyn_map: &DynMap) -> usize {
         let n_src = self
             .index_shape
             .iter()
@@ -3303,7 +3294,7 @@ impl MetalKernelOp for MetalScatterNoCopy {
         n_src * std::mem::size_of::<f32>()
     }
 
-    fn flops(&self, _dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn flops(&self, _dyn_map: &DynMap) -> usize {
         0
     }
 
@@ -3431,7 +3422,7 @@ impl MetalKernelOp for MetalCast {
         pipeline: &ComputePipelineState,
         inputs: &[&Buffer],
         output: &Buffer,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) {
         let n_elements = self.size.exec(dyn_map).unwrap_or(0) as u32;
 
@@ -3450,19 +3441,19 @@ impl MetalKernelOp for MetalCast {
     }
 
     // Cast is memory-bound: 1 read, 1 write, minimal compute
-    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_loaded(&self, dyn_map: &DynMap) -> usize {
         let n = self.size.exec(dyn_map).unwrap_or(0);
         // TODO: input dtype is not encoded; treat as 4B for now (matches current MetalRuntime IO path).
         n * std::mem::size_of::<f32>()
     }
 
-    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn bytes_stored(&self, dyn_map: &DynMap) -> usize {
         let n = self.size.exec(dyn_map).unwrap_or(0);
         // TODO: output dtype sizing should be wired through MetalRuntime allocation.
         n * std::mem::size_of::<f32>()
     }
 
-    fn flops(&self, _dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn flops(&self, _dyn_map: &DynMap) -> usize {
         0 // Type conversion has negligible compute cost
     }
 }

--- a/crates/luminal_metal/src/memory_analysis.rs
+++ b/crates/luminal_metal/src/memory_analysis.rs
@@ -29,7 +29,7 @@ const DTYPE_BITS: &[(&str, usize)] = &[
 pub(crate) fn metal_memory_analysis_pass(
     ops: &[Arc<Box<dyn EgglogOp>>],
     max_memory_bytes: Option<usize>,
-    _dyn_map: &FxHashMap<char, usize>,
+    _dyn_map: &DynMap,
 ) -> LateEgglogPass {
     let mut sorts = ops
         .iter()
@@ -86,7 +86,7 @@ pub(crate) fn metal_memory_analysis_pass(
 pub(crate) fn estimate_graph_memory_bytes<'a>(
     egraph: &'a SerializedEGraph,
     choices: &EGraphChoiceSet<'a>,
-    dyn_map: &FxHashMap<char, usize>,
+    dyn_map: &DynMap,
 ) -> Option<usize> {
     ChoiceMemoryEstimator::new(egraph, choices, dyn_map)
         .root_state()
@@ -213,7 +213,7 @@ pub(crate) struct MemorySplitStats {
 pub(crate) fn split_egraph_by_memory_limit(
     egraph: &mut SerializedEGraph,
     limit: usize,
-    dyn_map: &FxHashMap<char, usize>,
+    dyn_map: &DynMap,
 ) -> MemorySplitStats {
     let original_enodes = egraph.enodes.len();
     let original_eclasses = egraph.eclasses.len();
@@ -236,7 +236,7 @@ struct StateSplitter<'a> {
     original: &'a SerializedEGraph,
     split: SerializedEGraph,
     limit: usize,
-    dyn_map: &'a FxHashMap<char, usize>,
+    dyn_map: &'a DynMap,
     sort_by_name: FxHashMap<String, SortDef>,
     ir_memo: FxHashMap<ClassId, Vec<(MemoryState, ClassId)>>,
     list_memo: FxHashMap<ClassId, Vec<(ListMemoryState, ClassId)>>,
@@ -253,11 +253,7 @@ struct StateSplitter<'a> {
 }
 
 impl<'a> StateSplitter<'a> {
-    fn new(
-        original: &'a SerializedEGraph,
-        limit: usize,
-        dyn_map: &'a FxHashMap<char, usize>,
-    ) -> Self {
+    fn new(original: &'a SerializedEGraph, limit: usize, dyn_map: &'a DynMap) -> Self {
         let mut split = SerializedEGraph {
             enodes: FxHashMap::default(),
             eclasses: FxHashMap::default(),
@@ -761,7 +757,7 @@ impl<'a> StateSplitter<'a> {
 struct ChoiceMemoryEstimator<'a> {
     egraph: &'a SerializedEGraph,
     choices: &'a EGraphChoiceSet<'a>,
-    dyn_map: &'a FxHashMap<char, usize>,
+    dyn_map: &'a DynMap,
     sort_by_name: FxHashMap<String, SortDef>,
     ir_cache: FxHashMap<ClassId, MemoryState>,
     list_cache: FxHashMap<ClassId, ListMemoryState>,
@@ -773,7 +769,7 @@ impl<'a> ChoiceMemoryEstimator<'a> {
     fn new(
         egraph: &'a SerializedEGraph,
         choices: &'a EGraphChoiceSet<'a>,
-        dyn_map: &'a FxHashMap<char, usize>,
+        dyn_map: &'a DynMap,
     ) -> Self {
         Self {
             egraph,
@@ -936,7 +932,7 @@ fn kind_memory_for_node(
     egraph: &SerializedEGraph,
     sort_by_name: &FxHashMap<String, SortDef>,
     node: &NodeId,
-    dyn_map: &FxHashMap<char, usize>,
+    dyn_map: &DynMap,
 ) -> Option<KindMemory> {
     let (kind_label, kind_child_classes) = egraph.enodes.get(node)?;
     if zero_local_op_kind(kind_label) {
@@ -970,9 +966,9 @@ fn first_data_node<'a>(egraph: &'a SerializedEGraph, class: &'a ClassId) -> Opti
     nodes.iter().find(|node| egraph.enodes.contains_key(*node))
 }
 
-fn eval_bytes(expr: IntExpr, dyn_map: &FxHashMap<char, usize>) -> Option<usize> {
+fn eval_bytes(expr: IntExpr, dyn_map: &DynMap) -> Option<usize> {
     let mut dyn_map = dyn_map.clone();
-    dyn_map.entry('z').or_insert(1);
+    dyn_map.entry(Symbol::reserved_index()).or_insert(1);
     expr.simplify().exec(&dyn_map)
 }
 

--- a/crates/luminal_metal/src/runtime.rs
+++ b/crates/luminal_metal/src/runtime.rs
@@ -1,4 +1,4 @@
-use crate::kernel::{DYN_SLOT_COUNT, MetalEncodeContext, MetalKernelOp, MpsKernelCache};
+use crate::kernel::{MetalEncodeContext, MetalKernelOp, MpsKernelCache, clear_dyn_dims_order};
 use half::{bf16, f16};
 use itertools::Itertools;
 use luminal::{
@@ -7,7 +7,7 @@ use luminal::{
     hlir::{Input, Output, ReferenceData},
     op::{ExecutionStats, Runtime, RuntimeStats, TimingMethod},
     prelude::{
-        FxHashMap, NodeIndex, ToId,
+        DynMap, FxHashMap, NodeIndex, Symbol, ToId,
         petgraph::{Direction, algo::toposort, prelude::StableGraph, visit::EdgeRef},
     },
 };
@@ -45,7 +45,7 @@ struct MetalExecutionStep {
 
 #[derive(Clone)]
 struct MetalCompiledBucket {
-    bucket_indices: FxHashMap<char, usize>,
+    bucket_indices: DynMap,
     llir_graph: LLIRGraph,
     llir_to_hlir: FxHashMap<NodeIndex, NodeIndex>,
     node_dtypes: FxHashMap<NodeIndex, DType>,
@@ -66,8 +66,12 @@ pub struct MetalRuntime {
     pub buffers: FxHashMap<NodeIndex, Buffer>,
     /// Logical byte length for each active LLIR buffer.
     buffer_lengths: FxHashMap<NodeIndex, u64>,
-    /// Dynamic dimensions table (a-z), shared across all kernels.
+    /// Dynamic dimension sizes, shared across all kernels. Slot `i` holds
+    /// `dyn_dims_order[i]`.
     dyn_buffer: Buffer,
+    /// Layout of `dyn_buffer`. Duplicated from the codegen thread-local so an
+    /// upload on another thread still sees this runtime's layout.
+    dyn_dims_order: Vec<Symbol>,
     /// Retained MPS descriptors/kernels reused across command encodes.
     mps_cache: RefCell<MpsKernelCache>,
     /// The current LLIR graph
@@ -85,7 +89,7 @@ pub struct MetalRuntime {
     /// Precomputed executable nodes and input metadata for the active LLIR graph.
     execution_plan: Vec<MetalExecutionStep>,
     /// Bucket definitions for dynamic dimensions.
-    dim_buckets: FxHashMap<char, Vec<DimBucket>>,
+    dim_buckets: FxHashMap<Symbol, Vec<DimBucket>>,
     /// Compiled LLIR variants, one per bucket combination.
     compiled_buckets: Vec<MetalCompiledBucket>,
     /// Currently active compiled bucket.
@@ -343,7 +347,7 @@ impl Runtime for MetalRuntime {
     fn late_egglog_passes(
         ops: &[std::sync::Arc<Box<dyn luminal::op::EgglogOp>>],
         _options: &luminal::graph::CompileOptions,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
     ) -> Vec<luminal::egglog_utils::LateEgglogPass> {
         vec![crate::memory_analysis::metal_memory_analysis_pass(
             ops, None, dyn_map,
@@ -353,8 +357,9 @@ impl Runtime for MetalRuntime {
     fn initialize(_: Self::CompileArg) -> Self {
         let device = Device::system_default().expect("No Metal device found!");
         let command_queue = device.new_command_queue();
+        // Resized in finish_dyn_dims_layout once the dim set is known.
         let dyn_buffer = device.new_buffer(
-            (DYN_SLOT_COUNT * std::mem::size_of::<i32>()) as u64,
+            std::mem::size_of::<i32>() as u64,
             MTLResourceOptions::StorageModeShared,
         );
 
@@ -366,6 +371,7 @@ impl Runtime for MetalRuntime {
             buffers: FxHashMap::default(),
             buffer_lengths: FxHashMap::default(),
             dyn_buffer,
+            dyn_dims_order: Vec::new(),
             mps_cache: RefCell::new(MpsKernelCache::default()),
             llir_graph: StableGraph::default(),
             llir_to_hlir: FxHashMap::default(),
@@ -389,7 +395,9 @@ impl Runtime for MetalRuntime {
         self.buffers.clear();
         self.buffer_lengths.clear();
         self.dim_buckets.clear();
+        clear_dyn_dims_order();
         self.compiled_buckets = vec![self.compile_bucket(FxHashMap::default(), llir_graph)];
+        self.finish_dyn_dims_layout();
         self.activate_bucket(0);
     }
 
@@ -397,7 +405,7 @@ impl Runtime for MetalRuntime {
     fn profile(
         &mut self,
         llir_graph: &LLIRGraph,
-        dyn_map: &FxHashMap<char, usize>,
+        dyn_map: &DynMap,
         trials: usize,
         timeout: Option<std::time::Duration>,
         early_stop: Option<(Self::ProfileMetric, f64)>,
@@ -432,7 +440,7 @@ impl Runtime for MetalRuntime {
     }
 
     #[tracing::instrument(skip_all)]
-    fn execute(&mut self, dyn_map: &FxHashMap<char, usize>) -> Self::ExecReturn {
+    fn execute(&mut self, dyn_map: &DynMap) -> Self::ExecReturn {
         autoreleasepool(|| {
             self.select_bucket(dyn_map);
             self.allocate_active_intermediate_buffers(dyn_map);
@@ -495,12 +503,15 @@ impl Runtime for MetalRuntime {
 
     fn load_llir_buckets(
         &mut self,
-        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
+        dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
         bucket_llirs: &[BucketLLIR],
     ) {
         self.buffers.clear();
         self.buffer_lengths.clear();
         self.dim_buckets = dim_buckets.clone();
+        // Every bucket encodes against the same dyn_buffer, so one layout covers
+        // all of them; compiling in sequence accumulates into it.
+        clear_dyn_dims_order();
         self.compiled_buckets = bucket_llirs
             .iter()
             .map(|(bucket_indices, _, llir)| self.compile_bucket(bucket_indices.clone(), llir))
@@ -509,12 +520,13 @@ impl Runtime for MetalRuntime {
             !self.compiled_buckets.is_empty(),
             "Metal runtime received no bucketed LLIRs"
         );
+        self.finish_dyn_dims_layout();
         self.activate_bucket(0);
     }
 }
 
 impl RuntimeStats for MetalRuntime {
-    fn execute_with_stats(&mut self, dyn_map: &FxHashMap<char, usize>) -> Option<ExecutionStats> {
+    fn execute_with_stats(&mut self, dyn_map: &DynMap) -> Option<ExecutionStats> {
         let mut total_bytes_loaded = 0usize;
         let mut total_bytes_stored = 0usize;
         let mut total_flops = 0usize;
@@ -569,12 +581,12 @@ impl MetalRuntime {
         }
     }
 
-    pub fn allocate_intermediate_buffers(&mut self, dyn_map: &FxHashMap<char, usize>) {
+    pub fn allocate_intermediate_buffers(&mut self, dyn_map: &DynMap) {
         self.select_bucket(dyn_map);
         self.allocate_active_intermediate_buffers(dyn_map);
     }
 
-    fn allocate_active_intermediate_buffers(&mut self, dyn_map: &FxHashMap<char, usize>) {
+    fn allocate_active_intermediate_buffers(&mut self, dyn_map: &DynMap) {
         let mut planned = Vec::new();
         let capacity_dyn_map = self.active_capacity_dyn_map(dyn_map);
 
@@ -613,16 +625,12 @@ impl MetalRuntime {
         }
     }
 
-    fn output_bytes(
-        kernel_op: &dyn MetalKernelOp,
-        dtype: DType,
-        dyn_map: &FxHashMap<char, usize>,
-    ) -> u64 {
+    fn output_bytes(kernel_op: &dyn MetalKernelOp, dtype: DType, dyn_map: &DynMap) -> u64 {
         let size = kernel_op.output_size().exec(dyn_map).unwrap();
         (size * dtype.bits().div_ceil(8)) as u64
     }
 
-    fn active_capacity_dyn_map(&self, dyn_map: &FxHashMap<char, usize>) -> FxHashMap<char, usize> {
+    fn active_capacity_dyn_map(&self, dyn_map: &DynMap) -> DynMap {
         let mut capacity_dyn_map = dyn_map.clone();
         let Some(active_bucket) = self.compiled_buckets.get(self.active_bucket) else {
             return capacity_dyn_map;
@@ -641,7 +649,7 @@ impl MetalRuntime {
 
     fn compile_bucket(
         &self,
-        bucket_indices: FxHashMap<char, usize>,
+        bucket_indices: DynMap,
         llir_graph: &LLIRGraph,
     ) -> MetalCompiledBucket {
         let mut node_dtypes = FxHashMap::default();
@@ -759,7 +767,7 @@ impl MetalRuntime {
         }
     }
 
-    fn select_bucket(&mut self, dyn_map: &FxHashMap<char, usize>) {
+    fn select_bucket(&mut self, dyn_map: &DynMap) {
         if self.compiled_buckets.len() <= 1 {
             return;
         }
@@ -770,7 +778,7 @@ impl MetalRuntime {
         }
     }
 
-    fn resolve_bucket(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+    fn resolve_bucket(&self, dyn_map: &DynMap) -> usize {
         self.compiled_buckets
             .iter()
             .position(|bucket| {
@@ -791,25 +799,36 @@ impl MetalRuntime {
             })
     }
 
-    fn update_dyn_buffer(&mut self, dyn_map: &FxHashMap<char, usize>) {
+    /// Adopt the layout codegen built and size the buffer to it. Runs *after*
+    /// compiling, since that is when the dims are discovered.
+    fn finish_dyn_dims_layout(&mut self) {
+        self.dyn_dims_order = crate::kernel::dyn_dims_order();
+        // Metal rejects a zero-length buffer; a graph with no dynamic dims
+        // still binds this argument but never reads it.
+        self.dyn_buffer = self.device.new_buffer(
+            (self.dyn_dims_order.len().max(1) * std::mem::size_of::<i32>()) as u64,
+            MTLResourceOptions::StorageModeShared,
+        );
+    }
+
+    fn update_dyn_buffer(&mut self, dyn_map: &DynMap) {
         let ptr = self.dyn_buffer.contents() as *mut i32;
-        unsafe {
-            for idx in 0..DYN_SLOT_COUNT {
-                *ptr.add(idx) = 0;
-            }
-            for (&symbol, &value) in dyn_map {
-                if symbol.is_ascii_lowercase() {
-                    let slot = (symbol as u8 - b'a') as usize;
-                    if slot < DYN_SLOT_COUNT {
-                        *ptr.add(slot) = value as i32;
-                    }
-                }
-            }
+        // By layout position, not by iterating dyn_map: every slot the kernels
+        // can read gets a value, and unreferenced dims are ignored.
+        for (slot, symbol) in self.dyn_dims_order.iter().enumerate() {
+            let value = dyn_map.get(symbol).copied().unwrap_or_else(|| {
+                panic!(
+                    "Metal has no value for dim {symbol}, which its kernels read \
+                     from dyn[{slot}]. Bound dims: {:?}",
+                    dyn_map.keys().collect::<Vec<_>>(),
+                )
+            });
+            unsafe { *ptr.add(slot) = value as i32 };
         }
     }
 
     /// Execute and return GPU-side execution time in microseconds.
-    fn execute_timed(&mut self, dyn_map: &FxHashMap<char, usize>) -> (f64, TimingMethod) {
+    fn execute_timed(&mut self, dyn_map: &DynMap) -> (f64, TimingMethod) {
         autoreleasepool(|| {
             self.select_bucket(dyn_map);
             self.allocate_active_intermediate_buffers(dyn_map);

--- a/crates/luminal_metal/src/tests.rs
+++ b/crates/luminal_metal/src/tests.rs
@@ -277,19 +277,61 @@ fn generate_layer_weights(layer: &MiniTransformerLayer) -> Vec<(GraphTensor, Vec
         .collect()
 }
 
-/// dynamic symbols in kernel expressions should route through dyn buffer.
-#[test]
-fn dynamic_const_codegen_uses_dyn_buffer() {
-    let expr = (IntExpr::from('a') * 2 + IntExpr::from('z')).simplify();
-    let code = lower_expression_for_metal(&expr, "idx");
+/// Which slot a dim gets, by lowering it and reading the emitted subscript.
+fn slot_of(name: &str) -> usize {
+    lower_expression_for_metal(&IntExpr::from(Symbol::new(name)), "idx")
+        .trim_start_matches("dyn[")
+        .trim_end_matches(']')
+        .parse::<usize>()
+        .unwrap()
+}
 
-    assert!(
-        !code.contains("*const_"),
-        "dynamic symbols should be lowered via dyn buffer, got: {code}"
+/// Slots come from the layout, not from the name. The old ABI computed one as
+/// `name_byte - b'a'`, so it could only carry a single `a`..`y` and had no
+/// representation at all for a multi-char or upper-case name.
+#[test]
+fn dyn_slots_are_assigned_by_position_not_by_letter() {
+    crate::kernel::clear_dyn_dims_order();
+
+    // None of these is a single letter, and the last would have collided with
+    // the first under the old byte arithmetic.
+    assert_eq!(slot_of("context_tokens"), 0);
+    assert_eq!(slot_of("input_tokens"), 1);
+    assert_eq!(slot_of("Cached"), 2);
+}
+
+/// A slot is assigned once and never moves. Codegen bakes it into emitted
+/// source as it goes, so a dim discovered later must append rather than
+/// displace one already written.
+#[test]
+fn a_slot_is_stable_once_assigned() {
+    crate::kernel::clear_dyn_dims_order();
+
+    assert_eq!(slot_of("input_tokens"), 0);
+    // Sorts before input_tokens, so it would displace it if the layout re-sorted.
+    assert_eq!(slot_of("cached_tokens"), 1);
+    assert_eq!(slot_of("input_tokens"), 0, "existing slot must be stable");
+    assert_eq!(
+        crate::kernel::dyn_dims_order().len(),
+        2,
+        "the runtime sizes the buffer from this, so every slot must be visible"
     );
-    assert!(
-        code.contains("dyn["),
-        "expected generated kernel expression to reference dyn buffer, got: {code}"
+}
+
+/// Each graph load starts from an empty layout, or slots carry over and the
+/// buffer is sized for dims the new graph never reads.
+#[test]
+fn clearing_the_layout_resets_slot_assignment() {
+    crate::kernel::clear_dyn_dims_order();
+    assert_eq!(slot_of("input_tokens"), 0);
+    assert_eq!(slot_of("cached_tokens"), 1);
+
+    crate::kernel::clear_dyn_dims_order();
+    assert!(crate::kernel::dyn_dims_order().is_empty());
+    assert_eq!(
+        slot_of("cached_tokens"),
+        0,
+        "a fresh graph starts at slot 0"
     );
 }
 

--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -32,8 +32,8 @@ fn copy_host_bytes(ptr: u64, n_bytes: usize, buffer_kind: &str) -> PyResult<Vec<
     Ok(unsafe { std::slice::from_raw_parts(ptr as *const u8, n_bytes).to_vec() })
 }
 
-/// Maps symbolic dimension parameter names (e.g. "seq_len") to luminal IntExpr variable chars.
-pub type DimParamMap = HashMap<String, char>;
+/// Maps symbolic dimension parameter names (e.g. "seq_len") to their dim symbol.
+pub type DimParamMap = HashMap<String, Symbol>;
 
 /// Recover a single-variable dim's variable value from an observed runtime size.
 ///
@@ -43,12 +43,12 @@ pub type DimParamMap = HashMap<String, char>;
 /// — multi-variable expressions, non-affine forms, slope==0, and inversions
 /// that don't divide cleanly are all rejected so we never write a wrong
 /// guess into `dyn_map`.
-fn solve_single_var_dim(expr: &IntExpr, dim_val: usize) -> Option<(char, usize)> {
+fn solve_single_var_dim(expr: &IntExpr, dim_val: usize) -> Option<(Symbol, usize)> {
     use luminal::shape::Term;
     let terms = expr.terms.read();
 
     // Identify the unique variable, if any.
-    let mut var: Option<char> = None;
+    let mut var: Option<Symbol> = None;
     for t in terms.iter() {
         if let Term::Var(c) = t {
             match var {

--- a/crates/luminal_python/rust/src/pt2_compiled_model.rs
+++ b/crates/luminal_python/rust/src/pt2_compiled_model.rs
@@ -17,7 +17,7 @@ type PreloadResult = (Vec<(String, TypedData)>, HashMap<String, usize>);
 
 fn resolve_dim_sizes(
     sizes: &[pt2_schema::DimSize],
-    sym_to_char: &HashMap<String, char>,
+    sym_to_symbol: &HashMap<String, Symbol>,
 ) -> Vec<IntExpr> {
     sizes
         .iter()
@@ -32,10 +32,10 @@ fn resolve_dim_sizes(
                 // the bare-Symbol fast path when that fails — the parser
                 // bails on unrecognised heads (Pow, Min, etc.) and we'd
                 // rather lose the symbolic info than misinterpret it.
-                parse_sympy_expr(s, sym_to_char)
+                parse_sympy_expr(s, sym_to_symbol)
                     .or_else(|| {
                         pt2_parser::extract_symbol_name_pub(s)
-                            .and_then(|sym| sym_to_char.get(&sym).map(|c| IntExpr::from(*c)))
+                            .and_then(|sym| sym_to_symbol.get(&sym).map(|c| IntExpr::from(*c)))
                     })
                     .or_else(|| {
                         // As a last resort, if the EP gave us a concrete `hint`
@@ -133,7 +133,7 @@ pub fn translate_pt2(
     // Set initial dynamic dim values from symbol ranges. PT2 emits
     // `min_val: null` when the constraint is unbounded; fall back to 1 in
     // that case (the smallest valid dim — used only as an initial value).
-    for (sym_name, c) in &translated.sym_map.sym_to_char {
+    for (sym_name, c) in &translated.sym_map.sym_to_symbol {
         if let Some(rc) = translated.sym_map.ranges.get(sym_name) {
             let initial = rc.min_val.unwrap_or(1).max(0) as usize;
             graph.set_dim(*c, initial);
@@ -147,7 +147,7 @@ pub fn translate_pt2(
         .map(|(name, _id)| {
             parsed
                 .tensor_meta(name)
-                .map(|meta| resolve_dim_sizes(&meta.sizes, &translated.sym_map.sym_to_char))
+                .map(|meta| resolve_dim_sizes(&meta.sizes, &translated.sym_map.sym_to_symbol))
                 .unwrap_or_default()
         })
         .collect();
@@ -181,7 +181,7 @@ pub fn translate_pt2(
         .map(|(name, _id)| {
             parsed
                 .tensor_meta(name)
-                .map(|meta| resolve_dim_sizes(&meta.sizes, &translated.sym_map.sym_to_char))
+                .map(|meta| resolve_dim_sizes(&meta.sizes, &translated.sym_map.sym_to_symbol))
                 .unwrap_or_default()
         })
         .collect();
@@ -251,7 +251,7 @@ pub fn translate_pt2(
         }
     }
 
-    let dim_param_map: DimParamMap = translated.sym_map.sym_to_char;
+    let dim_param_map: DimParamMap = translated.sym_map.sym_to_symbol;
 
     let translation = GraphTranslation {
         graph,

--- a/crates/luminal_python/rust/src/pt2_expr.rs
+++ b/crates/luminal_python/rust/src/pt2_expr.rs
@@ -41,22 +41,22 @@ struct BoundedExpr {
 /// Supports the subset of sympy heads PT2 emits for symbolic shape metadata.
 pub(crate) fn parse_sympy_expr(
     expr: &str,
-    sym_to_char: &HashMap<String, char>,
+    sym_to_symbol: &HashMap<String, Symbol>,
 ) -> Option<IntExpr> {
-    parse_sympy_expr_with_ranges(expr, sym_to_char, &HashMap::new())
+    parse_sympy_expr_with_ranges(expr, sym_to_symbol, &HashMap::new())
 }
 
 pub(crate) fn parse_sympy_expr_with_ranges(
     expr: &str,
-    sym_to_char: &HashMap<String, char>,
+    sym_to_symbol: &HashMap<String, Symbol>,
     ranges: &HashMap<String, RangeConstraint>,
 ) -> Option<IntExpr> {
-    parse_sympy_expr_inner(expr, sym_to_char, ranges).map(|parsed| parsed.expr)
+    parse_sympy_expr_inner(expr, sym_to_symbol, ranges).map(|parsed| parsed.expr)
 }
 
-pub(crate) fn sym_char_ranges(sym_map: &SymDimMap) -> FxHashMap<char, ExprBounds> {
+pub(crate) fn sym_char_ranges(sym_map: &SymDimMap) -> FxHashMap<Symbol, ExprBounds> {
     sym_map
-        .sym_to_char
+        .sym_to_symbol
         .iter()
         .map(|(sym_name, sym_char)| {
             let range = sym_map.ranges.get(sym_name);
@@ -74,7 +74,7 @@ pub(crate) fn sym_char_ranges(sym_map: &SymDimMap) -> FxHashMap<char, ExprBounds
 
 pub(crate) fn simplify_expr_with_ranges(
     expr: IntExpr,
-    sym_ranges: &FxHashMap<char, ExprBounds>,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
 ) -> IntExpr {
     simplify_bound_expr(expr, sym_ranges).expr
 }
@@ -82,7 +82,7 @@ pub(crate) fn simplify_expr_with_ranges(
 pub(crate) fn same_expr_with_ranges(
     lhs: IntExpr,
     rhs: IntExpr,
-    sym_ranges: &FxHashMap<char, ExprBounds>,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
 ) -> bool {
     let lhs = simplify_bound_expr(lhs, sym_ranges);
     let rhs = simplify_bound_expr(rhs, sym_ranges);
@@ -94,7 +94,7 @@ pub(crate) fn same_expr_with_ranges(
 pub(crate) fn canonical_equal_expr(
     lhs: IntExpr,
     rhs: IntExpr,
-    sym_ranges: &FxHashMap<char, ExprBounds>,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
 ) -> Option<IntExpr> {
     if !same_expr_with_ranges(lhs, rhs, sym_ranges) {
         return None;
@@ -110,7 +110,7 @@ pub(crate) fn canonical_equal_expr(
 
 fn parse_sympy_expr_inner(
     expr: &str,
-    sym_to_char: &HashMap<String, char>,
+    sym_to_symbol: &HashMap<String, Symbol>,
     ranges: &HashMap<String, RangeConstraint>,
 ) -> Option<ParsedExpr> {
     let expr = expr.trim();
@@ -127,7 +127,7 @@ fn parse_sympy_expr_inner(
         "Symbol" => {
             let name = extract_first_quoted(body)?;
             let bounds = infer_symbol_bounds(body, ranges.get(&name));
-            sym_to_char.get(&name).map(|c| ParsedExpr {
+            sym_to_symbol.get(&name).map(|c| ParsedExpr {
                 expr: IntExpr::from(*c),
                 bounds,
             })
@@ -145,9 +145,9 @@ fn parse_sympy_expr_inner(
                 return None;
             }
             let mut iter = parts.into_iter();
-            let mut acc = parse_sympy_expr_inner(iter.next()?, sym_to_char, ranges)?;
+            let mut acc = parse_sympy_expr_inner(iter.next()?, sym_to_symbol, ranges)?;
             for part in iter {
-                let rhs = parse_sympy_expr_inner(part, sym_to_char, ranges)?;
+                let rhs = parse_sympy_expr_inner(part, sym_to_symbol, ranges)?;
                 acc = match head {
                     "Mul" => ParsedExpr {
                         expr: normalize_mul_expr(acc.expr, rhs.expr),
@@ -166,8 +166,8 @@ fn parse_sympy_expr_inner(
         }
         "FloorDiv" => {
             let mut parts = split_top_level_args(body).into_iter();
-            let lhs = parse_sympy_expr_inner(parts.next()?, sym_to_char, ranges)?;
-            let rhs = parse_sympy_expr_inner(parts.next()?, sym_to_char, ranges)?;
+            let lhs = parse_sympy_expr_inner(parts.next()?, sym_to_symbol, ranges)?;
+            let rhs = parse_sympy_expr_inner(parts.next()?, sym_to_symbol, ranges)?;
             if parts.next().is_some() {
                 return None;
             }
@@ -178,8 +178,8 @@ fn parse_sympy_expr_inner(
         }
         "Mod" => {
             let mut parts = split_top_level_args(body).into_iter();
-            let lhs = parse_sympy_expr_inner(parts.next()?, sym_to_char, ranges)?;
-            let rhs = parse_sympy_expr_inner(parts.next()?, sym_to_char, ranges)?;
+            let lhs = parse_sympy_expr_inner(parts.next()?, sym_to_symbol, ranges)?;
+            let rhs = parse_sympy_expr_inner(parts.next()?, sym_to_symbol, ranges)?;
             if parts.next().is_some() {
                 return None;
             }
@@ -437,7 +437,7 @@ fn simplify_add(lhs: BoundedExpr, rhs: BoundedExpr) -> BoundedExpr {
 fn simplify_sub(
     lhs: BoundedExpr,
     rhs: BoundedExpr,
-    sym_ranges: &FxHashMap<char, ExprBounds>,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
 ) -> BoundedExpr {
     if same_expr_with_ranges(lhs.expr, rhs.expr, sym_ranges) {
         return exact_expr(0);
@@ -459,7 +459,7 @@ fn simplify_sub(
 fn simplify_min(
     lhs: BoundedExpr,
     rhs: BoundedExpr,
-    sym_ranges: &FxHashMap<char, ExprBounds>,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
 ) -> BoundedExpr {
     let bounds = min_bounds(lhs.bounds, rhs.bounds);
     if same_expr_with_ranges(lhs.expr, rhs.expr, sym_ranges) {
@@ -493,7 +493,7 @@ fn simplify_min(
 fn simplify_max(
     lhs: BoundedExpr,
     rhs: BoundedExpr,
-    sym_ranges: &FxHashMap<char, ExprBounds>,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
 ) -> BoundedExpr {
     let bounds = max_bounds(lhs.bounds, rhs.bounds);
     if same_expr_with_ranges(lhs.expr, rhs.expr, sym_ranges) {
@@ -524,7 +524,10 @@ fn simplify_max(
     with_bounds(normalize_expr(lhs.expr.max(rhs.expr)), bounds)
 }
 
-fn simplify_bound_expr(expr: IntExpr, sym_ranges: &FxHashMap<char, ExprBounds>) -> BoundedExpr {
+fn simplify_bound_expr(
+    expr: IntExpr,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
+) -> BoundedExpr {
     let mut stack: Vec<BoundedExpr> = Vec::new();
     let terms = expr.terms.read().clone();
     for term in terms {

--- a/crates/luminal_python/rust/src/pt2_parser.rs
+++ b/crates/luminal_python/rust/src/pt2_parser.rs
@@ -10,6 +10,9 @@ use std::io::Read;
 use anyhow::{Context, Result};
 use zip::ZipArchive;
 
+use luminal::prelude::Symbol;
+use luminal::prelude::tracing::warn;
+
 use crate::pt2_schema::*;
 
 /// Parsed PT2 file contents — everything needed for graph translation.
@@ -42,11 +45,14 @@ pub enum InputKind {
     UserInput { graph_name: String },
 }
 
-/// Symbolic dimension mapping: PT2 symbol name -> luminal char variable.
+/// Symbolic dimension mapping: PT2 symbol name -> luminal dim symbol.
+///
+/// Usually the same string — torch's `s77` stays `s77` — but a name luminal
+/// cannot use is mapped to a minted one.
 #[derive(Debug, Clone)]
 pub struct SymDimMap {
-    /// Maps PT2 symbol names (e.g., "s77") to luminal char variables ('a', 'b', ...)
-    pub sym_to_char: HashMap<String, char>,
+    /// Maps PT2 symbol names (e.g. "s77") to the dim symbol of the same name.
+    pub sym_to_symbol: HashMap<String, Symbol>,
     /// Range constraints for each symbol
     pub ranges: HashMap<String, RangeConstraint>,
 }
@@ -134,8 +140,7 @@ impl ParsedPT2 {
 
     /// Build the symbolic dimension mapping.
     pub fn build_sym_dim_map(&self) -> SymDimMap {
-        let mut sym_to_char = HashMap::new();
-        let mut next_char = b'a';
+        let mut sym_to_symbol = HashMap::new();
 
         // Collect all symbolic dimension names from tensor_values
         let mut sym_set = std::collections::HashSet::new();
@@ -152,15 +157,36 @@ impl ParsedPT2 {
         let mut sym_names: Vec<String> = sym_set.into_iter().collect();
         sym_names.sort();
 
+        // A name we cannot use is remapped, not dropped: a symbol absent from
+        // this map never gets a value, so its dim would freeze at the export
+        // hint while torch, told it was dynamic, declines to recompile.
+        //
+        // Counted rather than derived, because deriving is not injective —
+        // `a.b` and `a-b` both sanitize to `a_b`, putting two dims on one
+        // symbol. Loops because `Dim("pt2_dim_0")` is legal input.
+        let mut minted = 0usize;
         for name in &sym_names {
-            if next_char <= b'z' {
-                sym_to_char.insert(name.clone(), next_char as char);
-                next_char += 1;
-            }
+            let symbol = Symbol::try_new_dim(name).unwrap_or_else(|e| {
+                let replacement = loop {
+                    let candidate = format!("pt2_dim_{minted}");
+                    minted += 1;
+                    if !sym_names.contains(&candidate) {
+                        break candidate;
+                    }
+                };
+                warn!(
+                    "PT2 symbol {name:?} is not a usable luminal dimension name \
+                     ({e}); using {replacement:?} internally. The dim stays \
+                     dynamic and is still addressed as {name:?}."
+                );
+                Symbol::try_new_dim(&replacement)
+                    .expect("minted names are well-formed by construction")
+            });
+            sym_to_symbol.insert(name.clone(), symbol);
         }
 
         SymDimMap {
-            sym_to_char,
+            sym_to_symbol,
             ranges: self.program.range_constraints.clone(),
         }
     }
@@ -318,9 +344,92 @@ mod tests {
         }
         let parsed = parse_pt2(path).unwrap();
         let sym_map = parsed.build_sym_dim_map();
-        // Should have one symbolic dim (s77)
-        assert_eq!(sym_map.sym_to_char.len(), 1);
-        assert!(sym_map.sym_to_char.contains_key("s77"));
-        assert_eq!(sym_map.sym_to_char["s77"], 'a');
+        // Should have one symbolic dim (s77), keeping the name torch gave it.
+        // This used to assert 'a' — the first char out of the 51-name pool.
+        assert_eq!(sym_map.sym_to_symbol.len(), 1);
+        assert!(sym_map.sym_to_symbol.contains_key("s77"));
+        assert_eq!(sym_map.sym_to_symbol["s77"].to_string(), "s77");
+    }
+
+    /// Builds a program whose only tensor has one dim per given symbol name.
+    fn program_with_dim_symbols(names: &[&str]) -> ParsedPT2 {
+        let sizes = names
+            .iter()
+            .map(|n| {
+                format!(
+                    r#"{{"as_expr":{{"expr_str":"Symbol('{n}', positive=True, integer=True)"}}}}"#
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        let json = format!(
+            r#"{{"graph_module":{{"graph":{{"inputs":[],"outputs":[],"nodes":[],
+               "tensor_values":{{"x":{{"dtype":6,"sizes":[{sizes}]}}}}}},
+               "signature":{{"input_specs":[]}}}}}}"#
+        );
+        ParsedPT2 {
+            program: serde_json::from_str(&json).expect("fixture must parse"),
+            constants_config: None,
+            archive_prefix: String::new(),
+            pt2_path: String::new(),
+        }
+    }
+
+    /// torch lets a user write `Dim("_batch")` or `Dim("a__b")` — ordinary
+    /// Python names that are not usable C++ identifiers — and `z` is luminal's
+    /// reserved loop index, which is our constraint leaking into their
+    /// namespace. Every one of them still has to produce a *dynamic* dim:
+    /// dropping the symbol freezes it at the export-time hint (or 1) with
+    /// nothing to correct it later, and torch will not recompile.
+    #[test]
+    fn build_sym_dim_map_remaps_unusable_names_and_keeps_them_dynamic() {
+        let names = ["s77", "u0", "batch", "_batch", "a__b", "z"];
+        let map = program_with_dim_symbols(&names).build_sym_dim_map();
+
+        assert_eq!(map.sym_to_symbol.len(), 6, "no dim may be dropped");
+        for name in names {
+            assert!(map.sym_to_symbol.contains_key(name), "{name} addressable");
+        }
+        // Usable names keep their spelling; only the rejects are renamed.
+        for ok in ["s77", "u0", "batch"] {
+            assert_eq!(map.sym_to_symbol[ok].to_string(), ok);
+        }
+        for rejected in ["_batch", "a__b", "z"] {
+            assert_ne!(map.sym_to_symbol[rejected].to_string(), rejected);
+        }
+
+        let distinct: std::collections::HashSet<_> =
+            map.sym_to_symbol.values().map(|s| s.to_string()).collect();
+        assert_eq!(distinct.len(), 6, "two dims must never share a symbol");
+    }
+
+    /// Minting must not collide with a name the user actually wrote. Deriving
+    /// the replacement from the rejected name would also collapse `a.b` and
+    /// `a-b` onto one symbol, which is why it is counted instead.
+    #[test]
+    fn build_sym_dim_map_mints_around_a_name_the_user_already_used() {
+        let map = program_with_dim_symbols(&["pt2_dim_0", "z"]).build_sym_dim_map();
+
+        assert_eq!(map.sym_to_symbol["pt2_dim_0"].to_string(), "pt2_dim_0");
+        assert_ne!(
+            map.sym_to_symbol["z"].to_string(),
+            "pt2_dim_0",
+            "minted name must not steal the one the user declared"
+        );
+    }
+
+    /// The ceiling this branch removed. `build_sym_dim_map` used to hand each
+    /// symbol a char from an `a..y` + `A..Z` pool and panic at 52 — and symbol
+    /// #26 landed on `z`, the reserved index, so it vanished from the buffer
+    /// planner. A 32-layer llama under sdpa + DynamicCache mints more than 26.
+    #[test]
+    fn build_sym_dim_map_has_no_symbol_ceiling() {
+        let names: Vec<String> = (0..200).map(|n| format!("s{n}")).collect();
+        let refs: Vec<&str> = names.iter().map(String::as_str).collect();
+        let map = program_with_dim_symbols(&refs).build_sym_dim_map();
+        assert_eq!(map.sym_to_symbol.len(), 200);
+        let distinct: std::collections::HashSet<_> =
+            map.sym_to_symbol.values().map(|s| s.to_string()).collect();
+        assert_eq!(distinct.len(), 200, "every dim must stay distinct");
     }
 }

--- a/crates/luminal_python/rust/src/translator/binary.rs
+++ b/crates/luminal_python/rust/src/translator/binary.rs
@@ -11,7 +11,7 @@ use super::Translator;
 fn normalize_equal_dims(
     a: &mut GraphTensor,
     b: &mut GraphTensor,
-    sym_ranges: &FxHashMap<char, ExprBounds>,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
 ) {
     for i in 0..a.legacy_tracker_ref().len() {
         let lhs = a.legacy_tracker_ref().dims[i];
@@ -26,7 +26,7 @@ fn normalize_equal_dims(
 fn same_dims(
     lhs: &[IntExpr],
     rhs: &[IntExpr],
-    sym_ranges: &FxHashMap<char, ExprBounds>,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
 ) -> bool {
     lhs.len() == rhs.len()
         && lhs
@@ -185,7 +185,7 @@ mod tests {
         let lhs = (a.min(1) + a).min(a + 1) - 1;
         let rhs = (a.min(1) + a).min(a);
         let sym_ranges = [(
-            'a',
+            Symbol::from('a'),
             ExprBounds {
                 min: Some(2),
                 max: None,

--- a/crates/luminal_python/rust/src/translator/mod.rs
+++ b/crates/luminal_python/rust/src/translator/mod.rs
@@ -384,10 +384,10 @@ impl<'a> Translator<'a> {
     }
 
     pub(crate) fn resolve_expr_str(&self, expr_str: &str) -> Option<IntExpr> {
-        parse_sympy_expr_with_ranges(expr_str, &self.sym_map.sym_to_char, &self.sym_map.ranges)
+        parse_sympy_expr_with_ranges(expr_str, &self.sym_map.sym_to_symbol, &self.sym_map.ranges)
             .or_else(|| {
                 crate::pt2_parser::extract_symbol_name_pub(expr_str)
-                    .and_then(|sym| self.sym_map.sym_to_char.get(&sym).copied())
+                    .and_then(|sym| self.sym_map.sym_to_symbol.get(&sym).copied())
                     .map(IntExpr::from)
             })
     }

--- a/crates/luminal_python/rust/src/translator/movement.rs
+++ b/crates/luminal_python/rust/src/translator/movement.rs
@@ -17,7 +17,7 @@ fn normalize_concat_dims(
     lhs: &mut GraphTensor,
     rhs: &mut GraphTensor,
     skip_dim: Option<usize>,
-    sym_ranges: &FxHashMap<char, ExprBounds>,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
 ) {
     for i in 0..lhs.legacy_tracker_ref().len() {
         if Some(i) == skip_dim {

--- a/crates/luminal_training/src/reference.rs
+++ b/crates/luminal_training/src/reference.rs
@@ -111,7 +111,7 @@ impl OptimizerStep {
 /// calling `new`.
 pub struct Trainer<O> {
     pub rt: ReferenceRuntime,
-    dyn_map: FxHashMap<char, usize>,
+    dyn_map: DynMap,
     step: OptimizerStep,
     params: Vec<GraphTensor>,
     resident: Vec<GraphTensor>,

--- a/crates/luminal_training/src/view.rs
+++ b/crates/luminal_training/src/view.rs
@@ -168,7 +168,7 @@ pub(crate) fn static_scatter_add(
     m: usize,
     l: usize,
 ) -> Option<GraphTensor> {
-    if m > MAX_STATIC_MAP || !f.dyn_vars().iter().all(|c| *c == 'z') {
+    if m > MAX_STATIC_MAP || !f.dyn_vars().iter().all(|c| c.is_reserved()) {
         return None;
     }
     let mut vals = Vec::with_capacity(m);

--- a/crates/luminal_training/tests/optimizers.rs
+++ b/crates/luminal_training/tests/optimizers.rs
@@ -19,7 +19,7 @@ fn seq(n: usize, lo: f32, hi: f32) -> Vec<f32> {
 /// step scalars; reads updated params and state back after each execute.
 struct OptTrainer {
     rt: ReferenceRuntime,
-    dyn_map: FxHashMap<char, usize>,
+    dyn_map: DynMap,
     loss_out: GraphTensor,
     step: OptimizerStep,
     param_ids: Vec<NodeIndex>,

--- a/crates/luminal_training/tests/training.rs
+++ b/crates/luminal_training/tests/training.rs
@@ -21,7 +21,7 @@ fn seq(n: usize, lo: f32, hi: f32) -> Vec<f32> {
 /// a real training loop would rebind weight buffers.
 struct Trainer {
     rt: ReferenceRuntime,
-    dyn_map: FxHashMap<char, usize>,
+    dyn_map: DynMap,
     loss_out: GraphTensor,
     grad_outs: Vec<GraphTensor>,
     param_ids: Vec<NodeIndex>,

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -34,6 +34,7 @@ Dispositions:
 | `6a5313f2` | #398 | Support for PyTorch OpInfo tests | MIXED — FILE-LEVEL (python + workflow) / RE-EXPRESSED (`TypedBuffer::F64` + typed unary kernels) / DROPPED (`ConstantF64`, the empty-Vec fix) | branch `merge/main-398-opinfo` (two commits) | OpInfo harness, the arange-metadata and acos/acosh lowerings = M4 translator requirements; typed `LogicalConstant`; F32<->F64 cast policy; F64 on CL — see **#398 OpInfo + F64** below |
 | `db3c80fd` | #399 | Add native narrow integer HLIR dtypes | MIXED — FILE-LEVEL (python) / RE-EXPRESSED (I8/U8/I16 TypedBuffer + kernels, int-safe `abs`) | branch `merge/main-399-narrow-ints` (two commits) | **CARVE-OUT to confirm at review**: I8/U8/I16 wrap, I32/I64 stay checked — see **#399 narrow ints** below |
 | `727918cd` | #394 | Optimize CUDA graph materialization and StaticCache writebacks | FILE-LEVEL (parks) + INTENT-ONLY (core) | branch `merge/main-394-cuda-graph-park` | REQUIREMENT FOR THE CL EXECUTOR: durable external device-pointer registration, exact binding-delta graph patching, cached reverse indexes, resource-signature reuse — see **#394 CL executor persistence** below |
+| `b3b975ae` | #396 | shape: name symbolic dimensions instead of numbering them a..z | FILE-LEVEL (parks) + LANDED-BY-EQUIVALENT (core, `90f687bf`) + RE-EXPRESSED (`Symbol::try_new_dim`) | branch `merge/main-396-symbol-parked` | core: resolve later — the branch's own Symbol is the keeper; the PT2 remap and Metal's `dyn[]` slot layout are re-attachment requirements; see **#396 Symbol** below |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -563,3 +564,87 @@ poke (`CudaRuntime`, `CompiledBucket`) is absent here. The two pure helpers
 `device_ranges_overlap` and `should_consume_hlir_input` are ~15 lines and are
 the only directly liftable fragments; copy them when the CL executor needs
 them.
+
+## #396 Symbol — parks tracked, core landed-by-equivalent
+
+RULED 2026-09-02 (ruling 4): *"let's merge the content, we can resolve
+later"*, with the CORE files explicitly NOT applied.
+
+**CORE: LANDED-BY-EQUIVALENT, resolve later.** This branch landed the same
+design independently and deliberately on the same day, as `90f687bf` ("Symbol
+lands: string-backed validated dim names (our PR #396)", 2026-08-13). Same
+contract — `Term::Var(Symbol)`, a Copy handle to an arbitrary-length name,
+equality/hash/order BY NAME so backend slot assignment is a function of the
+graph rather than of interning order — with a simpler mechanism: this branch
+interns one leaked `&'static str` in a process-global map, so `Symbol` derives
+Eq/Hash/Ord and there is no interior mutability inside map keys, which is why
+it needs no `clippy.toml` `mutable_key_type` whitelist (main's arena version
+does, and that is the `clippy.toml` hunk this commit does NOT take). Applying
+main's `src/shape/{symbol,expression,tracker,mod}.rs`, `src/graph.rs`,
+`src/op.rs`, `src/hlir.rs`, `src/dyn_backend.rs` and `src/egglog_utils/*`
+would REGRESS the branch, not advance it; five of those files do not exist
+here at all. The two headline bugs main fixes are already fixed here: the
+extraction truncation (`name.chars().next()` turning `"s77"` into `'s'`) at
+`src/egglog_core/egglog_utils/mod.rs:214-230`, and the 26-name pool overflow,
+which cannot occur because names are strings. Main also reserves `"z"`; this
+branch reserves nothing — `z` was retired 2026-08-06.
+
+**FILE-LEVEL, into the parks.** `crates/luminal_cuda_lite/` (31 files)
+path-rewritten into `crates/luminal_cuda_lite_hlir/`, plus
+`crates/luminal_python` (7), `crates/luminal_metal` (6),
+`crates/luminal_bench` (1) and `crates/luminal_training` (4). The training
+crate is not named in the ruling's parenthetical list of parks; it is the same
+kind of thing — a non-member crate — and its four hunks are one-line
+`FxHashMap<char, usize>` -> `DynMap` retypings, so it is carried with the rest
+and flagged here rather than silently dropped.
+
+55 conflicts in the park and 17 in metal/python, all the same shape: the
+branch's `Expression` -> `IntExpr` rename (A2 quarantine) meeting main's new
+`Symbol`/`DynMap` types. Every one resolves to MAIN's content in the BRANCH's
+spelling. Two needed more than that:
+
+- `crates/luminal_cuda_lite_hlir/src/tests/flashinfer.rs` — main writes
+  `named_tensor(name, dim).as_dtype(Int)`; `as_dtype` was DELETED here
+  (frontend purity rulings 2026-07-30), so the branch's
+  `named_tensor_dtyped(name, dim, Int)` is kept with main's new `token_dim` /
+  `context_dim` variables.
+- `crates/luminal_metal/src/tests.rs` — main REPLACES its own test
+  `dynamic_const_codegen_uses_dyn_buffer` with
+  `dyn_slots_are_assigned_by_position_not_by_letter`, because the mechanism
+  the old one tested (the `dyn[byte - b'a']` ABI) is what the commit deletes.
+  Main's replacement is taken. Nothing is weakened here that this branch runs:
+  metal is not a workspace member.
+
+**UNCARRIED.** `clippy.toml` (+10) — a whitelist for a hazard the branch's
+`Symbol` does not have. `examples/qwen/src/lib.rs` (+1/-1) — no such example
+here; the branch has `examples/qwen3`, a different file, and the hunk is a
+one-line `FxHashMap<char, usize>` -> `DynMap` signature change with no
+counterpart.
+
+**RE-EXPRESSED into live core: `Symbol::try_new_dim`.** Ruling 4 makes this
+conditional on the banked PT2 remap actually referencing it, and it does —
+`crates/luminal_python/rust/src/pt2_parser.rs` calls it twice. So
+`src/shape/symbol.rs` gains the FALLIBLE door beside the panicking
+`Symbol::new` (which now delegates to it, so the two report identically and
+the existing `should_panic` test is untouched), plus an `InvalidSymbolName`
+error type. Main's is a two-variant enum (`Malformed | Reserved`); this branch
+reserves no name, so malformedness is the only failure and the type is a
+struct. The point of the fallible door, written into its doc comment: a
+frontend importing someone else's graph must be able to SEE a rejection and
+remap, because DROPPING an unusable dim is the worst available outcome — a dim
+absent from the symbol map never gets a value, so it freezes at the export
+hint while the frontend, told it was dynamic, declines to recompile. Names are
+still rejected, never sanitized. Test:
+`luminal::shape::symbol::tests::try_new_dim_reports_instead_of_unwinding`.
+
+**Requirements carried, for whenever these crates are re-attached.**
+
+1. **PT2 remap** (`crates/luminal_python/rust/src/pt2_parser.rs`): keep
+   torch's own name, remap to a COUNTED `pt2_dim_{n}` only when the name is
+   unusable, never drop and never sanitize (sanitizing is not injective —
+   `a.b` and `a-b` collide). The banked file now says this; the live door it
+   needs (`try_new_dim`) exists as of this commit.
+2. **Metal `dyn[]` slots** (`crates/luminal_metal/src/kernel/ops.rs`): the
+   per-graph DISCOVERED slot layout replaces `dyn[byte - b'a']`. Under any
+   scheme, a 27th dim writes past an unchecked pointer, so this is a
+   soundness requirement on the metal re-attachment, not a cleanup.

--- a/src/shape/mod.rs
+++ b/src/shape/mod.rs
@@ -1,5 +1,5 @@
 pub mod symbol;
-pub use symbol::{DynMap, Symbol};
+pub use symbol::{DynMap, InvalidSymbolName, Symbol};
 mod expression;
 
 pub use expression::*;

--- a/src/shape/symbol.rs
+++ b/src/shape/symbol.rs
@@ -40,6 +40,29 @@ fn is_well_formed(name: &str) -> bool {
         && !name.contains("__")
 }
 
+/// A name that cannot be a dimension — the REPORTED form of the
+/// rejection [`Symbol::new`] panics on. Main's PR #396 spells this as a
+/// two-variant enum (`Malformed` | `Reserved`); this branch retired the
+/// reserved index with 'z' (z-var retirement, 2026-08-06), so
+/// malformedness is the only way a name can fail here and the type is a
+/// struct. The `Display` text is the panic text verbatim, so the two
+/// doors report identically.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidSymbolName(String);
+
+impl std::fmt::Display for InvalidSymbolName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "symbol name {:?} must match [A-Za-z][A-Za-z0-9_]* with no \
+             doubled underscore (reject, never sanitize)",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for InvalidSymbolName {}
+
 /// An interned symbolic-dimension name.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Symbol(&'static str);
@@ -47,13 +70,28 @@ pub struct Symbol(&'static str);
 impl Symbol {
     /// Intern a validated name — panics loudly on malformed input.
     pub fn new(name: impl AsRef<str>) -> Self {
+        Self::try_new_dim(name).unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Intern a validated name, REPORTING the rejection instead of
+    /// unwinding (main's `Symbol::try_new_dim`, PR #396).
+    ///
+    /// This is the door for a name the caller did not choose. A
+    /// frontend importing someone else's graph — PT2 hands over names
+    /// like `s77`, `u0`, and occasionally things that are not
+    /// identifiers at all — must be able to see the rejection and remap,
+    /// because DROPPING an unusable dim is the worst outcome available:
+    /// a dim absent from the symbol map never gets a value, so it
+    /// freezes at the export hint while the frontend, told it was
+    /// dynamic, declines to recompile. Names are still rejected, never
+    /// sanitized: sanitizing is not injective, so `a.b` and `a-b` would
+    /// land on one symbol.
+    pub fn try_new_dim(name: impl AsRef<str>) -> Result<Self, InvalidSymbolName> {
         let name = name.as_ref();
-        assert!(
-            is_well_formed(name),
-            "symbol name {name:?} must match [A-Za-z][A-Za-z0-9_]* with no \
-             doubled underscore (reject, never sanitize)"
-        );
-        Self::intern(name)
+        if !is_well_formed(name) {
+            return Err(InvalidSymbolName(name.to_string()));
+        }
+        Ok(Self::intern(name))
     }
 
     fn intern(name: &str) -> Self {
@@ -153,6 +191,27 @@ mod tests {
     #[should_panic(expected = "reject, never sanitize")]
     fn malformed_names_are_rejected() {
         Symbol::new("a.b");
+    }
+
+    /// The fallible door reports exactly what the panicking one panics
+    /// with, and accepts exactly what it accepts. No name is reserved on
+    /// this branch, so a bare `"z"` is an ordinary dimension.
+    #[test]
+    fn try_new_dim_reports_instead_of_unwinding() {
+        assert_eq!(
+            Symbol::try_new_dim("seq_len").unwrap(),
+            Symbol::new("seq_len")
+        );
+        assert_eq!(Symbol::try_new_dim("s77").unwrap().name(), "s77");
+        assert_eq!(Symbol::try_new_dim("z").unwrap().name(), "z");
+
+        for bad in ["a.b", "a-b", "", "1st", "a__b"] {
+            let error = Symbol::try_new_dim(bad).unwrap_err().to_string();
+            assert!(
+                error.contains("reject, never sanitize") && error.contains(&format!("{bad:?}")),
+                "the report must name the offending string and the policy, got: {error}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
**Stack.** PR 4 of 8, batch 3 of the main rejoin (walking main's post-split commits chronologically). Base: `merge/main-394-cuda-graph-park`. Merge in order; before merging, retarget to `logical-ssa-project` with `gh pr edit --base logical-ssa-project`.

**Summary.** Carries main `b3b975ae` (#396) per ruling 4: parks file-level (cuda_lite → the hlir park, 31 files; python 7; metal 6; bench 1; plus `crates/luminal_training` 4 — a non-member crate not named in the ruling, one-line `DynMap` retypes, carried and flagged). CORE files NOT applied: the branch landed the equivalent Symbol design (`90f687bf`) — "core: landed-by-equivalent, resolve later".

**What was re-expressed and why.** `Symbol::try_new_dim` (fallible constructor) added to `src/shape/symbol.rs`, as the ruling permits, because the banked PT2 remap calls it (`pt2_parser.rs:169,182`). `Symbol::new` now delegates to it (same panic text; existing `should_panic` test untouched). Error type is a struct `InvalidSymbolName`, not main's `Malformed|Reserved` enum — this branch reserves no name (z retired 2026-08-06); the parked caller uses only `Display`, so nothing dangles. `clippy.toml` (+10, a `mutable_key_type` whitelist for main's arena handle) not created — the branch's `Symbol` has no interior mutability. `examples/qwen/src/lib.rs` has no counterpart.

**Audit.** Parked diff-of-diffs vs `b3b975ae` = `Expression`->`IntExpr` re-spellings and the park's pre-existing `named_tensor_dtyped(…, Int)` (as_dtype is deleted here) only; no rename reverted. `try_new_dim_reports_instead_of_unwinding` green; luminal lib 245/0.

**Not verified.** Parks do not compile; metal's `dyn[]` slot-layout replacement is a re-attachment requirement recorded, not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
