### PR TITLE
Reclaim CUDA memory before graph replacement

### DIFF
--- a/crates/luminal_cuda_lite/src/kernel/to_host.rs
+++ b/crates/luminal_cuda_lite/src/kernel/to_host.rs
@@ -11,7 +11,8 @@ use std::{
 };
 
 use cudarc::driver::{
-    CudaFunction, CudaModule, CudaSlice, CudaStream, DevicePtr, sys::CUgraphNode,
+    CudaFunction, CudaModule, CudaSlice, CudaStream, DevicePtr,
+    sys::{self, CUgraphNode},
 };
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
@@ -937,6 +938,23 @@ impl CudaGraphArenaOrdering {
 }
 
 impl CudaGraphOp {
+    /// Destroy an executable that rejected a source-graph update before
+    /// allocating its replacement. CUDA can retain a model-sized graph
+    /// allocation until both the executable is destroyed and the device graph
+    /// pool is trimmed; instantiating first transiently requires both copies.
+    fn retire_failed_graph_exec(
+        stream: &Arc<CudaStream>,
+        exec: CudaGraphExecHandle,
+    ) -> anyhow::Result<()> {
+        stream.synchronize()?;
+        drop(exec);
+        stream.context().bind_to_thread()?;
+        unsafe {
+            sys::cuDeviceGraphMemTrim(stream.context().cu_device()).result()?;
+        }
+        Ok(())
+    }
+
     /// Whether this packaged graph currently owns both a mutable source graph
     /// and an executable instance. Bucket-LRU eviction deliberately releases
     /// both while retaining the compiled operation descriptions.
@@ -3069,6 +3087,14 @@ impl CudaGraphOp {
                                 "CudaGraph cuBLASLt exec update failed after recapture; reinstantiating executable graph: {err:?}",
                             );
                         }
+                        // `exec` still owns the rejected executable. Retire it
+                        // before instantiating the replacement so peak graph
+                        // memory is one executable, not two.
+                        Self::retire_failed_graph_exec(
+                            stream,
+                            exec.take()
+                                .expect("failed graph update lost its executable"),
+                        )?;
                         let timer = Instant::now();
                         state.cuda_graph_exec =
                             Some(state.cuda_graph.as_ref().unwrap().instantiate()?);
@@ -3999,7 +4025,13 @@ impl CudaGraphOp {
         let exec = if let Some(mut exec) = old_exec {
             match exec.update_from_graph(&graph) {
                 Ok(()) => exec,
-                Err(_) => graph.instantiate()?,
+                Err(_) => {
+                    // The rejected executable may own most of the device graph
+                    // pool. It must be destroyed and the unused pool returned
+                    // before allocating the replacement.
+                    Self::retire_failed_graph_exec(stream, exec)?;
+                    graph.instantiate()?
+                }
             }
         } else {
             graph.instantiate()?

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -870,6 +870,12 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         self.cuda_stream
             .synchronize()
             .expect("failed to synchronize after evicting bucket CUDA graphs");
+        // Releasing a bucket also drops prepared library workspaces and
+        // internal buffers allocated from CUDA's stream-ordered pool. The
+        // graph allocator cannot reuse pages retained there, so trim both
+        // independent pools before materializing the replacement bucket.
+        Self::trim_current_memory_pool(&self.cuda_stream)
+            .expect("failed to trim CUDA memory pool after bucket eviction");
         Self::trim_device_graph_memory(&self.cuda_stream)
             .expect("failed to trim CUDA graph memory after bucket eviction");
     }


### PR DESCRIPTION
## Summary
- destroy a CUDA graph executable before instantiating its replacement after an update rejection
- trim unused driver graph memory between the old and replacement executables
- trim both the stream-ordered and graph memory pools after bucket eviction

## Why
The H200 serving sweep showed graph replacement failing with only 13,893,632 bytes free on a 150,110,011,392-byte device. The intermediate arena was correctly capped at 512 MiB. The replacement path still held the rejected executable during instantiation, and bucket eviction returned only graph-pool memory while retired prepared-library allocations remained reserved in the async pool.

## Validation
- CUDARC_CUDA_VERSION=12080 cargo check -p luminal_cuda_lite --lib
- CUDARC_CUDA_VERSION=12080 cargo clippy -p luminal_cuda_lite --lib -- -D warnings
- cargo fmt --all -- --check
- targeted CUDA unit test could not build on this macOS host because nvcc is unavailable