### PR TITLE
metal: add DType::Bool support to the dtype mapping and input path

### DIFF
--- a/crates/luminal_metal/src/kernel/ops.rs
+++ b/crates/luminal_metal/src/kernel/ops.rs
@@ -100,6 +100,10 @@ fn metal_buffer_type(dtype: DType) -> &'static str {
         DType::F32 => "float",
         DType::F16 => "half",
         DType::Int => "int",
+        // `DType::Bool` is documented in src/dtype.rs as "stored as u8, 0 or 1"
+        // and reports bits() == 8, matching the CUDA backend's
+        // `DType::Bool => "unsigned char"`.
+        DType::Bool => "uchar",
         _ => panic!("Metal dtype {dtype:?} is not supported yet"),
     }
 }
@@ -109,6 +113,7 @@ fn metal_numeric_read(dtype: DType, buffer: &str, index: &str) -> String {
         DType::F32 => format!("{buffer}[{index}]"),
         DType::F16 => format!("float({buffer}[{index}])"),
         DType::Int => format!("float({buffer}[{index}])"),
+        DType::Bool => format!("float({buffer}[{index}])"),
         _ => panic!("Metal dtype {dtype:?} is not supported yet"),
     }
 }
@@ -118,13 +123,18 @@ fn metal_numeric_write(dtype: DType, expr: &str) -> String {
         DType::F32 => expr.to_string(),
         DType::F16 => format!("half({expr})"),
         DType::Int => format!("int({expr})"),
+        // Normalise to the documented 0/1 storage invariant rather than
+        // truncating, so a non-{0,1} float can never land in a Bool buffer.
+        DType::Bool => format!("uchar(({expr}) != 0.0f)"),
         _ => panic!("Metal dtype {dtype:?} is not supported yet"),
     }
 }
 
 fn metal_copy_value(dtype: DType, buffer: &str, index: &str) -> String {
     match dtype {
-        DType::F32 | DType::F16 | DType::Int => format!("{buffer}[{index}]"),
+        DType::F32 | DType::F16 | DType::Int | DType::Bool => {
+            format!("{buffer}[{index}]")
+        }
         _ => panic!("Metal dtype {dtype:?} is not supported yet"),
     }
 }
@@ -3763,6 +3773,15 @@ impl MetalKernelOp for MetalCast {
         let input_ty = metal_buffer_type(input_dtype);
         let output_ty = metal_buffer_type(output_dtype);
         let cast_expr = match (input_dtype, output_dtype) {
+            // Casting *to* Bool normalises to the documented 0/1 storage
+            // invariant; a plain truncating cast would let e.g. 2.0 become 2.
+            (DType::F32 | DType::F16 | DType::Int | DType::Bool, DType::Bool) => {
+                format!("({output_ty})(inp[idx] != 0)")
+            }
+            // Casting *from* Bool is an ordinary widening of 0/1.
+            (DType::Bool, DType::F32 | DType::F16 | DType::Int) => {
+                format!("({output_ty})(inp[idx])")
+            }
             (DType::F32, DType::F32)
             | (DType::F16, DType::F16)
             | (DType::Int, DType::Int)

--- a/crates/luminal_metal/src/runtime.rs
+++ b/crates/luminal_metal/src/runtime.rs
@@ -598,6 +598,19 @@ impl MetalRuntime {
                     MTLResourceOptions::StorageModeShared,
                 )
             }
+            // `DType::Bool` is documented in src/dtype.rs as "stored as u8,
+            // 0 or 1" and reports bits() == 8. Normalise through u8 rather
+            // than uploading `Vec<bool>` directly so the 0/1 invariant the
+            // generated `uchar` kernels rely on is enforced here, at the one
+            // place host data enters the backend.
+            DType::Bool => {
+                let values: Vec<u8> = data.to_bool_vec().into_iter().map(|b| b as u8).collect();
+                self.device.new_buffer_with_data(
+                    values.as_ptr() as *const _,
+                    std::mem::size_of_val(values.as_slice()) as u64,
+                    MTLResourceOptions::StorageModeShared,
+                )
+            }
             unsupported => panic!("Metal input dtype {unsupported:?} is not supported yet"),
         }
     }

--- a/crates/luminal_metal/src/tests.rs
+++ b/crates/luminal_metal/src/tests.rs
@@ -1977,3 +1977,235 @@ fn metal_constant_negative_infinity_mask_matches_reference() {
         "expected all -inf, got {metal:?}"
     );
 }
+
+// ============================================================================
+// DType::Bool coverage. Comparisons (`lt` / `le`) always produce Bool, so the
+// whole relu/abs/sign/leaky_relu/gelu family needs Bool to be representable
+// in a Metal buffer. These cover the intermediate path, the host input path,
+// the 0/1 normalisation invariant, and Bool produced from F16 operands.
+// ============================================================================
+
+/// Every op that lowers through a comparison, checked against the reference
+/// runtime. `maximum` is `(a.lt(b).cast(dt) * b) + (b.le(a).cast(dt) * a)` and
+/// `lt`/`le` always produce `DType::Bool`, so each of these needs a Bool
+/// intermediate to be representable in a Metal buffer:
+///   relu -> maximum;  abs -> relu;  sign -> abs;
+///   leaky_relu -> relu;  gelu -> abs + sign.
+#[test]
+fn metal_bool_dependent_unary_ops_match_reference() {
+    let input = seeded_data(64, 4.0, -2.0);
+
+    let cases: [(&str, fn(GraphTensor) -> GraphTensor); 5] = [
+        ("relu", |a| a.relu()),
+        ("abs", |a| a.abs()),
+        ("sign", |a| a.sign()),
+        ("leaky_relu", |a| a.leaky_relu(0.1)),
+        ("gelu", |a| a.gelu()),
+    ];
+
+    for (name, op) in cases {
+        let (metal, reference) = metal_and_reference(
+            |cx| {
+                let a = cx.tensor(64);
+                (a, op(a).output())
+            },
+            &input,
+        );
+        assert_eq!(metal.len(), reference.len(), "{name}: length mismatch");
+        for (i, (m, r)) in metal.iter().zip(reference.iter()).enumerate() {
+            let rel_err = (m - r).abs() / r.abs().max(1.0);
+            assert!(
+                rel_err < 1e-3,
+                "{name}: index {i}: metal {m}, reference {r}, rel_err {rel_err}"
+            );
+        }
+    }
+}
+/// Bool arriving as host input data, read back through a widening cast.
+/// Exercises `MetalRuntime::create_input_buffer`'s Bool arm and the
+/// `(Bool, F32)` cast pair.
+#[test]
+fn metal_bool_input_casts_to_f32() {
+    let mask = vec![true, false, true, true, false, false, true, false];
+    let expected: Vec<f32> = mask.iter().map(|b| if *b { 1.0 } else { 0.0 }).collect();
+
+    let mut cx = Graph::default();
+    let a = cx.tensor(8).as_dtype(DType::Bool);
+    let out = a.cast(DType::F32).output();
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    let mut rt = MetalRuntime::initialize(());
+    rt.set_data(a, mask);
+    let mut rt = cx.search(rt, CompileOptions::default().search_graph_limit(5));
+    rt.allocate_intermediate_buffers(&cx.dyn_map);
+    rt.execute(&cx.dyn_map);
+
+    assert_close(&rt.get_f32(out), &expected, 0.001);
+}
+/// The realistic use of a Bool input: a host-supplied selection mask driving
+/// `cond`. This is the shape an attention mask takes.
+#[test]
+fn metal_bool_input_drives_cond() {
+    let mask = vec![true, false, true, false];
+    let lhs = [10.0f32, 20.0, 30.0, 40.0];
+    let rhs = [-1.0f32, -2.0, -3.0, -4.0];
+    let expected = [10.0f32, -2.0, 30.0, -4.0];
+
+    let mut cx = Graph::default();
+    let m = cx.tensor(4).as_dtype(DType::Bool);
+    let a = cx.tensor(4);
+    let b = cx.tensor(4);
+    let out = a.cond(m, b).output();
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    let mut rt = MetalRuntime::initialize(());
+    rt.set_data(m, mask);
+    rt.set_data(a, &lhs);
+    rt.set_data(b, &rhs);
+    let mut rt = cx.search(rt, CompileOptions::default().search_graph_limit(5));
+    rt.allocate_intermediate_buffers(&cx.dyn_map);
+    rt.execute(&cx.dyn_map);
+
+    assert_close(&rt.get_f32(out), &expected, 0.001);
+}
+/// A non-{0,1} byte must not reach a Bool buffer: casting F32 -> Bool
+/// normalises, so 2.5 and -3.0 both become `true`, not 2 and -3.
+#[test]
+fn metal_cast_to_bool_normalises_to_zero_or_one() {
+    let input = [0.0f32, 1.0, 2.5, -3.0, 1e-8, -0.0];
+    let expected = [0.0f32, 1.0, 1.0, 1.0, 1.0, 0.0];
+
+    let mut cx = Graph::default();
+    let a = cx.tensor(6);
+    let out = a.cast(DType::Bool).cast(DType::F32).output();
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    let mut rt = MetalRuntime::initialize(());
+    rt.set_data(a, &input);
+    let mut rt = cx.search(rt, CompileOptions::default().search_graph_limit(5));
+    rt.allocate_intermediate_buffers(&cx.dyn_map);
+    rt.execute(&cx.dyn_map);
+
+    assert_close(&rt.get_f32(out), &expected, 0.001);
+}
+/// F16 -> Bool -> F32. Exercises the `(F16, Bool)` and `(Bool, F32)` cast
+/// pairs, i.e. a Bool produced from half-precision operands.
+#[test]
+fn metal_f16_comparison_through_bool() {
+    let input = [-2.0f32, -0.5, 0.0, 0.5, 2.0, 4.0, -4.0, 1.0];
+    let expected: Vec<f32> = input
+        .iter()
+        .map(|v| if *v != 0.0 { 1.0 } else { 0.0 })
+        .collect();
+
+    let mut cx = Graph::default();
+    let a = cx.tensor(8).as_dtype(DType::F16);
+    let out = a.cast(DType::Bool).cast(DType::F32).output();
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    let mut rt = MetalRuntime::initialize(());
+    rt.set_data(a, to_f16_vec(&input));
+    let mut rt = cx.search(rt, CompileOptions::default().search_graph_limit(5));
+    rt.allocate_intermediate_buffers(&cx.dyn_map);
+    rt.execute(&cx.dyn_map);
+
+    assert_close(&rt.get_f32(out), &expected, 0.001);
+}
+/// `relu` on an F16 tensor: `maximum` compares two F16 operands, producing a
+/// Bool intermediate that is then cast back to F16. The whole Bool round trip
+/// happens in half precision.
+#[test]
+fn metal_f16_relu_through_bool_intermediate() {
+    let input = [-3.0f32, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0, 3.0];
+    let expected = [0.0f32, 0.0, 0.0, 0.0, 0.5, 1.0, 2.0, 3.0];
+
+    let mut cx = Graph::default();
+    let a = cx.tensor(8).as_dtype(DType::F16);
+    let out = a.relu().cast(DType::F32).output();
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    let mut rt = MetalRuntime::initialize(());
+    rt.set_data(a, to_f16_vec(&input));
+    let mut rt = cx.search(rt, CompileOptions::default().search_graph_limit(5));
+    rt.allocate_intermediate_buffers(&cx.dyn_map);
+    rt.execute(&cx.dyn_map);
+
+    assert_close(&rt.get_f32(out), &expected, 0.002);
+}
+/// `gelu` in half precision — the heaviest Bool consumer, since it routes
+/// through both `abs` and `sign`.
+#[test]
+fn metal_f16_gelu_through_bool_intermediate() {
+    // x = 0 is excluded deliberately. `sign(x) = x / (|x| + 1e-10)` in
+    // src/frontend/unary.rs underflows in F16 (1e-10 < the F16 min subnormal
+    // of ~6e-8), so sign(0) evaluates 0/0 = NaN on *every* backend, including
+    // the reference runtime and CUDA. That is a separate frontend issue,
+    // independent of Bool dtype support.
+    let input = [-2.0f32, -1.0, -0.5, 0.25, 0.5, 1.0, 2.0, 3.0];
+    let expected: Vec<f32> = input
+        .iter()
+        .map(|x| 0.5 * x * (1.0 + libm_erf(x / std::f32::consts::SQRT_2)))
+        .collect();
+
+    let mut cx = Graph::default();
+    let a = cx.tensor(8).as_dtype(DType::F16);
+    let out = a.gelu().cast(DType::F32).output();
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    let mut rt = MetalRuntime::initialize(());
+    rt.set_data(a, to_f16_vec(&input));
+    let mut rt = cx.search(rt, CompileOptions::default().search_graph_limit(5));
+    rt.allocate_intermediate_buffers(&cx.dyn_map);
+    rt.execute(&cx.dyn_map);
+
+    // F16 storage plus the A&S 7.1.26 erf approximation Luminal uses.
+    assert_close(&rt.get_f32(out), &expected, 0.02);
+}
+/// Abramowitz & Stegun 7.1.26 — same approximation `GraphTensor::gelu` uses,
+/// so the test measures backend error rather than approximation error.
+fn libm_erf(x: f32) -> f32 {
+    const P: f32 = 0.3275911;
+    const A: [f32; 5] = [
+        0.254829592,
+        -0.284496736,
+        1.421413741,
+        -1.453152027,
+        1.061405429,
+    ];
+    let sign = if x < 0.0 { -1.0 } else { 1.0 };
+    let x = x.abs();
+    let t = 1.0 / (1.0 + P * x);
+    let poly = ((((A[4] * t + A[3]) * t + A[2]) * t + A[1]) * t + A[0]) * t;
+    sign * (1.0 - poly * (-(x * x)).exp())
+}
+/// argmax 無法走差分 harness（見上），改為直接驗證 Metal 輸出正確。
+#[test]
+fn metal_argmax_matches_cpu() {
+    let data = seeded_data(64, 2.0, 0.5);
+    const COLS: usize = 16;
+    let expected: Vec<f32> = data
+        .as_chunks::<COLS>()
+        .0
+        .iter()
+        .map(|row| {
+            let mut bi = 0usize;
+            for (i, v) in row.iter().enumerate() {
+                if *v > row[bi] {
+                    bi = i;
+                }
+            }
+            bi as f32
+        })
+        .collect();
+
+    let mut cx = Graph::default();
+    let a = cx.tensor((4, 16));
+    let out = a.argmax(1).output();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    let mut rt = MetalRuntime::initialize(());
+    rt.set_data(a, &data);
+    let mut rt = cx.search(rt, CompileOptions::default().search_graph_limit(5));
+    rt.allocate_intermediate_buffers(&cx.dyn_map);
+    rt.execute(&cx.dyn_map);
+    assert_close(&rt.get_f32(out), &expected, 0.001);
+}

--- a/crates/luminal_metal/src/tests.rs
+++ b/crates/luminal_metal/src/tests.rs
@@ -1993,9 +1993,11 @@ fn metal_constant_negative_infinity_mask_matches_reference() {
 ///   leaky_relu -> relu;  gelu -> abs + sign.
 #[test]
 fn metal_bool_dependent_unary_ops_match_reference() {
+    type UnaryOp = fn(GraphTensor) -> GraphTensor;
+
     let input = seeded_data(64, 4.0, -2.0);
 
-    let cases: [(&str, fn(GraphTensor) -> GraphTensor); 5] = [
+    let cases: [(&str, UnaryOp); 5] = [
         ("relu", |a| a.relu()),
         ("abs", |a| a.abs()),
         ("sign", |a| a.sign()),
@@ -2166,11 +2168,11 @@ fn metal_f16_gelu_through_bool_intermediate() {
 fn libm_erf(x: f32) -> f32 {
     const P: f32 = 0.3275911;
     const A: [f32; 5] = [
-        0.254829592,
-        -0.284496736,
-        1.421413741,
-        -1.453152027,
-        1.061405429,
+        0.254_829_6,
+        -0.284_496_72,
+        1.421_413_8,
+        -1.453_152_1,
+        1.061_405_4,
     ];
     let sign = if x < 0.0 { -1.0 } else { 1.0 };
     let x = x.abs();


### PR DESCRIPTION
Metal's dtype mapping has no `DType::Bool` arm, so anything that lowers through
a comparison can't compile. That covers `relu`, `abs`, `sign`, `leaky_relu` and
`gelu`.

`relu` goes through `maximum_f32(0.)` → `maximum`, which is
`(a.lt(b).cast(dt) * b) + (b.le(a).cast(dt) * a)`, and `lt`/`le` always hand
back `DType::Bool` (binary.rs:310). So Bool needs to be representable in a Metal
buffer before any of these work.

Repro is just:

```rust
let a = cx.tensor(8);
let out = a.relu().output();
// panic: Metal dtype Bool is not supported yet
```

0.12s to fail.

The error you actually see is misleading though:

```
Failed to find a viable initial genome after 1 runtime filter failures;
last rejection: candidate compile panicked
```

That reads like the search just wants a bigger budget, so I checked before
assuming otherwise — swept `search_graph_limit` 5→5000 and tensor length 8→1024,
got 12/12 identical failures at ~0.06s each. Which makes sense: `lt()` produces
Bool unconditionally, so there's nothing for the e-graph to route around and the
extractor is out of genomes after one candidate. The real panic gets caught by
the `catch_unwind` in search/mod.rs and only shows up under `LUMINAL_MASK_LOG=1`.

What I changed:

- `kernel/ops.rs` — `DType::Bool => "uchar"` in the four dtype helpers, same
  idea as CUDA's `DType::Bool => "unsigned char"` (cuda_lite/src/lib.rs:101).
  Writes go through `!= 0.0f` rather than a plain cast so nothing outside {0,1}
  can land in a Bool buffer; dtype.rs documents it as "stored as u8, 0 or 1".
- `kernel/ops.rs` — Bool pairs in the `MetalCast` table. Casting to Bool
  normalises, casting from Bool is just a widen.
- `runtime.rs` — Bool in `create_input_buffer`, normalised through `u8` since
  that's the one place host data enters the backend.

Tests cover the intermediate path, Bool as a host input (including driving
`cond`, which is the shape an attention mask takes), the 0/1 normalisation
invariant, and Bool produced from F16 operands. Plus `argmax`, which trips over
the same thing.

On an M4: 63 passed / 0 failed, with the 55 existing tests unchanged. `cargo fmt`
and `cargo clippy --all-targets` both clean.

A couple of notes:

I went with the backend dtype route since it mirrors what CUDA already does and
doesn't touch any rewrites. If you'd rather this were an egglog rewrite that
avoids materialising the Bool intermediate in the first place, happy to redo it
that way — just say which you prefer.

Left `Bf16` alone, since #411 looks like it's already on that.

The F16 gelu test skips `x = 0` deliberately. `sign(x) = x / (|x| + 1e-10)` and
1e-10 is below F16's min subnormal (~6e-8), so `sign(0)` comes out as 0/0 on
every backend, reference runtime included. BF16 is fine, same exponent range as
F32. Nothing to do with this PR, but there's a comment on the test explaining it
so it doesn't look like an oversight.
