### PR TITLE
main rejoin: translate_module seam (#402): four files banked, scatter fix superseded

### DIFF
--- a/crates/luminal_python/rust/Cargo.toml
+++ b/crates/luminal_python/rust/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition.workspace = true
 
 [lib]
-name = "luminal"
-crate-type = ["cdylib"]
+name = "luminal_python"
+crate-type = ["cdylib", "rlib"]
 path = "src/lib.rs"
 
 [features]

--- a/crates/luminal_python/rust/src/lib.rs
+++ b/crates/luminal_python/rust/src/lib.rs
@@ -1,26 +1,28 @@
-mod compiled_graph;
+pub mod compiled_graph;
 mod dim_arith;
 pub mod torch_dtype;
 pub mod typed_data;
 
 // PT2 modules
-mod pt2_compiled_model;
+pub mod pt2_compiled_model;
 mod pt2_expr;
-mod pt2_parser;
-mod pt2_schema;
+pub mod pt2_parser;
+pub mod pt2_schema;
 mod pt2_util;
-mod translator;
+pub mod translator;
 
 use compiled_graph::CompiledGraph;
-use pt2_compiled_model::process_pt2;
+use pt2_compiled_model::{TranslatedModule, process_pt2, translate_module};
 use pyo3::prelude::*;
 use pyo3::types::PyCapsule;
 use std::collections::HashMap;
 use torch_dtype::TorchDType;
 
 #[pymodule]
-fn luminal(m: &Bound<'_, PyModule>) -> PyResult<()> {
+pub fn luminal(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(process_pt2, m)?)?;
+    m.add_function(wrap_pyfunction!(translate_module, m)?)?;
+    m.add_class::<TranslatedModule>()?;
     m.add_class::<CompiledGraph>()?;
     m.add_function(wrap_pyfunction!(_reference_factory_capsule, m)?)?;
     m.add_function(wrap_pyfunction!(_torch_dtype_codes, m)?)?;

--- a/crates/luminal_python/rust/src/pt2_compiled_model.rs
+++ b/crates/luminal_python/rust/src/pt2_compiled_model.rs
@@ -54,6 +54,75 @@ fn resolve_dim_sizes(
         .collect()
 }
 
+/// A translated module: the HLIR graph and its weights, before any backend
+/// compilation.
+///
+/// Handed to Python only so it can be returned from a `torch.compile` backend;
+/// the embedding host then calls [`TranslatedModule::take`] and owns the
+/// translation outright. Nothing here is `Send`, but nothing needs to be — once
+/// taken, the value never goes back through the interpreter.
+#[pyclass(unsendable)]
+pub struct TranslatedModule {
+    inner: Option<(GraphTranslation, WeightData)>,
+}
+
+impl TranslatedModule {
+    /// Move the translation out. `None` on a second call.
+    pub fn take(&mut self) -> Option<(GraphTranslation, WeightData)> {
+        self.inner.take()
+    }
+}
+
+#[pymethods]
+impl TranslatedModule {
+    /// Whether the translation is still held (false once a host has taken it).
+    fn is_available(&self) -> bool {
+        self.inner.is_some()
+    }
+
+    fn input_names(&self) -> Vec<String> {
+        self.inner
+            .as_ref()
+            .map(|(t, _)| t.input_names.clone())
+            .unwrap_or_default()
+    }
+
+    fn output_names(&self) -> Vec<String> {
+        self.inner
+            .as_ref()
+            .map(|(t, _)| t.output_names.clone())
+            .unwrap_or_default()
+    }
+
+    fn writeback_outputs(&self) -> Vec<(usize, String)> {
+        self.inner
+            .as_ref()
+            .map(|(t, _)| t.writeback_outputs.clone())
+            .unwrap_or_default()
+    }
+}
+
+/// Translate an exported `.pt2` WITHOUT compiling a backend for it.
+///
+/// `process_pt2` translates and then immediately compiles, which fixes the
+/// search budget, the dim buckets and the graph itself at that moment. A host
+/// that wants to make those choices — or to extend the graph before lowering —
+/// needs the translation on its own.
+#[pyfunction]
+#[pyo3(signature = (pt2_path, weights_path, weight_device_ptrs=None))]
+pub fn translate_module(
+    pt2_path: &str,
+    weights_path: &str,
+    weight_device_ptrs: Option<HashMap<String, (u64, usize)>>,
+) -> PyResult<TranslatedModule> {
+    let (translation, mut weights) = translate_pt2(pt2_path, weights_path)
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+    weights.device_ptrs = weight_device_ptrs.unwrap_or_default();
+    Ok(TranslatedModule {
+        inner: Some((translation, weights)),
+    })
+}
+
 #[pyfunction]
 #[pyo3(signature = (pt2_path, weights_path, search_iters, factory_capsule, weight_device_ptrs=None))]
 pub fn process_pt2(

--- a/crates/luminal_python/src/luminal/pt2.py
+++ b/crates/luminal_python/src/luminal/pt2.py
@@ -707,6 +707,67 @@ def _build_dynamic_shapes_from_dim_arg(dynamic_dim, example_args):
     return (spec,) + rest
 
 
+def translate_module(gm, example_inputs, dynamic_shapes=None):
+    """Translate a Dynamo graph module and STOP — no backend compilation.
+
+    Shaped like a torch.compile backend, but returns a `TranslatedModule`
+    instead of a callable: the HLIR graph, its name maps, shape expressions,
+    write-back outputs and weights, with nothing lowered yet.
+
+    That is the difference from `pt2_backend`, which translates and compiles in
+    one step and so fixes the search budget, the dim buckets and the graph
+    itself at that moment. A host that wants to choose those — or to extend the
+    graph before lowering — needs the translation on its own. It also owns the
+    result outright, so no part of serving has to re-enter the interpreter.
+
+    Returns `(TranslatedModule, placeholder_names, keep_alive)`. The names are Dynamo's
+    (`l_input_ids_`), positionally matching the graph's inputs; the translated
+    graph names them `args_N`, and the mapping exists nowhere else.
+    """
+    from .luminal import translate_module as _translate_module
+
+    user_inputs = list(example_inputs)
+    user_inputs, _post_strip, _strip_ok = _strip_symint_placeholders(gm, user_inputs)
+    # AFTER the strip: it removes symint placeholders from `gm`, so what remains
+    # aligns one-to-one with `user_inputs`. Reading them before, or zipping
+    # against the original `example_inputs`, silently misaligns the names.
+    placeholders = [n.name for n in gm.graph.nodes if n.op == "placeholder"]
+
+    try:
+        ep = torch.export.export(
+            gm, tuple(user_inputs), dynamic_shapes=dynamic_shapes, **_export_kwargs()
+        )
+    except Exception:
+        if dynamic_shapes is None:
+            raise
+        ep = torch.export.export(gm, tuple(user_inputs), **_export_kwargs())
+    # LUM-499, same as the compile path: dropped before run_decompositions
+    # calls ep.module().
+    _drop_input_guards(ep)
+    _drop_dead_data_dependent_ops(ep.graph_module)
+    ep = ep.run_decompositions(_decomp_table())
+
+    tmpdir = tempfile.mkdtemp(prefix="luminal_translate_")
+    try:
+        pt2_path = os.path.join(tmpdir, "model.pt2")
+        torch.export.save(ep, pt2_path)
+        # Weights arrive as ordinary graph inputs, keyed by placeholder name,
+        # so their device pointers can be bound without a second copy.
+        named = {
+            name: tensor
+            for name, tensor in zip(placeholders, user_inputs)
+            if isinstance(tensor, torch.Tensor) and tensor.is_cuda
+        }
+        keep_alive, weight_device_ptrs, _cpu = _collect_weight_pointers(named)
+        module = _translate_module(pt2_path, "", weight_device_ptrs)
+        # `keep_alive` is returned, not attached: the bound pointers borrow from
+        # these tensors — including any contiguous copies made here — and the
+        # caller must hold them until it has taken the translation.
+        return module, placeholders, keep_alive
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 def _eager_pt2_compile(
     gm,
     user_inputs,

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -38,6 +38,7 @@ Dispositions:
 | `2fbf5b6a` | #400 | cuda_lite: retype dim maps | DROPPED | — | ruling 5 of 2026-09-02: *"okay, we can drop"*. But the mismatch it repairs is now VERIFIABLY PRESENT in the park — see **#400 dropped** below, which names all 8 sites |
 | `1d07093c` | #401 | Reuse persistent CUDA intermediate arena | FILE-LEVEL (park) + INTENT-ONLY (core) | branch `merge/main-401-arena-park` | REQUIREMENT FOR THE CL EXECUTOR: honour the plan's `BufferAlloc`/`BufferFree` against one runtime-owned high-water slab; park-don't-free, keep-the-largest, re-attach-only-if-wanted — see **#401 persistent arena** below |
 | `7e7deb2a` | #404 | Spec | FILE-LEVEL (`spec.md`) | branch `merge/main-404-spec` | ruling 7 of 2026-09-02: *"this is just a snapshot, we'll update it later"* — the text describes main's architecture (translator-fed HLIR, loop-rolling, genetic LLIR extraction), NOT this branch's; see **#404 spec.md** below for the line-by-line divergence |
+| `d6d26cbe` | #402 | translate_module: hand back the translated graph without the pytorch wrappings | FILE-LEVEL (4 seam files) + SUPERSEDED (the `scatter_nd` fix) | branch `merge/main-402-translate-seam` | the seam's REQUIREMENT for the python re-attachment: a host must be able to take the translated graph WITHOUT inheriting luminal's dim buckets or search budget — see **#402 translate_module** below |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -784,3 +785,59 @@ Profiling -> unrolled LLIR -> Runtime`. On this branch:
 `extractor` + `implementation_search` / `bufferize` / CL flow. Adapting this
 text line by line would be worse than starting from the pipeline as it is;
 what should survive the rewrite is the contracts section, not the diagram.
+
+## #402 translate_module — the seam banked, the scatter fix superseded
+
+RULED 2026-09-02 (ruling 8): *"I like your merge plan"* — the four
+translate-seam files file-level, the `scatter_nd` half dropped as superseded.
+
+**FILE-LEVEL.** `crates/luminal_python/rust/{Cargo.toml, src/lib.rs,
+src/pt2_compiled_model.rs}` and `crates/luminal_python/src/luminal/pt2.py`,
+applied cleanly (empty diff-of-diffs against `d6d26cbe` for those paths). The
+commit adds a "translate and stop" entry point: `translate_module` traces and
+exports a Dynamo `GraphModule`, translates the `.pt2` into a
+`GraphTranslation` + `WeightData`, and hands that back in an unsendable
+`TranslatedModule` pyclass INSTEAD of compiling a backend and returning a
+callable. The packaging change is what makes that usable: the crate builds as
+`rlib` alongside `cdylib` (lib renamed `luminal` -> `luminal_python`) and the
+PT2 modules become `pub`, so a Rust host can LINK the translator rather than
+drive it through the interpreter. Note the `#[pymodule]` is still `fn
+luminal`, so the name Python imports is unchanged — the rename is safe exactly
+as long as that stays true.
+
+**The REQUIREMENT this banks**, for the python re-attachment: *an embedding
+host must be able to take the translated graph without inheriting luminal's
+dim buckets or its search budget.* `process_pt2` chooses both; a host that
+wants to pick its own has nowhere to intervene. On this branch the natural
+expression is handing back the recorded `Graph` (plus its `InputSpec` /
+`output_named` bindings) BEFORE `implementation_search` runs — at which point
+`GraphTranslation` itself has to be redefined in recorder terms, since it
+currently carries HLIR `NodeIndex`es.
+
+**SUPERSEDED — the `pt2_scatter_nd` fix, deliberately not ported.** Main's
+bug: the per-trailing-dim `arange` scaffolding gave the tensor expanded
+(0-stride) dims and then OVERWROTE its `ShapeTracker` with a contiguous
+`[trailing_numel]` view, which is unsound for a virtual dim — at data rank >= 3
+the scatter wrote one element per row. Main replaces it with
+`flat_base.expand_dim(1, trailing_numel) + arange(trailing_numel).expand_dim(0,
+batch_numel)`, which is correct because the trailing offsets happen to be
+row-major over the trailing block.
+
+This branch fixed the same defect independently and by a STRONGER mechanism,
+in its own frontend: `src/frontend/movement.rs:563` `GraphTensor::scatter_nd`
+computes the trailing offset as a real coordinate function —
+`graph().iota(trailing_shape, |c| sum c[ti] * trailing_strides[ti])` over the
+ACTUAL trailing strides, then `expand_rhs` / `expand_lhs` broadcasts (comments
+cite ruling 2026-08-26, "ONE iota + two broadcast applies replace the per-dim
+arange/expand scaffolding"). It does not rely on the trailing block being
+row-major, it uses the strides. And main's buggy CONSTRUCT is not expressible
+here at all: `legacy_tracker_mut` has no definition left anywhere in branch
+`src/`, so there is no ShapeTracker to overwrite.
+
+Porting the hunk into the parked file would create a second, divergent
+spelling of a bug this branch already fixed, which a future reader could
+mistake for the contract. Dropped.
+
+Two bullets in main's own commit message — `DynBackend::move_buffer` and
+`CudaRuntime::write_external` — describe code that is absent from main
+entirely. Do not go looking for them.

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -292,7 +292,10 @@ reference banked at main's spelling, the same standing cost as
 `early_stop_exceeded` in the #386 parks.
 
 **UNCARRIED.** `src/dyn_backend.rs` (+56) and `src/hlir.rs` (+240/-53) are
-deleted on this branch and were dropped from the pick. Of their content:
+deleted on this branch and were dropped from the pick. `src/frontend/other.rs`
+(+11) is live here but was not carried either: its whole hunk is the
+`Graph::constant_float64` door, which is the `ConstantF64` question settled
+below (SUPERSEDED). Of their content:
 
 - The **`bytes_to_reference_data` empty-Vec dtype fix** is DROPPED, not owed:
   it repairs `ReferenceData::from_raw_parts` reinterpreting an empty byte
@@ -340,7 +343,16 @@ dispatch. The pieces:
   an arbitrary hole.
 - Storage and readback: the `PlanDtype::F64` arm in
   `ReferenceRuntime::materialize` (staged F64 accepted, zeros otherwise) and
-  `ReferenceRuntime::get_f64`. The reference BINDING needed no change — it
+  `ReferenceRuntime::get_f64`.
+- **Arm inventory, so "executable" is read at its true width.** F64 executes
+  through the unary family above, through `move_gathered` in
+  `crates/luminal_reference/src/kernels/mod.rs` (gather, index-map
+  materialize, dense layout copy), and through staging and readback. It has
+  NO arm in `add`, `mul`, `less_than`, `reduce_sum`, `reduce_max`, `scatter`
+  or `iota`; each refuses an F64 operand loudly by name at its catch-all.
+  Main had those arms pre-split, via `ReferenceData::F64` in `src/hlir.rs`.
+  **Owed** together with the cast policy in the next paragraph: an F64
+  program today is unary-and-movement only. The reference BINDING needed no change — it
   emits `(bits-of (F64))` through the generic `{dtype:?}` arm, and the
   preamble already sets that row to 64.
 - `crates/luminal_cuda_lite/src/device.rs` gains an F64 arm in
@@ -432,8 +444,9 @@ three `PlanDtype` materialize arms and `get_i8` / `get_u8` / `get_i16`.
 > escaped error that the bounds lattice can and does prove away. The
 > argument against is that it is two overflow semantics in one runtime,
 > distinguishable only by width. If ruled the other way, the change is
-> local: swap `Ok(a.wrapping_add(b))` for a `checked_add` in the six narrow
-> arms and add `(I8)/(U8)/(I16)` proof gates beside the `(Int)` ones.
+> local: swap the `wrapping_*` calls for `checked_*` at the fifteen narrow
+> call sites (`add`, `mul`, `reduce_sum`, `trunc_div`, `trunc_rem`, three
+> widths each) and add `(I8)/(U8)/(I16)` proof gates beside the `(Int)` ones.
 
 **Main's `as` casts: carried for integers, NOT for floats.** A cast touching
 a narrow int routes through one `narrow_cast` helper in
@@ -674,7 +687,10 @@ of this shape).
 
 **What is true NOW, having applied #394 (P3) and #396 (P4) to the park.** The
 park has inherited main's race exactly. Verified after this batch's earlier
-commits, all in `crates/luminal_cuda_lite_hlir/`:
+commits, all in `crates/luminal_cuda_lite_hlir/`. Line numbers are as of
+`e259d33d` (this row's commit); after #401 (P6) the four `src/runtime.rs`
+rows below line 81 sit at 3079, 3080, 3099 and 5353, the `to_host.rs` rows
+do not move:
 
 | file | line | current | #400 would make it |
 | --- | --- | --- | --- |


### PR DESCRIPTION
**Stack.** PR 8 of 8, batch 3 of the main rejoin (walking main's post-split commits chronologically). Base: `merge/main-404-spec`. Merge in order; before merging, retarget to `logical-ssa-project` with `gh pr edit --base logical-ssa-project`.

**Summary.** Carries main `d6d26cbe` (#402) per ruling 8: the four translate_module seam files file-level (`rust/Cargo.toml`, `rust/src/lib.rs`, `pt2_compiled_model.rs`, `pt2.py`) — rlib + cdylib packaging and a "translate and stop" entry point handing back `TranslatedModule`. The `pt2_scatter_nd` hunk is SUPERSEDED and not ported.

**What was re-expressed and why.** Nothing in code. Main's scatter fix replaces an unsound tracker overwrite with `arange(trailing_numel)` broadcast (correct only because trailing offsets happen to be row-major). This branch fixed the same defect by a stronger mechanism: `src/frontend/movement.rs:563` `scatter_nd` builds the trailing offset as one iota over the ACTUAL trailing strides (`:630–640`), and `legacy_tracker_mut` no longer exists in `src/`, so main's buggy construct is inexpressible. Ledger records the seam requirement for the python re-attachment.

**Audit.** Four-file diff-of-diffs vs `d6d26cbe` empty; `translator/movement_dynamic.rs` untouched; `#[pymodule] fn luminal` name unchanged.

**Not verified.** Parked crate does not build.

**Also on this tip:** `ec494a71` docs-only ledger corrections from the batch review (the #398 UNCARRIED path, the F64 arm inventory, the fifteen-not-six wrapping call sites, the #400 table's line pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
