### PR TITLE
main rejoin: Metal RMSNorm + simd reductions (#407): park banked, CL intent recorded

### DIFF
--- a/crates/luminal_metal/src/kernel/ops.rs
+++ b/crates/luminal_metal/src/kernel/ops.rs
@@ -40,6 +40,7 @@ pub type MetalOps = (
     // Reduce ops
     MetalSumReduce,
     MetalMaxReduce,
+    MetalRMSNorm,
     // Matrix ops
     MPSMatmul,
     MPSBatchedMatmul,
@@ -70,6 +71,22 @@ fn compile_shader(device: &Device, source: &str, function_name: &str) -> Compute
         .unwrap_or_else(|err| {
             panic!("Failed to create Metal compute pipeline state for {function_name}: {err:?}\n{source}")
         })
+}
+
+fn reduction_thread_count(pipeline: &ComputePipelineState, reduction_len: usize) -> usize {
+    let simd_width = usize::try_from(pipeline.thread_execution_width())
+        .expect("Metal SIMD width does not fit usize")
+        .max(1);
+    let pipeline_limit = usize::try_from(pipeline.max_total_threads_per_threadgroup())
+        .expect("Metal threadgroup limit does not fit usize");
+    let preferred_limit = 256usize.max(simd_width).min(pipeline_limit);
+    let aligned_limit = (preferred_limit / simd_width) * simd_width;
+    assert!(
+        aligned_limit > 0,
+        "Metal reduction pipeline cannot launch one SIMD group"
+    );
+
+    reduction_len.max(1).min(aligned_limit).div_ceil(simd_width) * simd_width
 }
 
 pub(crate) fn lower_expression_for_metal(expr: &IntExpr, index_var: &str) -> String {
@@ -375,6 +392,359 @@ metal_unary_op!(MetalLog2, "MetalLog2", |x: &str| format!("log2({x})"));
 metal_unary_op!(MetalSin, "MetalSin", |x: &str| format!("sin({x})"));
 metal_unary_op!(MetalSqrt, "MetalSqrt", |x: &str| format!("sqrt({x})"));
 metal_unary_op!(MetalRecip, "MetalRecip", |x: &str| format!("1.0f / ({x})"));
+
+#[derive(Debug, Clone)]
+pub struct MetalRMSNorm {
+    rows: IntExpr,
+    cols: usize,
+    eps: f32,
+}
+
+impl Default for MetalRMSNorm {
+    fn default() -> Self {
+        Self {
+            rows: IntExpr::from(0),
+            cols: 0,
+            eps: 0.0,
+        }
+    }
+}
+
+impl EgglogOp for MetalRMSNorm {
+    fn sort(&self) -> SortDef {
+        sort(
+            OP_KIND,
+            "MetalRMSNorm",
+            &[("out_shape", ELIST), ("eps", F64)],
+        )
+    }
+
+    fn n_inputs(&self) -> usize {
+        2
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![Rule::raw(
+            "(relation metal_rms_rinv (IR IR f64 IntExpr IntExpr))
+            (rule
+                (
+                    (= (F32) (dtype ?x))
+                    (= ?sq (Op (MetalMul ?sq_shape ?sq_a ?sq_b ?sq_o)
+                        (ICons ?x (ICons ?x2 (INil)))))
+                    (= ?x ?x2)
+                    (= ?sq_shape (ECons ?rows (ECons ?cols (ENil))))
+                    (= ?cols (MNum ?cols_n))
+                    (= ?sq_a
+                        (ECons (MMul (MIter) ?cols) (ECons (MIter) (ENil))))
+                    (= ?sq_b
+                        (ECons (MMul (MIter) ?cols) (ECons (MIter) (ENil))))
+                    (= ?sq_o
+                        (ECons (MMul (MIter) ?cols) (ECons (MIter) (ENil))))
+                    (= ?sum (Op (MetalSum ?sum_shape ?cols ?sum_in (MIter) ?sum_out)
+                        (ICons ?sq (INil))))
+                    (= ?sum_shape (ECons ?rows (ENil)))
+                    (= ?sum_in (ECons (MMul (MIter) ?cols) (ENil)))
+                    (= ?sum_out (ECons (MIter) (ENil)))
+
+                    (= ?mean (Op (MetalMul ?mn_shape ?mn_a ?mn_b ?mn_o)
+                        (ICons ?sum (ICons ?rcpn (INil)))))
+                    (= ?mn_shape (ECons ?rows (ENil)))
+                    (= ?mn_a (ECons (MIter) (ENil)))
+                    (= ?mn_b (ECons (MIter) (ENil)))
+                    (= ?mn_o (ECons (MIter) (ENil)))
+                    (= ?rcpn (Op (MetalRecip ?rn_shape ?rn_in ?rn_out)
+                        (ICons ?ncast (INil))))
+                    (= ?rn_shape (ECons ?rows (ENil)))
+                    (= ?rn_in (ECons (MNum 0) (ENil)))
+                    (= ?rn_out (ECons (MIter) (ENil)))
+                    (= ?ncast (MetalCast ?ncst ?nc_size (F32)))
+                    (= ?ncst (MetalIota ?cols2 ?nc_range))
+                    (= ?nc_size (MNum 1))
+                    (= ?nc_range (MNum 1))
+                    (= ?cols ?cols2)
+
+                    (= ?plus_eps (Op (MetalAdd ?pe_shape ?pe_a ?pe_b ?pe_o)
+                        (ICons ?mean (ICons ?eps_const (INil)))))
+                    (= ?pe_shape (ECons ?rows (ENil)))
+                    (= ?pe_a (ECons (MIter) (ENil)))
+                    (= ?pe_b (ECons (MNum 0) (ENil)))
+                    (= ?pe_o (ECons (MIter) (ENil)))
+                    (= ?eps_const (MetalConstant ?eps))
+                    (= ?sqrt (Op (MetalSqrt ?sqrt_shape ?sqrt_in ?sqrt_out)
+                        (ICons ?plus_eps (INil))))
+                    (= ?sqrt_shape (ECons ?rows (ENil)))
+                    (= ?sqrt_in (ECons (MIter) (ENil)))
+                    (= ?sqrt_out (ECons (MIter) (ENil)))
+                    (= ?rinv (Op (MetalRecip ?ri_shape ?ri_in ?ri_out)
+                        (ICons ?sqrt (INil))))
+                    (= ?ri_shape (ECons ?rows (ENil)))
+                    (= ?ri_in (ECons (MIter) (ENil)))
+                    (= ?ri_out (ECons (MIter) (ENil)))
+                )
+                ((metal_rms_rinv ?rinv ?x ?eps ?rows ?cols))
+                :ruleset kernel_fuse_late_pre
+                :name \"metal rms inverse root mean square\"
+            )
+            (rule
+                (
+                    (metal_rms_rinv ?rinv ?x ?eps ?rows ?cols)
+
+                    (= ?norm (Op (MetalMul ?norm_shape ?norm_a ?norm_b ?norm_o)
+                        (ICons ?rinv (ICons ?x3 (INil)))))
+                    (= ?x ?x3)
+                    (= ?norm_shape (ECons ?rows (ECons ?cols (ENil))))
+                    (= ?norm_a (ECons (MIter) (ECons (MNum 0) (ENil))))
+                    (= ?norm_b
+                        (ECons (MMul (MIter) ?cols) (ECons (MIter) (ENil))))
+                    (= ?norm_o
+                        (ECons (MMul (MIter) ?cols) (ECons (MIter) (ENil))))
+
+                    (= ?weighted (Op (MetalMul ?out_shape ?weighted_a ?weighted_b ?weighted_o)
+                        (ICons ?norm (ICons ?weight (INil)))))
+                    (= (F32) (dtype ?weight))
+                    (= ?out_shape (ECons ?rows (ECons ?cols (ENil))))
+                    (= ?weighted_a
+                        (ECons (MMul (MIter) ?cols) (ECons (MIter) (ENil))))
+                    (= ?weighted_b (ECons (MNum 0) (ECons (MIter) (ENil))))
+                    (= ?weighted_o
+                        (ECons (MMul (MIter) ?cols) (ECons (MIter) (ENil))))
+                )
+                (
+                    (let ?rms (Op (MetalRMSNorm ?out_shape ?eps)
+                        (ICons ?x (ICons ?weight (INil)))))
+                    (union ?weighted ?rms)
+                    (set (dtype ?rms) (F32))
+                )
+                :ruleset kernel_fuse_late
+                :name \"metal fused rms norm f32 2d\"
+            )",
+        )]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<IntExpr>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, IntExpr>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        let out_shape = luminal::egglog_utils::extract_expr_list(
+            egraph,
+            kind_children[0],
+            list_cache,
+            expr_cache,
+        )
+        .unwrap();
+        assert_eq!(out_shape.len(), 2, "Metal RMSNorm output must be 2-D");
+        let eps: f64 = egraph.enodes[kind_children[1]]
+            .0
+            .replace('"', "")
+            .parse()
+            .unwrap();
+        let rows = out_shape[0];
+        let cols = out_shape[1]
+            .to_usize()
+            .expect("Metal RMSNorm's last dimension must be static");
+        (
+            LLIROp::new::<dyn MetalKernelOp>(Box::new(Self {
+                rows,
+                cols,
+                eps: eps as f32,
+            })),
+            input_enodes,
+        )
+    }
+}
+
+impl MetalKernelOp for MetalRMSNorm {
+    fn compile(
+        &self,
+        device: &Device,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) -> Option<ComputePipelineState> {
+        let input_dtype = input_dtypes.first().copied().unwrap_or(DType::F32);
+        let weight_dtype = input_dtypes.get(1).copied().unwrap_or(DType::F32);
+        let input_ty = metal_buffer_type(input_dtype);
+        let weight_ty = metal_buffer_type(weight_dtype);
+        let output_ty = metal_buffer_type(output_dtype);
+        let x_val = metal_numeric_read(input_dtype, "x", "base + col");
+        let weight_val = metal_numeric_read(weight_dtype, "weight", "col");
+        let output_val = metal_numeric_write(
+            output_dtype,
+            &format!("({x_val}) * inv_rms * ({weight_val})"),
+        );
+        let cols = self.cols;
+        let eps_bits = self.eps.to_bits();
+        let eps_literal = format!("as_type<float>(0x{eps_bits:08x}u)");
+
+        let vectors_per_thread = cols / (256 * 4);
+        let source = if input_dtype == DType::F32
+            && weight_dtype == DType::F32
+            && output_dtype == DType::F32
+            && cols.is_multiple_of(256 * 4)
+            && vectors_per_thread > 0
+            && vectors_per_thread <= 4
+        {
+            format!(
+                r#"
+                #include <metal_stdlib>
+                using namespace metal;
+
+                #define THREADS_PER_GROUP 256
+                #define VECTORS_PER_THREAD {vectors_per_thread}
+
+                kernel void rms_norm(
+                    const device float4 *x [[buffer(0)]],
+                    const device float4 *weight [[buffer(1)]],
+                    device float4 *out [[buffer(2)]],
+                    uint row [[threadgroup_position_in_grid]],
+                    uint tid [[thread_index_in_threadgroup]],
+                    uint lane [[thread_index_in_simdgroup]],
+                    uint simd_group [[simdgroup_index_in_threadgroup]],
+                    uint simd_width [[threads_per_simdgroup]]
+                ) {{
+                    threadgroup float partials[256];
+                    const uint base = row * ({cols} / 4);
+                    float4 values[VECTORS_PER_THREAD];
+                    float sum = 0.0f;
+
+                    for (uint item = 0; item < VECTORS_PER_THREAD; ++item) {{
+                        const uint col = tid + item * THREADS_PER_GROUP;
+                        const float4 value = x[base + col];
+                        values[item] = value;
+                        sum += dot(value, value);
+                    }}
+
+                    const float simd_total = simd_sum(sum);
+                    if (lane == 0) partials[simd_group] = simd_total;
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+                    if (simd_group == 0) {{
+                        const uint simd_groups =
+                            (THREADS_PER_GROUP + simd_width - 1) / simd_width;
+                        float total = 0.0f;
+                        for (uint group = lane; group < simd_groups; group += simd_width) {{
+                            total += partials[group];
+                        }}
+                        total = simd_sum(total);
+                        if (lane == 0) {{
+                            partials[0] = rsqrt(total / float({cols}) + {eps_literal});
+                        }}
+                    }}
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+                    const float inv_rms = partials[0];
+                    for (uint item = 0; item < VECTORS_PER_THREAD; ++item) {{
+                        const uint col = tid + item * THREADS_PER_GROUP;
+                        out[base + col] = values[item] * inv_rms * weight[col];
+                    }}
+                }}
+                "#,
+            )
+        } else {
+            format!(
+                r#"
+            #include <metal_stdlib>
+            using namespace metal;
+
+            #define THREADS_PER_GROUP 256
+
+            kernel void rms_norm(
+                const device {input_ty} *x [[buffer(0)]],
+                const device {weight_ty} *weight [[buffer(1)]],
+                device {output_ty} *out [[buffer(2)]],
+                uint row [[threadgroup_position_in_grid]],
+                uint tid [[thread_index_in_threadgroup]],
+                uint lane [[thread_index_in_simdgroup]],
+                uint simd_group [[simdgroup_index_in_threadgroup]],
+                uint simd_width [[threads_per_simdgroup]]
+            ) {{
+                threadgroup float partials[256];
+                const uint base = row * {cols};
+                float sum = 0.0f;
+                for (uint col = tid; col < {cols}; col += THREADS_PER_GROUP) {{
+                    float value = {x_val};
+                    sum += value * value;
+                }}
+
+                const float simd_total = simd_sum(sum);
+                if (lane == 0) partials[simd_group] = simd_total;
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+
+                if (simd_group == 0) {{
+                    const uint simd_groups =
+                        (THREADS_PER_GROUP + simd_width - 1) / simd_width;
+                    float total = 0.0f;
+                    for (uint group = lane; group < simd_groups; group += simd_width) {{
+                        total += partials[group];
+                    }}
+                    total = simd_sum(total);
+                    if (lane == 0) {{
+                        partials[0] = rsqrt(total / float({cols}) + {eps_literal});
+                    }}
+                }}
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+                const float inv_rms = partials[0];
+
+                for (uint col = tid; col < {cols}; col += THREADS_PER_GROUP) {{
+                    out[base + col] = {output_val};
+                }}
+            }}
+            "#,
+            )
+        };
+        Some(compile_shader(device, &source, "rms_norm"))
+    }
+
+    fn output_size(&self) -> IntExpr {
+        self.rows * self.cols
+    }
+
+    fn encode_compute(
+        &self,
+        encoder: &ComputeCommandEncoderRef,
+        pipeline: &ComputePipelineState,
+        inputs: &[&Buffer],
+        output: &Buffer,
+        dyn_map: &DynMap,
+    ) {
+        assert_eq!(inputs.len(), 2, "MetalRMSNorm expects x and weight");
+        let rows = self.rows.exec(dyn_map).unwrap() as u64;
+        encoder.set_compute_pipeline_state(pipeline);
+        encoder.set_buffer(0, Some(inputs[0]), 0);
+        encoder.set_buffer(1, Some(inputs[1]), 0);
+        encoder.set_buffer(2, Some(output), 0);
+        encoder.dispatch_thread_groups(MTLSize::new(rows, 1, 1), MTLSize::new(256, 1, 1));
+    }
+
+    fn bytes_loaded(&self, dyn_map: &DynMap) -> usize {
+        let elements = self.output_size().exec(dyn_map).unwrap_or(0);
+        let vectors_per_thread = self.cols / (256 * 4);
+        let inputs_per_element = if self.cols.is_multiple_of(256 * 4)
+            && vectors_per_thread > 0
+            && vectors_per_thread <= 4
+        {
+            2
+        } else {
+            3
+        };
+        elements * inputs_per_element * std::mem::size_of::<f32>()
+    }
+
+    fn bytes_stored(&self, dyn_map: &DynMap) -> usize {
+        self.output_size().exec(dyn_map).unwrap_or(0) * std::mem::size_of::<f32>()
+    }
+
+    fn flops(&self, dyn_map: &DynMap) -> usize {
+        self.output_size().exec(dyn_map).unwrap_or(0) * 4
+    }
+}
 
 #[derive(Debug, Default, Clone)]
 pub struct MetalAdd {
@@ -1027,41 +1397,44 @@ impl MetalKernelOp for MetalSumReduce {
             #include <metal_stdlib>
             using namespace metal;
 
-            #define THREADS_PER_GROUP 256
-
             kernel void mkernel(
                 const device {input_ty} *in [[buffer(0)]],
                 device {output_ty} *out [[buffer(1)]],
                 constant int *dyn [[buffer({dyn_buffer_index})]],
                 constant uint &n_outputs [[buffer({n_outputs_index})]],
+                constant uint &thread_count [[buffer({thread_count_index})]],
                 uint gid [[threadgroup_position_in_grid]],
-                uint tid [[thread_index_in_threadgroup]]
+                uint tid [[thread_index_in_threadgroup]],
+                uint lane [[thread_index_in_simdgroup]],
+                uint simd_group [[simdgroup_index_in_threadgroup]],
+                uint simd_width [[threads_per_simdgroup]]
             ) {{
                 if (gid >= n_outputs) return;
 
-                threadgroup float partials[THREADS_PER_GROUP];
+                threadgroup float partials[256];
 
                 int in_start = {in_idx};
                 int iters = {iters};
                 (void)dyn;
 
                 float sum = 0.0f;
-                for (int i = tid; i < iters; i += THREADS_PER_GROUP) {{
+                for (int i = tid; i < iters; i += thread_count) {{
                     sum += {in_val};
                 }}
 
-                partials[tid] = sum;
+                const float simd_total = simd_sum(sum);
+                if (lane == 0) partials[simd_group] = simd_total;
                 threadgroup_barrier(mem_flags::mem_threadgroup);
-                for (uint stride = THREADS_PER_GROUP / 2; stride > 0; stride >>= 1) {{
-                    if (tid < stride) {{
-                        partials[tid] += partials[tid + stride];
-                    }}
-                    threadgroup_barrier(mem_flags::mem_threadgroup);
-                }}
 
-                if (tid == 0) {{
-                    float block_sum = partials[0];
-                    out[{out_idx}] = {out_val};
+                if (simd_group == 0) {{
+                    const uint simd_groups =
+                        (thread_count + simd_width - 1) / simd_width;
+                    float block_sum = 0.0f;
+                    for (uint group = lane; group < simd_groups; group += simd_width) {{
+                        block_sum += partials[group];
+                    }}
+                    block_sum = simd_sum(block_sum);
+                    if (lane == 0) out[{out_idx}] = {out_val};
                 }}
             }}
             "#,
@@ -1071,6 +1444,7 @@ impl MetalKernelOp for MetalSumReduce {
             out_val = out_val,
             dyn_buffer_index = 2u64,
             n_outputs_index = 3u64,
+            thread_count_index = 4u64,
         );
         Some(compile_shader(device, &source, "mkernel"))
     }
@@ -1102,8 +1476,14 @@ impl MetalKernelOp for MetalSumReduce {
             &n_outputs as *const u32 as *const _,
         );
 
-        // One threadgroup per output element
-        let thread_group_size = MTLSize::new(256, 1, 1);
+        let reduction_len = self.iters.exec(dyn_map).unwrap_or(256);
+        let threads = reduction_thread_count(pipeline, reduction_len) as u32;
+        encoder.set_bytes(
+            4,
+            std::mem::size_of::<u32>() as u64,
+            &threads as *const u32 as *const _,
+        );
+        let thread_group_size = MTLSize::new(threads as u64, 1, 1);
         let thread_groups = MTLSize::new(n_outputs as u64, 1, 1);
         encoder.dispatch_thread_groups(thread_groups, thread_group_size);
     }
@@ -1198,7 +1578,6 @@ impl MetalKernelOp for MetalMaxReduce {
             #include <metal_stdlib>
             using namespace metal;
 
-            #define THREADS_PER_GROUP 256
             #define NEG_INF_F (-INFINITY)
 
             kernel void mkernel(
@@ -1206,34 +1585,39 @@ impl MetalKernelOp for MetalMaxReduce {
                 device {output_ty} *out [[buffer(1)]],
                 constant int *dyn [[buffer({dyn_buffer_index})]],
                 constant uint &n_outputs [[buffer({n_outputs_index})]],
+                constant uint &thread_count [[buffer({thread_count_index})]],
                 uint gid [[threadgroup_position_in_grid]],
-                uint tid [[thread_index_in_threadgroup]]
+                uint tid [[thread_index_in_threadgroup]],
+                uint lane [[thread_index_in_simdgroup]],
+                uint simd_group [[simdgroup_index_in_threadgroup]],
+                uint simd_width [[threads_per_simdgroup]]
             ) {{
                 if (gid >= n_outputs) return;
 
-                threadgroup float partials[THREADS_PER_GROUP];
+                threadgroup float partials[256];
 
                 int in_start = {in_idx};
                 int iters = {iters};
                 (void)dyn;
 
                 float max_val = NEG_INF_F;
-                for (int i = tid; i < iters; i += THREADS_PER_GROUP) {{
+                for (int i = tid; i < iters; i += thread_count) {{
                     max_val = fmax(max_val, {in_val});
                 }}
 
-                partials[tid] = max_val;
+                const float simd_maximum = simd_max(max_val);
+                if (lane == 0) partials[simd_group] = simd_maximum;
                 threadgroup_barrier(mem_flags::mem_threadgroup);
-                for (uint stride = THREADS_PER_GROUP / 2; stride > 0; stride >>= 1) {{
-                    if (tid < stride) {{
-                        partials[tid] = fmax(partials[tid], partials[tid + stride]);
-                    }}
-                    threadgroup_barrier(mem_flags::mem_threadgroup);
-                }}
 
-                if (tid == 0) {{
-                    float block_max = partials[0];
-                    out[{out_idx}] = {out_val};
+                if (simd_group == 0) {{
+                    const uint simd_groups =
+                        (thread_count + simd_width - 1) / simd_width;
+                    float block_max = NEG_INF_F;
+                    for (uint group = lane; group < simd_groups; group += simd_width) {{
+                        block_max = fmax(block_max, partials[group]);
+                    }}
+                    block_max = simd_max(block_max);
+                    if (lane == 0) out[{out_idx}] = {out_val};
                 }}
             }}
             "#,
@@ -1243,6 +1627,7 @@ impl MetalKernelOp for MetalMaxReduce {
             out_val = out_val,
             dyn_buffer_index = 2u64,
             n_outputs_index = 3u64,
+            thread_count_index = 4u64,
         );
         Some(compile_shader(device, &source, "mkernel"))
     }
@@ -1274,7 +1659,14 @@ impl MetalKernelOp for MetalMaxReduce {
             &n_outputs as *const u32 as *const _,
         );
 
-        let thread_group_size = MTLSize::new(256, 1, 1);
+        let reduction_len = self.iters.exec(dyn_map).unwrap_or(256);
+        let threads = reduction_thread_count(pipeline, reduction_len) as u32;
+        encoder.set_bytes(
+            4,
+            std::mem::size_of::<u32>() as u64,
+            &threads as *const u32 as *const _,
+        );
+        let thread_group_size = MTLSize::new(threads as u64, 1, 1);
         let thread_groups = MTLSize::new(n_outputs as u64, 1, 1);
         encoder.dispatch_thread_groups(thread_groups, thread_group_size);
     }

--- a/crates/luminal_metal/src/tests.rs
+++ b/crates/luminal_metal/src/tests.rs
@@ -35,6 +35,79 @@ fn assert_close(actual: &[f32], expected: &[f32], tolerance: f32) {
     }
 }
 
+#[test]
+fn metal_rms_norm_rewrite_matches_reference() {
+    const ROWS: usize = 3;
+    const COLS: usize = 2048;
+    const EPS: f32 = 1e-5;
+
+    let mut cx = Graph::default();
+    let input = cx.tensor(('s', COLS));
+    let weight = cx.tensor(COLS);
+    let output = rms_norm(input, weight, EPS).output();
+    cx.set_dim('s', ROWS);
+
+    let input_data = seeded_data(ROWS * COLS, 1.8, -0.9);
+    let weight_data = seeded_data(COLS, 0.8, 0.6);
+    let mut expected = vec![0.0; ROWS * COLS];
+    for row in 0..ROWS {
+        let values = &input_data[row * COLS..(row + 1) * COLS];
+        let mean_square = values.iter().map(|value| value * value).sum::<f32>() / COLS as f32;
+        let inv_rms = 1.0 / (mean_square + EPS).sqrt();
+        for col in 0..COLS {
+            expected[row * COLS + col] = values[col] * inv_rms * weight_data[col];
+        }
+    }
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    assert!(
+        egraph_has_op(&cx, "MetalRMSNorm"),
+        "expected the decomposed RMSNorm to offer a fused Metal candidate"
+    );
+    let llir = extract_llir_with_op(&cx, "MetalRMSNorm");
+    let mut runtime = MetalRuntime::initialize(());
+    runtime.load_llir(&llir);
+    runtime.set_data(input, &input_data);
+    runtime.set_data(weight, &weight_data);
+    let selected_ops = runtime.debug_kernel_ops();
+    assert!(
+        selected_ops.iter().any(|op| op.contains("MetalRMSNorm")),
+        "expected fused RMSNorm, selected ops: {selected_ops:?}"
+    );
+    runtime.allocate_intermediate_buffers(&cx.dyn_map);
+    runtime.execute(&cx.dyn_map);
+
+    assert_close(&runtime.get_f32(output), &expected, 2e-4);
+}
+
+#[test]
+fn metal_rms_norm_preserves_small_epsilon() {
+    const ROWS: usize = 2;
+    const COLS: usize = 17;
+    const EPS: f32 = 1e-12;
+
+    let mut cx = Graph::default();
+    let input = cx.tensor((ROWS, COLS));
+    let weight = cx.tensor(COLS);
+    let output = rms_norm(input, weight, EPS).output();
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    let llir = extract_llir_with_op(&cx, "MetalRMSNorm");
+    let mut runtime = MetalRuntime::initialize(());
+    runtime.load_llir(&llir);
+    runtime.set_data(input, vec![0.0f32; ROWS * COLS]);
+    runtime.set_data(weight, vec![1.0f32; COLS]);
+    runtime.allocate_intermediate_buffers(&cx.dyn_map);
+    runtime.execute(&cx.dyn_map);
+
+    let actual = runtime.get_f32(output);
+    assert!(
+        actual.iter().all(|value| value.is_finite()),
+        "small positive epsilon must prevent zero-input NaNs: {actual:?}"
+    );
+    assert_close(&actual, &[0.0; ROWS * COLS], 1e-6);
+}
+
 fn bytes_of<T: bytemuck::NoUninit>(values: &[T]) -> Vec<u8> {
     bytemuck::cast_slice(values).to_vec()
 }
@@ -54,6 +127,118 @@ fn egraph_has_op(cx: &Graph, op_name: &str) -> bool {
         .enodes
         .values()
         .any(|(label, _)| label == op_name)
+}
+
+fn extract_llir_with_op(cx: &Graph, op_name: &str) -> luminal::graph::LLIRGraph {
+    let egraph = cx.egraph().expect("search space should be built");
+    let ops = cx
+        .egglog_ops()
+        .expect("search space should have registered egglog ops");
+    let ir_nodes = egraph
+        .enodes
+        .iter()
+        .filter_map(|(node, (label, children))| {
+            if label != "Op" {
+                return None;
+            }
+            let kind_class = children.first()?;
+            egraph.eclasses[kind_class]
+                .1
+                .iter()
+                .any(|kind_node| egraph.enodes[kind_node].0 == op_name)
+                .then_some(node)
+        })
+        .collect::<Vec<_>>();
+    assert!(!ir_nodes.is_empty(), "no {op_name} IR candidate found");
+
+    let mut last_error = None;
+    for ir_node in ir_nodes {
+        for background in 0..64 {
+            let mut rng = StdRng::seed_from_u64(0x4D45_5441_4C00 + background);
+            let mut choices = luminal::egglog_utils::random_initial_choice(egraph, &mut rng);
+            choices.insert(&egraph.node_to_class[ir_node], ir_node);
+            if let Err(error) = luminal::egglog_utils::validate_choice_set(egraph, &choices, ops) {
+                last_error = Some(error);
+                continue;
+            }
+
+            let mut list_cache = FxHashMap::default();
+            let mut expr_cache = FxHashMap::default();
+            let llir = luminal::egglog_utils::egglog_to_llir(
+                egraph,
+                choices,
+                ops,
+                &cx.custom_ops,
+                &mut list_cache,
+                &mut expr_cache,
+                None,
+            );
+            if llir.node_indices().any(|node| {
+                llir[node]
+                    .to_dialect::<dyn crate::kernel::MetalKernelOp>()
+                    .is_some_and(|op| format!("{op:?}").contains(op_name))
+            }) {
+                return llir;
+            }
+            last_error = Some(format!("forced {op_name} candidate did not reach LLIR"));
+        }
+    }
+
+    panic!(
+        "failed to extract {op_name} candidate: {}",
+        last_error.as_deref().unwrap_or("no valid choice set")
+    );
+}
+
+#[test]
+fn metal_rms_norm_rewrite_rejects_noncontiguous_input() {
+    let mut cx = Graph::default();
+    let input = cx.tensor((32, 4)).permute((1, 0));
+    let weight = cx.tensor(32);
+    rms_norm(input, weight, 1e-5).output();
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    assert!(
+        !egraph_has_op(&cx, "MetalRMSNorm"),
+        "the contiguous-only fused kernel must not replace a strided RMSNorm"
+    );
+}
+
+#[test]
+fn metal_rms_norm_rewrite_rejects_dynamic_last_dimension() {
+    let mut cx = Graph::default();
+    let input = cx.tensor(('s', 'h'));
+    let weight = cx.tensor('h');
+    rms_norm(input, weight, 1e-5).output();
+    cx.set_dim('s', 2);
+    cx.set_dim('h', 32);
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    assert!(
+        !egraph_has_op(&cx, "MetalRMSNorm"),
+        "the static-column fused kernel must not be selectable for a dynamic last dimension"
+    );
+}
+
+#[test]
+fn metal_rms_norm_rewrite_rejects_mismatched_square_views() {
+    const SIZE: usize = 8;
+
+    let mut cx = Graph::default();
+    let input = cx.tensor((SIZE, SIZE));
+    let weight = cx.tensor(SIZE);
+    let axis = input.shape.last_axis();
+    let inverse_rms = ((input * input.permute((1, 0))).mean(axis) + 1e-5)
+        .sqrt()
+        .reciprocal()
+        .expand_to_shape_on_axes(input.shape, axis);
+    ((inverse_rms * input) * weight.expand_lhs([SIZE])).output();
+
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    assert!(
+        !egraph_has_op(&cx, "MetalRMSNorm"),
+        "the fusion must reject a lookalike whose square reads x through different layouts"
+    );
 }
 
 fn assert_matmul_options(cx: &Graph, mps_op_name: &str) {
@@ -682,6 +867,37 @@ fn metal_simple_max_reduce() {
 
     let out = rt.get_f32(output);
     assert_close(&out, &[4.0, 8.0], 0.001);
+}
+
+#[test]
+fn metal_reductions_cover_simd_boundaries() {
+    const ROWS: usize = 2;
+
+    for cols in [17, 33, 65, 257, 1025] {
+        let mut cx = Graph::default();
+        let input = cx.tensor((ROWS, cols));
+        let sum_output = input.sum(1).output();
+        let max_output = input.max(1).output();
+        let input_data = seeded_data(ROWS * cols, 2.0, -1.0);
+        let expected_sum = input_data
+            .chunks_exact(cols)
+            .map(|row| row.iter().sum::<f32>())
+            .collect::<Vec<_>>();
+        let expected_max = input_data
+            .chunks_exact(cols)
+            .map(|row| row.iter().copied().fold(f32::NEG_INFINITY, f32::max))
+            .collect::<Vec<_>>();
+
+        cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+        let mut rt = MetalRuntime::initialize(());
+        rt.set_data(input, &input_data);
+        rt = cx.search(rt, CompileOptions::default().search_graph_limit(5));
+        rt.allocate_intermediate_buffers(&cx.dyn_map);
+        rt.execute(&cx.dyn_map);
+
+        assert_close(&rt.get_f32(sum_output), &expected_sum, 0.001);
+        assert_close(&rt.get_f32(max_output), &expected_max, 0.001);
+    }
 }
 
 #[test]

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -41,6 +41,7 @@ Dispositions:
 | `d6d26cbe` | #402 | translate_module: hand back the translated graph without the pytorch wrappings | FILE-LEVEL (4 seam files) + SUPERSEDED (the `scatter_nd` fix) | branch `merge/main-402-translate-seam` | the seam's REQUIREMENT for the python re-attachment: a host must be able to take the translated graph WITHOUT inheriting luminal's dim buckets or search budget — see **#402 translate_module** below |
 | `be22fa60` | #405 | ci: stop running the OpInfo suite in the main Python CUDA job | FILE-LEVEL | branch `merge/main-405-ci-opinfo` | — (the ignore flag is a main-side CI decision; nothing in this workflow runs on this branch) |
 | `ad437d8c` | #403 | luminal_python: promote integer operands on true division | FILE-LEVEL | branch `merge/main-403-int-div-promote` | the promotion point is a REQUIREMENT on the M4 translator re-attachment: this branch lowers `a / b` to `a * b.reciprocal()` exactly as main does, and `LogicalRecip` on an Int64 buffer refuses in the reference kernel — see **#403 int true division** below |
+| `eb7a5d6e` | #407 | metal: add fused RMSNorm and simd-group reductions | FILE-LEVEL (park) + INTENT-ONLY (CL) | branch `merge/main-407-metal-rmsnorm` | REQUIREMENT FOR CL: the live CUDA `reduce` codegen is a serial per-output loop with NO warp-level reduction, and no fused RMSNorm op exists — main`s `simd_sum`/`simd_max` block reduction is the CUDA-applicable half; see **#407 metal RMSNorm + simd reductions** below |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -965,3 +966,134 @@ two Int64 tensors today gets a kernel refusal, not an answer.
 torch, Prompt-Guard-86M at cosine 1.0 / max abs diff 7e-06, mdeberta-v3-base
 compiling — are main's, run against main's HLIR backend. `crates/luminal_python`
 is not a workspace member on this branch, so none of it was rebuilt or rerun.
+
+## #407 metal RMSNorm + simd reductions — banked, and what CL owes
+
+`crates/luminal_metal/src/kernel/ops.rs` (+456/-32) and
+`crates/luminal_metal/src/tests.rs` (+216) take main's diff. `luminal_metal` is
+parked (not a workspace member, does not build here), and the branch's ONLY
+delta to it since the split `325e2e3c` is two re-spellings — `Expression` ->
+`IntExpr` (`ab3b5c66`) and, in `tests.rs` only, `as_dtype(dt)` ->
+`tensor_dtyped(shape, dt)` (`cdeb73c7`, the purity ruling). Main's #396 and
+#386 metal hunks were already banked in batch 3, so nothing else diverges.
+
+**Residue.** `tests.rs`: EMPTY — main's new tests construct their tensors with
+`cx.tensor(...)` and never touch `as_dtype`, so the purity re-spelling had
+nothing to bite. `ops.rs`: 8 lines, every one of them `Expression` -> `IntExpr`
+(6 added lines, 2 context). One conflict, at `lower_expression_for_metal`, where
+main inserts `reduction_thread_count` immediately above a signature this branch
+had already renamed; resolved by taking main's new function verbatim and keeping
+`&IntExpr`.
+
+**The rename reaches inside the egglog strings too**, which is worth stating
+because it is not obvious. `ops.rs:428` is
+`"(relation metal_rms_rinv (IR IR f64 Expression Expression))` — an egglog SORT
+name inside a `Rule::raw` string, not a Rust type — and it was re-spelled to
+`IntExpr` like the rest. That follows the park's own precedent: `ab3b5c66`,
+the rename commit, rewrote
+`crates/luminal_metal/src/memory_analysis.rs:44-45` from
+`(relation metal_output_bytes (OpKind Expression))` to
+`(OpKind IntExpr)`, sort name and all, and every `.rs` file in both the
+`luminal_metal` and `luminal_cuda_lite_hlir` parks is uniformly `IntExpr`
+today (`git grep -c '\bExpression\b' -- 'crates/luminal_*/**/*.rs'` on
+`4ab3ce0c` returns nothing). Note the parks are NOT internally consistent about
+this: the `.egg` FILES under `crates/luminal_cuda_lite_hlir/src/host/` still say
+`Expression` (e.g. `cublaslt_output_witness.egg:23`). Nothing typechecks either
+spelling here — the HLIR schema that declared the sort went with `src/hlir.rs`
+— so the rule is simply to match the file's own crate, and for `.rs` that is
+`IntExpr`.
+
+### What the commit actually does
+
+Two things, and the smaller one is the headline.
+
+**1. `MetalRMSNorm`** — an egglog rewrite (`metal_rms_rinv`) that matches the
+`x*x -> mean -> +eps -> rsqrt -> broadcast-mul -> *weight` chain and folds it
+into one op, plus a fused shader with two code paths: a `float4`-vectorized
+path guarded on `input/weight/output` ALL being `DType::F32` and
+`cols % 1024 == 0` with `1 <= cols/1024 <= 4` (`ops.rs:586-593`), and a scalar
+path for everything else. Six new tests, four of them REFUSAL tests
+(`..._rejects_noncontiguous_input`, `..._rejects_dynamic_last_dimension`,
+`..._rejects_mismatched_square_views`) — the rewrite is guarded, and the guards
+are what the tests pin.
+
+**2. `simd_sum` / `simd_max` block reductions** in the GENERIC `MetalSumReduce`
+and `MetalMaxReduce` (`ops.rs:1425,1436,1608,1619`), replacing an 8-step
+shared-memory tree (`for stride = 128; stride > 0; stride >>= 1`, a
+`threadgroup_barrier` inside every step, 256 floats of threadgroup memory
+written by every thread) with: one `simd_sum` per SIMD group — a hardware
+reduction, no barrier — one lane-0 write per group into `partials[]`, ONE
+barrier, then group 0 folds the handful of per-group partials with a strided
+loop and one more `simd_sum`. Alongside it, `reduction_thread_count`
+(`ops.rs:76`) sizes the threadgroup to the reduction length instead of always
+launching 256: `min(reduction_len, aligned_limit)` rounded UP to a whole
+multiple of `pipeline.thread_execution_width()`, where `aligned_limit` is
+`max(256, simd_width)` clamped to `max_total_threads_per_threadgroup` and
+floored to the SIMD width. The thread count then has to be passed into the
+shader as buffer 4, because the strided load loop (`i += thread_count`) and the
+partial-count arithmetic both depend on it.
+
+### The CL intent this implies — verified against the live crate
+
+`crates/luminal_metal` is a park, so nothing here executes. But the second half
+is a strategy, not a Metal detail, and this branch's live CUDA backend does not
+have it. Three findings, all checked in the tree at `4ab3ce0c`:
+
+**(a) The live reduce is a serial per-output loop.** `crates/luminal_cuda_lite/src/kernels.rs:790`,
+`pub(crate) fn reduce(...)`, whose own doc comment says it: *"Axis reduction,
+axis zero-based FROM THE END (the DPS convention). One thread per output
+element; the reduced extent is looped."* The emitted kernel is one
+`for (unsigned long long r = 0; r < {extent}ULL; ++r) { ... acc = {fold}; }`
+per output element, with `acc` a thread-local register. There is no warp-level
+reduction anywhere in the crate: `grep -rn '__shfl|__syncthreads|__shared__|warpSize|cub::' crates/luminal_cuda_lite/src/`
+returns NOTHING. So a reduction over a long axis with few outputs — exactly the
+RMSNorm shape, one row reduced to one scalar — runs on a single thread. Main's
+strategy is CUDA-applicable essentially unchanged: `simd_sum` is
+`__shfl_down_sync`/`__reduce_add_sync` over a 32-lane warp, the threadgroup
+`partials[]` array is `__shared__`, `threadgroup_barrier` is `__syncthreads()`,
+and `reduction_thread_count`'s SIMD-width alignment is warp alignment. THAT is
+the larger half of this commit's value here, and it is owed to CL as a real
+block-reduction `reduce`, not as an RMSNorm op.
+
+**(b) No fused RMSNorm exists on CL.** `crates/luminal_cuda_lite/src/ops/`
+holds: `add cast constant cublaslt div exp exp2 gather
+index_map_apply_materialize index_map_apply_view iota less_than log2
+materialize_layout_copy modulo mul recip reduce_max reduce_sum scatter sin
+sqrt trunc_div trunc_rem`. An RMSNorm on CL today is that chain of primitives,
+each with its own kernel launch and its own round trip to global memory. A
+fused op is a legitimate future backend matcher — and per the standing doctrine
+("backend matchers match exactly"), it would match the literal chain the
+recorder emits, with the equivalence reasoning left to the general rules.
+
+**(c) Two numeric notes that do NOT transfer unexamined.**
+
+- The fused kernel accumulates in `float` and computes
+  `rsqrt(total / float(cols) + eps)` in f32 REGARDLESS of the input dtype
+  (`ops.rs:635-637` and `687-689`): `float sum`, `float total`,
+  `threadgroup float partials[256]`, and `metal_numeric_read` converts each
+  loaded element to `float` on the way in. For an f16 input that is an
+  opmath UPGRADE — arguably the right answer, and the same thing torch's
+  fused norms do — but it is a silent precision decision taken inside a
+  backend kernel, and on this branch dtype is declared, never implied. A CL
+  equivalent has to state its accumulation dtype rather than inherit one.
+  Note also that the reduction ORDER changes: a strided partial sum per lane,
+  then `simd_sum`, whose intra-warp order is unspecified. Float addition is not
+  associative, and this branch's float-assoc rewrites are dtype-gated to
+  Int/Int64 for exactly that reason — the kernel is free to do this (it is a
+  backend implementation, not an e-graph rewrite), but it means the fused
+  result is not bit-identical to the unfused chain. Main's own tolerances say
+  so: `assert_close(..., 2e-4)`.
+- `MetalRMSNorm::bytes_loaded` (`ops.rs:726-737`) reports
+  `elements * inputs_per_element * 4`, where `inputs_per_element` is **2** on
+  the vectorized path and **3** otherwise — a shader-path-dependent COST, and
+  a fictional one either way (it prices `size_of::<f32>()` regardless of the
+  actual dtype, and it prices the weight per output element rather than per
+  row). This branch's cost model is different by ruling (2026-08-10,
+  `src/extractor.rs:1684-1718`): `heuristic_cost` is bytes moved — operand
+  bytes for every declared READ plus result bytes for every declared WRITE,
+  with symbolic dims at the midpoint of their seeded interval bounds, computed
+  from the layout's own extents and the element's real bit width. A CL fused
+  RMSNorm would price itself through `candidate_heuristic_cost` from its
+  declared reads and writes; it would NOT get to invent a per-element input
+  count, and it would not get a different cost for choosing a different
+  shader. Do not port `bytes_loaded`.


### PR DESCRIPTION
**Stack.** PR 3 of 4, batch 4 of the main rejoin (main's post-split commits, chronological). Base: `merge/main-403-int-div-promote`. Merge in order; before merging, retarget to `logical-ssa-project` with `gh pr edit --base logical-ssa-project`.

**Gate policy (Austin, 2026-09-03):** run at risk — minimal gate (build, the added/changed tests by exact name, lib-only clippy, fmt); the full suite runs detached and any failure is a follow-up, not a blocker.

## `967d2b2f` Metal RMSNorm + simd reductions (#407): park banked, CL intent recorded

Carries main's eb7a5d6e ("metal: add fused RMSNorm and simd-group reductions",
#407) file-level into the parked luminal_metal crate:
src/kernel/ops.rs (+456/-32) and src/tests.rs (+216).

The crate is parked here — not a workspace member, does not build — and the
branch's only delta to it since the split 325e2e3c is two re-spellings:
Expression -> IntExpr (ab3b5c66) and, in tests.rs only, as_dtype(dt) ->
tensor_dtyped(shape, dt) (cdeb73c7, the purity ruling). Main's #396 and #386
metal hunks were already banked in batch 3, so nothing else diverged.

Diff-of-diffs residue: tests.rs is EMPTY (main's new tests build their tensors
with cx.tensor(...) and never touch as_dtype). ops.rs is 8 lines, all of them
Expression -> IntExpr — 6 added lines plus 2 context. One conflict, at
lower_expression_for_metal, where main inserts reduction_thread_count directly
above a signature this branch had already renamed; resolved by taking main's
new function verbatim and keeping &IntExpr.

The rename reaches inside the egglog strings too, which is worth stating
because it is not obvious: ops.rs:428 is
"(relation metal_rms_rinv (IR IR f64 Expression Expression))", an egglog SORT
name in a Rule::raw string rather than a Rust type, and it was re-spelled to
IntExpr along with everything else. That follows the park's own precedent —
ab3b5c66 rewrote crates/luminal_metal/src/memory_analysis.rs:44-45 from
(relation metal_output_bytes (OpKind Expression)) to (OpKind IntExpr), sort
name included — and every .rs file in both the luminal_metal and
luminal_cuda_lite_hlir parks is uniformly IntExpr today. The parks are not
internally consistent about it (the .egg FILES under
crates/luminal_cuda_lite_hlir/src/host/ still say Expression), but nothing
typechecks either spelling now that the HLIR schema is deleted, so the rule is
to match the file's own crate.

The commit is two things, and the smaller one is the headline. MetalRMSNorm is
a guarded egglog rewrite folding x*x -> mean -> +eps -> rsqrt -> mul -> *weight
into one op, with a float4 path gated on all-F32 and cols a multiple of 1024,
a scalar path otherwise, and six tests of which four are refusal tests. The
larger half is simd_sum / simd_max block reductions in the GENERIC
MetalSumReduce and MetalMaxReduce, replacing an 8-step shared-memory tree with
a barrier per step by one hardware reduction per SIMD group, one barrier, and a
fold of the per-group partials; plus reduction_thread_count, which sizes the
threadgroup to the reduction length rounded up to the SIMD width instead of
always launching 256 threads.

That second half is a strategy, not a Metal detail, and the ledger records it
as an intent CL owes, verified against the live crate at 4ab3ce0c:

(a) crates/luminal_cuda_lite/src/kernels.rs:790 fn reduce is a serial
per-output loop — its own doc says "One thread per output element; the reduced
extent is looped" — and the crate contains NO warp-level reduction at all
(grep for __shfl / __syncthreads / __shared__ / warpSize / cub:: returns
nothing). A long-axis reduction with few outputs, exactly the RMSNorm shape,
runs on one thread. Main's strategy ports essentially unchanged: simd_sum is a
warp shuffle, partials[] is __shared__, threadgroup_barrier is
__syncthreads(), SIMD-width alignment is warp alignment.

(b) No fused RMSNorm op exists on CL: crates/luminal_cuda_lite/src/ops/ holds
24 primitives and none of them is a norm.

(c) Two numeric notes that do NOT transfer unexamined. The fused kernel
accumulates in float and computes rsqrt(total / float(cols) + eps) in f32
regardless of input dtype — an opmath upgrade for f16 that is silently taken
inside a backend kernel, where on this branch dtype is declared, never implied;
and the reduction order changes, so the fused result is not bit-identical to
the chain (main's own tolerance is 2e-4). And bytes_loaded reports 2 vs 3
inputs per element depending on which shader path fires, priced at
size_of::<f32>() regardless of dtype — a shader-path-dependent, fictional cost.
This branch prices by ruling (2026-08-10): heuristic_cost is bytes moved,
operand bytes per declared read plus result bytes per declared write, from the
layout's own extents and the element's real width (src/extractor.rs:1684).
Do not port bytes_loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
