### PR TITLE
main rejoin: ATen coverage (#414): the python park banked in one go

### DIFF
--- a/crates/luminal_cuda_lite_hlir/src/runtime.rs
+++ b/crates/luminal_cuda_lite_hlir/src/runtime.rs
@@ -1616,15 +1616,19 @@ impl CudaRuntime {
             "get_i16: buffer dtype is {buf_dtype:?}, expected I16"
         );
         self.get_output_data(id)
-            .chunks_exact(2)
-            .map(|bytes| i16::from_ne_bytes([bytes[0], bytes[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|bytes| i16::from_ne_bytes(*bytes))
             .collect_vec()
     }
 
     pub fn get_i32(&self, id: impl ToId) -> Vec<i32> {
         self.get_output_data(id)
-            .chunks_exact(4)
-            .map(|c| i32::from_ne_bytes([c[0], c[1], c[2], c[3]]))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|bytes| i32::from_ne_bytes(*bytes))
             .collect_vec()
     }
 
@@ -1642,8 +1646,10 @@ impl CudaRuntime {
             );
         }
         self.get_output_data(id)
-            .chunks_exact(8)
-            .map(|c| i64::from_ne_bytes([c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]]))
+            .as_chunks::<8>()
+            .0
+            .iter()
+            .map(|bytes| i64::from_ne_bytes(*bytes))
             .collect_vec()
     }
 
@@ -1661,8 +1667,10 @@ impl CudaRuntime {
             );
         }
         self.get_output_data(id)
-            .chunks_exact(8)
-            .map(|c| f64::from_ne_bytes([c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]]))
+            .as_chunks::<8>()
+            .0
+            .iter()
+            .map(|bytes| f64::from_ne_bytes(*bytes))
             .collect_vec()
     }
 

--- a/crates/luminal_cuda_lite_hlir/src/tests/flashinfer.rs
+++ b/crates/luminal_cuda_lite_hlir/src/tests/flashinfer.rs
@@ -1461,8 +1461,10 @@ fn f32s_to_bf16_bytes(data: &[f32]) -> Vec<u8> {
 
 fn bf16_bytes_to_f32s(bytes: &[u8]) -> Vec<f32> {
     bytes
-        .chunks_exact(2)
-        .map(|c| half::bf16::from_le_bytes([c[0], c[1]]).to_f32())
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|c| half::bf16::from_le_bytes(*c).to_f32())
         .collect()
 }
 

--- a/crates/luminal_python/rust/src/pt2_expr.rs
+++ b/crates/luminal_python/rust/src/pt2_expr.rs
@@ -79,6 +79,13 @@ pub(crate) fn simplify_expr_with_ranges(
     simplify_bound_expr(expr, sym_ranges).expr
 }
 
+pub(crate) fn bounds_of_expr(
+    expr: IntExpr,
+    sym_ranges: &FxHashMap<Symbol, ExprBounds>,
+) -> ExprBounds {
+    simplify_bound_expr(expr, sym_ranges).bounds
+}
+
 pub(crate) fn same_expr_with_ranges(
     lhs: IntExpr,
     rhs: IntExpr,

--- a/crates/luminal_python/rust/src/pt2_schema.rs
+++ b/crates/luminal_python/rust/src/pt2_schema.rs
@@ -285,6 +285,18 @@ impl Argument {
     pub fn as_float(&self) -> Option<f64> {
         match self {
             Argument::Float(f) => Some(f.as_float),
+            // PT2 JSON cannot encode IEEE non-finite values as JSON numbers,
+            // so torch serializes them as strings inside the usual as_float
+            // wrapper (notably linalg_vector_norm's +/-Infinity orders).
+            Argument::Other(value) => value
+                .get("as_float")
+                .and_then(serde_json::Value::as_str)
+                .and_then(|value| match value {
+                    "Infinity" | "+Infinity" => Some(f64::INFINITY),
+                    "-Infinity" => Some(f64::NEG_INFINITY),
+                    "NaN" => Some(f64::NAN),
+                    _ => value.parse().ok(),
+                }),
             _ => None,
         }
     }

--- a/crates/luminal_python/rust/src/translator/binary.rs
+++ b/crates/luminal_python/rust/src/translator/binary.rs
@@ -64,18 +64,28 @@ impl<'a> Translator<'a> {
 
     fn promoted_binary_inputs(&mut self, node: &Node) -> Result<(GraphTensor, GraphTensor)> {
         let dtype = self.output_meta_dtype(node)?;
-        let mut a = self.get_input_tensor(node, 0)?.cast(dtype);
-        let mut b = if let Some(name) = node.inputs[1].arg.as_tensor_name() {
-            self.get_tensor(name)?.cast(dtype)
-        } else {
-            let value = node.inputs[1]
+        let mut operand = |index: usize| -> Result<GraphTensor> {
+            if let Some(name) = node.inputs[index].arg.as_tensor_name() {
+                return Ok(self.get_tensor(name)?.cast(dtype));
+            }
+            let value = node.inputs[index]
                 .arg
                 .as_int()
                 .map(|value| value as f64)
-                .or_else(|| node.inputs[1].arg.as_float())
-                .ok_or_else(|| anyhow::anyhow!("{} requires a numeric RHS", node.target))?;
-            self.scalar_constant(value, dtype)
+                .or_else(|| node.inputs[index].arg.as_float())
+                .or_else(|| {
+                    node.inputs[index]
+                        .arg
+                        .as_bool()
+                        .map(|value| if value { 1.0 } else { 0.0 })
+                })
+                .ok_or_else(|| {
+                    anyhow::anyhow!("{} input {index} must be tensor or numeric", node.target)
+                })?;
+            Ok(self.scalar_constant(value, dtype))
         };
+        let mut a = operand(0)?;
+        let mut b = operand(1)?;
         (a, b) = broadcast_binary(a, b);
 
         let sym_ranges = sym_char_ranges(&self.sym_map);
@@ -160,6 +170,70 @@ impl<'a> Translator<'a> {
         Ok(result)
     }
 
+    /// Stable hypot avoids overflow from directly squaring the larger input.
+    pub(crate) fn translate_hypot(&mut self, node: &Node) -> Result<GraphTensor> {
+        let (lhs, rhs) = self.promoted_binary_inputs(node)?;
+        let lhs = self.real_abs(lhs);
+        let rhs = self.real_abs(rhs);
+        let lhs_infinite = self.is_inf(lhs);
+        let rhs_infinite = self.is_inf(rhs);
+        let any_infinite = self.bool_or(lhs_infinite, rhs_infinite);
+        let larger = lhs.maximum(rhs);
+        let smaller = lhs.minimum(rhs);
+        let zero = self.constant_like(larger, 0.0);
+        let ratio = smaller / larger;
+        let finite = larger * (self.constant_like(larger, 1.0) + ratio.square()).sqrt();
+        let both_zero = self.is_zero(larger);
+        let result = self.select(both_zero, zero, finite);
+        let infinity = self.constant_like(larger, f64::INFINITY);
+        Ok(self.select(any_infinite, infinity, result))
+    }
+
+    pub(crate) fn translate_gcd(&mut self, node: &Node) -> Result<GraphTensor> {
+        let output_dtype = self.output_meta_dtype(node)?;
+        let (lhs, rhs) = self.promoted_binary_inputs(node)?;
+        // Signed I64 covers every supported input dtype, including U8. The
+        // Euclidean algorithm needs at most 93 divisions for 64-bit inputs;
+        // 128 static rounds leave margin without tensor-controlled looping.
+        let mut lhs = lhs.cast(DType::I64);
+        let mut rhs = rhs.cast(DType::I64);
+        let zero = self.constant_like(lhs, 0.0);
+        let one = self.constant_like(lhs, 1.0);
+        for _ in 0..128 {
+            let finished = self.is_zero(rhs);
+            let safe_rhs = self.select(finished, one, rhs);
+            let remainder = lhs % safe_rhs;
+            lhs = self.select(finished, lhs, rhs);
+            rhs = self.select(finished, zero, remainder);
+        }
+        let negative = lhs.lt(zero);
+        let magnitude = self.select(negative, -lhs, lhs);
+        Ok(magnitude.cast(output_dtype))
+    }
+
+    pub(crate) fn translate_scalar_base_pow(&mut self, node: &Node) -> Result<GraphTensor> {
+        let exponent = self
+            .get_input_tensor(node, 1)?
+            .cast(self.output_meta_dtype(node)?);
+        let base = self.get_float_arg(node, 0)?;
+        let magnitude = self.constant_like(exponent, base.abs());
+        let mut result = self.real_exp(exponent * magnitude.log());
+
+        let zero_exponent = self.is_zero(exponent);
+        let one = self.constant_like(exponent, 1.0);
+        result = self.select(zero_exponent, one, result);
+        if base < 0.0 {
+            let truncated = exponent.cast(DType::I64).cast(exponent.dtype);
+            let integral = self.is_zero(exponent - truncated);
+            let odd = (truncated % self.constant_like(exponent, 2.0))
+                .ne(self.constant_like(exponent, 0.0));
+            let signed = self.select(odd, result * -1.0, result);
+            let nan = self.constant_like(exponent, f64::NAN);
+            result = self.select(integral, signed, nan);
+        }
+        Ok(result)
+    }
+
     /// Lower boolean OR through numeric HLIR ops until HLIR has native logical ops.
     pub(crate) fn apply_bool_or(&mut self, a: GraphTensor, b: GraphTensor) -> GraphTensor {
         let a = a.cast(DType::F32);
@@ -199,6 +273,27 @@ impl<'a> Translator<'a> {
     }
 
     pub(crate) fn translate_binary_op(&mut self, node: &Node, op: BinaryOp) -> Result<GraphTensor> {
+        if node.inputs[0].arg.as_tensor_name().is_none() {
+            let alpha = self.get_explicit_alpha(node, op)?;
+            let (a, mut b) = self.promoted_binary_inputs(node)?;
+            let is_bool_add = matches!(op, BinaryOp::Add) && a.dtype == DType::Bool;
+            if !is_bool_add && let Some(alpha) = alpha {
+                b = self.apply_scalar_op(b, alpha, BinaryOp::Mul);
+            }
+            if is_bool_add {
+                return Ok(if alpha == Some(0.0) {
+                    a
+                } else {
+                    self.apply_bool_or(a, b)
+                });
+            }
+            return Ok(match op {
+                BinaryOp::Add => a + b,
+                BinaryOp::Mul => a * b,
+                BinaryOp::Sub => a - b,
+                BinaryOp::Div => a / b,
+            });
+        }
         let a = self.get_input_tensor(node, 0)?;
         let alpha = self.get_explicit_alpha(node, op)?;
         let arg1 = &node.inputs[1].arg;

--- a/crates/luminal_python/rust/src/translator/complex.rs
+++ b/crates/luminal_python/rust/src/translator/complex.rs
@@ -8,7 +8,8 @@
 use anyhow::{Context, Result, bail};
 use luminal::prelude::*;
 
-use crate::pt2_schema::Node;
+use crate::dim_arith::product_of_dims;
+use crate::pt2_schema::{Argument, Node, OptionalTensorEntry};
 use crate::pt2_util::{
     BinaryOp, ReductionOp, broadcast_binary, normalize_dim, normalize_slice_bound, reshape_tensor,
 };
@@ -17,8 +18,10 @@ use crate::torch_dtype::TorchDType;
 use super::Translator;
 use super::movement::{
     diagonal_indices, diagonal_scatter_tensor, flip_indices, index_select_tensor,
-    normalize_diagonal_dims, normalize_flip_dims, unfold_tensor,
+    masked_scatter_tensor, materialize_tensor, narrow_copy_tensor, nonzero_static_from_truth,
+    normalize_diagonal_dims, normalize_flip_dims, put_tensor, slice_scatter_tensor, unfold_tensor,
 };
+use super::movement_dynamic::ScatterReduction;
 use super::tensor::{ConstructorScalar, copy_tensor};
 
 #[derive(Clone, Copy, Debug)]
@@ -183,6 +186,47 @@ impl<'a> Translator<'a> {
                 let value = self.get_complex_input(node, 0)?;
                 self.store_complex(output_name, value.map(|component| component * -1.0));
             }
+            "torch.ops.aten.reciprocal.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let one = self.complex_constant_like(value.real, 1.0, 0.0, value.torch_dtype);
+                let result = self.stable_complex_div(one, value)?;
+                self.store_complex(output_name, result);
+            }
+            "torch.ops.aten.sqrt.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let result = self.complex_sqrt(value);
+                self.store_complex(output_name, result);
+            }
+            "torch.ops.aten.rsqrt.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let root = self.complex_sqrt(value);
+                let one = self.complex_constant_like(root.real, 1.0, 0.0, root.torch_dtype);
+                let result = self.stable_complex_div(one, root)?;
+                self.store_complex(output_name, result);
+            }
+            "torch.ops.aten.sigmoid.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let negative = value.map(|component| component * -1.0);
+                let exponential = self.complex_exp(negative);
+                let one = self.complex_constant_like(value.real, 1.0, 0.0, value.torch_dtype);
+                let denominator = self.add_complex(one, exponential);
+                let result = self.stable_complex_div(one, denominator)?;
+                self.store_complex(output_name, result);
+            }
+            "torch.ops.aten.ldexp.Tensor" => {
+                let value = self.get_complex_input(node, 0)?;
+                let exponent = self.get_input_tensor(node, 1)?.cast(value.real.dtype);
+                let (real, real_exponent) = broadcast_binary(value.real, exponent);
+                let (imag, imag_exponent) = broadcast_binary(value.imag, exponent);
+                self.store_complex(
+                    output_name,
+                    ComplexTensor::new(
+                        real * real_exponent.exp2(),
+                        imag * imag_exponent.exp2(),
+                        value.torch_dtype,
+                    ),
+                );
+            }
             "torch.ops.aten._conj.default"
             | "torch.ops.aten._conj_physical.default"
             | "torch.ops.aten.conj_physical.default" => {
@@ -195,6 +239,22 @@ impl<'a> Translator<'a> {
             "torch.ops.aten.resolve_conj.default" | "torch.ops.aten.alias.default" => {
                 self.store_complex(output_name, self.get_complex_input(node, 0)?);
             }
+            "torch.ops.aten._fft_c2c.default" => {
+                let value = self.translate_fft_c2c(node, output_name)?;
+                self.store_complex(output_name, value);
+            }
+            "torch.ops.aten._fft_r2c.default" => {
+                let value = self.translate_fft_r2c(node, output_name)?;
+                self.store_complex(output_name, value);
+            }
+            "torch.ops.aten._fft_c2r.default" => {
+                let value = self.translate_fft_c2r(node)?;
+                self.tensors.insert(output_name.to_string(), value);
+            }
+            "torch.ops.aten.index_put.default" | "torch.ops.aten.index_put_.default" => {
+                let value = self.translate_complex_index_put(node)?;
+                self.store_complex(output_name, value);
+            }
             "torch.ops.aten.clone.default" => {
                 let value = self.get_complex_input(node, 0)?;
                 let value = value.map(|component| self.materialize(component));
@@ -203,6 +263,99 @@ impl<'a> Translator<'a> {
             "torch.ops.aten.abs.default" => {
                 let value = self.get_complex_input(node, 0)?;
                 let out = self.complex_abs(value);
+                self.tensors.insert(output_name.to_string(), out);
+            }
+            "torch.ops.aten.linalg_vector_norm.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                // A complex dtype= override changes the precision of the
+                // magnitude computation even though the recorded output is
+                // its real component dtype.
+                let component_dtype = self.output_meta_dtype(node)?;
+                let compute_dtype = match component_dtype {
+                    DType::F16 => TorchDType::ComplexHalf,
+                    DType::F32 => TorchDType::ComplexFloat,
+                    DType::F64 => TorchDType::ComplexDouble,
+                    other => anyhow::bail!(
+                        "complex linalg_vector_norm requires a floating component dtype, got {other:?}"
+                    ),
+                };
+                let value = ComplexTensor::new(
+                    value.real.cast(component_dtype),
+                    value.imag.cast(component_dtype),
+                    compute_dtype,
+                );
+                let magnitude = self.complex_abs(value);
+                let out = self.vector_norm_from_magnitude(node, magnitude)?;
+                self.tensors.insert(output_name.to_string(), out);
+            }
+            "torch.ops.aten.dist.default" => {
+                let lhs_name = self.input_value_name(node, 0)?;
+                let rhs_name = self.input_value_name(node, 1)?;
+                let dtype = self
+                    .complex_tensors
+                    .get(lhs_name)
+                    .or_else(|| self.complex_tensors.get(rhs_name))
+                    .context("complex dist has no complex operand")?
+                    .torch_dtype;
+                let lhs = self.value_as_complex(lhs_name, dtype)?;
+                let rhs = self.value_as_complex(rhs_name, dtype)?;
+                let (lhs_real, rhs_real) = broadcast_binary(lhs.real, rhs.real);
+                let (lhs_imag, rhs_imag) = broadcast_binary(lhs.imag, rhs.imag);
+                let real = lhs_real - rhs_real;
+                let imag = lhs_imag - rhs_imag;
+                let magnitude = (real.square() + imag.square()).sqrt();
+                let p = self.get_float_arg(node, 2).unwrap_or(2.0);
+                let axes = (0..magnitude.legacy_tracker_ref().len()).collect();
+                let out = self.p_norm(magnitude, p, axes);
+                self.tensors.insert(output_name.to_string(), out);
+            }
+            "torch.ops.aten.angle.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let out = self.real_atan2(value.imag, value.real);
+                self.tensors.insert(output_name.to_string(), out);
+            }
+            "torch.ops.aten.isinf.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let real = self.is_inf(value.real);
+                let imag = self.is_inf(value.imag);
+                let out = self.bool_or(real, imag);
+                self.tensors.insert(output_name.to_string(), out);
+            }
+            "torch.ops.aten.isnan.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let real = self.is_nan(value.real);
+                let imag = self.is_nan(value.imag);
+                let out = self.bool_or(real, imag);
+                self.tensors.insert(output_name.to_string(), out);
+            }
+            "torch.ops.aten.any.default" | "torch.ops.aten.any.dim" | "torch.ops.aten.any.dims" => {
+                let value = self.get_complex_input(node, 0)?;
+                let real_zero = self.is_zero(value.real);
+                let imag_zero = self.is_zero(value.imag);
+                let both_zero = self.bool_and(real_zero, imag_zero);
+                let truth = self.bool_not(both_zero);
+                let out = self.translate_any_from_truth(node, truth)?;
+                self.tensors.insert(output_name.to_string(), out);
+            }
+            "torch.ops.aten.logical_not.default" => {
+                let name = self.input_value_name(node, 0)?;
+                let truth = self.truth_of_value(name)?;
+                let out = self.bool_not(truth);
+                self.tensors.insert(output_name.to_string(), out);
+            }
+            "torch.ops.aten.logical_and.default"
+            | "torch.ops.aten.logical_or.default"
+            | "torch.ops.aten.logical_xor.default" => {
+                let lhs_name = self.input_value_name(node, 0)?;
+                let rhs_name = self.input_value_name(node, 1)?;
+                let lhs = self.truth_of_value(lhs_name)?;
+                let rhs = self.truth_of_value(rhs_name)?;
+                let (lhs, rhs) = broadcast_binary(lhs, rhs);
+                let out = match target {
+                    "torch.ops.aten.logical_and.default" => self.bool_and(lhs, rhs),
+                    "torch.ops.aten.logical_or.default" => self.bool_or(lhs, rhs),
+                    _ => lhs.ne(rhs),
+                };
                 self.tensors.insert(output_name.to_string(), out);
             }
             "torch.ops.aten.acos.default" | "torch.ops.aten.acosh.default" => {
@@ -242,6 +395,77 @@ impl<'a> Translator<'a> {
                 let result = self.complex_exp(value);
                 self.store_complex(output_name, result);
             }
+            "torch.ops.aten.expm1.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let result = self.complex_exp(value);
+                let one = self.constant_like(result.real, 1.0);
+                self.store_complex(
+                    output_name,
+                    ComplexTensor::new(result.real - one, result.imag, result.torch_dtype),
+                );
+            }
+            "torch.ops.aten.exp2.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let ln_two = self.constant_like(value.real, std::f64::consts::LN_2);
+                let scaled =
+                    ComplexTensor::new(value.real * ln_two, value.imag * ln_two, value.torch_dtype);
+                let result = self.complex_exp(scaled);
+                self.store_complex(output_name, result);
+            }
+            "torch.ops.aten.log.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let result = self.complex_log(value);
+                self.store_complex(output_name, result);
+            }
+            "torch.ops.aten.log1p.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let one = self.constant_like(value.real, 1.0);
+                let shifted = ComplexTensor::new(value.real + one, value.imag, value.torch_dtype);
+                let result = self.complex_log(shifted);
+                self.store_complex(output_name, result);
+            }
+            "torch.ops.aten.log2.default" | "torch.ops.aten.log10.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let result = self.complex_log(value);
+                let denominator = if target == "torch.ops.aten.log2.default" {
+                    std::f64::consts::LN_2
+                } else {
+                    std::f64::consts::LN_10
+                };
+                let denominator = self.constant_like(result.real, denominator);
+                self.store_complex(
+                    output_name,
+                    ComplexTensor::new(
+                        result.real / denominator,
+                        result.imag / denominator,
+                        result.torch_dtype,
+                    ),
+                );
+            }
+            "torch.ops.aten.sin.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let result = self.complex_sin(value);
+                self.store_complex(output_name, result);
+            }
+            "torch.ops.aten.sinh.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let result = self.complex_sinh(value);
+                self.store_complex(output_name, result);
+            }
+            "torch.ops.aten.tan.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let numerator = self.complex_sin(value);
+                let denominator = self.complex_cos(value);
+                let result = self.stable_complex_div(numerator, denominator)?;
+                self.store_complex(output_name, result);
+            }
+            "torch.ops.aten.tanh.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let numerator = self.complex_sinh(value);
+                let denominator = self.complex_cosh(value);
+                let result = self.stable_complex_div(numerator, denominator)?;
+                self.store_complex(output_name, result);
+            }
             "torch.ops.aten.cos.default" => {
                 let value = self.get_complex_input(node, 0)?;
                 let result = self.complex_cos(value);
@@ -275,6 +499,22 @@ impl<'a> Translator<'a> {
                     value.map(|component| component.expand_rhs(shape.clone()))
                 };
                 self.store_complex(output_name, value);
+            }
+            "torch.ops.aten.empty.memory_format"
+            | "torch.ops.aten.empty_permuted.default"
+            | "torch.ops.aten.empty_strided.default"
+            | "torch.ops.aten.new_empty_strided.default" => {
+                let dtype = self.output_complex_dtype(output_name)?;
+                let component_dtype = dtype.complex_component_dtype().unwrap();
+                let shape = self.output_meta_shape(node)?;
+                let zero = self.graph.constant_float(0.0).cast(component_dtype);
+                let real = if shape.is_empty() {
+                    zero
+                } else {
+                    zero.expand_rhs(shape)
+                };
+                let imag = self.constant_like(real, 0.0);
+                self.store_complex(output_name, ComplexTensor::new(real, imag, dtype));
             }
             "torch.ops.aten.scalar_tensor.default" => {
                 let dtype = self.output_complex_dtype(output_name)?;
@@ -377,24 +617,55 @@ impl<'a> Translator<'a> {
                     self.tensors.insert(output_name.to_string(), out);
                 }
             }
-            "torch.ops.aten.view.default" => {
+            "torch.ops.aten.view.default" | "torch.ops.aten.view_copy.default" => {
                 let value = self.get_complex_input(node, 0)?;
                 let shape = self.output_meta_shape(node)?;
-                let value =
+                let mut value =
                     value.map(|component| self.reshape_complex_component(component, shape.clone()));
+                if target == "torch.ops.aten.view_copy.default" {
+                    value = value.map(materialize_tensor);
+                }
                 self.store_complex(output_name, value);
             }
-            "torch.ops.aten.permute.default" => {
+            "torch.ops.aten.permute.default" | "torch.ops.aten.permute_copy.default" => {
                 let value = self.get_complex_input(node, 0)?;
                 let dims = self.get_ints_arg(node, 1)?;
                 let axes: Vec<usize> = dims
                     .iter()
                     .map(|&dim| normalize_dim(dim, value.real.legacy_tracker_ref().len()))
                     .collect();
+                let copy = target == "torch.ops.aten.permute_copy.default";
+                let value = value.map(|component| {
+                    let component = component.permute(axes.clone());
+                    if copy {
+                        materialize_tensor(component)
+                    } else {
+                        component
+                    }
+                });
+                self.store_complex(output_name, value);
+            }
+            "torch.ops.aten.narrow_copy.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let raw_dim = self.get_int_arg(node, 1)?;
+                anyhow::ensure!(
+                    raw_dim >= -(value.real.legacy_tracker_ref().len() as i64)
+                        && raw_dim < value.real.legacy_tracker_ref().len() as i64,
+                    "complex narrow_copy dimension {raw_dim} out of range for rank {}",
+                    value.real.legacy_tracker_ref().len()
+                );
+                let dim = normalize_dim(raw_dim, value.real.legacy_tracker_ref().len());
+                let start = self.get_expr_arg(node, 2)?;
+                let length = self.get_expr_arg(node, 3)?;
+                let real = narrow_copy_tensor(value.real, dim, start, length)?;
+                let imag = narrow_copy_tensor(value.imag, dim, start, length)?;
                 self.store_complex(
                     output_name,
-                    value.map(|component| component.permute(axes.clone())),
+                    ComplexTensor::new(real, imag, value.torch_dtype),
                 );
+            }
+            "torch.ops.aten.unbind_copy.int" => {
+                self.translate_complex_unbind_copy(node)?;
             }
             "torch.ops.aten.flip.default" => {
                 let value = self.get_complex_input(node, 0)?;
@@ -547,6 +818,97 @@ impl<'a> Translator<'a> {
                     value.try_map(|component| self.slice_complex_component(component, node))?;
                 self.store_complex(output_name, value);
             }
+            "torch.ops.aten.index.Tensor" => {
+                let value = self.get_complex_input(node, 0)?;
+                let real = self.translate_index_tensor_from_source(node, value.real)?;
+                let imag = self.translate_index_tensor_from_source(node, value.imag)?;
+                self.store_complex(
+                    output_name,
+                    ComplexTensor::new(real, imag, value.torch_dtype),
+                );
+            }
+            "torch.ops.aten.gather.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let raw_dim = self.get_int_arg(node, 1)?;
+                let dim = normalize_dim(raw_dim, value.real.legacy_tracker_ref().len());
+                let indices = self.get_input_tensor(node, 2)?;
+                let real = super::movement_dynamic::pt2_gather_elements(value.real, indices, dim);
+                let imag = super::movement_dynamic::pt2_gather_elements(value.imag, indices, dim);
+                self.store_complex(
+                    output_name,
+                    ComplexTensor::new(real, imag, value.torch_dtype),
+                );
+            }
+            "torch.ops.aten.slice_scatter.default" => {
+                let dtype = self.output_complex_dtype(output_name)?;
+                let destination = self.value_as_complex(self.input_value_name(node, 0)?, dtype)?;
+                let source = self.value_as_complex(self.input_value_name(node, 1)?, dtype)?;
+                let dim = normalize_dim(
+                    self.get_int_arg(node, 2).unwrap_or(0),
+                    destination.real.legacy_tracker_ref().len(),
+                );
+                let start = normalize_slice_bound(
+                    self.get_expr_arg(node, 3)
+                        .unwrap_or_else(|_| IntExpr::from(0)),
+                    destination.real.dims()[dim],
+                );
+                let step = self.get_int_arg(node, 5).unwrap_or(1);
+                self.store_complex(
+                    output_name,
+                    ComplexTensor::new(
+                        slice_scatter_tensor(destination.real, source.real, dim, start, step)?,
+                        slice_scatter_tensor(destination.imag, source.imag, dim, start, step)?,
+                        dtype,
+                    ),
+                );
+            }
+            "torch.ops.aten.masked_scatter.default" => {
+                let dtype = self.output_complex_dtype(output_name)?;
+                let destination = self.value_as_complex(self.input_value_name(node, 0)?, dtype)?;
+                let mask = self.get_input_tensor(node, 1)?;
+                let source = self.value_as_complex(self.input_value_name(node, 2)?, dtype)?;
+                let real = masked_scatter_tensor(self, destination.real, mask, source.real)?;
+                let imag = masked_scatter_tensor(self, destination.imag, mask, source.imag)?;
+                self.store_complex(output_name, ComplexTensor::new(real, imag, dtype));
+            }
+            "torch.ops.aten.put.default" => {
+                let dtype = self.output_complex_dtype(output_name)?;
+                let destination = self.value_as_complex(self.input_value_name(node, 0)?, dtype)?;
+                let indices = self.get_input_tensor(node, 1)?;
+                let source = self.value_as_complex(self.input_value_name(node, 2)?, dtype)?;
+                let accumulate = self.get_bool_arg(node, 3).unwrap_or(false);
+                self.store_complex(
+                    output_name,
+                    ComplexTensor::new(
+                        put_tensor(destination.real, indices, source.real, accumulate)?,
+                        put_tensor(destination.imag, indices, source.imag, accumulate)?,
+                        dtype,
+                    ),
+                );
+            }
+            "torch.ops.aten.nonzero_static.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let real_zero = self.is_zero(value.real);
+                let imag_zero = self.is_zero(value.imag);
+                let truth = self.bool_not(self.bool_and(real_zero, imag_zero));
+                let size_index = node
+                    .inputs
+                    .iter()
+                    .position(|input| input.name == "size")
+                    .unwrap_or(1);
+                let size = self.get_expr_arg(node, size_index)?;
+                let fill_value = node
+                    .inputs
+                    .iter()
+                    .position(|input| input.name == "fill_value")
+                    .and_then(|index| self.get_int_arg(node, index).ok())
+                    .unwrap_or(-1);
+                let result = nonzero_static_from_truth(self, truth, size, fill_value);
+                self.tensors.insert(output_name.to_string(), result);
+            }
+            "torch.ops.aten.split_with_sizes.default" => {
+                self.translate_complex_split_with_sizes(node)?;
+            }
             "torch.ops.aten.select.int" => {
                 let value = self.get_complex_input(node, 0)?;
                 let value =
@@ -556,6 +918,64 @@ impl<'a> Translator<'a> {
             "torch.ops.aten.cat.default" => {
                 self.translate_complex_cat(node, output_name)?;
             }
+            "torch.ops.aten.where.self" => {
+                let condition = self.get_input_tensor(node, 0)?;
+                let dtype = self.output_complex_dtype(output_name)?;
+                let lhs = self.value_as_complex(self.input_value_name(node, 1)?, dtype)?;
+                let rhs = self.value_as_complex(self.input_value_name(node, 2)?, dtype)?;
+                let (lhs_real, rhs_real) = broadcast_binary(lhs.real, rhs.real);
+                let (lhs_imag, rhs_imag) = broadcast_binary(lhs.imag, rhs.imag);
+                let (condition, lhs_real) = broadcast_binary(condition, lhs_real);
+                let (rhs_real, _) = broadcast_binary(rhs_real, lhs_real);
+                let (lhs_imag, _) = broadcast_binary(lhs_imag, lhs_real);
+                let (rhs_imag, _) = broadcast_binary(rhs_imag, lhs_real);
+                let real = self.select(condition, lhs_real, rhs_real);
+                let imag = self.select(condition, lhs_imag, rhs_imag);
+                self.store_complex(output_name, ComplexTensor::new(real, imag, dtype));
+            }
+            "torch.ops.aten.polar.default" => {
+                let magnitude = self.get_input_tensor(node, 0)?;
+                let angle = self.get_input_tensor(node, 1)?;
+                let (magnitude, angle) = broadcast_binary(magnitude, angle);
+                let dtype = self.output_complex_dtype(output_name)?;
+                let component_dtype = dtype.complex_component_dtype().unwrap();
+                let magnitude = magnitude.cast(component_dtype);
+                let angle = angle.cast(component_dtype);
+                let real = magnitude * self.real_cos(angle);
+                let imag = magnitude * angle.sin();
+                self.store_complex(output_name, ComplexTensor::new(real, imag, dtype));
+            }
+            "torch.ops.aten.pow.Tensor_Scalar" => {
+                let dtype = self.output_complex_dtype(output_name)?;
+                let base = self.value_as_complex(self.input_value_name(node, 0)?, dtype)?;
+                let (real, imag) = self.complex_scalar_arg(node, 1)?;
+                let exponent = self.complex_constant_like(base.real, real, imag, dtype);
+                let result = self.complex_pow(base, exponent);
+                self.store_complex(output_name, result);
+            }
+            "torch.ops.aten.pow.Tensor_Tensor" => {
+                let dtype = self.output_complex_dtype(output_name)?;
+                let mut base = self.value_as_complex(self.input_value_name(node, 0)?, dtype)?;
+                let mut exponent = self.value_as_complex(self.input_value_name(node, 1)?, dtype)?;
+                let (base_real, exponent_real) = broadcast_binary(base.real, exponent.real);
+                let (base_imag, exponent_imag) = broadcast_binary(base.imag, exponent.imag);
+                base.real = base_real;
+                base.imag = base_imag;
+                exponent.real = exponent_real;
+                exponent.imag = exponent_imag;
+                let result = self.complex_pow(base, exponent);
+                self.store_complex(output_name, result);
+            }
+            "torch.ops.aten.scatter.src"
+            | "torch.ops.aten.scatter.reduce"
+            | "torch.ops.aten.scatter_add.default" => {
+                let result = self.translate_complex_scatter_src(node, output_name)?;
+                self.store_complex(output_name, result);
+            }
+            "torch.ops.aten.scatter.value" | "torch.ops.aten.scatter.value_reduce" => {
+                let result = self.translate_complex_scatter_value(node, output_name)?;
+                self.store_complex(output_name, result);
+            }
             "torch.ops.aten.sum.dim_IntList" | "torch.ops.aten.sum.default" => {
                 let value = self.translate_complex_reduction(node, ReductionOp::Sum)?;
                 self.store_complex(output_name, value);
@@ -563,6 +983,21 @@ impl<'a> Translator<'a> {
             "torch.ops.aten.mean.dim" | "torch.ops.aten.mean.default" => {
                 let value = self.translate_complex_reduction(node, ReductionOp::Mean)?;
                 self.store_complex(output_name, value);
+            }
+            "torch.ops.aten.var.default"
+            | "torch.ops.aten.var.dim"
+            | "torch.ops.aten.var.correction" => {
+                let (variance, _) = self.translate_complex_var_mean(node)?;
+                self.tensors.insert(output_name.to_string(), variance);
+            }
+            "torch.ops.aten.var_mean.default"
+            | "torch.ops.aten.var_mean.dim"
+            | "torch.ops.aten.var_mean.correction" => {
+                let (variance, mean) = self.translate_complex_var_mean(node)?;
+                let names = Self::tensor_output_names(node);
+                anyhow::ensure!(names.len() == 2, "complex var_mean must have two outputs");
+                self.tensors.insert(names[0].clone(), variance);
+                self.store_complex(&names[1], mean);
             }
             "torch.ops.aten.prod.dim_int" | "torch.ops.aten.prod.default" => {
                 let value = self.translate_complex_product(node, output_name)?;
@@ -575,6 +1010,68 @@ impl<'a> Translator<'a> {
                 } else {
                     let dim = normalize_dim(self.get_int_arg(node, 1)?, value.real.legacy_tracker_ref().len());
                     self.store_complex(output_name, value.map(|component| component.cumsum(dim)));
+                }
+            }
+            "torch.ops.aten.logcumsumexp.default" => {
+                let value = self.get_complex_input(node, 0)?;
+                let raw_dim = self.get_int_arg(node, 1)?;
+                if value.real.legacy_tracker_ref().is_empty() {
+                    anyhow::ensure!(
+                        matches!(raw_dim, -1 | 0),
+                        "dimension out of range for scalar"
+                    );
+                    self.store_complex(output_name, value);
+                } else {
+                    let dim = normalize_dim(raw_dim, value.real.legacy_tracker_ref().len());
+                    let rank = value.real.legacy_tracker_ref().len();
+                    let length = value.real.dims()[dim];
+                    let mut padding = vec![(IntExpr::from(0), IntExpr::from(0)); rank];
+                    padding[dim] = (length - 1, IntExpr::from(0));
+                    let negative_infinity =
+                        self.floating_scalar(f64::NEG_INFINITY, value.real.dtype);
+                    let zero = self.floating_scalar(0.0, value.imag.dtype);
+                    let mut real_windows = value.real.pad_with(padding.clone(), negative_infinity);
+                    let mut imag_windows = value.imag.pad_with(padding, zero);
+                    let mut kernel = vec![IntExpr::from(1); rank];
+                    kernel[dim] = length;
+                    real_windows =
+                        real_windows.unfold(kernel.clone(), vec![1usize; rank], vec![1usize; rank]);
+                    imag_windows =
+                        imag_windows.unfold(kernel, vec![1usize; rank], vec![1usize; rank]);
+                    for kernel_axis in (0..rank).rev() {
+                        if kernel_axis != dim {
+                            real_windows = real_windows.squeeze(rank + kernel_axis);
+                            imag_windows = imag_windows.squeeze(rank + kernel_axis);
+                        }
+                    }
+
+                    // Factor out the largest real component in each prefix.
+                    // This is the complex analogue of the stable real
+                    // log-sum-exp identity and prevents exp(real(z)) overflow.
+                    let reduction_axis = rank;
+                    let maximum = real_windows.max(reduction_axis);
+                    let expanded =
+                        maximum.expand_dim(reduction_axis, real_windows.dims()[reduction_axis]);
+                    let magnitude = self.real_exp(real_windows - expanded);
+                    let terms = ComplexTensor::new(
+                        magnitude * self.real_cos(imag_windows),
+                        magnitude * imag_windows.sin(),
+                        value.torch_dtype,
+                    );
+                    let summed = ComplexTensor::new(
+                        terms.real.sum(reduction_axis),
+                        terms.imag.sum(reduction_axis),
+                        value.torch_dtype,
+                    );
+                    let logarithm = self.complex_log(summed);
+                    self.store_complex(
+                        output_name,
+                        ComplexTensor::new(
+                            logarithm.real + maximum,
+                            logarithm.imag,
+                            value.torch_dtype,
+                        ),
+                    );
                 }
             }
             "torch.ops.aten.cumprod.default" => {
@@ -644,6 +1141,26 @@ impl<'a> Translator<'a> {
                 let out = self.translate_complex_comparison(node, is_eq)?;
                 self.tensors.insert(output_name.to_string(), out);
             }
+            "torch.ops.aten.eq.Scalar" | "torch.ops.aten.ne.Scalar" => {
+                let value = self.get_complex_input(node, 0)?;
+                let (real, imag) = self.complex_scalar_arg(node, 1)?;
+                let scalar = self.complex_constant_like(value.real, real, imag, value.torch_dtype);
+                let value_real_nan = self.is_nan(value.real);
+                let scalar_real_nan = self.is_nan(scalar.real);
+                let real_nan = self.bool_or(value_real_nan, scalar_real_nan);
+                let value_imag_nan = self.is_nan(value.imag);
+                let scalar_imag_nan = self.is_nan(scalar.imag);
+                let imag_nan = self.bool_or(value_imag_nan, scalar_imag_nan);
+                let real_eq = self.bool_and(value.real.eq(scalar.real), self.bool_not(real_nan));
+                let imag_eq = self.bool_and(value.imag.eq(scalar.imag), self.bool_not(imag_nan));
+                let equal = self.bool_and(real_eq, imag_eq);
+                let out = if target == "torch.ops.aten.eq.Scalar" {
+                    equal
+                } else {
+                    self.bool_not(equal)
+                };
+                self.tensors.insert(output_name.to_string(), out);
+            }
             other => bail!(
                 "Unsupported complex ATen op: {other}. Complex values must be lowered into real components before HLIR"
             ),
@@ -673,6 +1190,236 @@ impl<'a> Translator<'a> {
             .arg
             .as_value_name()
             .with_context(|| format!("Input {idx} of {} is not tensor-backed", node.target))
+    }
+
+    fn truth_of_value(&mut self, name: &str) -> Result<GraphTensor> {
+        if let Some(value) = self.complex_tensors.get(name).copied() {
+            let real_zero = self.is_zero(value.real);
+            let imag_zero = self.is_zero(value.imag);
+            let both_zero = self.bool_and(real_zero, imag_zero);
+            Ok(self.bool_not(both_zero))
+        } else {
+            let value = self.get_tensor(name)?;
+            let zero = self.constant_like(value, 0.0);
+            Ok(value.ne(zero))
+        }
+    }
+
+    fn complex_scatter_reduction(&self, node: &Node) -> Result<ScatterReduction> {
+        if node.target == "torch.ops.aten.scatter_add.default" {
+            return Ok(ScatterReduction::Add);
+        }
+        let reduce = node
+            .inputs
+            .iter()
+            .find(|input| input.name == "reduce")
+            .and_then(|input| match &input.arg {
+                Argument::Other(value) => value
+                    .as_str()
+                    .or_else(|| value.get("as_string").and_then(|value| value.as_str())),
+                _ => None,
+            })
+            .with_context(|| format!("{} is missing its reduce argument", node.target))?;
+        match reduce {
+            "add" | "sum" => Ok(ScatterReduction::Add),
+            "multiply" | "prod" => Ok(ScatterReduction::Multiply),
+            other => bail!("Unsupported complex scatter reduction: {other}"),
+        }
+    }
+
+    fn reduce_complex_scatter(
+        &mut self,
+        data: ComplexTensor,
+        indices: GraphTensor,
+        updates: ComplexTensor,
+        axis: usize,
+        reduction: ScatterReduction,
+    ) -> Result<ComplexTensor> {
+        anyhow::ensure!(
+            indices.legacy_tracker_ref().len() == updates.real.legacy_tracker_ref().len(),
+            "complex scatter reduction requires index/update ranks to match"
+        );
+        let index_shape = indices.dims();
+        let update_shape = updates.real.dims();
+        anyhow::ensure!(
+            index_shape
+                .iter()
+                .zip(&update_shape)
+                .all(|(index, update)| index == update || index.egglog_equal(*update)),
+            "complex scatter reduction currently requires index and update shapes to match"
+        );
+        let update_count = product_of_dims(index_shape.iter().copied())
+            .to_usize()
+            .context("complex scatter reduction requires a concrete update element count")?;
+        let destinations =
+            super::movement_dynamic::pt2_scatter_element_indices(data.real, indices, axis);
+        let output_shape = data.real.dims();
+        let update_real = updates.real.flatten();
+        let update_imag = updates.imag.flatten();
+        let mut output_real = data.real.flatten();
+        let mut output_imag = data.imag.flatten();
+
+        for index in 0..update_count {
+            let destination = destinations.slice_along(index..index + 1, 0);
+            let incoming = ComplexTensor::new(
+                update_real.slice_along(index..index + 1, 0),
+                update_imag.slice_along(index..index + 1, 0),
+                data.torch_dtype,
+            );
+            let current = ComplexTensor::new(
+                output_real.gather(destination),
+                output_imag.gather(destination),
+                data.torch_dtype,
+            );
+            let combined = match reduction {
+                ScatterReduction::Add => ComplexTensor::new(
+                    current.real + incoming.real,
+                    current.imag + incoming.imag,
+                    data.torch_dtype,
+                ),
+                ScatterReduction::Multiply => self.complex_mul(current, incoming),
+            };
+            output_real = combined.real.scatter(destination, output_real);
+            output_imag = combined.imag.scatter(destination, output_imag);
+        }
+
+        *output_real.legacy_tracker_mut() = ShapeTracker::new(output_shape.clone());
+        *output_imag.legacy_tracker_mut() = ShapeTracker::new(output_shape);
+        Ok(ComplexTensor::new(
+            output_real,
+            output_imag,
+            data.torch_dtype,
+        ))
+    }
+
+    fn translate_complex_scatter_src(
+        &mut self,
+        node: &Node,
+        output_name: &str,
+    ) -> Result<ComplexTensor> {
+        let dtype = self.output_complex_dtype(output_name)?;
+        let data = self.value_as_complex(self.input_value_name(node, 0)?, dtype)?;
+        let raw_dim = self.get_int_arg(node, 1)?;
+        anyhow::ensure!(
+            raw_dim >= -(data.real.legacy_tracker_ref().len() as i64) && raw_dim < data.real.legacy_tracker_ref().len() as i64,
+            "complex scatter dimension {raw_dim} out of range for rank {}",
+            data.real.legacy_tracker_ref().len()
+        );
+        let dim = normalize_dim(raw_dim, data.real.legacy_tracker_ref().len());
+        let indices = self.get_input_tensor(node, 2)?.cast(DType::Int);
+        let updates = self.value_as_complex(self.input_value_name(node, 3)?, dtype)?;
+        if node.target == "torch.ops.aten.scatter.src" {
+            Ok(ComplexTensor::new(
+                super::movement_dynamic::pt2_scatter_elements(
+                    data.real,
+                    indices,
+                    updates.real,
+                    dim,
+                ),
+                super::movement_dynamic::pt2_scatter_elements(
+                    data.imag,
+                    indices,
+                    updates.imag,
+                    dim,
+                ),
+                dtype,
+            ))
+        } else {
+            let reduction = self.complex_scatter_reduction(node)?;
+            self.reduce_complex_scatter(data, indices, updates, dim, reduction)
+        }
+    }
+
+    fn translate_complex_scatter_value(
+        &mut self,
+        node: &Node,
+        output_name: &str,
+    ) -> Result<ComplexTensor> {
+        let dtype = self.output_complex_dtype(output_name)?;
+        let data = self.value_as_complex(self.input_value_name(node, 0)?, dtype)?;
+        let raw_dim = self.get_int_arg(node, 1)?;
+        anyhow::ensure!(
+            raw_dim >= -(data.real.legacy_tracker_ref().len() as i64) && raw_dim < data.real.legacy_tracker_ref().len() as i64,
+            "complex scatter dimension {raw_dim} out of range for rank {}",
+            data.real.legacy_tracker_ref().len()
+        );
+        let dim = normalize_dim(raw_dim, data.real.legacy_tracker_ref().len());
+        let indices = self.get_input_tensor(node, 2)?.cast(DType::Int);
+        let scalar = self.complex_constructor_scalar_arg(node, 3, dtype)?;
+        let updates = ComplexTensor::new(
+            scalar.real.expand_rhs(indices.dims()),
+            scalar.imag.expand_rhs(indices.dims()),
+            dtype,
+        );
+        if node.target == "torch.ops.aten.scatter.value" {
+            Ok(ComplexTensor::new(
+                super::movement_dynamic::pt2_scatter_elements(
+                    data.real,
+                    indices,
+                    updates.real,
+                    dim,
+                ),
+                super::movement_dynamic::pt2_scatter_elements(
+                    data.imag,
+                    indices,
+                    updates.imag,
+                    dim,
+                ),
+                dtype,
+            ))
+        } else {
+            let reduction = self.complex_scatter_reduction(node)?;
+            self.reduce_complex_scatter(data, indices, updates, dim, reduction)
+        }
+    }
+
+    fn translate_complex_unbind_copy(&mut self, node: &Node) -> Result<()> {
+        let value = self.get_complex_input(node, 0)?;
+        let raw_dim = self.get_int_arg(node, 1).unwrap_or(0);
+        anyhow::ensure!(
+            raw_dim >= -(value.real.legacy_tracker_ref().len() as i64) && raw_dim < value.real.legacy_tracker_ref().len() as i64,
+            "complex unbind_copy dimension {raw_dim} out of range for rank {}",
+            value.real.legacy_tracker_ref().len()
+        );
+        let dim = normalize_dim(raw_dim, value.real.legacy_tracker_ref().len());
+        let output_names: Vec<String> = node
+            .outputs
+            .iter()
+            .flat_map(|output| {
+                output
+                    .as_tensors
+                    .as_ref()
+                    .map(|tensors| {
+                        tensors
+                            .iter()
+                            .map(|tensor| tensor.name.clone())
+                            .collect::<Vec<_>>()
+                    })
+                    .or_else(|| {
+                        output
+                            .as_tensor
+                            .as_ref()
+                            .map(|tensor| vec![tensor.name.clone()])
+                    })
+                    .unwrap_or_default()
+            })
+            .collect();
+        let axis_size = value.real.legacy_tracker_ref().dims[dim]
+            .to_usize()
+            .context("complex unbind_copy requires a concrete unbound dimension")?;
+        anyhow::ensure!(
+            output_names.len() == axis_size,
+            "complex unbind_copy produced {} outputs for an axis of size {axis_size}",
+            output_names.len()
+        );
+        for (index, name) in output_names.into_iter().enumerate() {
+            let real = value.real.slice_along(index..index + 1, dim).squeeze(dim);
+            let imag = value.imag.slice_along(index..index + 1, dim).squeeze(dim);
+            let real = materialize_tensor(real);
+            let imag = materialize_tensor(imag);
+            self.store_complex(&name, ComplexTensor::new(real, imag, value.torch_dtype));
+        }
+        Ok(())
     }
 
     fn output_complex_dtype(&self, output_name: &str) -> Result<TorchDType> {
@@ -1252,6 +1999,97 @@ impl<'a> Translator<'a> {
         )
     }
 
+    fn complex_sin(&mut self, value: ComplexTensor) -> ComplexTensor {
+        let cosh = self.real_cosh(value.imag);
+        let sinh = self.real_sinh(value.imag);
+        ComplexTensor::new(
+            value.real.sin() * cosh,
+            self.real_cos(value.real) * sinh,
+            value.torch_dtype,
+        )
+    }
+
+    fn complex_sinh(&mut self, value: ComplexTensor) -> ComplexTensor {
+        let sinh = self.real_sinh(value.real);
+        let cosh = self.real_cosh(value.real);
+        ComplexTensor::new(
+            sinh * self.real_cos(value.imag),
+            cosh * value.imag.sin(),
+            value.torch_dtype,
+        )
+    }
+
+    fn complex_sqrt(&mut self, value: ComplexTensor) -> ComplexTensor {
+        // Stable principal square root. Choosing the formula by the real
+        // component avoids cancellation in `hypot(z) +/- real(z)`.
+        let magnitude = self.complex_abs(value);
+        let half = self.constant_like(magnitude, 0.5);
+        let real_negative = self.signbit(value.real);
+
+        let positive_real = (magnitude * half + value.real * half).sqrt();
+        let positive_denom = positive_real * 2.0;
+        let positive_imag = self.safe_div(value.imag, positive_denom);
+
+        let negative_imag_magnitude = (magnitude * half - value.real * half).sqrt();
+        let negative_imag = self.copy_sign(negative_imag_magnitude, value.imag);
+        let negative_denom = negative_imag_magnitude * 2.0;
+        let imag_magnitude = self.real_abs(value.imag);
+        let negative_real = self.safe_div(imag_magnitude, negative_denom);
+
+        let mut real = self.select(real_negative, negative_real, positive_real);
+        let mut imag = self.select(real_negative, negative_imag, positive_imag);
+
+        // Both signed complex zeros need an explicit branch because the
+        // quotient formulas above contain 0/0. Preserve the input imaginary
+        // sign, as required by the principal branch.
+        let magnitude_zero = self.is_zero(magnitude);
+        let zero = self.constant_like(real, 0.0);
+        let signed_zero = self.copy_sign(zero, value.imag);
+        real = self.select(magnitude_zero, zero, real);
+        imag = self.select(magnitude_zero, signed_zero, imag);
+
+        // An infinite imaginary component has infinite magnitude in both
+        // output lanes. The quotient branch would otherwise form inf/inf.
+        let imag_inf = self.is_inf(value.imag);
+        let infinity = self.constant_like(real, f64::INFINITY);
+        let signed_infinity = self.copy_sign(infinity, value.imag);
+        real = self.select(imag_inf, infinity, real);
+        imag = self.select(imag_inf, signed_infinity, imag);
+
+        ComplexTensor::new(real, imag, value.torch_dtype)
+    }
+
+    fn complex_pow(&mut self, base: ComplexTensor, exponent: ComplexTensor) -> ComplexTensor {
+        let logarithm = self.complex_log(base);
+        let exponent_imag_zero = self.is_zero(exponent.imag);
+        let general = self.complex_mul(exponent, logarithm);
+        let real_exponent = ComplexTensor::new(
+            exponent.real * logarithm.real,
+            exponent.real * logarithm.imag,
+            base.torch_dtype,
+        );
+        let product = ComplexTensor::new(
+            self.select(exponent_imag_zero, real_exponent.real, general.real),
+            self.select(exponent_imag_zero, real_exponent.imag, general.imag),
+            base.torch_dtype,
+        );
+        let result = self.complex_exp(product);
+
+        // ATen defines z**0 as exactly 1+0j for every z, including zero,
+        // infinities, and NaNs. Select structurally so the unused logarithm
+        // branch cannot contaminate that result.
+        let real_zero = self.is_zero(exponent.real);
+        let imag_zero = self.is_zero(exponent.imag);
+        let exponent_zero = self.bool_and(real_zero, imag_zero);
+        let one = self.constant_like(result.real, 1.0);
+        let zero = self.constant_like(result.imag, 0.0);
+        ComplexTensor::new(
+            self.select(exponent_zero, one, result.real),
+            self.select(exponent_zero, zero, result.imag),
+            base.torch_dtype,
+        )
+    }
+
     fn complex_cos(&mut self, value: ComplexTensor) -> ComplexTensor {
         let cosh = self.real_cosh(value.imag);
         let sinh = self.real_sinh(value.imag);
@@ -1407,6 +2245,130 @@ impl<'a> Translator<'a> {
         }
     }
 
+    fn translate_complex_split_with_sizes(&mut self, node: &Node) -> Result<()> {
+        let value = self.get_complex_input(node, 0)?;
+        let sizes = self.get_ints_arg(node, 1)?;
+        let dim = normalize_dim(
+            if node.inputs.len() > 2 {
+                self.get_int_arg(node, 2).unwrap_or(0)
+            } else {
+                0
+            },
+            value.real.legacy_tracker_ref().len(),
+        );
+        let output_names: Vec<String> = node
+            .outputs
+            .iter()
+            .flat_map(|output| {
+                if let Some(tensor) = output.as_tensor.as_ref() {
+                    vec![tensor.name.clone()]
+                } else if let Some(tensors) = output.as_tensors.as_ref() {
+                    tensors.iter().map(|tensor| tensor.name.clone()).collect()
+                } else {
+                    vec![]
+                }
+            })
+            .collect();
+
+        anyhow::ensure!(
+            sizes.len() == output_names.len(),
+            "complex split_with_sizes produced {} outputs for {} sizes",
+            output_names.len(),
+            sizes.len()
+        );
+
+        let mut offset = 0usize;
+        for (name, size) in output_names.into_iter().zip(sizes) {
+            let size = usize::try_from(size)
+                .context("complex split_with_sizes sizes must be nonnegative")?;
+            let end = offset
+                .checked_add(size)
+                .context("complex split_with_sizes offset overflow")?;
+            self.store_complex(
+                &name,
+                ComplexTensor::new(
+                    value.real.slice_along(offset..end, dim),
+                    value.imag.slice_along(offset..end, dim),
+                    value.torch_dtype,
+                ),
+            );
+            offset = end;
+        }
+        Ok(())
+    }
+
+    fn translate_complex_index_put(&mut self, node: &Node) -> Result<ComplexTensor> {
+        let data = self.get_complex_input(node, 0)?;
+        let values = self.get_complex_input(node, 2)?.cast(data.torch_dtype);
+        let entries = node.inputs[1]
+            .arg
+            .as_optional_tensors()
+            .context("complex index_put requires optional tensor indices")?;
+
+        let mut axis_and_name = None;
+        for (axis, entry) in entries.iter().enumerate() {
+            if let OptionalTensorEntry::Tensor(tensor) = entry {
+                anyhow::ensure!(
+                    axis_and_name.is_none(),
+                    "complex index_put supports one tensor index"
+                );
+                axis_and_name = Some((axis, tensor.as_tensor.name.as_str()));
+            }
+        }
+        let (axis, index_name) =
+            axis_and_name.context("complex index_put requires one tensor index")?;
+        let index = self.get_tensor(index_name)?.cast(DType::Int);
+        anyhow::ensure!(
+            index.legacy_tracker_ref().len() == 1,
+            "complex index_put requires a 1-D tensor index"
+        );
+        anyhow::ensure!(
+            values.real.legacy_tracker_ref().len() == data.real.legacy_tracker_ref().len(),
+            "complex index_put does not support value broadcasting"
+        );
+        anyhow::ensure!(
+            axis < values.real.legacy_tracker_ref().len(),
+            "complex index_put axis is outside the value rank"
+        );
+
+        let mut expanded_index = index;
+        for (dim, &size) in values.real.dims().iter().enumerate().take(axis) {
+            expanded_index = expanded_index.expand_dim(dim, size);
+        }
+        for (dim, &size) in values.real.dims().iter().enumerate().skip(axis + 1) {
+            expanded_index = expanded_index.expand_dim(dim, size);
+        }
+
+        let accumulate = node
+            .inputs
+            .get(3)
+            .and_then(|input| input.arg.as_bool())
+            .unwrap_or(false);
+        let update = |component_data, component_values| {
+            if accumulate {
+                super::movement_dynamic::pt2_scatter_elements_reduce(
+                    component_data,
+                    expanded_index,
+                    component_values,
+                    axis,
+                    ScatterReduction::Add,
+                )
+            } else {
+                Ok(super::movement_dynamic::pt2_scatter_elements(
+                    component_data,
+                    expanded_index,
+                    component_values,
+                    axis,
+                ))
+            }
+        };
+        Ok(ComplexTensor::new(
+            update(data.real, values.real)?,
+            update(data.imag, values.imag)?,
+            data.torch_dtype,
+        ))
+    }
+
     fn select_complex_component(&self, value: GraphTensor, node: &Node) -> Result<GraphTensor> {
         let dim = normalize_dim(self.get_int_arg(node, 1)?, value.legacy_tracker_ref().len());
         let raw_index = self.get_int_arg(node, 2)?;
@@ -1452,6 +2414,274 @@ impl<'a> Translator<'a> {
         Ok(())
     }
 
+    fn fft_dims(&self, node: &Node, rank: usize) -> Result<Vec<usize>> {
+        anyhow::ensure!(rank > 0, "{} requires a non-scalar input", node.target);
+        let mut axes = Vec::new();
+        for dim in self.get_ints_arg(node, 1)? {
+            anyhow::ensure!(
+                dim >= -(rank as i64) && dim < rank as i64,
+                "FFT dimension {dim} is out of range for rank {rank}"
+            );
+            let axis = normalize_dim(dim, rank);
+            anyhow::ensure!(!axes.contains(&axis), "FFT dimensions must be unique");
+            axes.push(axis);
+        }
+        Ok(axes)
+    }
+
+    /// Apply one ordinary complex DFT along `axis` using only existing HLIR
+    /// arithmetic, trigonometric, movement, matmul, and reduction primitives.
+    /// The Fourier matrix has expression-shaped `[N, N]` extents, so dynamic
+    /// lengths do not change graph topology.
+    fn complex_dft_axis(
+        &mut self,
+        value: ComplexTensor,
+        axis: usize,
+        forward: bool,
+    ) -> ComplexTensor {
+        let component_dtype = value.real.dtype;
+        let original_shape = value.real.dims();
+        let rank = original_shape.len();
+        let length = original_shape[axis];
+
+        let mut permutation = (0..rank).filter(|&dim| dim != axis).collect::<Vec<_>>();
+        permutation.push(axis);
+        let mut inverse_permutation = vec![0; rank];
+        for (position, &original_axis) in permutation.iter().enumerate() {
+            inverse_permutation[original_axis] = position;
+        }
+
+        // A direct F32 Fourier matrix followed by an F32 reduction accumulates
+        // noticeably more error than ATen's FFT kernels. Compose the DFT in
+        // F64 and round once at the axis boundary. Cast, trig, matmul, and
+        // reduction are all existing HLIR primitives.
+        let real = self.materialize(value.real.cast(DType::F64).permute(permutation.clone()));
+        let imag = self.materialize(value.imag.cast(DType::F64).permute(permutation));
+        let permuted_shape = real.dims();
+        let batch_shape = &permuted_shape[..rank - 1];
+        let batch = product_of_dims(batch_shape.iter().copied());
+        let real = reshape_tensor(real, vec![batch, length]);
+        let imag = reshape_tensor(imag, vec![batch, length]);
+
+        // Row-major matrix coordinates: input frequency/time index `j` is
+        // z/N and output index `k` is z%N. Reducing j*k modulo N bounds the
+        // trigonometric arguments to [0, 2pi), improving large-N accuracy.
+        let z = IntExpr::from('z');
+        let input_index = z / length;
+        let output_index = z % length;
+        let phase_index = (input_index * output_index) % length;
+        let phase = self
+            .graph
+            .iota(phase_index, vec![length, length])
+            .cast(real.dtype);
+        let denominator = self
+            .graph
+            .constant(length)
+            .cast(real.dtype)
+            .expand_rhs(phase.dims());
+        let tau = self.constant_like(phase, std::f64::consts::TAU);
+        let angle = phase * tau / denominator;
+        let cosine = self.real_cos(angle);
+        let sine = angle.sin();
+
+        let real_cosine = real.matmul(cosine);
+        let imag_cosine = imag.matmul(cosine);
+        let real_sine = real.matmul(sine);
+        let imag_sine = imag.matmul(sine);
+        let (out_real, out_imag) = if forward {
+            (real_cosine + imag_sine, imag_cosine - real_sine)
+        } else {
+            (real_cosine - imag_sine, imag_cosine + real_sine)
+        };
+
+        let mut permuted_output_shape = batch_shape.to_vec();
+        permuted_output_shape.push(length);
+        let out_real = reshape_tensor(out_real, permuted_output_shape.clone())
+            .permute(inverse_permutation.clone())
+            .cast(component_dtype);
+        let out_imag = reshape_tensor(out_imag, permuted_output_shape)
+            .permute(inverse_permutation)
+            .cast(component_dtype);
+        ComplexTensor::new(out_real, out_imag, value.torch_dtype)
+    }
+
+    /// Finish the final one-sided dimension of a complex-to-real inverse DFT.
+    /// Endpoint imaginary values are explicitly ignored, matching ATen for DC
+    /// and (when N is even) Nyquist. Interior bins contribute their conjugate
+    /// partner through a factor of two.
+    fn complex_to_real_dft_axis(
+        &mut self,
+        value: ComplexTensor,
+        axis: usize,
+        output_length: IntExpr,
+        output_dtype: DType,
+    ) -> GraphTensor {
+        let input_shape = value.real.dims();
+        let rank = input_shape.len();
+        let input_length = input_shape[axis];
+
+        let mut permutation = (0..rank).filter(|&dim| dim != axis).collect::<Vec<_>>();
+        permutation.push(axis);
+        let mut inverse_permutation = vec![0; rank];
+        for (position, &original_axis) in permutation.iter().enumerate() {
+            inverse_permutation[original_axis] = position;
+        }
+
+        let real = self.materialize(value.real.cast(DType::F64).permute(permutation.clone()));
+        let imag = self.materialize(value.imag.cast(DType::F64).permute(permutation));
+        let permuted_shape = real.dims();
+        let batch_shape = &permuted_shape[..rank - 1];
+        let batch = product_of_dims(batch_shape.iter().copied());
+        let real = reshape_tensor(real, vec![batch, input_length]);
+        let imag = reshape_tensor(imag, vec![batch, input_length]);
+
+        let z = IntExpr::from('z');
+        let frequency = z / output_length;
+        let time = z % output_length;
+        let phase_index = (frequency * time) % output_length;
+        let matrix_shape = vec![input_length, output_length];
+        let phase = self
+            .graph
+            .iota(phase_index, matrix_shape.clone())
+            .cast(DType::F64);
+        let denominator = self
+            .graph
+            .constant(output_length)
+            .cast(DType::F64)
+            .expand_rhs(phase.dims());
+        let tau = self.constant_like(phase, std::f64::consts::TAU);
+        let angle = phase * tau / denominator;
+        let cosine = self.real_cos(angle);
+        let sine = angle.sin();
+
+        let frequency = IntExpr::from('z') / output_length;
+        let interior = frequency.gte(1) * (frequency * 2).lt(output_length);
+        let real_coefficient = self
+            .graph
+            .iota(1 + interior, matrix_shape.clone())
+            .cast(DType::F64);
+        let imag_coefficient = self.graph.iota(interior * 2, matrix_shape).cast(DType::F64);
+        let out = real.matmul(cosine * real_coefficient) - imag.matmul(sine * imag_coefficient);
+
+        let mut permuted_output_shape = batch_shape.to_vec();
+        permuted_output_shape.push(output_length);
+        reshape_tensor(out, permuted_output_shape)
+            .permute(inverse_permutation)
+            .cast(output_dtype)
+    }
+
+    fn fft_normalization(&self, node: &Node) -> Result<i64> {
+        let normalization = self.get_int_arg(node, 2)?;
+        anyhow::ensure!(
+            (0..=2).contains(&normalization),
+            "Unsupported FFT normalization code {normalization}"
+        );
+        Ok(normalization)
+    }
+
+    fn normalize_complex_fft(
+        &mut self,
+        value: ComplexTensor,
+        transformed_elements: IntExpr,
+        normalization: i64,
+    ) -> ComplexTensor {
+        if normalization == 0 {
+            return value;
+        }
+        value.map(|component| {
+            let mut divisor = self
+                .graph
+                .constant(transformed_elements)
+                .cast(component.dtype);
+            if normalization == 1 {
+                divisor = divisor.sqrt();
+            }
+            component / divisor.expand_rhs(component.dims())
+        })
+    }
+
+    fn normalize_real_fft(
+        &mut self,
+        value: GraphTensor,
+        transformed_elements: IntExpr,
+        normalization: i64,
+    ) -> GraphTensor {
+        if normalization == 0 {
+            return value;
+        }
+        let mut divisor = self.graph.constant(transformed_elements).cast(value.dtype);
+        if normalization == 1 {
+            divisor = divisor.sqrt();
+        }
+        value / divisor.expand_rhs(value.dims())
+    }
+
+    fn translate_fft_c2c(&mut self, node: &Node, output_name: &str) -> Result<ComplexTensor> {
+        let dtype = self.output_complex_dtype(output_name)?;
+        let mut value = self.value_as_complex(self.input_value_name(node, 0)?, dtype)?;
+        let axes = self.fft_dims(node, value.real.legacy_tracker_ref().len())?;
+        let transformed_elements =
+            product_of_dims(axes.iter().map(|&axis| value.real.dims()[axis]));
+        let forward = self.get_bool_arg(node, 3)?;
+        for axis in axes {
+            value = self.complex_dft_axis(value, axis, forward);
+        }
+        let normalization = self.fft_normalization(node)?;
+        Ok(self.normalize_complex_fft(value, transformed_elements, normalization))
+    }
+
+    fn translate_fft_r2c(&mut self, node: &Node, output_name: &str) -> Result<ComplexTensor> {
+        let dtype = self.output_complex_dtype(output_name)?;
+        let mut value = self.value_as_complex(self.input_value_name(node, 0)?, dtype)?;
+        let axes = self.fft_dims(node, value.real.legacy_tracker_ref().len())?;
+        let transformed_elements =
+            product_of_dims(axes.iter().map(|&axis| value.real.dims()[axis]));
+        for &axis in &axes {
+            value = self.complex_dft_axis(value, axis, true);
+        }
+        if self.get_bool_arg(node, 3)? {
+            let last_axis = *axes
+                .last()
+                .context("one-sided r2c FFT requires a dimension")?;
+            let one_sided_length = (value.real.dims()[last_axis] / 2 + 1).simplify();
+            value = value.map(|component| {
+                let mut component = component.slice_along(..one_sided_length, last_axis);
+                component.legacy_tracker_mut().dims[last_axis] = one_sided_length;
+                component
+            });
+        }
+        let normalization = self.fft_normalization(node)?;
+        Ok(self.normalize_complex_fft(value, transformed_elements, normalization))
+    }
+
+    fn translate_fft_c2r(&mut self, node: &Node) -> Result<GraphTensor> {
+        let output_dtype = self.output_meta_dtype(node)?;
+        let compute_dtype = match output_dtype {
+            DType::F32 => TorchDType::ComplexFloat,
+            DType::F64 => TorchDType::ComplexDouble,
+            DType::F16 => TorchDType::ComplexHalf,
+            other => anyhow::bail!("c2r FFT requires a floating output dtype, got {other:?}"),
+        };
+        let mut value = self.value_as_complex(self.input_value_name(node, 0)?, compute_dtype)?;
+        let axes = self.fft_dims(node, value.real.legacy_tracker_ref().len())?;
+        let last_axis = *axes.last().context("c2r FFT requires a dimension")?;
+        let output_length = self.get_expr_arg(node, 3)?;
+        let transformed_elements = product_of_dims(axes.iter().map(|&axis| {
+            if axis == last_axis {
+                output_length
+            } else {
+                value.real.dims()[axis]
+            }
+        }));
+
+        for &axis in &axes[..axes.len() - 1] {
+            value = self.complex_dft_axis(value, axis, false);
+        }
+        let output = self.complex_to_real_dft_axis(value, last_axis, output_length, output_dtype);
+        let normalization = self.fft_normalization(node)?;
+        Ok(self.normalize_real_fft(output, transformed_elements, normalization))
+    }
+
     fn translate_complex_reduction(
         &mut self,
         node: &Node,
@@ -1484,6 +2714,47 @@ impl<'a> Translator<'a> {
             }
         }
         Ok(result)
+    }
+
+    fn translate_complex_var_mean(&mut self, node: &Node) -> Result<(GraphTensor, ComplexTensor)> {
+        let value = self.get_complex_input(node, 0)?;
+        let axes = self.composed_reduction_axes(node, value.real.legacy_tracker_ref().len())?;
+        let keepdim = node
+            .inputs
+            .iter()
+            .position(|input| input.name == "keepdim")
+            .and_then(|index| self.get_bool_arg(node, index).ok())
+            .unwrap_or(false);
+        let correction = self.variance_correction(node);
+        let component_dtype = value.torch_dtype.complex_component_dtype().unwrap();
+        let real = value.real.cast(component_dtype);
+        let imag = value.imag.cast(component_dtype);
+        let n = product_of_dims(axes.iter().map(|&axis| real.dims()[axis]));
+        let mean = if axes.is_empty() {
+            ComplexTensor::new(real, imag, value.torch_dtype)
+        } else {
+            ComplexTensor::new(
+                real.sum(axes.clone()) / n,
+                imag.sum(axes.clone()) / n,
+                value.torch_dtype,
+            )
+        };
+        let centered_real = real - mean.real.expand_to_shape_on_axes(real.dims(), axes.clone());
+        let centered_imag = imag - mean.imag.expand_to_shape_on_axes(imag.dims(), axes.clone());
+        let numerator =
+            (centered_real * centered_real + centered_imag * centered_imag).sum(axes.clone());
+        let degrees = self.graph.constant(n).cast(component_dtype)
+            - self.floating_scalar(correction, component_dtype);
+        let zero = self.floating_scalar(0.0, component_dtype);
+        let divisor = degrees.maximum(zero).expand_rhs(numerator.dims());
+        let variance = numerator / divisor;
+        let variance = self.restore_reduced_dims(variance, &axes, keepdim);
+        let mean = ComplexTensor::new(
+            self.restore_reduced_dims(mean.real, &axes, keepdim),
+            self.restore_reduced_dims(mean.imag, &axes, keepdim),
+            mean.torch_dtype,
+        );
+        Ok((variance, mean))
     }
 
     fn translate_complex_product(

--- a/crates/luminal_python/rust/src/translator/dispatch.rs
+++ b/crates/luminal_python/rust/src/translator/dispatch.rs
@@ -6,6 +6,7 @@ use crate::pt2_util::*;
 
 use super::Translator;
 use super::reduction::{ArgExtremum, CumExtremum};
+use super::unary::ChebyshevKind;
 
 impl<'a> Translator<'a> {
     pub(crate) fn translate_node(&mut self, node: &Node) -> Result<()> {
@@ -99,11 +100,16 @@ impl<'a> Translator<'a> {
             "torch.ops.aten.copysign.Scalar" => self.translate_copysign_scalar(node)?,
             "torch.ops.aten.fmax.default" => self.translate_fmax_fmin(node, true)?,
             "torch.ops.aten.fmin.default" => self.translate_fmax_fmin(node, false)?,
+            "torch.ops.aten.hypot.default" => self.translate_hypot(node)?,
+            "torch.ops.aten.gcd.default" => self.translate_gcd(node)?,
 
             // Unary ops
             "torch.ops.aten.neg.default" => self.translate_unary_op(node, |a| a * (-1.0))?,
             "torch.ops.aten.exp.default" => self.translate_exp(node)?,
+            "torch.ops.aten.expm1.default" => self.translate_expm1(node)?,
             "torch.ops.aten.sin.default" => self.translate_unary_op(node, |a| a.sin())?,
+            "torch.ops.aten.sinh.default" => self.translate_sinh(node)?,
+            "torch.ops.aten.tan.default" => self.translate_tan(node)?,
             "torch.ops.aten.cos.default" => self.translate_cos(node)?,
             "torch.ops.aten.acos.default" => self.translate_acos(node)?,
             "torch.ops.aten.acosh.default" => self.translate_acosh(node)?,
@@ -127,10 +133,85 @@ impl<'a> Translator<'a> {
             "torch.ops.aten.gelu.default" => self.translate_gelu(node)?,
             "torch.ops.aten.abs.default" => self.translate_unary_op(node, |a| a.abs())?,
             "torch.ops.aten.log.default" => self.translate_unary_op(node, |a| a.log())?,
+            "torch.ops.aten.log1p.default" => self.translate_log1p(node)?,
             "torch.ops.aten.log2.default" => self.translate_unary_op(node, |a| a.log2())?,
+            "torch.ops.aten.log10.default" => self.translate_log10(node)?,
             "torch.ops.aten.exp2.default" => self.translate_unary_op(node, |a| a.exp2())?,
+            "torch.ops.aten.angle.default" => self.translate_angle(node)?,
+            "torch.ops.aten.isinf.default" => self.translate_isinf(node)?,
+            "torch.ops.aten.ldexp.Tensor" => self.translate_ldexp(node)?,
             "torch.ops.aten.sign.default" => self.translate_sign(node)?,
+            "torch.ops.aten.signbit.default" => self.translate_signbit(node)?,
             "torch.ops.aten.bitwise_not.default" => self.translate_bitwise_not(node)?,
+            "torch.ops.aten.hardtanh.default" => self.translate_hardtanh(node)?,
+            "torch.ops.aten.elu.default" => self.translate_elu(node)?,
+            "torch.ops.aten.leaky_relu.default" => self.translate_leaky_relu(node)?,
+            "torch.ops.aten.round.default" | "torch.ops.aten.round.decimals" => {
+                self.translate_round(node)?
+            }
+            "torch.ops.aten.erfc.default" => self.translate_erfc(node)?,
+            "torch.ops.aten.special_erfcx.default" => self.translate_erfcx(node)?,
+            "torch.ops.aten.lgamma.default" => self.translate_lgamma(node)?,
+            "torch.ops.aten.digamma.default" => self.translate_digamma(node)?,
+            "torch.ops.aten.polygamma.default" => self.translate_polygamma(node)?,
+            bessel @ ("torch.ops.aten.i0.default"
+            | "torch.ops.aten.special_i0e.default"
+            | "torch.ops.aten.special_i1.default"
+            | "torch.ops.aten.special_i1e.default"
+            | "torch.ops.aten.special_modified_bessel_i0.default"
+            | "torch.ops.aten.special_modified_bessel_i1.default") => {
+                let order = usize::from(bessel.contains("i1"));
+                self.translate_modified_bessel(
+                    node,
+                    order,
+                    bessel.contains("i0e") || bessel.contains("i1e"),
+                )?
+            }
+            "torch.ops.aten.special_spherical_bessel_j0.default" => {
+                self.translate_spherical_bessel_j0(node)?
+            }
+            bessel @ ("torch.ops.aten.special_bessel_j0.default"
+            | "torch.ops.aten.special_bessel_j1.default"
+            | "torch.ops.aten.special_bessel_y0.default"
+            | "torch.ops.aten.special_bessel_y1.default") => {
+                let order = usize::from(bessel.contains("j1") || bessel.contains("y1"));
+                self.translate_cylindrical_bessel(node, order, bessel.contains("_y"))?
+            }
+            bessel @ ("torch.ops.aten.special_modified_bessel_k0.default"
+            | "torch.ops.aten.special_modified_bessel_k1.default"
+            | "torch.ops.aten.special_scaled_modified_bessel_k0.default"
+            | "torch.ops.aten.special_scaled_modified_bessel_k1.default") => {
+                let order = usize::from(bessel.contains("k1"));
+                self.translate_modified_bessel_k(node, order, bessel.contains("scaled"))?
+            }
+            "torch.ops.aten.special_airy_ai.default" => self.translate_airy_ai(node)?,
+            "torch.ops.aten.special_ndtri.default" => self.translate_ndtri(node)?,
+            "torch.ops.aten.erfinv.default" => self.translate_erfinv(node)?,
+            "torch.ops.aten.special_chebyshev_polynomial_t.default" => {
+                self.translate_chebyshev_polynomial(node, ChebyshevKind::First, false)?
+            }
+            "torch.ops.aten.special_chebyshev_polynomial_u.default" => {
+                self.translate_chebyshev_polynomial(node, ChebyshevKind::Second, false)?
+            }
+            "torch.ops.aten.special_chebyshev_polynomial_v.default" => {
+                self.translate_chebyshev_polynomial(node, ChebyshevKind::Third, false)?
+            }
+            "torch.ops.aten.special_chebyshev_polynomial_w.default" => {
+                self.translate_chebyshev_polynomial(node, ChebyshevKind::Fourth, false)?
+            }
+            "torch.ops.aten.special_shifted_chebyshev_polynomial_t.default" => {
+                self.translate_chebyshev_polynomial(node, ChebyshevKind::First, true)?
+            }
+            "torch.ops.aten.special_shifted_chebyshev_polynomial_u.default" => {
+                self.translate_chebyshev_polynomial(node, ChebyshevKind::Second, true)?
+            }
+            "torch.ops.aten.special_shifted_chebyshev_polynomial_v.default" => {
+                self.translate_chebyshev_polynomial(node, ChebyshevKind::Third, true)?
+            }
+            "torch.ops.aten.special_shifted_chebyshev_polynomial_w.default" => {
+                self.translate_chebyshev_polynomial(node, ChebyshevKind::Fourth, true)?
+            }
+            "torch.ops.aten.logcumsumexp.default" => self.translate_logcumsumexp(node)?,
 
             // Cast
             "torch.ops.aten._to_copy.default" => self.translate_to_copy(node)?,
@@ -140,9 +221,26 @@ impl<'a> Translator<'a> {
 
             // Shape ops
             "torch.ops.aten.view.default" => self.translate_reshape(node)?,
+            "torch.ops.aten.view_copy.default" => {
+                let value = self.translate_reshape(node)?;
+                super::movement::materialize_tensor(value)
+            }
             "torch.ops.aten.upsample_nearest2d.vec" => self.translate_upsample_nearest2d(node)?,
+            "torch.ops.aten.upsample_bilinear2d.vec" => self.translate_upsample_bilinear2d(node)?,
+            "torch.ops.aten._upsample_bilinear2d_aa.default" => {
+                self.translate_upsample_bilinear2d_aa(node)?
+            }
             "torch.ops.aten.repeat.default" => self.translate_repeat(node)?,
             "torch.ops.aten.permute.default" => self.translate_permute(node)?,
+            "torch.ops.aten.permute_copy.default" => {
+                let value = self.translate_permute(node)?;
+                super::movement::materialize_tensor(value)
+            }
+            "torch.ops.aten.narrow_copy.default" => self.translate_narrow_copy(node)?,
+            "torch.ops.aten.unbind_copy.int" => {
+                self.translate_unbind_copy(node)?;
+                return Ok(());
+            }
             "torch.ops.aten.flip.default" => self.translate_flip(node)?,
             "torch.ops.aten.diagonal.default" => self.translate_diagonal(node)?,
             "torch.ops.aten.diagonal_scatter.default" => self.translate_diagonal_scatter(node)?,
@@ -187,6 +285,10 @@ impl<'a> Translator<'a> {
             }
             "torch.ops.aten.addmv.default" => self.translate_addmv(node)?,
             "torch.ops.aten.addbmm.default" => self.translate_addbmm(node)?,
+            "torch.ops.aten._trilinear.default" => self.translate_trilinear(node)?,
+            "torch.ops.aten.dist.default" => self.translate_dist(node)?,
+            "torch.ops.aten._cdist_forward.default" => self.translate_cdist(node)?,
+            "torch.ops.aten._pdist_forward.default" => self.translate_pdist(node)?,
 
             // addmm: beta*input + alpha*(mat1 @ mat2)
             "torch.ops.aten.addmm.default" => {
@@ -211,15 +313,42 @@ impl<'a> Translator<'a> {
             "torch.ops.aten.sum.dim_IntList" => self.translate_reduction(node, ReductionOp::Sum)?,
             "torch.ops.aten.mean.dim" => self.translate_reduction(node, ReductionOp::Mean)?,
             "torch.ops.aten.amax.default" => self.translate_reduction(node, ReductionOp::Max)?,
+            "torch.ops.aten.linalg_vector_norm.default" => {
+                self.translate_linalg_vector_norm(node)?
+            }
+            "torch.ops.aten.var.default"
+            | "torch.ops.aten.var.dim"
+            | "torch.ops.aten.var.correction" => self.translate_var(node)?,
+            "torch.ops.aten.var_mean.default"
+            | "torch.ops.aten.var_mean.dim"
+            | "torch.ops.aten.var_mean.correction" => {
+                self.translate_var_mean(node)?;
+                return Ok(());
+            }
+            "torch.ops.aten.any.default" | "torch.ops.aten.any.dim" | "torch.ops.aten.any.dims" => {
+                self.translate_any(node)?
+            }
 
             // Slice/index ops
             "torch.ops.aten.slice.Tensor" => self.translate_slice(node)?,
             "torch.ops.aten.select.int" => self.translate_select(node)?,
             "torch.ops.aten.cat.default" => self.translate_cat(node)?,
             "torch.ops.aten.index.Tensor" => self.translate_index_tensor(node)?,
+            "torch.ops.aten.slice_scatter.default" => self.translate_slice_scatter(node)?,
+            "torch.ops.aten.masked_scatter.default" => self.translate_masked_scatter(node)?,
+            "torch.ops.aten.put.default" => self.translate_put(node)?,
+            "torch.ops.aten.nonzero_static.default" => self.translate_nonzero_static(node)?,
+            "torch.ops.aten.repeat_interleave.Tensor" => {
+                self.translate_repeat_interleave_tensor(node)?
+            }
 
             // Embedding
             "torch.ops.aten.embedding.default" => self.translate_embedding(node)?,
+            "torch.ops.aten.embedding_renorm.default" => self.translate_embedding_renorm(node)?,
+            "torch.ops.aten._embedding_bag_forward_only.default" => {
+                self.translate_embedding_bag(node)?;
+                return Ok(());
+            }
 
             // Softmax
             "torch.ops.aten._softmax.default" => {
@@ -228,12 +357,47 @@ impl<'a> Translator<'a> {
                 let dim = normalize_dim(dim, a.legacy_tracker_ref().len());
                 a.softmax(dim)
             }
+            "torch.ops.aten._log_softmax.default" => self.translate_log_softmax(node)?,
 
             // LayerNorm
             "torch.ops.aten.native_layer_norm.default" => self.translate_layer_norm(node)?,
 
             // GroupNorm
             "torch.ops.aten.native_group_norm.default" => self.translate_group_norm(node)?,
+
+            // Pooling and batch normalization composites.
+            "torch.ops.aten.avg_pool2d.default" => self.translate_avg_pool(node, 2)?,
+            "torch.ops.aten.avg_pool3d.default" => self.translate_avg_pool(node, 3)?,
+            pool @ ("torch.ops.aten._adaptive_avg_pool2d.default"
+            | "torch.ops.aten._adaptive_avg_pool3d.default") => {
+                self.translate_adaptive_avg_pool(node, 2 + usize::from(pool.contains("3d")))?
+            }
+            pool @ ("torch.ops.aten.max_pool2d_with_indices.default"
+            | "torch.ops.aten.max_pool3d_with_indices.default") => {
+                self.translate_max_pool(node, 2 + usize::from(pool.contains("3d")))?;
+                return Ok(());
+            }
+            "torch.ops.aten.max_pool2d_with_indices_backward.default" => {
+                self.translate_max_pool_backward(node)?
+            }
+            pool @ ("torch.ops.aten.adaptive_max_pool2d.default"
+            | "torch.ops.aten.adaptive_max_pool3d.default") => {
+                self.translate_adaptive_max_pool(node, 2 + usize::from(pool.contains("3d")))?;
+                return Ok(());
+            }
+            pool @ ("torch.ops.aten.fractional_max_pool2d.default"
+            | "torch.ops.aten.fractional_max_pool3d.default") => {
+                self.translate_fractional_max_pool(node, 2 + usize::from(pool.contains("3d")))?;
+                return Ok(());
+            }
+            "torch.ops.aten.grid_sampler_2d.default" => self.translate_grid_sampler(node, 2)?,
+            "torch.ops.aten.grid_sampler_3d.default" => self.translate_grid_sampler(node, 3)?,
+            "torch.ops.aten._native_batch_norm_legit.no_stats"
+            | "torch.ops.aten._native_batch_norm_legit_functional.default"
+            | "torch.ops.aten._batch_norm_with_update_functional.default" => {
+                self.translate_batch_norm_functional(node)?;
+                return Ok(());
+            }
 
             // RMSNorm
             "torch.ops.aten._fused_rms_norm.default" => self.translate_fused_rms_norm(node)?,
@@ -259,6 +423,7 @@ impl<'a> Translator<'a> {
                 let (a, b) = broadcast_binary(a, b);
                 (b * a.log2()).exp2()
             }
+            "torch.ops.aten.pow.Scalar" => self.translate_scalar_base_pow(node)?,
 
             // Creation ops
             "torch.ops.aten.arange.start_step" => self.translate_arange(node)?,
@@ -271,11 +436,18 @@ impl<'a> Translator<'a> {
             // PyTorch's side, and downstream writes overwrite our zeros.
             // Qwen3MoE's MoE block uses `empty_permuted` to allocate the
             // expert-output staging tensor before scatter-adding into it.
-            "torch.ops.aten.empty.memory_format" | "torch.ops.aten.empty_permuted.default" => {
-                self.translate_empty(node)?
-            }
+            "torch.ops.aten.empty.memory_format"
+            | "torch.ops.aten.empty_permuted.default"
+            | "torch.ops.aten.empty_strided.default"
+            | "torch.ops.aten.new_empty_strided.default" => self.translate_empty(node)?,
             // Qwen3-MoE's expert-balance counts tokens-per-expert via histc.
             "torch.ops.aten.histc.default" => self.translate_histc(node)?,
+            "torch.ops.aten.bucketize.Tensor"
+            | "torch.ops.aten.searchsorted.Tensor"
+            | "torch.ops.aten.searchsorted.Scalar" => self.translate_searchsorted(node)?,
+            "torch.ops.aten.tril_indices.default" | "torch.ops.aten.triu_indices.default" => {
+                self.translate_triangular_indices(node)?
+            }
 
             // Grouped matmul (MoE expert dispatch).
             // aten._grouped_mm is the native op; transformers::grouped_mm_fallback
@@ -416,27 +588,7 @@ impl<'a> Translator<'a> {
                 let adjust = a.gt(trunc).cast(DType::F32);
                 trunc + adjust
             }
-            "torch.ops.aten.erf.default" => {
-                let a = self.get_input_tensor(node, 0)?;
-                // Abramowitz & Stegun approximation 7.1.28 (max error ~1.5e-7)
-                // erf(x) = sign(x) * (1 - poly(t) * exp(-x^2))
-                // where t = 1/(1 + 0.3275911*|x|), poly in Horner form
-                let ax = a.abs();
-                let x2 = a * a;
-                let t = (ax * 0.3275911_f32 + 1.0).reciprocal();
-                // Horner: t*(a1 + t*(a2 + t*(a3 + t*(a4 + t*a5))))
-                let poly = t
-                    * (t * (t
-                        * (t * (t * 1.061_405_4_f32 + (-1.453_152_1_f32)) + 1.421_413_8_f32)
-                        + (-0.284_496_72_f32))
-                        + 0.254_829_6_f32);
-                let result_abs =
-                    self.graph.constant_float(1.0).expand_rhs(a.dims()) - poly * (x2 * (-1.0)).exp();
-                // sign(x) = 2*(x >= 0) - 1
-                let zero = self.graph.constant_float(0.0).expand_rhs(a.dims());
-                let sign = a.ge(zero).cast(DType::F32) * 2.0 - 1.0;
-                result_abs * sign
-            }
+            "torch.ops.aten.erf.default" => self.translate_erf(node)?,
             "torch.ops.aten.isnan.default" => {
                 let a = self.get_input_tensor(node, 0)?;
                 a.ne(a)
@@ -503,13 +655,48 @@ impl<'a> Translator<'a> {
             "torch.ops.aten.argmin.default" => {
                 self.translate_argextremum(node, ArgExtremum::Min)?
             }
-
+            "torch.ops.aten.max.dim" => {
+                self.translate_dim_extremum(node, ArgExtremum::Max)?;
+                return Ok(());
+            }
+            "torch.ops.aten.min.dim" => {
+                self.translate_dim_extremum(node, ArgExtremum::Min)?;
+                return Ok(());
+            }
+            "torch.ops.aten.median.default" | "torch.ops.aten.median.dim" => {
+                self.translate_median(node)?;
+                return Ok(());
+            }
+            "torch.ops.aten.nanmedian.default" | "torch.ops.aten.nanmedian.dim" => {
+                self.translate_nanmedian(node)?;
+                return Ok(());
+            }
+            "torch.ops.aten.segment_reduce.default" => self.translate_segment_reduce(node)?,
+            "torch.ops.aten.histogram.bin_ct" | "torch.ops.aten.histogram.bins_tensor" => {
+                self.translate_histogram(node)?;
+                return Ok(());
+            }
+            "torch.ops.aten._histogramdd_bin_edges.default" => {
+                self.translate_histogramdd_bin_edges(node)?;
+                return Ok(());
+            }
+            "torch.ops.aten._histogramdd_from_bin_cts.default" => {
+                self.translate_histogramdd(node, false)?
+            }
+            "torch.ops.aten._histogramdd_from_bin_tensors.default" => {
+                self.translate_histogramdd(node, true)?
+            }
             // Gather (axis-aware)
             "torch.ops.aten.gather.default" => self.translate_gather(node)?,
 
             // Scatter ops
             "torch.ops.aten.scatter.src" => self.translate_scatter_src(node)?,
             "torch.ops.aten.scatter.value" => self.translate_scatter_value(node)?,
+            "torch.ops.aten.scatter.reduce" => self.translate_scatter_src_reduce(node)?,
+            "torch.ops.aten.scatter.value_reduce" => self.translate_scatter_value_reduce(node)?,
+            "torch.ops.aten.scatter_add.default" => self.translate_scatter_add(node)?,
+            "torch.ops.aten.scatter_reduce.two" => self.translate_scatter_reduce(node)?,
+            "torch.ops.aten.index_reduce.default" => self.translate_index_reduce(node)?,
             "torch.ops.aten.index_put_.default" | "torch.ops.aten.index_put.default" => {
                 self.translate_index_put(node)?
             }
@@ -528,7 +715,7 @@ impl<'a> Translator<'a> {
             }
 
             // Sort — handles its own output storage, returns early
-            "torch.ops.aten.sort.default" => {
+            "torch.ops.aten.sort.default" | "torch.ops.aten.sort.stable" => {
                 self.translate_sort(node)?;
                 return Ok(());
             }
@@ -553,6 +740,14 @@ impl<'a> Translator<'a> {
                 let b = self.get_input_tensor(node, 1)?;
                 let (a, b) = broadcast_binary(a, b);
                 a % b
+            }
+            "torch.ops.aten.fmod.Scalar" => {
+                let a = self.get_input_tensor(node, 0)?;
+                let value = self.constructor_scalar_arg(node, 1)?;
+                let scalar = self
+                    .typed_scalar_constant(&value, a.dtype)?
+                    .expand_rhs(a.dims());
+                a % scalar
             }
             // Remainder (Python-style modulo). For float tensors aten.remainder
             // returns the same value as `%` would in luminal (Mod follows the

--- a/crates/luminal_python/rust/src/translator/mod.rs
+++ b/crates/luminal_python/rust/src/translator/mod.rs
@@ -9,7 +9,9 @@ mod conv;
 mod dispatch;
 mod movement;
 mod movement_dynamic;
+mod pooling;
 mod reduction;
+mod sampling;
 mod tensor;
 mod unary;
 
@@ -357,6 +359,86 @@ impl<'a> Translator<'a> {
             .arg;
         arg.as_bool()
             .with_context(|| format!("Input {idx} of {} is not a bool: {:?}", node.target, arg))
+    }
+
+    pub(crate) fn named_input_index(node: &Node, name: &str) -> Option<usize> {
+        node.inputs.iter().position(|input| input.name == name)
+    }
+
+    pub(crate) fn named_int_arg(&self, node: &Node, name: &str) -> Option<i64> {
+        Self::named_input_index(node, name).and_then(|index| self.get_int_arg(node, index).ok())
+    }
+
+    pub(crate) fn named_float_arg(&self, node: &Node, name: &str) -> Option<f64> {
+        Self::named_input_index(node, name).and_then(|index| self.get_float_arg(node, index).ok())
+    }
+
+    pub(crate) fn named_bool_arg(&self, node: &Node, name: &str) -> Option<bool> {
+        Self::named_input_index(node, name).and_then(|index| self.get_bool_arg(node, index).ok())
+    }
+
+    pub(crate) fn named_tensor_arg(&self, node: &Node, name: &str) -> Result<Option<GraphTensor>> {
+        let tensor_name = node
+            .inputs
+            .iter()
+            .find(|input| input.name == name)
+            .and_then(|input| input.arg.as_tensor_name());
+        tensor_name.map(|name| self.get_tensor(name)).transpose()
+    }
+
+    pub(crate) fn tensor_output_names(node: &Node) -> Vec<String> {
+        node.outputs
+            .iter()
+            .flat_map(|output| {
+                output
+                    .as_tensors
+                    .as_ref()
+                    .map(|values| values.iter().map(|value| value.name.clone()).collect())
+                    .unwrap_or_else(|| {
+                        output
+                            .as_tensor
+                            .as_ref()
+                            .map(|value| vec![value.name.clone()])
+                            .unwrap_or_default()
+                    })
+            })
+            .collect()
+    }
+
+    pub(crate) fn store_tensor_outputs(
+        &mut self,
+        node: &Node,
+        outputs: &[GraphTensor],
+    ) -> Result<()> {
+        let names = Self::tensor_output_names(node);
+        anyhow::ensure!(names.len() == outputs.len(), "tensor output count mismatch");
+        self.tensors
+            .extend(names.into_iter().zip(outputs.iter().copied()));
+        Ok(())
+    }
+
+    pub(crate) fn axis_positions(&mut self, full_shape: &[IntExpr], axis: usize) -> GraphTensor {
+        let mut positions = self.graph.arange(full_shape[axis]).cast(DType::Int);
+        for (dim, size) in full_shape.iter().copied().enumerate() {
+            if dim != axis {
+                positions = positions.expand_dim(dim, size);
+            }
+        }
+        positions
+    }
+
+    pub(crate) fn full_tensor(
+        &mut self,
+        shape: Vec<IntExpr>,
+        dtype: DType,
+        value: f64,
+    ) -> GraphTensor {
+        let scalar = if dtype == DType::F64 {
+            self.graph.constant_float64(value)
+        } else {
+            self.graph.constant_float(value as f32)
+        };
+        scalar.cast(dtype).expand_rhs(shape)
     }
 
     pub(crate) fn tensor_meta_to_shape(&self, meta: &TensorMeta) -> Result<Vec<IntExpr>> {

--- a/crates/luminal_python/rust/src/translator/movement.rs
+++ b/crates/luminal_python/rust/src/translator/movement.rs
@@ -2,18 +2,29 @@ use anyhow::{Context, Result, bail};
 use luminal::prelude::*;
 use rustc_hash::FxHashMap;
 
-use crate::pt2_expr::{ExprBounds, canonical_equal_expr, sym_char_ranges};
+use crate::dim_arith::product_of_dims;
+use crate::pt2_expr::{ExprBounds, bounds_of_expr, canonical_equal_expr, sym_char_ranges};
 use crate::pt2_schema::*;
 use crate::pt2_util::*;
 
 use super::Translator;
 
+use super::movement_dynamic::ScatterReduction;
 use super::movement_dynamic::{logical_flat_indices, row_major_strides};
 
 const SCATTER_INPUT_ARG: usize = 0;
 const SCATTER_DIM_ARG: usize = 1;
 const SCATTER_INDEX_ARG: usize = 2;
 const SCATTER_VALUE_ARG: usize = 3;
+
+#[derive(Clone, Copy, Debug)]
+enum ModernScatterReduction {
+    Sum,
+    Product,
+    Mean,
+    Maximum,
+    Minimum,
+}
 
 pub(crate) fn normalize_flip_dims(dims: &[i64], rank: usize) -> Result<Vec<usize>> {
     let mut normalized = Vec::with_capacity(dims.len());
@@ -198,6 +209,206 @@ pub(crate) fn unfold_tensor(
     Ok(result)
 }
 
+pub(crate) fn narrow_copy_tensor(
+    input: GraphTensor,
+    dim: usize,
+    start: IntExpr,
+    length: IntExpr,
+) -> Result<GraphTensor> {
+    let start = normalize_slice_bound(start, input.legacy_tracker_ref().dims[dim]);
+    let end = (start + length).simplify();
+    Ok(materialize_tensor(input.slice_along(start..end, dim)))
+}
+
+pub(crate) fn materialize_tensor(input: GraphTensor) -> GraphTensor {
+    // Copy variants require fresh logical storage even when a sliced view has
+    // contiguous strides. A stride-only check cannot distinguish such a view
+    // from a full allocation, and returning its backing op would expose all
+    // source elements at the PT2 output boundary.
+    let indices = input.graph().iota(IntExpr::from('z'), input.dims());
+    input.gather(indices)
+}
+
+pub(crate) fn slice_scatter_tensor(
+    destination: GraphTensor,
+    source: GraphTensor,
+    dim: usize,
+    start: IntExpr,
+    step: i64,
+) -> Result<GraphTensor> {
+    anyhow::ensure!(step > 0, "slice_scatter step must be positive, got {step}");
+    anyhow::ensure!(
+        destination.dtype == source.dtype,
+        "slice_scatter source and destination dtypes must match"
+    );
+    anyhow::ensure!(
+        destination.legacy_tracker_ref().len() == source.legacy_tracker_ref().len(),
+        "slice_scatter source and destination ranks must match"
+    );
+
+    let destination = materialize_tensor(destination);
+    let source = materialize_tensor(source);
+    let strides = row_major_strides(&destination.dims());
+    let contributions = strides
+        .iter()
+        .enumerate()
+        .map(|(axis, &stride)| {
+            if axis == dim {
+                IntExpr::from('z') * IntExpr::from(step) * stride
+            } else {
+                IntExpr::from('z') * stride
+            }
+        })
+        .collect::<Vec<_>>();
+    let indices = logical_flat_indices(
+        destination.graph(),
+        &source.dims(),
+        &contributions,
+        start * strides[dim],
+    )
+    .flatten();
+    let output = source.flatten().scatter(indices, destination.flatten());
+    Ok(reshape_tensor(output, destination.dims()))
+}
+
+pub(crate) fn masked_scatter_tensor(
+    translator: &mut Translator<'_>,
+    destination: GraphTensor,
+    mask: GraphTensor,
+    source: GraphTensor,
+) -> Result<GraphTensor> {
+    let output_shape = destination.dims();
+    let (mask, destination) = broadcast_binary(mask, destination);
+    anyhow::ensure!(
+        mask.dims() == destination.dims(),
+        "masked_scatter mask must broadcast to the destination shape"
+    );
+    let mask = mask.cast(DType::Int).flatten();
+    let destination = materialize_tensor(destination).flatten();
+    let source = materialize_tensor(source).flatten();
+    if source.dims()[0].to_usize() == Some(0) {
+        return Ok(reshape_tensor(destination, output_shape));
+    }
+    let prefix = mask.cumsum(0);
+    let zero = translator.graph.constant(0).expand_rhs(prefix.dims());
+    let indices = (prefix - 1).maximum(zero);
+    let updates = source.gather(indices);
+    let output = translator.select(mask.cast(DType::Bool), updates, destination);
+    Ok(reshape_tensor(output, output_shape))
+}
+
+pub(crate) fn put_tensor(
+    destination: GraphTensor,
+    mut indices: GraphTensor,
+    source: GraphTensor,
+    accumulate: bool,
+) -> Result<GraphTensor> {
+    if destination.dtype == DType::Bool && accumulate {
+        return Ok(put_tensor(
+            destination.cast(DType::Int),
+            indices,
+            source.cast(DType::Int),
+            true,
+        )?
+        .cast(DType::Bool));
+    }
+    let destination = materialize_tensor(destination);
+    let source = materialize_tensor(source.cast(destination.dtype));
+    let output_shape = destination.dims();
+    let flat_destination = destination.flatten();
+    let flat_size = product_of_dims(output_shape.iter().copied());
+    indices = indices.cast(DType::Int).flatten();
+    let zero = destination.graph().constant(0).expand_rhs(indices.dims());
+    let negative = indices.lt(zero).cast(DType::Int);
+    indices += negative * flat_size;
+    let output = if accumulate {
+        super::movement_dynamic::pt2_scatter_elements_reduce(
+            flat_destination,
+            indices,
+            source.flatten(),
+            0,
+            ScatterReduction::Add,
+        )?
+    } else {
+        source.flatten().scatter(indices, flat_destination)
+    };
+    Ok(reshape_tensor(output, output_shape))
+}
+
+pub(crate) fn nonzero_static_from_truth(
+    translator: &mut Translator<'_>,
+    truth: GraphTensor,
+    size: IntExpr,
+    fill_value: i64,
+) -> GraphTensor {
+    let input_shape = truth.dims();
+    let rank = input_shape.len();
+    let numel = product_of_dims(input_shape.iter().copied());
+    if rank == 0 {
+        return translator
+            .graph
+            .iota(0, vec![size, IntExpr::from(rank)])
+            .cast(DType::I64);
+    }
+    if numel.to_usize() == Some(0) {
+        return translator
+            .graph
+            .constant(fill_value)
+            .cast(DType::I64)
+            .expand_rhs(vec![size, IntExpr::from(rank)]);
+    }
+
+    let truth = materialize_tensor(truth).flatten();
+    let sorted = truth
+        .cast(DType::F32)
+        .stable_argsort(0, true)
+        .cast(DType::Int);
+    let count = truth.cast(DType::Int).sum(0);
+    let positions = translator.graph.arange(size).cast(DType::Int);
+    let zero = translator.graph.constant(0).expand_rhs(positions.dims());
+    let last = translator
+        .graph
+        .constant(numel - 1)
+        .cast(DType::Int)
+        .expand_rhs(positions.dims());
+    let clamped = positions.maximum(zero).minimum(last);
+    let flat_indices = sorted.gather(clamped);
+    let count = count.expand_rhs(positions.dims());
+    let numel_tensor = translator
+        .graph
+        .constant(numel)
+        .cast(DType::Int)
+        .expand_rhs(positions.dims());
+    let valid = translator.bool_and(positions.lt(count), positions.lt(numel_tensor));
+    let fill = translator
+        .graph
+        .constant(fill_value)
+        .cast(DType::I64)
+        .expand_rhs(positions.dims());
+
+    let strides = row_major_strides(&input_shape);
+    let mut columns = Vec::with_capacity(rank);
+    for axis in 0..rank {
+        let numerator = flat_indices.cast(DType::F64);
+        let denominator = translator
+            .graph
+            .constant(strides[axis])
+            .cast(DType::F64)
+            .expand_rhs(numerator.dims());
+        let quotient = (numerator / denominator).cast(DType::I64);
+        let dimension = translator
+            .graph
+            .constant(input_shape[axis])
+            .cast(DType::I64)
+            .expand_rhs(quotient.dims());
+        let coordinate = quotient % dimension;
+        columns.push(translator.select(valid, coordinate, fill).unsqueeze(1));
+    }
+    columns[1..]
+        .iter()
+        .fold(columns[0], |result, column| result.concat_along(*column, 1))
+}
+
 fn normalize_concat_dims(
     lhs: &mut GraphTensor,
     rhs: &mut GraphTensor,
@@ -378,6 +589,66 @@ impl<'a> Translator<'a> {
             .map(|&d| normalize_dim(d, a.legacy_tracker_ref().len()))
             .collect();
         Ok(a.permute(axes))
+    }
+
+    pub(crate) fn translate_narrow_copy(&mut self, node: &Node) -> Result<GraphTensor> {
+        let input = self.get_input_tensor(node, 0)?;
+        let raw_dim = self.get_int_arg(node, 1)?;
+        anyhow::ensure!(
+            raw_dim >= -(input.legacy_tracker_ref().len() as i64) && raw_dim < input.legacy_tracker_ref().len() as i64,
+            "narrow_copy dimension {raw_dim} out of range for rank {}",
+            input.legacy_tracker_ref().len()
+        );
+        let dim = normalize_dim(raw_dim, input.legacy_tracker_ref().len());
+        let start = self.get_expr_arg(node, 2)?;
+        let length = self.get_expr_arg(node, 3)?;
+        narrow_copy_tensor(input, dim, start, length)
+    }
+
+    pub(crate) fn translate_unbind_copy(&mut self, node: &Node) -> Result<()> {
+        let input = self.get_input_tensor(node, 0)?;
+        let raw_dim = self.get_int_arg(node, 1).unwrap_or(0);
+        anyhow::ensure!(
+            raw_dim >= -(input.legacy_tracker_ref().len() as i64) && raw_dim < input.legacy_tracker_ref().len() as i64,
+            "unbind_copy dimension {raw_dim} out of range for rank {}",
+            input.legacy_tracker_ref().len()
+        );
+        let dim = normalize_dim(raw_dim, input.legacy_tracker_ref().len());
+        let output_names: Vec<String> = node
+            .outputs
+            .iter()
+            .flat_map(|output| {
+                output
+                    .as_tensors
+                    .as_ref()
+                    .map(|tensors| {
+                        tensors
+                            .iter()
+                            .map(|tensor| tensor.name.clone())
+                            .collect::<Vec<_>>()
+                    })
+                    .or_else(|| {
+                        output
+                            .as_tensor
+                            .as_ref()
+                            .map(|tensor| vec![tensor.name.clone()])
+                    })
+                    .unwrap_or_default()
+            })
+            .collect();
+        let axis_size = input.legacy_tracker_ref().dims[dim]
+            .to_usize()
+            .context("unbind_copy requires a concrete unbound dimension")?;
+        anyhow::ensure!(
+            output_names.len() == axis_size,
+            "unbind_copy produced {} outputs for an axis of size {axis_size}",
+            output_names.len()
+        );
+        for (index, name) in output_names.into_iter().enumerate() {
+            let selected = input.slice_along(index..index + 1, dim).squeeze(dim);
+            self.tensors.insert(name, materialize_tensor(selected));
+        }
+        Ok(())
     }
 
     pub(crate) fn translate_flip(&mut self, node: &Node) -> Result<GraphTensor> {
@@ -667,9 +938,212 @@ impl<'a> Translator<'a> {
         Ok(weight.gather1d(ids_expanded + arange_expanded))
     }
 
+    pub(crate) fn translate_embedding_renorm(&mut self, node: &Node) -> Result<GraphTensor> {
+        let weight = self.get_input_tensor(node, 0)?;
+        anyhow::ensure!(
+            weight.legacy_tracker_ref().len() == 2,
+            "embedding_renorm requires a matrix"
+        );
+        let indices = self.get_input_tensor(node, 1)?.cast(DType::Int).flatten();
+        let max_norm = self.get_float_arg(node, 2)?;
+        let norm_type = self.get_float_arg(node, 3)?;
+        anyhow::ensure!(
+            norm_type > 0.0,
+            "embedding_renorm requires a positive norm type"
+        );
+
+        let rows = weight.dims()[0];
+        let columns = weight.dims()[1];
+        let row_ids = self
+            .graph
+            .arange(rows)
+            .cast(DType::Int)
+            .expand_dim(1, indices.dims()[0]);
+        let indices = indices.expand_dim(0, rows);
+        let selected_count = row_ids.eq(indices).cast(DType::Int).sum(1);
+        let zero_count = self.graph.constant(0).expand_rhs(selected_count.dims());
+        let selected = selected_count.gt(zero_count);
+
+        let magnitude = self.real_abs(weight);
+        let norm = if norm_type == f64::INFINITY {
+            magnitude.max(1)
+        } else {
+            magnitude
+                .pow(norm_type as f32)
+                .sum(1)
+                .pow((1.0 / norm_type) as f32)
+        };
+        let maximum = self.constant_like(norm, max_norm);
+        let exceeds = norm.gt(maximum);
+        let apply = self.bool_and(selected, exceeds);
+        let scale = maximum / norm;
+        let scale = scale.expand_dim(1, columns);
+        let apply = apply.expand_dim(1, columns);
+        Ok(self.select(apply, weight * scale, weight))
+    }
+
+    pub(crate) fn translate_embedding_bag(&mut self, node: &Node) -> Result<()> {
+        let weight = self.get_input_tensor(node, 0)?;
+        let indices = self.get_input_tensor(node, 1)?.cast(DType::Int);
+        let offsets = self.get_input_tensor(node, 2)?.cast(DType::Int);
+        anyhow::ensure!(
+            weight.legacy_tracker_ref().len() == 2 && indices.legacy_tracker_ref().len() == 1 && offsets.legacy_tracker_ref().len() == 1,
+            "embedding_bag requires matrix weights and one-dimensional indices/offsets"
+        );
+        let mode = self.named_int_arg(node, "mode").unwrap_or(0);
+        anyhow::ensure!(
+            (0..=2).contains(&mode),
+            "unsupported embedding_bag mode {mode}"
+        );
+        let include_last_offset = self
+            .named_bool_arg(node, "include_last_offset")
+            .unwrap_or(false);
+        let padding_idx = self.named_int_arg(node, "padding_idx").unwrap_or(-1);
+
+        let index_count = indices.dims()[0];
+        let bag_count = offsets.dims()[0] - usize::from(include_last_offset);
+        let embedding_size = weight.dims()[1];
+        let positions = self
+            .graph
+            .arange(index_count)
+            .cast(DType::Int)
+            .expand_dim(0, bag_count);
+        let starts = offsets
+            .slice_along(IntExpr::from(0)..bag_count, 0)
+            .expand_dim(1, index_count);
+        let terminal = self.graph.constant(index_count).cast(DType::Int);
+        let ends = offsets
+            .pad_with(vec![(IntExpr::from(0), IntExpr::from(1))], terminal)
+            .slice_along(IntExpr::from(1)..(bag_count + 1), 0)
+            .expand_dim(1, index_count);
+        let bag_membership = self.bool_and(positions.ge(starts), positions.lt(ends));
+        let mut membership = bag_membership;
+        let expanded_indices = indices.expand_dim(0, bag_count);
+        if padding_idx >= 0 {
+            let padding = self
+                .graph
+                .constant(padding_idx)
+                .cast(DType::Int)
+                .expand_rhs(expanded_indices.dims());
+            membership = self.bool_and(membership, expanded_indices.ne(padding));
+        }
+
+        let flat_weight_indices = (indices * embedding_size).expand_dim(1, embedding_size)
+            + self
+                .graph
+                .arange(embedding_size)
+                .cast(DType::Int)
+                .expand_dim(0, index_count);
+        let gathered = weight.gather(flat_weight_indices).expand_dim(0, bag_count);
+        let membership_values = membership.expand_dim(2, embedding_size);
+        let zero_values = self.full_tensor(gathered.dims(), weight.dtype, 0.0);
+        let mut selected = self.select(membership_values, gathered, zero_values);
+        if let Some(per_sample) = self.named_tensor_arg(node, "per_sample_weights")? {
+            anyhow::ensure!(
+                mode == 0,
+                "per-sample weights require embedding_bag sum mode"
+            );
+            let per_sample = per_sample
+                .cast(weight.dtype)
+                .expand_dim(0, bag_count)
+                .expand_dim(2, embedding_size);
+            selected *= per_sample;
+        }
+
+        let counts = membership.cast(DType::Int).sum(1).cast(DType::I64);
+        let nonempty = counts.gt(self
+            .graph
+            .constant(0)
+            .cast(DType::I64)
+            .expand_rhs(counts.dims()));
+        let sum = selected.sum(1);
+        let (output, max_indices) = match mode {
+            0 => {
+                let zeros = self
+                    .graph
+                    .constant(0)
+                    .cast(DType::I64)
+                    .expand_rhs(vec![bag_count]);
+                (sum, zeros)
+            }
+            1 => {
+                let one = self
+                    .graph
+                    .constant(1)
+                    .cast(DType::I64)
+                    .expand_rhs(counts.dims());
+                let safe_counts = self.select(nonempty, counts, one);
+                let mean = sum / safe_counts.cast(weight.dtype).expand_dim(1, embedding_size);
+                (mean, counts)
+            }
+            2 => {
+                let lowest = self
+                    .floating_scalar(f64::NEG_INFINITY, weight.dtype)
+                    .expand_rhs(gathered.dims());
+                let candidates = self.select(membership_values, gathered, lowest);
+                let selected_positions = candidates
+                    .stable_argsort(1, true)
+                    .slice_along(IntExpr::from(0)..IntExpr::from(1), 1);
+                let values =
+                    super::movement_dynamic::pt2_gather_elements(candidates, selected_positions, 1)
+                        .squeeze(1);
+                let candidate_indices = expanded_indices.expand_dim(2, embedding_size);
+                let selected_indices = super::movement_dynamic::pt2_gather_elements(
+                    candidate_indices,
+                    selected_positions,
+                    1,
+                )
+                .squeeze(1)
+                .cast(DType::I64);
+                let output_nonempty = nonempty.expand_dim(1, embedding_size);
+                let zero_output = self.full_tensor(values.dims(), weight.dtype, 0.0);
+                let zero_indices = self
+                    .graph
+                    .constant(0)
+                    .cast(DType::I64)
+                    .expand_rhs(selected_indices.dims());
+                (
+                    self.select(output_nonempty, values, zero_output),
+                    self.select(output_nonempty, selected_indices, zero_indices),
+                )
+            }
+            _ => unreachable!(),
+        };
+
+        let offset_to_bag = if mode == 0 && padding_idx < 0 {
+            self.graph
+                .constant(0)
+                .cast(DType::I64)
+                .expand_rhs(vec![IntExpr::from(0)])
+        } else {
+            let bag_ids = self
+                .graph
+                .arange(bag_count)
+                .cast(DType::I64)
+                .expand_dim(1, index_count);
+            (bag_membership.cast(DType::I64) * bag_ids).sum(0)
+        };
+        let bag_size = if mode == 0 {
+            self.graph
+                .constant(0)
+                .cast(DType::I64)
+                .expand_rhs(vec![bag_count])
+        } else {
+            counts
+        };
+        self.store_tensor_outputs(node, &[output, offset_to_bag, bag_size, max_indices])
+    }
+
     pub(crate) fn translate_index_tensor(&mut self, node: &Node) -> Result<GraphTensor> {
         let source = self.get_input_tensor(node, 0)?;
+        self.translate_index_tensor_from_source(node, source)
+    }
 
+    pub(crate) fn translate_index_tensor_from_source(
+        &mut self,
+        node: &Node,
+        source: GraphTensor,
+    ) -> Result<GraphTensor> {
         // Handle indices as_tensors (all non-None) or as individual args with None entries
         let index_names: Vec<crate::pt2_schema::TensorName>;
         let mut first_non_none_dim = 0usize;
@@ -813,6 +1287,76 @@ impl<'a> Translator<'a> {
         }
     }
 
+    pub(crate) fn translate_slice_scatter(&mut self, node: &Node) -> Result<GraphTensor> {
+        let destination = self.get_input_tensor(node, 0)?;
+        let source = self.get_input_tensor(node, 1)?.cast(destination.dtype);
+        let dim = normalize_dim(
+            self.get_int_arg(node, 2).unwrap_or(0),
+            destination.legacy_tracker_ref().len(),
+        );
+        let start = self
+            .get_expr_arg(node, 3)
+            .unwrap_or_else(|_| IntExpr::from(0));
+        let start = normalize_slice_bound(start, destination.dims()[dim]);
+        let step = self.get_int_arg(node, 5).unwrap_or(1);
+        slice_scatter_tensor(destination, source, dim, start, step)
+    }
+
+    pub(crate) fn translate_masked_scatter(&mut self, node: &Node) -> Result<GraphTensor> {
+        let destination = self.get_input_tensor(node, 0)?;
+        let mask = self.get_input_tensor(node, 1)?;
+        let source = self.get_input_tensor(node, 2)?.cast(destination.dtype);
+        let output_shape = destination.dims();
+        let output = masked_scatter_tensor(self, destination, mask, source)?;
+        Ok(reshape_tensor(output, output_shape))
+    }
+
+    pub(crate) fn translate_put(&mut self, node: &Node) -> Result<GraphTensor> {
+        let destination = self.get_input_tensor(node, 0)?;
+        let indices = self.get_input_tensor(node, 1)?;
+        let source = self.get_input_tensor(node, 2)?;
+        let accumulate = self.get_bool_arg(node, 3).unwrap_or(false);
+        put_tensor(destination, indices, source, accumulate)
+    }
+
+    pub(crate) fn translate_repeat_interleave_tensor(
+        &mut self,
+        node: &Node,
+    ) -> Result<GraphTensor> {
+        let repeats = self.get_input_tensor(node, 0)?.cast(DType::Int).flatten();
+        let output_size_index = Self::named_input_index(node, "output_size")
+            .context(
+                "repeat_interleave.Tensor has a value-dependent output shape unless output_size is supplied",
+            )?;
+        let output_size = self.get_expr_arg(node, output_size_index).context(
+            "repeat_interleave.Tensor has a value-dependent output shape unless output_size is supplied",
+        )?;
+        let ends = repeats.cumsum(0);
+        let positions = self.graph.arange(output_size).cast(DType::Int);
+        let ends = ends.expand_dim(0, output_size);
+        let positions = positions.expand_dim(1, repeats.dims()[0]);
+        // The interval for input i is [ends[i-1], ends[i]); counting ends
+        // that are <= an output position gives exactly that input index.
+        Ok(ends.le(positions).cast(DType::I64).sum(1).cast(DType::I64))
+    }
+
+    pub(crate) fn translate_nonzero_static(&mut self, node: &Node) -> Result<GraphTensor> {
+        let value = self.get_input_tensor(node, 0)?;
+        let size_index = Self::named_input_index(node, "size").unwrap_or(1);
+        let size = self.get_expr_arg(node, size_index)?;
+        let fill_value = self.named_int_arg(node, "fill_value").unwrap_or(-1);
+        let truth = if matches!(
+            value.dtype,
+            DType::F16 | DType::Bf16 | DType::F32 | DType::F64
+        ) {
+            let zero = self.is_zero(value);
+            self.bool_not(zero)
+        } else {
+            value.ne(self.constant_like(value, 0.0))
+        };
+        Ok(nonzero_static_from_truth(self, truth, size, fill_value))
+    }
+
     pub(crate) fn translate_gather(&mut self, node: &Node) -> Result<GraphTensor> {
         let a = self.get_input_tensor(node, 0)?;
         let dim = self.get_int_arg(node, 1)?;
@@ -863,32 +1407,427 @@ impl<'a> Translator<'a> {
         ))
     }
 
-    pub(crate) fn translate_scatter_value(&mut self, node: &Node) -> Result<GraphTensor> {
-        let a = self.get_input_tensor(node, SCATTER_INPUT_ARG)?;
-        let dim = self.get_int_arg(node, SCATTER_DIM_ARG)?;
-        let dim = normalize_dim(dim, a.legacy_tracker_ref().len());
+    fn scatter_reduction(&self, node: &Node) -> Result<ScatterReduction> {
+        let reduce = node
+            .inputs
+            .iter()
+            .find(|input| input.name == "reduce")
+            .and_then(|input| match &input.arg {
+                Argument::Other(value) => value
+                    .as_str()
+                    .or_else(|| value.get("as_string").and_then(|value| value.as_str())),
+                _ => None,
+            })
+            .with_context(|| format!("{} is missing its reduce argument", node.target))?;
+        match reduce {
+            "add" | "sum" => Ok(ScatterReduction::Add),
+            "multiply" | "prod" => Ok(ScatterReduction::Multiply),
+            other => bail!("Unsupported scatter reduction: {other}"),
+        }
+    }
+
+    pub(crate) fn translate_scatter_src_reduce(&mut self, node: &Node) -> Result<GraphTensor> {
+        let data = self.get_input_tensor(node, SCATTER_INPUT_ARG)?;
+        let dim = normalize_dim(self.get_int_arg(node, SCATTER_DIM_ARG)?, data.legacy_tracker_ref().len());
         let indices = self.get_input_tensor(node, SCATTER_INDEX_ARG)?;
+        let updates = self.get_input_tensor(node, SCATTER_VALUE_ARG)?;
+        super::movement_dynamic::pt2_scatter_elements_reduce(
+            data,
+            indices.cast(DType::Int),
+            updates,
+            dim,
+            self.scatter_reduction(node)?,
+        )
+    }
+
+    pub(crate) fn translate_scatter_add(&mut self, node: &Node) -> Result<GraphTensor> {
+        let data = self.get_input_tensor(node, SCATTER_INPUT_ARG)?;
+        let dim = normalize_dim(self.get_int_arg(node, SCATTER_DIM_ARG)?, data.legacy_tracker_ref().len());
+        let indices = self.get_input_tensor(node, SCATTER_INDEX_ARG)?;
+        let updates = self.get_input_tensor(node, SCATTER_VALUE_ARG)?;
+        super::movement_dynamic::pt2_scatter_elements_reduce(
+            data,
+            indices.cast(DType::Int),
+            updates,
+            dim,
+            ScatterReduction::Add,
+        )
+    }
+
+    fn modern_scatter_reduction(&self, node: &Node) -> Result<ModernScatterReduction> {
+        let reduce = node
+            .inputs
+            .iter()
+            .find(|input| input.name == "reduce")
+            .and_then(|input| match &input.arg {
+                Argument::Other(value) => value
+                    .as_str()
+                    .or_else(|| value.get("as_string").and_then(|value| value.as_str())),
+                _ => None,
+            })
+            .with_context(|| format!("{} is missing its reduce argument", node.target))?;
+        match reduce {
+            "sum" => Ok(ModernScatterReduction::Sum),
+            "prod" => Ok(ModernScatterReduction::Product),
+            "mean" => Ok(ModernScatterReduction::Mean),
+            "amax" => Ok(ModernScatterReduction::Maximum),
+            "amin" => Ok(ModernScatterReduction::Minimum),
+            other => bail!("Unsupported {} reduction: {other}", node.target),
+        }
+    }
+
+    fn scatter_include_self(&self, node: &Node) -> bool {
+        node.inputs
+            .iter()
+            .position(|input| input.name == "include_self")
+            .and_then(|index| self.get_bool_arg(node, index).ok())
+            .unwrap_or(true)
+    }
+
+    fn scatter_extremum(
+        &mut self,
+        current: GraphTensor,
+        incoming: GraphTensor,
+        maximum: bool,
+    ) -> GraphTensor {
+        let ordered = if maximum {
+            self.select(current.ge(incoming), current, incoming)
+        } else {
+            self.select(current.le(incoming), current, incoming)
+        };
+        // ATen propagates NaNs for amax/amin. Comparisons alone would select
+        // whichever ordered arm happens to be the non-NaN value.
+        let can_nan = matches!(
+            current.dtype,
+            DType::F32 | DType::F64 | DType::F16 | DType::Bf16 | DType::TF32
+        );
+        if can_nan {
+            let current_nan = self.is_nan(current);
+            let incoming_nan = self.is_nan(incoming);
+            let current_or_ordered = self.select(current_nan, current, ordered);
+            self.select(incoming_nan, incoming, current_or_ordered)
+        } else {
+            ordered
+        }
+    }
+
+    /// Sequential read/modify/write lowering shared by scatter_reduce and
+    /// index_reduce. Core Scatter is overwrite-only, so preserving duplicate
+    /// update order requires one static graph step per update element. A
+    /// bounded symbolic update stream is padded to its compile-time upper
+    /// bound; validity guards make those padding lanes no-ops at runtime.
+    fn reduce_scatter_elements(
+        &mut self,
+        data: GraphTensor,
+        indices: GraphTensor,
+        updates: GraphTensor,
+        axis: usize,
+        reduction: ModernScatterReduction,
+        include_self: bool,
+    ) -> Result<GraphTensor> {
+        anyhow::ensure!(
+            indices.legacy_tracker_ref().len() == updates.legacy_tracker_ref().len(),
+            "{} reduction requires index/update ranks to match",
+            if include_self { "scatter" } else { "indexed" }
+        );
+        let index_shape = indices.dims();
+        anyhow::ensure!(
+            index_shape
+                .iter()
+                .zip(updates.dims())
+                .all(|(index, update)| index == &update || index.egglog_equal(update)),
+            "scatter reduction requires index and update shapes to match"
+        );
+        let logical_update_count = product_of_dims(index_shape.iter().copied());
+        let update_count = match logical_update_count.to_usize() {
+            Some(count) => count,
+            None => {
+                let ranges = sym_char_ranges(&self.sym_map);
+                let upper = bounds_of_expr(logical_update_count, &ranges)
+                    .max
+                    .context("scatter/index reduction requires a bounded update extent")?;
+                usize::try_from(upper)
+                    .context("scatter/index reduction update bound must fit usize")?
+            }
+        };
+
+        let mut destinations = super::movement_dynamic::pt2_scatter_element_indices(
+            data,
+            indices.cast(DType::Int),
+            axis,
+        );
+        let mut flat_updates = updates.flatten();
+        let mut valid_updates = None;
+        if logical_update_count.to_usize().is_none() {
+            let right_padding = IntExpr::from(update_count) - logical_update_count;
+            destinations = destinations.pad_with(
+                &[(IntExpr::from(0), right_padding)],
+                self.graph.constant(0),
+            );
+            flat_updates = flat_updates.pad_with(
+                &[(IntExpr::from(0), right_padding)],
+                self.graph.constant(0).cast(updates.dtype),
+            );
+            let valid = self.graph.iota(1, vec![logical_update_count]).pad_with(
+                &[(IntExpr::from(0), right_padding)],
+                self.graph.constant(0),
+            );
+            let padded_shape = ShapeTracker::new(vec![IntExpr::from(update_count)]);
+            *destinations.legacy_tracker_mut() = padded_shape;
+            *flat_updates.legacy_tracker_mut() = padded_shape;
+            let mut valid = valid;
+            *valid.legacy_tracker_mut() = padded_shape;
+            valid_updates = Some(valid);
+        }
+        let output_shape = data.dims();
+        let original = data.flatten();
+        let mut output = original;
+        let mut counts = self
+            .graph
+            .iota(if include_self { 1 } else { 0 }, output_shape.clone())
+            .cast(DType::Int)
+            .flatten();
+
+        for index in 0..update_count {
+            let destination = destinations.slice_along(index..index + 1, 0);
+            let incoming = flat_updates.slice_along(index..index + 1, 0);
+            let current = output.gather(destination);
+            let current_count = counts.gather(destination);
+            let zero_count = self.graph.constant(0).expand_rhs(current_count.dims());
+            let first_update = current_count.eq(zero_count);
+
+            let mut combined = match reduction {
+                ModernScatterReduction::Sum | ModernScatterReduction::Mean => {
+                    let accumulated = if data.dtype == DType::Bool {
+                        self.bool_or(current, incoming)
+                    } else {
+                        current + incoming
+                    };
+                    if include_self {
+                        accumulated
+                    } else {
+                        self.select(first_update, incoming, accumulated)
+                    }
+                }
+                ModernScatterReduction::Product => {
+                    let accumulated = if data.dtype == DType::Bool {
+                        self.bool_and(current, incoming)
+                    } else {
+                        current * incoming
+                    };
+                    if include_self {
+                        accumulated
+                    } else {
+                        self.select(first_update, incoming, accumulated)
+                    }
+                }
+                ModernScatterReduction::Maximum | ModernScatterReduction::Minimum => {
+                    let maximum = matches!(reduction, ModernScatterReduction::Maximum);
+                    let accumulated = if data.dtype == DType::Bool {
+                        if maximum {
+                            self.bool_or(current, incoming)
+                        } else {
+                            self.bool_and(current, incoming)
+                        }
+                    } else {
+                        self.scatter_extremum(current, incoming, maximum)
+                    };
+                    if include_self {
+                        accumulated
+                    } else {
+                        self.select(first_update, incoming, accumulated)
+                    }
+                }
+            };
+            let mut next_count =
+                current_count + self.graph.constant(1).expand_rhs(current_count.dims());
+            if let Some(valid_updates) = valid_updates {
+                let valid = valid_updates
+                    .slice_along(index..index + 1, 0)
+                    .ne(zero_count);
+                combined = self.select(valid, combined, current);
+                next_count = self.select(valid, next_count, current_count);
+            }
+            output = combined.scatter(destination, output);
+            counts = next_count.scatter(destination, counts);
+        }
+
+        if matches!(reduction, ModernScatterReduction::Mean) {
+            let zero = self.graph.constant(0).expand_rhs(counts.dims());
+            let has_values = counts.gt(zero);
+            let means = self.mean_divide(output, counts, data.dtype);
+            output = self.select(has_values, means, original);
+        }
+        *output.legacy_tracker_mut() = ShapeTracker::new(output_shape);
+        Ok(output)
+    }
+
+    pub(crate) fn translate_scatter_reduce(&mut self, node: &Node) -> Result<GraphTensor> {
+        let data = self.get_input_tensor(node, SCATTER_INPUT_ARG)?;
+        let rank = data.legacy_tracker_ref().len();
+        let raw_dim = self.get_int_arg(node, SCATTER_DIM_ARG)?;
+        let indices = self.get_input_tensor(node, SCATTER_INDEX_ARG)?;
+        let mut updates = self.get_input_tensor(node, SCATTER_VALUE_ARG)?;
+        let reduction = self.modern_scatter_reduction(node)?;
+        let include_self = self.scatter_include_self(node);
+        if rank == 0 {
+            anyhow::ensure!(
+                matches!(raw_dim, -1 | 0),
+                "scatter_reduce dimension {raw_dim} out of range for a scalar"
+            );
+            anyhow::ensure!(
+                indices.legacy_tracker_ref().is_empty() && updates.legacy_tracker_ref().is_empty(),
+                "scalar scatter_reduce requires scalar index and src"
+            );
+            return Ok(self
+                .reduce_scatter_elements(
+                    data.unsqueeze(0),
+                    indices.unsqueeze(0),
+                    updates.unsqueeze(0),
+                    0,
+                    reduction,
+                    include_self,
+                )?
+                .squeeze(0));
+        }
+        anyhow::ensure!(
+            raw_dim >= -(rank as i64) && raw_dim < rank as i64,
+            "scatter_reduce dimension {raw_dim} out of range for rank {rank}"
+        );
+        let dim = normalize_dim(raw_dim, rank);
+        anyhow::ensure!(
+            indices.legacy_tracker_ref().len() == data.legacy_tracker_ref().len() && updates.legacy_tracker_ref().len() == data.legacy_tracker_ref().len(),
+            "scatter_reduce requires self, index, and src to have equal rank"
+        );
+        // ATen reads src at the coordinates described by index; src may be
+        // larger than index along any axis, so crop those unused tails.
+        for (axis, size) in indices.dims().into_iter().enumerate() {
+            updates = updates.slice_along(..size, axis);
+        }
+        self.reduce_scatter_elements(data, indices, updates, dim, reduction, include_self)
+    }
+
+    pub(crate) fn translate_index_reduce(&mut self, node: &Node) -> Result<GraphTensor> {
+        let data = self.get_input_tensor(node, 0)?;
+        let rank = data.legacy_tracker_ref().len();
+        let raw_dim = self.get_int_arg(node, 1)?;
+        let index = self.get_input_tensor(node, 2)?;
+        let source = self.get_input_tensor(node, 3)?;
+        let reduction = self.modern_scatter_reduction(node)?;
+        anyhow::ensure!(
+            !matches!(reduction, ModernScatterReduction::Sum),
+            "index_reduce does not support the sum reduction"
+        );
+        let include_self = self.scatter_include_self(node);
+        if rank == 0 {
+            anyhow::ensure!(
+                matches!(raw_dim, -1 | 0),
+                "index_reduce dimension {raw_dim} out of range for a scalar"
+            );
+            anyhow::ensure!(
+                index.legacy_tracker_ref().len() == 1 && index.dims()[0].to_usize() == Some(1),
+                "scalar index_reduce requires a one-element index"
+            );
+            anyhow::ensure!(
+                source.legacy_tracker_ref().is_empty(),
+                "scalar index_reduce requires a scalar source"
+            );
+            return Ok(self
+                .reduce_scatter_elements(
+                    data.unsqueeze(0),
+                    index,
+                    source.unsqueeze(0),
+                    0,
+                    reduction,
+                    include_self,
+                )?
+                .squeeze(0));
+        }
+        anyhow::ensure!(
+            raw_dim >= -(rank as i64) && raw_dim < rank as i64,
+            "index_reduce dimension {raw_dim} out of range for rank {rank}"
+        );
+        let dim = normalize_dim(raw_dim, rank);
+        anyhow::ensure!(
+            index.legacy_tracker_ref().len() == 1,
+            "index_reduce index must be one-dimensional"
+        );
+        anyhow::ensure!(
+            source.legacy_tracker_ref().len() == rank,
+            "index_reduce source rank must match self"
+        );
+        anyhow::ensure!(
+            source.dims()[dim] == index.dims()[0]
+                || source.dims()[dim].egglog_equal(index.dims()[0]),
+            "index_reduce index length must equal source size along the reduced dimension"
+        );
+        for axis in 0..rank {
+            if axis != dim {
+                anyhow::ensure!(
+                    source.dims()[axis] == data.dims()[axis]
+                        || source.dims()[axis].egglog_equal(data.dims()[axis]),
+                    "index_reduce source/self sizes must match outside the reduced dimension"
+                );
+            }
+        }
+        let inserted_axes = (0..rank).filter(|&axis| axis != dim).collect::<Vec<_>>();
+        let expanded_index = index.expand_to_shape_on_axes(source.dims(), inserted_axes);
+        self.reduce_scatter_elements(data, expanded_index, source, dim, reduction, include_self)
+    }
+
+    fn scatter_scalar_value(&mut self, node: &Node, data: GraphTensor) -> Result<GraphTensor> {
         let value_arg = &node
             .inputs
             .get(SCATTER_VALUE_ARG)
             .context("scatter.value missing value input")?
             .arg;
-        let value = if let Some(b) = value_arg.as_bool() {
-            self.graph.constant(if b { 1 } else { 0 }).cast(a.dtype)
-        } else if let Some(i) = value_arg.as_int() {
-            self.graph.constant(i).cast(a.dtype)
-        } else if let Some(f) = value_arg.as_float() {
-            self.graph.constant_float(f as f32).cast(a.dtype)
+        Ok(if let Some(value) = value_arg.as_bool() {
+            self.graph
+                .constant(if value { 1 } else { 0 })
+                .cast(data.dtype)
+        } else if let Some(value) = value_arg.as_int() {
+            self.graph.constant(value).cast(data.dtype)
+        } else if let Some(value) = value_arg.as_float() {
+            if data.dtype == DType::F64 {
+                self.graph.constant_float64(value)
+            } else {
+                self.graph.constant_float(value as f32).cast(data.dtype)
+            }
         } else {
-            bail!("scatter.value: unsupported scalar argument {:?}", value_arg);
-        }
-        .expand_rhs(indices.dims());
+            bail!("scatter.value: unsupported scalar argument {value_arg:?}");
+        })
+    }
+
+    pub(crate) fn translate_scatter_value(&mut self, node: &Node) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, SCATTER_INPUT_ARG)?;
+        let dim = self.get_int_arg(node, SCATTER_DIM_ARG)?;
+        let dim = normalize_dim(dim, a.legacy_tracker_ref().len());
+        let indices = self.get_input_tensor(node, SCATTER_INDEX_ARG)?;
+        let value = self
+            .scatter_scalar_value(node, a)?
+            .expand_rhs(indices.dims());
         Ok(super::movement_dynamic::pt2_scatter_elements(
             a,
             indices.cast(DType::Int),
             value,
             dim,
         ))
+    }
+
+    pub(crate) fn translate_scatter_value_reduce(&mut self, node: &Node) -> Result<GraphTensor> {
+        let data = self.get_input_tensor(node, SCATTER_INPUT_ARG)?;
+        let dim = normalize_dim(self.get_int_arg(node, SCATTER_DIM_ARG)?, data.legacy_tracker_ref().len());
+        let indices = self.get_input_tensor(node, SCATTER_INDEX_ARG)?;
+        let updates = self
+            .scatter_scalar_value(node, data)?
+            .expand_rhs(indices.dims());
+        super::movement_dynamic::pt2_scatter_elements_reduce(
+            data,
+            indices.cast(DType::Int),
+            updates,
+            dim,
+            self.scatter_reduction(node)?,
+        )
     }
 
     pub(crate) fn translate_index_put(&mut self, node: &Node) -> Result<GraphTensor> {
@@ -946,7 +1885,22 @@ impl<'a> Translator<'a> {
             } else {
                 values.cast(a.dtype)
             };
-            let result = super::movement_dynamic::pt2_scatter_elements(a, idx_full, values, axis);
+            let accumulate = node
+                .inputs
+                .get(3)
+                .and_then(|input| input.arg.as_bool())
+                .unwrap_or(false);
+            let result = if accumulate {
+                super::movement_dynamic::pt2_scatter_elements_reduce(
+                    a,
+                    idx_full,
+                    values,
+                    axis,
+                    ScatterReduction::Add,
+                )?
+            } else {
+                super::movement_dynamic::pt2_scatter_elements(a, idx_full, values, axis)
+            };
             return Ok(result);
         }
         let index_names = if let Some(names) = node.inputs[1].arg.as_tensors() {

--- a/crates/luminal_python/rust/src/translator/movement_dynamic.rs
+++ b/crates/luminal_python/rust/src/translator/movement_dynamic.rs
@@ -23,6 +23,12 @@ use luminal::prelude::*;
 
 use crate::dim_arith::product_of_dims;
 
+#[derive(Clone, Copy, Debug)]
+pub(super) enum ScatterReduction {
+    Add,
+    Multiply,
+}
+
 /// Row-major strides as `IntExpr`s. `stride[i] = prod(dims[i+1..])`.
 pub(super) fn row_major_strides(dims: &[IntExpr]) -> Vec<IntExpr> {
     let rank = dims.len();
@@ -146,10 +152,9 @@ pub fn pt2_index_select(
 
 /// Translator-local `scatter_elements` that accepts symbolic shape dims.
 /// Same semantics as `GraphTensor::scatter_elements`.
-pub fn pt2_scatter_elements(
+pub(super) fn pt2_scatter_element_indices(
     data: GraphTensor,
     indices: GraphTensor,
-    updates: GraphTensor,
     axis: usize,
 ) -> GraphTensor {
     let data_dims = data.dims();
@@ -165,7 +170,17 @@ pub fn pt2_scatter_elements(
         .expand_rhs(idx_normalized.dims());
     let flat_dest = non_axis_flat + idx_normalized * stride_tensor;
 
-    let flat_dest_1d = flat_dest.flatten();
+    flat_dest.flatten()
+}
+
+pub fn pt2_scatter_elements(
+    data: GraphTensor,
+    indices: GraphTensor,
+    updates: GraphTensor,
+    axis: usize,
+) -> GraphTensor {
+    let data_dims = data.dims();
+    let flat_dest_1d = pt2_scatter_element_indices(data, indices, axis);
     let flat_updates = updates.flatten();
     let flat_data = data.flatten();
 
@@ -176,6 +191,62 @@ pub fn pt2_scatter_elements(
     let mut result = output_flat;
     *result.legacy_tracker_mut() = ShapeTracker::new(data_dims);
     result
+}
+
+/// Scatter with accumulation for ATen's legacy `reduce=` overloads and
+/// `scatter_add`. Core Scatter intentionally implements overwrite/last-write
+/// semantics, so duplicate destinations must be combined before each write.
+///
+/// The update extent controls how many dependent read-modify-write steps the
+/// graph contains and therefore must be concrete at translation time. This is
+/// an explicit graph-topology restriction, not a layout assumption; every
+/// rank, axis, negative index, and duplicate pattern is otherwise handled.
+pub(super) fn pt2_scatter_elements_reduce(
+    data: GraphTensor,
+    indices: GraphTensor,
+    updates: GraphTensor,
+    axis: usize,
+    reduction: ScatterReduction,
+) -> anyhow::Result<GraphTensor> {
+    anyhow::ensure!(
+        indices.legacy_tracker_ref().len() == updates.legacy_tracker_ref().len(),
+        "scatter reduction requires index/update ranks to match, got {} and {}",
+        indices.legacy_tracker_ref().len(),
+        updates.legacy_tracker_ref().len()
+    );
+    let index_shape = indices.dims();
+    let update_shape = updates.dims();
+    anyhow::ensure!(
+        index_shape
+            .iter()
+            .zip(&update_shape)
+            .all(|(index, update)| index == update || index.egglog_equal(*update)),
+        "scatter reduction currently requires index and update shapes to match"
+    );
+    let update_count = product_of_dims(index_shape.iter().copied())
+        .to_usize()
+        .ok_or_else(|| {
+            anyhow::anyhow!("scatter reduction requires a concrete update element count")
+        })?;
+
+    let flat_destinations = pt2_scatter_element_indices(data, indices, axis);
+    let flat_updates = updates.flatten();
+    let output_shape = data.dims();
+    let mut output = data.flatten();
+
+    for index in 0..update_count {
+        let destination = flat_destinations.slice_along(index..index + 1, 0);
+        let update = flat_updates.slice_along(index..index + 1, 0);
+        let current = output.gather(destination);
+        let combined = match reduction {
+            ScatterReduction::Add => current + update,
+            ScatterReduction::Multiply => current * update,
+        };
+        output = combined.scatter(destination, output);
+    }
+
+    *output.legacy_tracker_mut() = ShapeTracker::new(output_shape);
+    Ok(output)
 }
 
 /// Translator-local `scatter_nd` that accepts symbolic shape dims.

--- a/crates/luminal_python/rust/src/translator/pooling.rs
+++ b/crates/luminal_python/rust/src/translator/pooling.rs
@@ -1,0 +1,928 @@
+use anyhow::{Context, Result};
+use luminal::prelude::*;
+
+use crate::dim_arith::product_of_dims;
+use crate::pt2_schema::{Argument, Node};
+use crate::pt2_util::reshape_tensor;
+
+use super::Translator;
+
+fn expand_spatial(values: &[i64], spatial_rank: usize, default: i64) -> Result<Vec<usize>> {
+    let values = if values.is_empty() {
+        vec![default; spatial_rank]
+    } else if values.len() == 1 {
+        vec![values[0]; spatial_rank]
+    } else {
+        values.to_vec()
+    };
+    anyhow::ensure!(
+        values.len() == spatial_rank,
+        "expected {spatial_rank} spatial values"
+    );
+    values
+        .into_iter()
+        .map(|value| usize::try_from(value).context("spatial values must be nonnegative"))
+        .collect()
+}
+
+impl<'a> Translator<'a> {
+    fn pool_ints(&self, node: &Node, name: &str, index: usize) -> Result<Vec<i64>> {
+        let index = Self::named_input_index(node, name).unwrap_or(index);
+        self.get_ints_arg(node, index)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn pool_windows(
+        &mut self,
+        input: GraphTensor,
+        kernel: &[usize],
+        stride: &[usize],
+        padding: &[usize],
+        dilation: &[usize],
+        ceil_mode: bool,
+        output_shape: &[IntExpr],
+        fill: GraphTensor,
+    ) -> GraphTensor {
+        let rank = input.legacy_tracker_ref().len();
+        let spatial_rank = kernel.len();
+        let first_spatial = rank - spatial_rank;
+        let mut pad = vec![(IntExpr::from(0), IntExpr::from(0)); rank];
+        for spatial in 0..spatial_rank {
+            let right_extra = if ceil_mode { stride[spatial] - 1 } else { 0 };
+            pad[first_spatial + spatial] = (
+                IntExpr::from(padding[spatial]),
+                IntExpr::from(padding[spatial] + right_extra),
+            );
+        }
+        let padded = input.pad_with(pad, fill);
+
+        let mut full_kernel = vec![IntExpr::from(1); rank];
+        let mut full_stride = vec![IntExpr::from(1); rank];
+        let mut full_dilation = vec![IntExpr::from(1); rank];
+        for spatial in 0..spatial_rank {
+            full_kernel[first_spatial + spatial] = IntExpr::from(kernel[spatial]);
+            full_stride[first_spatial + spatial] = IntExpr::from(stride[spatial]);
+            full_dilation[first_spatial + spatial] = IntExpr::from(dilation[spatial]);
+        }
+        let mut windows = padded.unfold(full_kernel, full_stride, full_dilation);
+        for spatial in 0..spatial_rank {
+            let axis = first_spatial + spatial;
+            windows = windows.slice_along(IntExpr::from(0)..output_shape[axis], axis);
+        }
+        // Remove the size-one kernel axes belonging to batch/channel axes.
+        for axis in (0..first_spatial).rev() {
+            windows = windows.squeeze(rank + axis);
+        }
+        windows
+    }
+
+    pub(crate) fn translate_avg_pool(
+        &mut self,
+        node: &Node,
+        spatial_rank: usize,
+    ) -> Result<GraphTensor> {
+        let input = self.get_input_tensor(node, 0)?;
+        anyhow::ensure!(
+            input.legacy_tracker_ref().len() == spatial_rank + 1 || input.legacy_tracker_ref().len() == spatial_rank + 2,
+            "avg_pool{spatial_rank}d input rank is invalid"
+        );
+        let kernel_raw = self.pool_ints(node, "kernel_size", 1)?;
+        let kernel = expand_spatial(&kernel_raw, spatial_rank, 0)?;
+        anyhow::ensure!(
+            kernel.iter().all(|&value| value > 0),
+            "pool kernel must be positive"
+        );
+        let stride_raw = self.pool_ints(node, "stride", 2).unwrap_or_default();
+        let stride = if stride_raw.is_empty() {
+            kernel.clone()
+        } else {
+            expand_spatial(&stride_raw, spatial_rank, 0)?
+        };
+        anyhow::ensure!(
+            stride.iter().all(|&value| value > 0),
+            "pool stride must be positive"
+        );
+        let padding = expand_spatial(
+            &self.pool_ints(node, "padding", 3).unwrap_or_default(),
+            spatial_rank,
+            0,
+        )?;
+        let ceil_mode = self.named_bool_arg(node, "ceil_mode").unwrap_or(false);
+        let count_include_pad = self
+            .named_bool_arg(node, "count_include_pad")
+            .unwrap_or(true);
+        let divisor_override = self.named_int_arg(node, "divisor_override");
+        let output_shape = self.output_meta_shape(node)?;
+        let rank = input.legacy_tracker_ref().len();
+        let unit_dilation = vec![1; spatial_rank];
+        let zero = self.graph.constant_float(0.0).cast(input.dtype);
+        let windows = self.pool_windows(
+            input,
+            &kernel,
+            &stride,
+            &padding,
+            &unit_dilation,
+            ceil_mode,
+            &output_shape,
+            zero,
+        );
+        let kernel_axes = (rank..rank + spatial_rank).collect::<Vec<_>>();
+        let sum = windows.sum(kernel_axes.clone());
+
+        let divisor = if let Some(divisor) = divisor_override {
+            anyhow::ensure!(divisor != 0, "pool divisor_override cannot be zero");
+            self.graph
+                .constant(divisor)
+                .cast(input.dtype)
+                .expand_rhs(sum.dims())
+        } else if count_include_pad {
+            self.graph
+                .constant(product_of_dims(
+                    kernel.iter().copied().map(IntExpr::from),
+                ))
+                .cast(input.dtype)
+                .expand_rhs(sum.dims())
+        } else {
+            let one = self.graph.constant_float(1.0).cast(input.dtype);
+            let ones = one.expand_rhs(input.dims());
+            let zero = self.graph.constant_float(0.0).cast(input.dtype);
+            self.pool_windows(
+                ones,
+                &kernel,
+                &stride,
+                &padding,
+                &unit_dilation,
+                ceil_mode,
+                &output_shape,
+                zero,
+            )
+            .sum(kernel_axes)
+        };
+        Ok(sum / divisor)
+    }
+
+    fn adaptive_pool_candidates(
+        &mut self,
+        input: GraphTensor,
+        output_shape: &[IntExpr],
+        spatial_rank: usize,
+    ) -> (GraphTensor, GraphTensor, usize) {
+        let rank = input.legacy_tracker_ref().len();
+        let prefix_rank = rank - spatial_rank;
+        let input_shape = input.dims();
+        let input_spatial = &input_shape[prefix_rank..];
+        let output_spatial = &output_shape[prefix_rank..];
+        let mut full_shape = input_shape[..prefix_rank].to_vec();
+        full_shape.extend_from_slice(output_spatial);
+        full_shape.extend_from_slice(input_spatial);
+        let mut expanded = input;
+        for (spatial, size) in output_spatial.iter().copied().enumerate() {
+            expanded = expanded.expand_dim(prefix_rank + spatial, size);
+        }
+        let mut membership = self.graph.iota(1, full_shape.clone()).cast(DType::Bool);
+        for spatial in 0..spatial_rank {
+            let output_position = self.axis_positions(&full_shape, prefix_rank + spatial);
+            let input_position =
+                self.axis_positions(&full_shape, prefix_rank + spatial_rank + spatial);
+            let input_size = self
+                .graph
+                .constant(input_spatial[spatial])
+                .cast(DType::F64)
+                .expand_rhs(output_position.dims());
+            let output_size = self
+                .graph
+                .constant(output_spatial[spatial])
+                .cast(DType::F64)
+                .expand_rhs(output_position.dims());
+            let start =
+                (output_position.cast(DType::F64) * input_size / output_size).cast(DType::Int);
+            let end = (((output_position + 1) * input_spatial[spatial]
+                + (output_spatial[spatial] - 1))
+                .cast(DType::F64)
+                / output_size)
+                .cast(DType::Int);
+            membership = self.bool_and(
+                membership,
+                self.bool_and(input_position.ge(start), input_position.lt(end)),
+            );
+        }
+        (expanded, membership, prefix_rank)
+    }
+
+    pub(crate) fn translate_adaptive_avg_pool(
+        &mut self,
+        node: &Node,
+        spatial_rank: usize,
+    ) -> Result<GraphTensor> {
+        let input = self.get_input_tensor(node, 0)?;
+        let rank = input.legacy_tracker_ref().len();
+        anyhow::ensure!(
+            rank == spatial_rank + 1 || rank == spatial_rank + 2,
+            "adaptive_avg_pool{spatial_rank}d input rank is invalid"
+        );
+        let output_shape = self.output_meta_shape(node)?;
+        let (expanded, membership, prefix_rank) =
+            self.adaptive_pool_candidates(input, &output_shape, spatial_rank);
+        let zero = self.full_tensor(expanded.dims(), input.dtype, 0.0);
+        let selected = self.select(membership, expanded, zero);
+        let reduction_axes =
+            (prefix_rank + spatial_rank..prefix_rank + 2 * spatial_rank).collect::<Vec<_>>();
+        let sum = selected.sum(reduction_axes.clone());
+        let count = membership.cast(input.dtype).sum(reduction_axes);
+        Ok(sum / count)
+    }
+
+    pub(crate) fn translate_adaptive_max_pool(
+        &mut self,
+        node: &Node,
+        spatial_rank: usize,
+    ) -> Result<()> {
+        let input = self.get_input_tensor(node, 0)?;
+        let rank = input.legacy_tracker_ref().len();
+        anyhow::ensure!(
+            rank == spatial_rank + 1 || rank == spatial_rank + 2,
+            "adaptive max pool input rank is invalid"
+        );
+        let input_shape = input.dims();
+        let output_shape = self.output_meta_shape(node)?;
+        let (expanded, membership, prefix_rank) =
+            self.adaptive_pool_candidates(input, &output_shape, spatial_rank);
+        let input_spatial = &input_shape[prefix_rank..];
+        let output_spatial = &output_shape[prefix_rank..];
+        let spatial_numel = product_of_dims(input_spatial.iter().copied());
+        let logical_indices = self
+            .graph
+            .iota(IntExpr::from('z') % spatial_numel, input_shape.clone())
+            .cast(DType::I64);
+        let mut expanded_indices = logical_indices;
+        for (spatial, size) in output_spatial.iter().copied().enumerate() {
+            expanded_indices = expanded_indices.expand_dim(prefix_rank + spatial, size);
+        }
+
+        let lowest = self.lowest_scalar(input.dtype).expand_rhs(expanded.dims());
+        let candidates = self.select(membership, expanded, lowest);
+        let outputs = self.select_pool_max(candidates, expanded_indices, rank);
+        self.store_tensor_outputs(node, &outputs)
+    }
+
+    fn lowest_scalar(&mut self, dtype: DType) -> GraphTensor {
+        match dtype {
+            DType::F64 => self.graph.constant_float64(f64::NEG_INFINITY),
+            DType::F16 | DType::Bf16 | DType::F32 => {
+                self.graph.constant_float(f32::NEG_INFINITY).cast(dtype)
+            }
+            DType::I64 => self.graph.constant(i64::MIN).cast(dtype),
+            DType::Int => self.graph.constant(i32::MIN as i64).cast(dtype),
+            DType::I16 => self.graph.constant(i16::MIN as i64).cast(dtype),
+            DType::I8 | DType::I4 => self.graph.constant(i8::MIN as i64).cast(dtype),
+            DType::U16 | DType::U8 | DType::U4 | DType::Bool => self.graph.constant(0).cast(dtype),
+            _ => self.graph.constant_float(f32::NEG_INFINITY).cast(dtype),
+        }
+    }
+
+    fn select_pool_max(
+        &mut self,
+        mut candidates: GraphTensor,
+        mut indices: GraphTensor,
+        output_rank: usize,
+    ) -> [GraphTensor; 2] {
+        while candidates.legacy_tracker_ref().len() > output_rank + 1 {
+            let last = candidates.legacy_tracker_ref().len() - 1;
+            candidates = candidates.merge_dims(last - 1, last);
+            indices = indices.merge_dims(last - 1, last);
+        }
+        let key = if candidates.dtype == DType::Bool {
+            candidates.cast(DType::F32)
+        } else {
+            candidates
+        };
+        let selected = key
+            .stable_argsort(output_rank, true)
+            .slice_along(0..1, output_rank);
+        let values =
+            super::movement_dynamic::pt2_gather_elements(candidates, selected, output_rank)
+                .squeeze(output_rank);
+        let indices = super::movement_dynamic::pt2_gather_elements(indices, selected, output_rank)
+            .squeeze(output_rank)
+            .cast(DType::I64);
+        [values, indices]
+    }
+
+    pub(crate) fn translate_max_pool(&mut self, node: &Node, spatial_rank: usize) -> Result<()> {
+        let input = self.get_input_tensor(node, 0)?;
+        let rank = input.legacy_tracker_ref().len();
+        anyhow::ensure!(
+            rank == spatial_rank + 1 || rank == spatial_rank + 2,
+            "max pool requires channel-first input"
+        );
+        let kernel = expand_spatial(&self.pool_ints(node, "kernel_size", 1)?, spatial_rank, 0)?;
+        let stride_raw = self.pool_ints(node, "stride", 2).unwrap_or_default();
+        let stride = if stride_raw.is_empty() {
+            kernel.clone()
+        } else {
+            expand_spatial(&stride_raw, spatial_rank, 0)?
+        };
+        let padding = expand_spatial(
+            &self.pool_ints(node, "padding", 3).unwrap_or_default(),
+            spatial_rank,
+            0,
+        )?;
+        let dilation = expand_spatial(
+            &self.pool_ints(node, "dilation", 4).unwrap_or_default(),
+            spatial_rank,
+            1,
+        )?;
+        let ceil_mode = self.named_bool_arg(node, "ceil_mode").unwrap_or(false);
+        let output_shape = self.output_meta_shape(node)?;
+        let lowest = self.lowest_scalar(input.dtype);
+        let windows = self.pool_windows(
+            input,
+            &kernel,
+            &stride,
+            &padding,
+            &dilation,
+            ceil_mode,
+            &output_shape,
+            lowest,
+        );
+
+        let prefix_rank = rank - spatial_rank;
+        let spatial_numel = product_of_dims(input.dims()[prefix_rank..].iter().copied());
+        let logical_indices = self
+            .graph
+            .iota(IntExpr::from('z') % spatial_numel, input.dims())
+            .cast(DType::I64);
+        let zero_index = self.graph.constant(0i64).cast(DType::I64);
+        let index_windows = self.pool_windows(
+            logical_indices,
+            &kernel,
+            &stride,
+            &padding,
+            &dilation,
+            ceil_mode,
+            &output_shape,
+            zero_index,
+        );
+        let outputs = self.select_pool_max(windows, index_windows, rank);
+        self.store_tensor_outputs(node, &outputs)
+    }
+
+    pub(crate) fn translate_max_pool_backward(&mut self, node: &Node) -> Result<GraphTensor> {
+        let updates = self.get_input_tensor(node, 0)?;
+        let input = self.get_input_tensor(node, 1)?;
+        let indices = self.get_input_tensor(node, 7)?.cast(DType::Int);
+        let input_shape = input.dims();
+        let prefix_rank = input_shape.len() - 2;
+        let strides = super::movement_dynamic::row_major_strides(&input_shape);
+        let output_shape = updates.dims();
+        let contributions = output_shape
+            .iter()
+            .enumerate()
+            .map(|(axis, _)| {
+                if axis < prefix_rank {
+                    IntExpr::from('z') * strides[axis]
+                } else {
+                    IntExpr::from(0)
+                }
+            })
+            .collect::<Vec<_>>();
+        let base = super::movement_dynamic::logical_flat_indices(
+            &mut self.graph,
+            &output_shape,
+            &contributions,
+            0.into(),
+        );
+        let destinations = (base + indices).flatten();
+        let zero = self
+            .full_tensor(input_shape.clone(), input.dtype, 0.0)
+            .flatten();
+        let output = super::movement_dynamic::pt2_scatter_elements_reduce(
+            zero,
+            destinations,
+            updates.flatten(),
+            0,
+            super::movement_dynamic::ScatterReduction::Add,
+        )?;
+        Ok(reshape_tensor(output, input_shape))
+    }
+
+    pub(crate) fn translate_fractional_max_pool(
+        &mut self,
+        node: &Node,
+        spatial_rank: usize,
+    ) -> Result<()> {
+        let input = self.get_input_tensor(node, 0)?;
+        let random_samples = self.get_input_tensor(node, 3)?;
+        let rank = input.legacy_tracker_ref().len();
+        anyhow::ensure!(
+            rank == spatial_rank + 1 || rank == spatial_rank + 2,
+            "fractional max pool input rank is invalid"
+        );
+        anyhow::ensure!(
+            random_samples.legacy_tracker_ref().len() == 3
+                && random_samples.dims()[2].to_usize() == Some(spatial_rank),
+            "fractional max pool random_samples must have shape [N, C, spatial_rank]"
+        );
+        let kernel = expand_spatial(&self.pool_ints(node, "kernel_size", 1)?, spatial_rank, 0)?;
+        anyhow::ensure!(
+            kernel.iter().all(|&size| size > 0),
+            "fractional max pool kernel must be positive"
+        );
+        let output_shape = self.output_meta_shape(node)?;
+        let prefix_rank = rank - spatial_rank;
+        let input_shape = input.dims();
+        let output_spatial = &output_shape[prefix_rank..];
+        let input_spatial = &input_shape[prefix_rank..];
+        let mut window_shape = output_shape.clone();
+        window_shape.extend(kernel.iter().copied().map(IntExpr::from));
+
+        let input_strides = super::movement_dynamic::row_major_strides(&input_shape);
+        let mut flat_indices = self.axis_positions(&window_shape, 0) * input_strides[0];
+        for (prefix, stride) in input_strides
+            .iter()
+            .copied()
+            .enumerate()
+            .take(prefix_rank)
+            .skip(1)
+        {
+            flat_indices += self.axis_positions(&window_shape, prefix) * stride;
+        }
+        let mut logical_spatial_indices = self
+            .graph
+            .constant(0)
+            .cast(DType::Int)
+            .expand_rhs(window_shape.clone());
+
+        for spatial in 0..spatial_rank {
+            let sample_lane = if spatial_rank == 2 {
+                spatial_rank - 1 - spatial
+            } else {
+                spatial
+            };
+            let mut sample = random_samples
+                .slice_along(sample_lane..sample_lane + 1, 2)
+                .squeeze(2);
+            if prefix_rank == 1 {
+                sample = sample.squeeze(0);
+            }
+            for output_size in output_spatial.iter().copied() {
+                sample = sample.expand_dim(sample.legacy_tracker_ref().len(), output_size);
+            }
+            let output_axis = prefix_rank + spatial;
+            let output_position = self.axis_positions(&output_shape, output_axis);
+            let numerator = self
+                .graph
+                .constant(input_spatial[spatial] - kernel[spatial])
+                .cast(sample.dtype)
+                .expand_rhs(sample.dims());
+            let denominator = self
+                .graph
+                .constant(output_spatial[spatial] - 1)
+                .cast(sample.dtype)
+                .expand_rhs(sample.dims());
+            let output_is_one = self.is_zero(denominator);
+            let one = self.constant_like(denominator, 1.0);
+            let safe_denominator = self.select(output_is_one, one, denominator);
+            let alpha = numerator / safe_denominator;
+            let ordinary_start = self
+                .floor_tensor((output_position.cast(sample.dtype) + sample) * alpha)
+                - self.floor_tensor(sample * alpha);
+            let terminal_position = self
+                .graph
+                .constant(output_spatial[spatial] - 1)
+                .cast(DType::Int)
+                .expand_rhs(output_position.dims());
+            let final_position = output_position.eq(terminal_position);
+            let terminal_start = self
+                .graph
+                .constant(input_spatial[spatial] - kernel[spatial])
+                .cast(sample.dtype)
+                .expand_rhs(ordinary_start.dims());
+            let final_or_ordinary = self.select(final_position, terminal_start, ordinary_start);
+            let start = self.select(output_is_one, terminal_start, final_or_ordinary);
+            let mut coordinate = start;
+            for size in kernel.iter().copied() {
+                coordinate = coordinate.expand_dim(coordinate.legacy_tracker_ref().len(), size);
+            }
+            let kernel_axis = rank + spatial;
+            coordinate = coordinate
+                + self
+                    .axis_positions(&window_shape, kernel_axis)
+                    .cast(coordinate.dtype);
+            let coordinate = coordinate.cast(DType::Int);
+            flat_indices += coordinate * input_strides[prefix_rank + spatial];
+            let spatial_stride = product_of_dims(input_spatial[spatial + 1..].iter().copied());
+            logical_spatial_indices += coordinate * spatial_stride;
+        }
+
+        let candidates =
+            reshape_tensor(input.flatten().gather(flat_indices.flatten()), window_shape);
+        let outputs = self.select_pool_max(candidates, logical_spatial_indices, rank);
+        self.store_tensor_outputs(node, &outputs)
+    }
+
+    fn bilinear_axis(
+        &mut self,
+        input: GraphTensor,
+        axis: usize,
+        input_size: usize,
+        output_size: usize,
+        align_corners: bool,
+        explicit_scale: Option<f64>,
+    ) -> GraphTensor {
+        if input_size == output_size {
+            return input;
+        }
+        let positions = self.graph.arange(output_size).cast(DType::F32);
+        let source = if align_corners {
+            let scale = if output_size > 1 {
+                (input_size - 1) as f32 / (output_size - 1) as f32
+            } else {
+                0.0
+            };
+            positions * scale
+        } else {
+            let inverse =
+                explicit_scale.map_or(input_size as f64 / output_size as f64, |s| 1.0 / s) as f32;
+            ((positions + 0.5) * inverse - 0.5).maximum_f32(0.0)
+        };
+        let lower = source.cast(DType::Int);
+        let upper = (lower + 1).minimum(
+            self.graph
+                .constant((input_size - 1) as i64)
+                .cast(DType::Int)
+                .expand_rhs(lower.dims()),
+        );
+        let weight = source - lower.cast(DType::F32);
+        let mut lower = lower;
+        let mut upper = upper;
+        let mut weight = weight.cast(input.dtype);
+        for (dim, size) in input.dims().into_iter().enumerate() {
+            if dim != axis {
+                lower = lower.expand_dim(dim, size);
+                upper = upper.expand_dim(dim, size);
+                weight = weight.expand_dim(dim, size);
+            }
+        }
+        let left = super::movement_dynamic::pt2_gather_elements(input, lower, axis);
+        let right = super::movement_dynamic::pt2_gather_elements(input, upper, axis);
+        left + (right - left) * weight
+    }
+
+    fn static_resize_dimensions(
+        input: GraphTensor,
+        output_shape: &[IntExpr],
+        operation: &str,
+    ) -> Result<[usize; 4]> {
+        let [
+            Some(input_height),
+            Some(input_width),
+            Some(output_height),
+            Some(output_width),
+        ] = [
+            input.dims()[2],
+            input.dims()[3],
+            output_shape[2],
+            output_shape[3],
+        ]
+        .map(|size| size.to_usize())
+        else {
+            anyhow::bail!("{operation} dimensions must be static");
+        };
+        let dimensions = [input_height, input_width, output_height, output_width];
+        anyhow::ensure!(
+            dimensions.iter().all(|&size| size > 0),
+            "{operation} dimensions must be nonzero"
+        );
+        Ok(dimensions)
+    }
+
+    pub(crate) fn translate_upsample_bilinear2d(&mut self, node: &Node) -> Result<GraphTensor> {
+        let input = self.get_input_tensor(node, 0)?;
+        anyhow::ensure!(input.legacy_tracker_ref().len() == 4, "bilinear2d requires NCHW input");
+        let output_shape = self.output_meta_shape(node)?;
+        let [input_height, input_width, output_height, output_width] =
+            Self::static_resize_dimensions(input, &output_shape, "bilinear2d")?;
+        let align_corners = self.get_bool_arg(node, 2)?;
+        let scales = node.inputs.get(3).and_then(|input| match &input.arg {
+            Argument::Other(value) => {
+                let values = value.get("as_floats")?.as_array()?;
+                if values.len() == 2 {
+                    Some((values[0].as_f64()?, values[1].as_f64()?))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        });
+        let height = self.bilinear_axis(
+            input,
+            2,
+            input_height,
+            output_height,
+            align_corners,
+            scales.map(|value| value.0),
+        );
+        Ok(self.bilinear_axis(
+            height,
+            3,
+            input_width,
+            output_width,
+            align_corners,
+            scales.map(|value| value.1),
+        ))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn antialias_bilinear_axis(
+        &mut self,
+        input: GraphTensor,
+        axis: usize,
+        input_size: usize,
+        output_size: usize,
+        align_corners: bool,
+        explicit_scale: Option<f64>,
+        quantized_u8: bool,
+    ) -> GraphTensor {
+        if input_size == output_size {
+            return input;
+        }
+        let scale_value = if align_corners {
+            if output_size > 1 {
+                (input_size - 1) as f64 / (output_size - 1) as f64
+            } else {
+                0.0
+            }
+        } else {
+            explicit_scale.map_or(input_size as f64 / output_size as f64, |scale| {
+                scale.recip()
+            })
+        };
+        let support_value = scale_value.max(1.0);
+
+        // ATen's antialias path uses a normalized triangle filter. Construct
+        // the complete [output, input] weight matrix: both dimensions are
+        // static metadata here, and the tensor values never affect extents.
+        let weight_dtype = if quantized_u8 {
+            DType::F64
+        } else {
+            input.dtype
+        };
+        let output_positions = self
+            .graph
+            .arange(output_size)
+            .cast(weight_dtype)
+            .expand_dim(1, input_size);
+        let input_positions = self
+            .graph
+            .arange(input_size)
+            .cast(weight_dtype)
+            .expand_dim(0, output_size);
+        let half = self.constant_like(output_positions, 0.5);
+        let scale = self.constant_like(output_positions, scale_value);
+        let source = (output_positions + half) * scale - half;
+        let distance = self.real_abs(input_positions - source);
+        let one = self.constant_like(distance, 1.0);
+        let support = self.constant_like(distance, support_value);
+        let unbounded = one - distance / support;
+        let zero = self.constant_like(unbounded, 0.0);
+        let positive = unbounded.gt(zero);
+        let mut weights = self.select(positive, unbounded, zero);
+        let normalization = weights.sum(1).expand_dim(1, input_size);
+        weights /= normalization;
+
+        let weights_precision = if quantized_u8 {
+            let mut maximum = 0.0_f64;
+            for output_index in 0..output_size {
+                let center = scale_value * (output_index as f64 + 0.5);
+                let row = (0..input_size)
+                    .map(|input_index| {
+                        (1.0 - ((input_index as f64 + 0.5 - center) / support_value).abs()).max(0.0)
+                    })
+                    .collect::<Vec<_>>();
+                let total = row.iter().sum::<f64>();
+                maximum = maximum.max(
+                    row.into_iter()
+                        .map(|weight| weight / total)
+                        .fold(0.0_f64, f64::max),
+                );
+            }
+            let mut precision = 0_u32;
+            while precision < 22 {
+                let next = (0.5 + maximum * ((1_u64 << (precision + 1)) as f64)) as i64;
+                if next >= 1_i64 << 15 {
+                    break;
+                }
+                precision += 1;
+            }
+            let multiplier = self.constant_like(weights, (1_u64 << precision) as f64);
+            let half = self.constant_like(weights, 0.5);
+            weights = self
+                .floor_tensor(weights * multiplier + half)
+                .cast(DType::I64);
+            Some(precision)
+        } else {
+            None
+        };
+
+        let mut candidates = if quantized_u8 {
+            input.cast(DType::I64).expand_dim(axis, output_size)
+        } else {
+            input.expand_dim(axis, output_size)
+        };
+        for dim in 0..axis {
+            weights = weights.expand_dim(dim, input.dims()[dim]);
+        }
+        for dim in axis + 1..input.legacy_tracker_ref().len() {
+            weights = weights.expand_dim(dim + 1, input.dims()[dim]);
+        }
+        candidates *= weights;
+        let result = candidates.sum(axis + 1);
+        if let Some(precision) = weights_precision {
+            let result = result.cast(DType::F64);
+            let bias = self.constant_like(result, (1_u64 << (precision - 1)) as f64);
+            let divisor = self.constant_like(result, (1_u64 << precision) as f64);
+            let rounded = self.floor_tensor((result + bias) / divisor);
+            let zero = self.constant_like(rounded, 0.0);
+            let maximum = self.constant_like(rounded, u8::MAX as f64);
+            let lower = self.select(rounded.lt(zero), zero, rounded);
+            self.select(lower.gt(maximum), maximum, lower)
+                .cast(DType::U8)
+        } else {
+            result
+        }
+    }
+
+    pub(crate) fn translate_upsample_bilinear2d_aa(&mut self, node: &Node) -> Result<GraphTensor> {
+        let input = self.get_input_tensor(node, 0)?;
+        anyhow::ensure!(
+            input.legacy_tracker_ref().len() == 4,
+            "antialiased bilinear2d requires NCHW input"
+        );
+        let output_shape = self.output_meta_shape(node)?;
+        let [input_height, input_width, output_height, output_width] =
+            Self::static_resize_dimensions(input, &output_shape, "antialiased bilinear2d")?;
+        let align_corners = self.get_bool_arg(node, 2)?;
+        let scale_height = node.inputs.get(3).and_then(|input| input.arg.as_float());
+        let scale_width = node.inputs.get(4).and_then(|input| input.arg.as_float());
+        let quantized_u8 = input.dtype == DType::U8;
+        let compute = if quantized_u8 || input.dtype == DType::F64 {
+            input
+        } else {
+            input.cast(DType::F32)
+        };
+        // The CPU uint8 kernel quantizes after each separable pass, width first.
+        let width = self.antialias_bilinear_axis(
+            compute,
+            3,
+            input_width,
+            output_width,
+            align_corners,
+            scale_width,
+            quantized_u8,
+        );
+        let output = self.antialias_bilinear_axis(
+            width,
+            2,
+            input_height,
+            output_height,
+            align_corners,
+            scale_height,
+            quantized_u8,
+        );
+        Ok(if quantized_u8 {
+            output
+        } else {
+            output.cast(input.dtype)
+        })
+    }
+
+    fn store_zero_for_output(&mut self, name: &str) -> Result<()> {
+        let meta = self
+            .tensor_meta(name)
+            .context("batch norm output metadata is missing")?;
+        let shape = self.tensor_meta_to_shape(meta)?;
+        let dtype = crate::pt2_util::torch_dtype_int_to_luminal(meta.dtype);
+        let zero = self.full_tensor(shape, dtype, 0.0);
+        self.tensors.insert(name.to_string(), zero);
+        Ok(())
+    }
+
+    pub(crate) fn translate_batch_norm_functional(&mut self, node: &Node) -> Result<()> {
+        let input = self.get_input_tensor(node, 0)?;
+        anyhow::ensure!(
+            input.legacy_tracker_ref().len() >= 2,
+            "batch norm input rank must be at least two"
+        );
+        let output_names = Self::tensor_output_names(node);
+        anyhow::ensure!(!output_names.is_empty(), "batch norm has no tensor outputs");
+        let functional = node.target != "torch.ops.aten._native_batch_norm_legit.no_stats";
+        let training = if node.target == "torch.ops.aten._batch_norm_with_update_functional.default"
+        {
+            true
+        } else {
+            self.named_bool_arg(node, "training").unwrap_or(true)
+        };
+        anyhow::ensure!(
+            training || functional,
+            "batch norm without running stats requires training=true"
+        );
+        let momentum = self.named_float_arg(node, "momentum").unwrap_or(0.1);
+        let eps = self.named_float_arg(node, "eps").unwrap_or(1e-5);
+
+        let compute_dtype = if matches!(input.dtype, DType::F16 | DType::Bf16) {
+            DType::F32
+        } else {
+            input.dtype
+        };
+        let compute = input.cast(compute_dtype);
+        let axes = (0..input.legacy_tracker_ref().len())
+            .filter(|&axis| axis != 1)
+            .collect::<Vec<_>>();
+        let batch_mean = compute.mean(axes.clone());
+        let expanded_mean = batch_mean.expand_to_shape_on_axes(compute.dims(), axes.clone());
+        let centered = compute - expanded_mean;
+        let batch_var = centered.square().mean(axes.clone());
+
+        let running_mean = self.named_tensor_arg(node, "running_mean")?;
+        let running_var = self.named_tensor_arg(node, "running_var")?;
+        let (mean, variance) = if training {
+            (batch_mean, batch_var)
+        } else {
+            (
+                running_mean
+                    .context("inference batch norm requires running_mean")?
+                    .cast(compute_dtype),
+                running_var
+                    .context("inference batch norm requires running_var")?
+                    .cast(compute_dtype),
+            )
+        };
+        let invstd = (variance + self.constant_like(variance, eps))
+            .sqrt()
+            .reciprocal();
+        let mean_expanded = mean.expand_to_shape_on_axes(compute.dims(), axes.clone());
+        let invstd_expanded = invstd.expand_to_shape_on_axes(compute.dims(), axes.clone());
+        let mut output = (compute - mean_expanded) * invstd_expanded;
+        if let Some(weight) = self.named_tensor_arg(node, "weight")? {
+            let weight = weight
+                .cast(compute_dtype)
+                .expand_to_shape_on_axes(output.dims(), axes.clone());
+            output *= weight;
+        }
+        if let Some(bias) = self.named_tensor_arg(node, "bias")? {
+            let bias = bias
+                .cast(compute_dtype)
+                .expand_to_shape_on_axes(output.dims(), axes.clone());
+            output += bias;
+        }
+        self.tensors
+            .insert(output_names[0].clone(), output.cast(input.dtype));
+
+        for (index, statistic) in [(1, batch_mean), (2, invstd)] {
+            if output_names.len() > index {
+                if training {
+                    self.tensors.insert(output_names[index].clone(), statistic);
+                } else {
+                    self.store_zero_for_output(&output_names[index])?;
+                }
+            }
+        }
+
+        let running_start = output_names.len().saturating_sub(2);
+        if functional && output_names.len() >= 5 {
+            for name in &output_names[3..running_start] {
+                self.store_zero_for_output(name)?;
+            }
+            let running_mean =
+                running_mean.context("functional batch norm requires running_mean")?;
+            let running_var = running_var.context("functional batch norm requires running_var")?;
+            let (mean_out, var_out) = if training {
+                let mean_out = running_mean * (1.0 - momentum as f32)
+                    + batch_mean.cast(running_mean.dtype) * momentum as f32;
+                let count = product_of_dims(axes.iter().map(|&axis| input.dims()[axis]));
+                let count_tensor = self
+                    .graph
+                    .constant(count)
+                    .cast(batch_var.dtype)
+                    .expand_rhs(batch_var.dims());
+                let denominator = self
+                    .graph
+                    .constant(count - 1)
+                    .cast(batch_var.dtype)
+                    .expand_rhs(batch_var.dims());
+                let unbiased = batch_var * count_tensor / denominator;
+                let var_out = running_var * (1.0 - momentum as f32)
+                    + unbiased.cast(running_var.dtype) * momentum as f32;
+                (mean_out, var_out)
+            } else {
+                (running_mean, running_var)
+            };
+            self.tensors
+                .insert(output_names[running_start].clone(), mean_out);
+            self.tensors
+                .insert(output_names[running_start + 1].clone(), var_out);
+        }
+        Ok(())
+    }
+}

--- a/crates/luminal_python/rust/src/translator/reduction.rs
+++ b/crates/luminal_python/rust/src/translator/reduction.rs
@@ -1,6 +1,7 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use luminal::prelude::*;
 
+use crate::dim_arith::product_of_dims;
 use crate::pt2_schema::*;
 use crate::pt2_util::*;
 
@@ -59,6 +60,21 @@ fn dtype_can_contain_nan(dtype: DType) -> bool {
     )
 }
 
+fn is_integral_dtype(dtype: DType) -> bool {
+    matches!(
+        dtype,
+        DType::Int
+            | DType::I64
+            | DType::I4
+            | DType::U4
+            | DType::I8
+            | DType::U8
+            | DType::I16
+            | DType::U16
+            | DType::Bool
+    )
+}
+
 /// Compute total element count, returning an error if any dimension is symbolic.
 fn concrete_numel(a: &GraphTensor) -> Result<usize> {
     a.dims().iter().try_fold(1usize, |acc, d| {
@@ -69,6 +85,1069 @@ fn concrete_numel(a: &GraphTensor) -> Result<usize> {
 }
 
 impl<'a> Translator<'a> {
+    fn optional_float_list(node: &Node, name: &str) -> Option<Vec<f64>> {
+        let input = node.inputs.iter().find(|input| input.name == name)?;
+        match &input.arg {
+            Argument::Other(value) => value
+                .get("as_floats")?
+                .as_array()?
+                .iter()
+                .map(serde_json::Value::as_f64)
+                .collect(),
+            _ => None,
+        }
+    }
+
+    fn histogram_weight(
+        &mut self,
+        node: &Node,
+        sample_count: IntExpr,
+        dtype: DType,
+    ) -> Result<GraphTensor> {
+        if let Some(weight) = self.named_tensor_arg(node, "weight")? {
+            return Ok(reshape_tensor(weight.cast(dtype), vec![sample_count]));
+        }
+        Ok(self
+            .floating_scalar(1.0, dtype)
+            .expand_rhs(vec![sample_count]))
+    }
+
+    fn histogram_density(node: &Node) -> bool {
+        node.inputs
+            .iter()
+            .find(|input| input.name == "density")
+            .and_then(|input| input.arg.as_bool())
+            .unwrap_or(false)
+    }
+
+    fn uniform_histogram_edges(
+        &mut self,
+        values: GraphTensor,
+        bins: usize,
+        explicit_range: Option<(f64, f64)>,
+    ) -> GraphTensor {
+        let (mut lower, mut upper) = if let Some((lower, upper)) = explicit_range {
+            (
+                self.floating_scalar(lower, values.dtype),
+                self.floating_scalar(upper, values.dtype),
+            )
+        } else {
+            (values.min(0), values.max(0))
+        };
+        let equal = self.is_zero(upper - lower);
+        lower = self.select(equal, lower - 0.5, lower);
+        upper = self.select(equal, upper + 0.5, upper);
+        let position = self.graph.arange(bins + 1).cast(values.dtype);
+        let edge_shape = position.dims();
+        let lower_expanded = lower.expand_rhs(edge_shape.clone());
+        let width = (upper - lower).expand_rhs(edge_shape);
+        lower_expanded + position * width / bins as f32
+    }
+
+    fn histogram_from_edges(
+        &mut self,
+        columns: &[GraphTensor],
+        edges: &[GraphTensor],
+        weight: GraphTensor,
+        density: bool,
+    ) -> Result<GraphTensor> {
+        anyhow::ensure!(
+            !columns.is_empty(),
+            "histogram must have at least one dimension"
+        );
+        anyhow::ensure!(columns.len() == edges.len(), "histogram edge rank mismatch");
+        let sample_count = columns[0].dims()[0];
+        let mut bin_shape = Vec::with_capacity(edges.len());
+        for edge in edges {
+            let edge_count = edge.dims()[0];
+            anyhow::ensure!(
+                edge_count.to_usize().is_none_or(|count| count >= 2),
+                "histogram bin edges must contain at least two values"
+            );
+            bin_shape.push(edge_count - 1);
+        }
+
+        let mut full_shape = vec![sample_count];
+        full_shape.extend_from_slice(&bin_shape);
+        let mut membership = self
+            .graph
+            .constant(1)
+            .cast(DType::Bool)
+            .expand_rhs(full_shape.clone());
+        for (dimension, (column, edge)) in columns.iter().zip(edges).enumerate() {
+            let bins = bin_shape[dimension];
+            let left = edge.slice_along(IntExpr::from(0)..bins, 0);
+            let right = edge.slice_along(IntExpr::from(1)..(bins + 1), 0);
+
+            let mut column_shape = vec![IntExpr::from(1); columns.len() + 1];
+            column_shape[0] = sample_count;
+            let mut column = reshape_tensor(*column, column_shape);
+            column.legacy_tracker_mut().expand(full_shape.clone());
+            let mut edge_shape = vec![IntExpr::from(1); columns.len() + 1];
+            edge_shape[dimension + 1] = bins;
+            let mut left = reshape_tensor(left, edge_shape.clone());
+            left.legacy_tracker_mut().expand(full_shape.clone());
+            let mut right = reshape_tensor(right, edge_shape.clone());
+            right.legacy_tracker_mut().expand(full_shape.clone());
+
+            let below_right = column.lt(right);
+            let equal_right = self.is_zero(column - right);
+            let mut last_position = self.graph.arange(bins).cast(DType::Int);
+            let last_index = self
+                .graph
+                .constant(bins - 1)
+                .cast(DType::Int)
+                .expand_rhs(last_position.dims());
+            last_position = last_position.eq(last_index);
+            let mut last_position = reshape_tensor(last_position, edge_shape);
+            last_position.legacy_tracker_mut().expand(full_shape.clone());
+            let inclusive_last = self.bool_and(equal_right, last_position);
+            let upper = self.bool_or(below_right, inclusive_last);
+            let in_bin = self.bool_and(column.ge(left), upper);
+            let column_nan = self.is_nan(column);
+            let in_bin = self.bool_and(in_bin, self.bool_not(column_nan));
+            membership = self.bool_and(membership, in_bin);
+        }
+
+        let mut weight_shape = vec![IntExpr::from(1); columns.len() + 1];
+        weight_shape[0] = sample_count;
+        let mut weight = reshape_tensor(weight, weight_shape);
+        weight.legacy_tracker_mut().expand(full_shape);
+        let mut histogram = (membership.cast(weight.dtype) * weight).sum(0);
+        if density {
+            let axes = (0..bin_shape.len()).collect::<Vec<_>>();
+            let total = histogram.sum(axes).expand_rhs(bin_shape.clone());
+            let mut volume = self
+                .floating_scalar(1.0, histogram.dtype)
+                .expand_rhs(bin_shape.clone());
+            for (dimension, edge) in edges.iter().enumerate() {
+                let bins = bin_shape[dimension];
+                let widths = edge.slice_along(IntExpr::from(1)..(bins + 1), 0)
+                    - edge.slice_along(IntExpr::from(0)..bins, 0);
+                let mut width_shape = vec![IntExpr::from(1); edges.len()];
+                width_shape[dimension] = bins;
+                let mut widths = reshape_tensor(widths, width_shape);
+                widths.legacy_tracker_mut().expand(bin_shape.clone());
+                volume *= widths;
+            }
+            histogram = histogram / total / volume;
+        }
+        Ok(histogram)
+    }
+
+    fn histogram_columns(
+        &mut self,
+        input: GraphTensor,
+        dimensions: usize,
+    ) -> Result<(Vec<GraphTensor>, IntExpr)> {
+        anyhow::ensure!(dimensions > 0, "histogram dimension count must be positive");
+        anyhow::ensure!(
+            !input.legacy_tracker_ref().is_empty(),
+            "histogramdd input must have a coordinate dimension"
+        );
+        let input_dims = input.dims();
+        anyhow::ensure!(
+            input_dims.last().and_then(|dim| dim.to_usize()) == Some(dimensions),
+            "histogramdd coordinate dimension does not match bins"
+        );
+        let sample_count = product_of_dims(input_dims[..input_dims.len() - 1].iter().copied());
+        let matrix = reshape_tensor(input, vec![sample_count, IntExpr::from(dimensions)]);
+        let columns = (0..dimensions)
+            .map(|dimension| {
+                let column = matrix.slice_along(dimension..dimension + 1, 1).squeeze(1);
+                super::movement::materialize_tensor(column)
+            })
+            .collect();
+        Ok((columns, sample_count))
+    }
+
+    pub(crate) fn translate_histogram(&mut self, node: &Node) -> Result<()> {
+        let dtype = self.output_meta_dtype(node)?;
+        let input = self.get_input_tensor(node, 0)?.cast(dtype);
+        let sample_count = product_of_dims(input.dims());
+        let values = reshape_tensor(input, vec![sample_count]);
+        let weight = self.histogram_weight(node, sample_count, dtype)?;
+        let density = Self::histogram_density(node);
+        let edges = if node.target.ends_with("bins_tensor") {
+            self.get_input_tensor(node, 1)?.cast(dtype)
+        } else {
+            let bins = usize::try_from(self.get_int_arg(node, 1)?)
+                .context("histogram bins must be nonnegative")?;
+            anyhow::ensure!(bins > 0, "histogram bins must be positive");
+            let range = Self::optional_float_list(node, "range")
+                .filter(|range| !range.is_empty())
+                .map(|range| (range[0], range[1]));
+            self.uniform_histogram_edges(values, bins, range)
+        };
+        let histogram = self.histogram_from_edges(&[values], &[edges], weight, density)?;
+        self.store_tensor_outputs(node, &[histogram, edges])
+    }
+
+    fn histogramdd_uniform_edges(
+        &mut self,
+        node: &Node,
+        columns: &[GraphTensor],
+        bins: &[i64],
+    ) -> Result<Vec<GraphTensor>> {
+        let range = Self::optional_float_list(node, "range").filter(|range| !range.is_empty());
+        if let Some(range) = &range {
+            anyhow::ensure!(
+                range.len() == bins.len() * 2,
+                "histogramdd range rank mismatch"
+            );
+        }
+        bins.iter()
+            .copied()
+            .enumerate()
+            .map(|(dimension, bins)| {
+                let bins = usize::try_from(bins).context("histogramdd bins must be nonnegative")?;
+                anyhow::ensure!(bins > 0, "histogramdd bins must be positive");
+                let explicit = range
+                    .as_ref()
+                    .map(|range| (range[dimension * 2], range[dimension * 2 + 1]));
+                Ok(self.uniform_histogram_edges(columns[dimension], bins, explicit))
+            })
+            .collect()
+    }
+
+    pub(crate) fn translate_histogramdd_bin_edges(&mut self, node: &Node) -> Result<()> {
+        let bins = self.get_ints_arg(node, 1)?.to_vec();
+        let input = self.get_input_tensor(node, 0)?;
+        let (columns, _) = self.histogram_columns(input, bins.len())?;
+        let edges = self.histogramdd_uniform_edges(node, &columns, &bins)?;
+        self.store_tensor_outputs(node, &edges)
+    }
+
+    pub(crate) fn translate_histogramdd(
+        &mut self,
+        node: &Node,
+        tensor_edges: bool,
+    ) -> Result<GraphTensor> {
+        let dtype = self.output_meta_dtype(node)?;
+        let input = self.get_input_tensor(node, 0)?.cast(dtype);
+        let (edges, dimensions) = if tensor_edges {
+            let names = node.inputs[1]
+                .arg
+                .as_tensors()
+                .context("histogramdd tensor bins must be a tensor list")?;
+            let edges = names
+                .iter()
+                .map(|name| self.get_tensor(&name.name).map(|edge| edge.cast(dtype)))
+                .collect::<Result<Vec<_>>>()?;
+            let dimensions = edges.len();
+            (edges, dimensions)
+        } else {
+            let bins = self.get_ints_arg(node, 1)?.to_vec();
+            let dimensions = bins.len();
+            let (columns, _) = self.histogram_columns(input, dimensions)?;
+            (
+                self.histogramdd_uniform_edges(node, &columns, &bins)?,
+                dimensions,
+            )
+        };
+        let (columns, sample_count) = self.histogram_columns(input, dimensions)?;
+        let weight = self.histogram_weight(node, sample_count, dtype)?;
+        self.histogram_from_edges(&columns, &edges, weight, Self::histogram_density(node))
+    }
+
+    pub(crate) fn p_norm(
+        &mut self,
+        magnitude: GraphTensor,
+        p: f64,
+        axes: Vec<usize>,
+    ) -> GraphTensor {
+        if p == 0.0 {
+            let zero = self.is_zero(magnitude);
+            self.bool_not(zero).cast(magnitude.dtype).sum(axes)
+        } else if p == 1.0 {
+            magnitude.sum(axes)
+        } else if p == 2.0 {
+            magnitude.square().sum(axes).sqrt()
+        } else if p == f64::INFINITY {
+            magnitude.max(axes)
+        } else if p == f64::NEG_INFINITY {
+            magnitude.min(axes)
+        } else {
+            magnitude.pow(p as f32).sum(axes).pow((1.0 / p) as f32)
+        }
+    }
+
+    fn first_along_axis(&mut self, value: GraphTensor, axis: usize) -> GraphTensor {
+        (value.slice_along(0..1, axis).squeeze(axis) * 1).cast(value.dtype)
+    }
+
+    fn select_along_axis(
+        &mut self,
+        value: GraphTensor,
+        indices_without_axis: GraphTensor,
+        axis: usize,
+        keepdim: bool,
+    ) -> GraphTensor {
+        let indices = indices_without_axis.unsqueeze(axis);
+        let selected = super::movement_dynamic::pt2_gather_elements(value, indices, axis);
+        if keepdim {
+            selected
+        } else {
+            selected.squeeze(axis)
+        }
+    }
+
+    fn first_nan_index(&mut self, value: GraphTensor, axis: usize) -> (GraphTensor, GraphTensor) {
+        let nan = self.is_nan(value);
+        let first = self
+            .first_along_axis(nan.cast(DType::F32).stable_argsort(axis, true), axis)
+            .cast(DType::I64);
+        let count = nan.cast(DType::Int).sum(axis);
+        let zero = self.graph.constant(0).expand_rhs(count.dims());
+        (first, count.gt(zero))
+    }
+
+    fn nan_last_argsort(&mut self, value: GraphTensor, axis: usize) -> GraphTensor {
+        if !dtype_can_contain_nan(value.dtype) {
+            return value.stable_argsort(axis, false);
+        }
+        let nan = self.is_nan(value);
+        let positive_infinity = self.constant_like(value, f64::INFINITY);
+        self.select(nan, positive_infinity, value)
+            .stable_argsort(axis, false)
+    }
+
+    /// Replacing NaNs with +inf makes them sort last except that real +inf
+    /// entries share the same key. If a selected slot that belongs to the
+    /// non-NaN prefix lands on a NaN, redirect it to the first real +inf.
+    fn correct_nan_inf_collision(
+        &mut self,
+        value: GraphTensor,
+        axis: usize,
+        selected_index: GraphTensor,
+        belongs_to_non_nan_prefix: GraphTensor,
+    ) -> GraphTensor {
+        if !dtype_can_contain_nan(value.dtype) {
+            return selected_index;
+        }
+        let selected_value = self.select_along_axis(value, selected_index, axis, false);
+        let selected_nan = self.is_nan(selected_value);
+        let infinite = self.is_inf(value);
+        let negative = self.signbit(value);
+        let positive = self.bool_not(negative);
+        let positive_infinite = self.bool_and(infinite, positive);
+        let first_positive_infinite = self
+            .first_along_axis(
+                positive_infinite
+                    .cast(DType::F32)
+                    .stable_argsort(axis, true),
+                axis,
+            )
+            .cast(DType::I64);
+        let positive_infinite_count = positive_infinite.cast(DType::Int).sum(axis);
+        let zero = self
+            .graph
+            .constant(0)
+            .expand_rhs(positive_infinite_count.dims());
+        let has_positive_infinity = positive_infinite_count.gt(zero);
+        let replace = self.bool_and(
+            selected_nan,
+            self.bool_and(belongs_to_non_nan_prefix, has_positive_infinity),
+        );
+        self.select(replace, first_positive_infinite, selected_index)
+    }
+
+    pub(crate) fn translate_dim_extremum(&mut self, node: &Node, which: ArgExtremum) -> Result<()> {
+        let value = self.get_input_tensor(node, 0)?;
+        let raw_axis = self.get_int_arg(node, 1)?;
+        let keepdim = self.get_bool_arg(node, 2).unwrap_or(false);
+        let names = Self::tensor_output_names(node);
+        anyhow::ensure!(
+            names.len() == 2,
+            "max/min dim must produce values and indices"
+        );
+
+        if value.legacy_tracker_ref().is_empty() {
+            anyhow::ensure!(
+                matches!(raw_axis, -1 | 0),
+                "dimension out of range for scalar"
+            );
+            self.tensors.insert(names[0].clone(), value);
+            self.tensors
+                .insert(names[1].clone(), self.graph.constant(0i64).cast(DType::I64));
+            return Ok(());
+        }
+        let axis = normalize_dim(raw_axis, value.legacy_tracker_ref().len());
+        let sort_key = if value.dtype == DType::Bool {
+            value.cast(DType::F32)
+        } else {
+            value
+        };
+        let ordered_index = self
+            .first_along_axis(sort_key.stable_argsort(axis, which.descending()), axis)
+            .cast(DType::I64);
+        let index = if dtype_can_contain_nan(value.dtype) {
+            let (nan_index, has_nan) = self.first_nan_index(value, axis);
+            self.select(has_nan, nan_index, ordered_index)
+        } else {
+            ordered_index
+        };
+        let selected = self.select_along_axis(value, index, axis, keepdim);
+        let index = if keepdim {
+            index.unsqueeze(axis)
+        } else {
+            index
+        };
+        self.tensors.insert(names[0].clone(), selected);
+        self.tensors
+            .insert(names[1].clone(), index.cast(DType::I64));
+        Ok(())
+    }
+
+    pub(crate) fn translate_median(&mut self, node: &Node) -> Result<()> {
+        self.translate_median_impl(node, false)
+    }
+
+    pub(crate) fn translate_nanmedian(&mut self, node: &Node) -> Result<()> {
+        self.translate_median_impl(node, true)
+    }
+
+    fn translate_median_impl(&mut self, node: &Node, ignore_nan: bool) -> Result<()> {
+        let value = self.get_input_tensor(node, 0)?;
+        let names = Self::tensor_output_names(node);
+        let dim_variant = node.target.ends_with(".dim");
+        let (base, axis, keepdim) = if dim_variant {
+            if value.legacy_tracker_ref().is_empty() {
+                let raw_axis = self.get_int_arg(node, 1)?;
+                anyhow::ensure!(
+                    matches!(raw_axis, -1 | 0),
+                    "dimension out of range for scalar"
+                );
+                self.tensors.insert(names[0].clone(), value);
+                self.tensors
+                    .insert(names[1].clone(), self.graph.constant(0i64).cast(DType::I64));
+                return Ok(());
+            }
+            (
+                value,
+                normalize_dim(self.get_int_arg(node, 1)?, value.legacy_tracker_ref().len()),
+                self.get_bool_arg(node, 2).unwrap_or(false),
+            )
+        } else {
+            if value.legacy_tracker_ref().is_empty() {
+                self.tensors.insert(names[0].clone(), value);
+                return Ok(());
+            }
+            let numel = product_of_dims(value.dims().iter().copied());
+            (
+                reshape_tensor(super::movement::materialize_tensor(value), vec![numel]),
+                0,
+                false,
+            )
+        };
+
+        let index = if ignore_nan && dtype_can_contain_nan(base.dtype) {
+            let nan_count = self.is_nan(base).cast(DType::I64).sum(axis);
+            let axis_length = self
+                .graph
+                .constant(base.dims()[axis])
+                .cast(DType::I64)
+                .expand_rhs(nan_count.dims());
+            let valid_count = axis_length - nan_count;
+            let zero = self
+                .graph
+                .constant(0)
+                .cast(valid_count.dtype)
+                .expand_rhs(valid_count.dims());
+            let has_valid = valid_count.gt(zero);
+            let kth = (((valid_count - 1).maximum(zero)).cast(DType::F64) * 0.5).cast(DType::I64);
+            let sorted = self.nan_last_argsort(base, axis);
+            let index = self
+                .select_along_axis(sorted, kth, axis, false)
+                .cast(DType::I64);
+            self.correct_nan_inf_collision(base, axis, index, has_valid)
+        } else {
+            let axis_length = base.dims()[axis];
+            let reduced_shape = base
+                .dims()
+                .into_iter()
+                .enumerate()
+                .filter_map(|(dim, size)| (dim != axis).then_some(size))
+                .collect::<Vec<_>>();
+            let mut kth = self.graph.constant((axis_length - 1) / 2).cast(DType::Int);
+            if !reduced_shape.is_empty() {
+                kth = kth.expand_rhs(reduced_shape);
+            }
+            let ordered = self
+                .select_along_axis(base.stable_argsort(axis, false), kth, axis, false)
+                .cast(DType::I64);
+            if dtype_can_contain_nan(base.dtype) {
+                let (nan_index, has_nan) = self.first_nan_index(base, axis);
+                self.select(has_nan, nan_index, ordered)
+            } else {
+                ordered
+            }
+        };
+        let selected = self.select_along_axis(base, index, axis, keepdim);
+        self.tensors.insert(names[0].clone(), selected);
+        if dim_variant {
+            let index = if keepdim {
+                index.unsqueeze(axis)
+            } else {
+                index
+            };
+            self.tensors
+                .insert(names[1].clone(), index.cast(DType::I64));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn translate_segment_reduce(&mut self, node: &Node) -> Result<GraphTensor> {
+        let data = self.get_input_tensor(node, 0)?;
+        let reduction = node
+            .inputs
+            .iter()
+            .find(|input| input.name == "reduce")
+            .and_then(|input| match &input.arg {
+                Argument::Other(value) => value
+                    .as_str()
+                    .or_else(|| value.get("as_string").and_then(|value| value.as_str())),
+                _ => None,
+            })
+            .context("segment_reduce is missing its reduction name")?;
+        let axis = self.named_int_arg(node, "axis").unwrap_or(0);
+        let axis = normalize_dim(axis, data.legacy_tracker_ref().len());
+        let output_shape = self.output_meta_shape(node)?;
+        let segment_count = output_shape[axis];
+        let input_count = data.dims()[axis];
+
+        let lengths = self.named_tensor_arg(node, "lengths")?;
+        let offsets = self.named_tensor_arg(node, "offsets")?;
+        let (starts, ends) = if let Some(lengths) = lengths {
+            let lengths = lengths.cast(DType::Int);
+            let ends = lengths.cumsum(axis);
+            (ends - lengths, ends)
+        } else if let Some(offsets) = offsets {
+            let offsets = offsets.cast(DType::Int);
+            (
+                offsets.slice_along(IntExpr::from(0)..segment_count, axis),
+                offsets.slice_along(IntExpr::from(1)..(segment_count + 1), axis),
+            )
+        } else {
+            anyhow::bail!("segment_reduce requires lengths or offsets");
+        };
+
+        let mut pair_shape = output_shape.clone();
+        pair_shape.insert(axis + 1, input_count);
+        let mut starts = starts.expand_dim(axis + 1, input_count);
+        let mut ends = ends.expand_dim(axis + 1, input_count);
+        for suffix in data.dims()[axis + 1..].iter().copied() {
+            starts = starts.expand_dim(starts.legacy_tracker_ref().len(), suffix);
+            ends = ends.expand_dim(ends.legacy_tracker_ref().len(), suffix);
+        }
+        let mut positions = self.graph.arange(input_count).cast(DType::Int);
+        for (dimension, size) in pair_shape.iter().copied().enumerate() {
+            if dimension != axis + 1 {
+                positions = positions.expand_dim(dimension, size);
+            }
+        }
+        let membership = self.bool_and(positions.ge(starts), positions.lt(ends));
+        let expanded = data.expand_dim(axis, segment_count);
+        let candidate_axis = axis + 1;
+        let count = membership.cast(DType::Int).sum(candidate_axis);
+
+        let initial = Self::named_input_index(node, "initial")
+            .and_then(|index| self.constructor_scalar_arg(node, index).ok())
+            .map(|value| self.typed_scalar_constant(&value, data.dtype))
+            .transpose()?
+            .map(|value| value.expand_rhs(output_shape.clone()));
+        let has_initial = initial.is_some();
+        let zero = self.full_tensor(expanded.dims(), data.dtype, 0.0);
+        let one = self.full_tensor(expanded.dims(), data.dtype, 1.0);
+        match reduction {
+            "sum" | "mean" => {
+                let mut sum = self.select(membership, expanded, zero).sum(candidate_axis);
+                if let Some(initial) = initial {
+                    sum += initial;
+                }
+                if reduction == "sum" {
+                    Ok(sum)
+                } else {
+                    let zero_count = self.graph.constant(0).expand_rhs(count.dims());
+                    let nonempty = count.gt(zero_count);
+                    let one_count = self.graph.constant(1).expand_rhs(count.dims());
+                    let safe_count = self.select(nonempty, count, one_count);
+                    let mean = sum / safe_count.cast(data.dtype);
+                    if has_initial {
+                        Ok(mean)
+                    } else {
+                        let nan = self
+                            .floating_scalar(f64::NAN, data.dtype)
+                            .expand_rhs(mean.dims());
+                        Ok(self.select(nonempty, mean, nan))
+                    }
+                }
+            }
+            "prod" => {
+                let selected = self.select(membership, expanded, one);
+                let magnitude = self.real_abs(selected).prod(candidate_axis);
+                let negative_count = self.signbit(selected).cast(DType::Int).sum(candidate_axis);
+                let two = self.graph.constant(2).expand_rhs(negative_count.dims());
+                let zero = self.graph.constant(0).expand_rhs(negative_count.dims());
+                let odd = (negative_count % two).ne(zero);
+                let mut product = self.select(odd, magnitude * -1.0, magnitude);
+                if let Some(initial) = initial {
+                    product *= initial;
+                }
+                Ok(product)
+            }
+            "max" | "min" => {
+                let fill = self
+                    .floating_scalar(
+                        if reduction == "max" {
+                            f64::NEG_INFINITY
+                        } else {
+                            f64::INFINITY
+                        },
+                        data.dtype,
+                    )
+                    .expand_rhs(expanded.dims());
+                let values = self.select(membership, expanded, fill);
+                let mut result = if reduction == "max" {
+                    values.max(candidate_axis)
+                } else {
+                    values.min(candidate_axis)
+                };
+                let zero_count = self.graph.constant(0).expand_rhs(count.dims());
+                let nonempty = count.gt(zero_count);
+                if let Some(initial) = initial {
+                    let combined = if reduction == "max" {
+                        result.maximum(initial)
+                    } else {
+                        result.minimum(initial)
+                    };
+                    result = self.select(nonempty, combined, initial);
+                } else {
+                    let empty = self
+                        .floating_scalar(
+                            if reduction == "max" {
+                                f64::NEG_INFINITY
+                            } else {
+                                f64::INFINITY
+                            },
+                            data.dtype,
+                        )
+                        .expand_rhs(result.dims());
+                    result = self.select(nonempty, result, empty);
+                }
+                Ok(result)
+            }
+            other => anyhow::bail!("unsupported segment_reduce reduction {other}"),
+        }
+    }
+
+    /// Normalize an optional ATen reduction-dimension list. Both `None` and
+    /// `[]` mean a full reduction for the composed reductions in this file.
+    pub(crate) fn composed_reduction_axes(&self, node: &Node, rank: usize) -> Result<Vec<usize>> {
+        self.composed_reduction_axes_at(node, rank, 1)
+    }
+
+    fn composed_reduction_axes_at(
+        &self,
+        node: &Node,
+        rank: usize,
+        dim_arg: usize,
+    ) -> Result<Vec<usize>> {
+        let dims = self.get_ints_arg(node, dim_arg).ok();
+        let raw_dims = match dims {
+            Some(dims) if !dims.is_empty() => dims,
+            _ => (0..rank).map(|axis| axis as i64).collect(),
+        };
+        let mut axes = Vec::with_capacity(raw_dims.len());
+        for dim in raw_dims {
+            if rank == 0 {
+                anyhow::ensure!(
+                    matches!(dim, -1 | 0),
+                    "reduction dimension {dim} is out of range for a scalar"
+                );
+                continue;
+            }
+            anyhow::ensure!(
+                dim >= -(rank as i64) && dim < rank as i64,
+                "reduction dimension {dim} is out of range for rank {rank}"
+            );
+            let axis = normalize_dim(dim, rank);
+            anyhow::ensure!(!axes.contains(&axis), "reduction dimensions must be unique");
+            axes.push(axis);
+        }
+        Ok(axes)
+    }
+
+    pub(crate) fn restore_reduced_dims(
+        &self,
+        mut value: GraphTensor,
+        axes: &[usize],
+        keepdim: bool,
+    ) -> GraphTensor {
+        if keepdim {
+            let mut axes = axes.to_vec();
+            axes.sort_unstable();
+            for axis in axes {
+                value = value.unsqueeze(axis);
+            }
+        }
+        value
+    }
+
+    /// Lower `linalg_vector_norm` after the caller has constructed real-valued
+    /// magnitudes. Complex inputs use this same routine after `abs(z)`.
+    pub(crate) fn vector_norm_from_magnitude(
+        &mut self,
+        node: &Node,
+        magnitude: GraphTensor,
+    ) -> Result<GraphTensor> {
+        let output_dtype = self.output_meta_dtype(node)?;
+        let magnitude = magnitude.cast(output_dtype);
+        let axes = self.composed_reduction_axes_at(node, magnitude.legacy_tracker_ref().len(), 2)?;
+        let keepdim = self.get_bool_arg(node, 3).unwrap_or(false);
+        let ord = self.get_float_arg(node, 1).unwrap_or(2.0);
+
+        if (ord.is_infinite() || ord < 0.0)
+            && axes
+                .iter()
+                .any(|&axis| magnitude.dims()[axis].to_usize() == Some(0))
+        {
+            anyhow::bail!(
+                "linalg_vector_norm order {ord} has no identity for an empty reduction dimension"
+            );
+        }
+
+        let reduced = if ord == 0.0 {
+            let zero = self
+                .graph
+                .constant_float(0.0)
+                .cast(magnitude.dtype)
+                .expand_rhs(magnitude.dims());
+            let ordered_nonzero = self.bool_or(magnitude.lt(zero), magnitude.gt(zero));
+            let nonzero = if dtype_can_contain_nan(magnitude.dtype) {
+                let nan = self.is_nan(magnitude);
+                self.bool_or(ordered_nonzero, nan)
+            } else {
+                ordered_nonzero
+            };
+            nonzero.cast(output_dtype).sum(axes.clone())
+        } else if ord == 1.0 {
+            magnitude.sum(axes.clone())
+        } else if ord == 2.0 {
+            (magnitude * magnitude).sum(axes.clone()).sqrt()
+        } else if ord == f64::INFINITY {
+            magnitude.max(axes.clone())
+        } else if ord == f64::NEG_INFINITY {
+            magnitude.min(axes.clone())
+        } else {
+            magnitude
+                .pow(ord as f32)
+                .sum(axes.clone())
+                .pow((1.0 / ord) as f32)
+        };
+        Ok(self.restore_reduced_dims(reduced, &axes, keepdim))
+    }
+
+    pub(crate) fn translate_linalg_vector_norm(&mut self, node: &Node) -> Result<GraphTensor> {
+        let value = self.get_input_tensor(node, 0)?;
+        let magnitude = self.real_abs(value);
+        self.vector_norm_from_magnitude(node, magnitude)
+    }
+
+    pub(crate) fn translate_dist(&mut self, node: &Node) -> Result<GraphTensor> {
+        let lhs = self.get_input_tensor(node, 0)?;
+        let rhs = self.get_input_tensor(node, 1)?;
+        let (lhs, rhs) = ensure_same_dtype(lhs, rhs);
+        let (lhs, rhs) = broadcast_binary(lhs, rhs);
+        let magnitude = self.real_abs(lhs - rhs).cast(self.output_meta_dtype(node)?);
+        let p = self.get_float_arg(node, 2).unwrap_or(2.0);
+        Ok(self.p_norm(magnitude, p, (0..magnitude.legacy_tracker_ref().len()).collect()))
+    }
+
+    pub(crate) fn translate_cdist(&mut self, node: &Node) -> Result<GraphTensor> {
+        let lhs = self.get_input_tensor(node, 0)?;
+        let rhs = self.get_input_tensor(node, 1)?;
+        anyhow::ensure!(
+            lhs.legacy_tracker_ref().len() >= 2 && rhs.legacy_tracker_ref().len() >= 2,
+            "cdist inputs must be matrices"
+        );
+        let (mut lhs, mut rhs) = ensure_same_dtype(lhs, rhs);
+        let output_shape = self.output_meta_shape(node)?;
+        let feature = lhs.dims()[lhs.legacy_tracker_ref().len() - 1];
+        anyhow::ensure!(
+            feature == rhs.dims()[rhs.legacy_tracker_ref().len() - 1],
+            "cdist feature dimensions must match"
+        );
+        let mut pair_shape = output_shape;
+        pair_shape.push(feature);
+        lhs = lhs.expand_dim(lhs.legacy_tracker_ref().len() - 1, rhs.dims()[rhs.legacy_tracker_ref().len() - 2]);
+        rhs = rhs.expand_dim(rhs.legacy_tracker_ref().len() - 2, lhs.dims()[lhs.legacy_tracker_ref().len() - 3]);
+        lhs.legacy_tracker_mut().expand(pair_shape.clone());
+        rhs.legacy_tracker_mut().expand(pair_shape);
+        let magnitude = self.real_abs(lhs - rhs).cast(self.output_meta_dtype(node)?);
+        let p = self.get_float_arg(node, 2)?;
+        Ok(self.p_norm(magnitude, p, vec![magnitude.legacy_tracker_ref().len() - 1]))
+    }
+
+    pub(crate) fn translate_pdist(&mut self, node: &Node) -> Result<GraphTensor> {
+        let input = self.get_input_tensor(node, 0)?;
+        anyhow::ensure!(input.legacy_tracker_ref().len() == 2, "pdist input must be a matrix");
+        let rows = input.dims()[0];
+        let columns = input.dims()[1];
+        let output_shape = self.output_meta_shape(node)?;
+        let pairs = output_shape[0];
+        let k = self.graph.arange(pairs).cast(DType::F64);
+        let rows_f = self
+            .graph
+            .constant(rows)
+            .cast(DType::F64)
+            .expand_rhs(k.dims());
+        let discriminant = k * -8.0 + rows_f * (rows_f - 1.0) * 4.0 - 7.0;
+        let i = (rows_f
+            - 2.0
+            - (discriminant.sqrt() * 0.5 - 0.5)
+                .cast(DType::I64)
+                .cast(DType::F64))
+        .cast(DType::Int);
+        let i_f = i.cast(DType::F64);
+        let j = (k + i_f + 1.0 - rows_f * (rows_f - 1.0) * 0.5
+            + (rows_f - i_f) * (rows_f - i_f - 1.0) * 0.5)
+            .cast(DType::Int);
+        let i = i.expand_dim(1, columns);
+        let j = j.expand_dim(1, columns);
+        let left = super::movement_dynamic::pt2_index_select(
+            input,
+            i.slice_along(0..1, 1).squeeze(1),
+            0,
+            &[pairs, columns],
+        );
+        let right = super::movement_dynamic::pt2_index_select(
+            input,
+            j.slice_along(0..1, 1).squeeze(1),
+            0,
+            &[pairs, columns],
+        );
+        let magnitude = self
+            .real_abs(left - right)
+            .cast(self.output_meta_dtype(node)?);
+        let p = self.get_float_arg(node, 1).unwrap_or(2.0);
+        Ok(self.p_norm(magnitude, p, vec![1]))
+    }
+
+    pub(crate) fn translate_log_softmax(&mut self, node: &Node) -> Result<GraphTensor> {
+        let value = self
+            .get_input_tensor(node, 0)?
+            .cast(self.output_meta_dtype(node)?);
+        let rank = value.legacy_tracker_ref().len();
+        let raw_dim = self.get_int_arg(node, 1)?;
+        if rank == 0 {
+            anyhow::ensure!(
+                matches!(raw_dim, -1 | 0),
+                "log_softmax dimension {raw_dim} is out of range for a scalar"
+            );
+            // Preserve PyTorch's IEEE behavior: finite scalars become zero,
+            // while +/-inf and NaN become NaN through the ordinary stable
+            // log-softmax formula rather than an unconditional zero.
+            return Ok(value.unsqueeze(0).log_softmax(0).squeeze(0));
+        }
+        anyhow::ensure!(
+            raw_dim >= -(rank as i64) && raw_dim < rank as i64,
+            "log_softmax dimension {raw_dim} is out of range for rank {rank}"
+        );
+        Ok(value.log_softmax(normalize_dim(raw_dim, rank)))
+    }
+
+    pub(crate) fn variance_correction(&self, node: &Node) -> f64 {
+        if let Some(correction) = node
+            .inputs
+            .iter()
+            .position(|input| input.name == "correction")
+            .and_then(|index| self.get_float_arg(node, index).ok())
+        {
+            return correction;
+        }
+        node.inputs
+            .iter()
+            .position(|input| input.name == "unbiased")
+            .and_then(|index| self.get_bool_arg(node, index).ok())
+            .map_or(1.0, |unbiased| if unbiased { 1.0 } else { 0.0 })
+    }
+
+    pub(crate) fn floating_scalar(&mut self, value: f64, dtype: DType) -> GraphTensor {
+        if dtype == DType::F64 {
+            self.graph.constant_float64(value)
+        } else {
+            self.graph.constant_float(value as f32).cast(dtype)
+        }
+    }
+
+    /// Compute variance and mean for an ordinary real tensor. PyTorch clamps
+    /// non-positive degrees of freedom to zero before division, which yields
+    /// NaN for a zero numerator and infinity otherwise.
+    pub(crate) fn variance_mean_real(
+        &mut self,
+        node: &Node,
+        value: GraphTensor,
+    ) -> Result<(GraphTensor, GraphTensor)> {
+        let axes = self.composed_reduction_axes(node, value.legacy_tracker_ref().len())?;
+        let keepdim = node
+            .inputs
+            .iter()
+            .position(|input| input.name == "keepdim")
+            .and_then(|index| self.get_bool_arg(node, index).ok())
+            .unwrap_or(false);
+        let correction = self.variance_correction(node);
+        let output_dtype = self.output_meta_dtype(node)?;
+        let value = value.cast(output_dtype);
+        let n = product_of_dims(axes.iter().map(|&axis| value.dims()[axis]));
+        let mean = if axes.is_empty() {
+            value
+        } else {
+            value.sum(axes.clone()) / n
+        };
+        let expanded_mean = mean.expand_to_shape_on_axes(value.dims(), axes.clone());
+        let centered = value - expanded_mean;
+        let numerator = (centered * centered).sum(axes.clone());
+        let degrees = self.graph.constant(n).cast(output_dtype)
+            - self.floating_scalar(correction, output_dtype);
+        let zero = self.floating_scalar(0.0, output_dtype);
+        let divisor = degrees.maximum(zero).expand_rhs(numerator.dims());
+        let variance = numerator / divisor;
+        Ok((
+            self.restore_reduced_dims(variance, &axes, keepdim),
+            self.restore_reduced_dims(mean, &axes, keepdim),
+        ))
+    }
+
+    pub(crate) fn translate_var(&mut self, node: &Node) -> Result<GraphTensor> {
+        let value = self.get_input_tensor(node, 0)?;
+        Ok(self.variance_mean_real(node, value)?.0)
+    }
+
+    pub(crate) fn translate_var_mean(&mut self, node: &Node) -> Result<()> {
+        let value = self.get_input_tensor(node, 0)?;
+        let (variance, mean) = self.variance_mean_real(node, value)?;
+        let names = node
+            .outputs
+            .iter()
+            .flat_map(|output| {
+                output
+                    .as_tensors
+                    .as_ref()
+                    .map(|values| values.iter().map(|value| value.name.clone()).collect())
+                    .unwrap_or_else(|| {
+                        output
+                            .as_tensor
+                            .as_ref()
+                            .map(|value| vec![value.name.clone()])
+                            .unwrap_or_default()
+                    })
+            })
+            .collect::<Vec<_>>();
+        anyhow::ensure!(names.len() == 2, "var_mean must have two tensor outputs");
+        self.tensors.insert(names[0].clone(), variance);
+        self.tensors.insert(names[1].clone(), mean);
+        Ok(())
+    }
+
+    pub(crate) fn mean_divide(
+        &mut self,
+        sums: GraphTensor,
+        counts: GraphTensor,
+        output_dtype: DType,
+    ) -> GraphTensor {
+        if is_integral_dtype(output_dtype) {
+            let quotient = sums.cast(DType::F32) / counts.cast(DType::F32);
+            let trunc = quotient.cast(DType::Int).cast(DType::F32);
+            let floor = trunc - quotient.lt(trunc).cast(DType::F32);
+            floor.cast(output_dtype)
+        } else {
+            sums / counts.cast(output_dtype)
+        }
+    }
+
+    /// Reduce PyTorch truth values for the three `aten.any` overloads.
+    ///
+    /// `truth` is already boolean. `any.dims(dim=[])` is an elementwise bool
+    /// cast rather than a full reduction, while a missing dim list reduces
+    /// every axis. Keeping that distinction here lets the ordinary and
+    /// frontend-only complex paths share exactly the same axis semantics.
+    pub(crate) fn translate_any_from_truth(
+        &mut self,
+        node: &Node,
+        truth: GraphTensor,
+    ) -> Result<GraphTensor> {
+        let rank = truth.legacy_tracker_ref().len();
+        let (axes, keepdim) = match node.target.as_str() {
+            "torch.ops.aten.any.default" => ((0..rank).collect::<Vec<_>>(), false),
+            "torch.ops.aten.any.dim" => {
+                let dim = self.get_int_arg(node, 1)?;
+                let axis = if rank == 0 {
+                    anyhow::ensure!(
+                        matches!(dim, -1 | 0),
+                        "any dimension {dim} out of range for a scalar"
+                    );
+                    0
+                } else {
+                    anyhow::ensure!(
+                        dim >= -(rank as i64) && dim < rank as i64,
+                        "any dimension {dim} out of range for rank {rank}"
+                    );
+                    normalize_dim(dim, rank)
+                };
+                let keepdim = self.get_bool_arg(node, 2).unwrap_or(false);
+                (if rank == 0 { vec![] } else { vec![axis] }, keepdim)
+            }
+            "torch.ops.aten.any.dims" => {
+                let axes = match self.get_ints_arg(node, 1) {
+                    Ok(dims) => {
+                        let mut axes = Vec::with_capacity(dims.len());
+                        for dim in dims {
+                            anyhow::ensure!(
+                                dim >= -(rank as i64) && dim < rank as i64,
+                                "any dimension {dim} out of range for rank {rank}"
+                            );
+                            let axis = normalize_dim(dim, rank);
+                            anyhow::ensure!(!axes.contains(&axis), "any dimensions must be unique");
+                            axes.push(axis);
+                        }
+                        axes
+                    }
+                    Err(_) => (0..rank).collect(),
+                };
+                let keepdim = self.get_bool_arg(node, 2).unwrap_or(false);
+                (axes, keepdim)
+            }
+            other => anyhow::bail!("translate_any_from_truth called for {other}"),
+        };
+
+        if axes.is_empty() {
+            return Ok(truth.cast(DType::Bool));
+        }
+
+        let counts = truth.cast(DType::Int).sum(axes.clone());
+        let zero = self.graph.constant(0).expand_rhs(counts.dims());
+        let mut result = counts.ne(zero);
+        if keepdim {
+            let mut sorted_axes = axes;
+            sorted_axes.sort_unstable();
+            for axis in sorted_axes {
+                result = result.unsqueeze(axis);
+            }
+        }
+        Ok(result)
+    }
+
+    pub(crate) fn translate_any(&mut self, node: &Node) -> Result<GraphTensor> {
+        let input = self.get_input_tensor(node, 0)?;
+        let zero = self
+            .graph
+            .constant(0)
+            .cast(input.dtype)
+            .expand_rhs(input.dims());
+        self.translate_any_from_truth(node, input.ne(zero))
+    }
+
     /// Build the per-element source indices and validity mask for one
     /// Hillis-Steele inclusive-scan step. A lane at `i` reads `i - offset`;
     /// prefix lanes read zero but are subsequently kept unchanged by `valid`.
@@ -234,14 +1313,10 @@ impl<'a> Translator<'a> {
                     // and mean of a scalar is just the scalar.
                     return Ok(a);
                 }
-                let total = concrete_numel(&a)?;
                 let axes: Vec<usize> = (0..ndim).collect();
                 let result = match op {
                     ReductionOp::Sum => a.sum(axes),
-                    // Note: the luminal `mean` helper divides by the product of the
-                    // axis dims, but we already require concrete dims here so we
-                    // divide by the cached `total` to avoid recomputing.
-                    ReductionOp::Mean => a.sum(axes) / total as f32,
+                    ReductionOp::Mean => a.mean(axes),
                     ReductionOp::Max => a.max(axes),
                     ReductionOp::Min => a.min(axes),
                     ReductionOp::Prod => a.prod(axes),

--- a/crates/luminal_python/rust/src/translator/sampling.rs
+++ b/crates/luminal_python/rust/src/translator/sampling.rs
@@ -1,0 +1,314 @@
+use anyhow::Result;
+use luminal::prelude::*;
+
+use crate::pt2_schema::Node;
+use crate::pt2_util::reshape_tensor;
+
+use super::Translator;
+
+impl<'a> Translator<'a> {
+    fn clamp_coordinate(
+        &mut self,
+        value: GraphTensor,
+        minimum: GraphTensor,
+        maximum: GraphTensor,
+    ) -> GraphTensor {
+        let lower = self.select(value.lt(minimum), minimum, value);
+        self.select(lower.gt(maximum), maximum, lower)
+    }
+
+    fn reflect_coordinate(
+        &mut self,
+        value: GraphTensor,
+        size: IntExpr,
+        align_corners: bool,
+    ) -> GraphTensor {
+        let twice_low = if align_corners { 0.0 } else { -1.0 };
+        let minimum = self.constant_like(value, twice_low * 0.5);
+        let twice_high = self
+            .graph
+            .constant(size * 2 - if align_corners { 2 } else { 1 })
+            .cast(value.dtype)
+            .expand_rhs(value.dims());
+        let maximum = twice_high * self.constant_like(value, 0.5);
+        let span = maximum - minimum;
+        let span_is_zero = self.is_zero(span);
+        let one = self.constant_like(span, 1.0);
+        let safe_span = self.select(span_is_zero, one, span);
+        let distance = self.real_abs(value - minimum);
+        let quotient = self.floor_tensor(distance / safe_span);
+        let remainder = distance % safe_span;
+        let odd = (quotient.cast(DType::I64)
+            % self
+                .graph
+                .constant(2)
+                .cast(DType::I64)
+                .expand_rhs(quotient.dims()))
+        .ne(self
+            .graph
+            .constant(0)
+            .cast(DType::I64)
+            .expand_rhs(quotient.dims()));
+        let reflected = self.select(odd, safe_span - remainder, remainder) + minimum;
+        let zero = self.constant_like(reflected, 0.0);
+        self.select(span_is_zero, zero, reflected)
+    }
+
+    fn grid_source_coordinate(
+        &mut self,
+        normalized: GraphTensor,
+        size: IntExpr,
+        padding_mode: i64,
+        align_corners: bool,
+        nan_replacement: Option<f64>,
+    ) -> GraphTensor {
+        // Nearest sampling converts NaN through the integer-coordinate path
+        // (equivalent to normalized -1). The CPU 3-D border/reflection path
+        // clips NaN to the upper boundary; other linear/cubic paths propagate
+        // it through the interpolation weights.
+        let normalized = if let Some(replacement) = nan_replacement {
+            let nan = self.is_nan(normalized);
+            let replacement = self.constant_like(normalized, replacement);
+            self.select(nan, replacement, normalized)
+        } else {
+            normalized
+        };
+        let size_tensor = self
+            .graph
+            .constant(size)
+            .cast(normalized.dtype)
+            .expand_rhs(normalized.dims());
+        let one = self.constant_like(normalized, 1.0);
+        let two = self.constant_like(normalized, 2.0);
+        let coordinate = if align_corners {
+            (normalized + one) * (size_tensor - one) / two
+        } else {
+            ((normalized + one) * size_tensor - one) / two
+        };
+        if padding_mode == 0 {
+            coordinate
+        } else {
+            let padded = if padding_mode == 1 {
+                coordinate
+            } else {
+                self.reflect_coordinate(coordinate, size, align_corners)
+            };
+            let zero = self.constant_like(padded, 0.0);
+            self.clamp_coordinate(padded, zero, size_tensor - one)
+        }
+    }
+
+    fn bound_grid_index(
+        &mut self,
+        index: GraphTensor,
+        size: IntExpr,
+        padding_mode: i64,
+        align_corners: bool,
+    ) -> (GraphTensor, GraphTensor) {
+        let zero = self.constant_like(index, 0.0);
+        let size_tensor = self
+            .graph
+            .constant(size)
+            .cast(index.dtype)
+            .expand_rhs(index.dims());
+        let upper = size_tensor - self.constant_like(index, 1.0);
+        let (coordinate, valid) = match padding_mode {
+            0 => (index, self.bool_and(index.ge(zero), index.lt(size_tensor))),
+            1 => (index, self.full_tensor(index.dims(), DType::Bool, 1.0)),
+            2 => (
+                self.reflect_coordinate(index, size, align_corners),
+                self.full_tensor(index.dims(), DType::Bool, 1.0),
+            ),
+            _ => unreachable!(),
+        };
+        (
+            self.clamp_coordinate(coordinate, zero, upper)
+                .cast(DType::Int),
+            valid,
+        )
+    }
+
+    fn gather_grid_point(
+        &mut self,
+        input: GraphTensor,
+        indices: &[GraphTensor],
+        output_shape: &[IntExpr],
+        padding_mode: i64,
+        align_corners: bool,
+    ) -> GraphTensor {
+        let spatial_rank = indices.len();
+        let rank = input.legacy_tracker_ref().len();
+        let strides = super::movement_dynamic::row_major_strides(&input.dims());
+        let mut flat = self.axis_positions(output_shape, 0) * strides[0]
+            + self.axis_positions(output_shape, 1) * strides[1];
+        let mut valid = self
+            .graph
+            .constant(1)
+            .cast(DType::Bool)
+            .expand_rhs(indices[0].shape);
+        for (spatial, index) in indices.iter().copied().enumerate() {
+            let (bounded, coordinate_valid) = self.bound_grid_index(
+                index,
+                input.dims()[rank - spatial_rank + spatial],
+                padding_mode,
+                align_corners,
+            );
+            valid = self.bool_and(valid, coordinate_valid);
+            flat += bounded.expand_dim(1, output_shape[1]) * strides[rank - spatial_rank + spatial];
+        }
+        let gathered = reshape_tensor(
+            input.flatten().gather(flat.flatten()),
+            output_shape.to_vec(),
+        );
+        let valid = valid.expand_dim(1, output_shape[1]);
+        let zero = self.full_tensor(gathered.dims(), input.dtype, 0.0);
+        self.select(valid, gathered, zero)
+    }
+
+    fn cubic_coefficient(&mut self, distance: GraphTensor) -> GraphTensor {
+        let absolute = self.real_abs(distance);
+        let one = self.constant_like(absolute, 1.0);
+        let two = self.constant_like(absolute, 2.0);
+        let alpha = self.constant_like(absolute, -0.75);
+        let inner = ((alpha + two) * absolute - (alpha + self.constant_like(absolute, 3.0)))
+            * absolute
+            * absolute
+            + one;
+        let outer = ((alpha * absolute - alpha * self.constant_like(absolute, 5.0)) * absolute
+            + alpha * self.constant_like(absolute, 8.0))
+            * absolute
+            - alpha * self.constant_like(absolute, 4.0);
+        let inside_one = absolute.le(one);
+        let inside_two = absolute.lt(two);
+        let zero = self.constant_like(absolute, 0.0);
+        let outer_or_zero = self.select(inside_two, outer, zero);
+        self.select(inside_one, inner, outer_or_zero)
+    }
+
+    pub(crate) fn translate_grid_sampler(
+        &mut self,
+        node: &Node,
+        spatial_rank: usize,
+    ) -> Result<GraphTensor> {
+        let input = self.get_input_tensor(node, 0)?;
+        let grid = self.get_input_tensor(node, 1)?;
+        anyhow::ensure!(
+            input.legacy_tracker_ref().len() == spatial_rank + 2 && grid.legacy_tracker_ref().len() == spatial_rank + 2,
+            "grid_sampler_{spatial_rank}d received invalid ranks"
+        );
+        anyhow::ensure!(
+            grid.dims()[spatial_rank + 1].to_usize() == Some(spatial_rank),
+            "grid coordinate dimension must equal the spatial rank"
+        );
+        let interpolation_mode = self.get_int_arg(node, 2)?;
+        let padding_mode = self.get_int_arg(node, 3)?;
+        let align_corners = self.get_bool_arg(node, 4)?;
+        anyhow::ensure!(
+            matches!(interpolation_mode, 0 | 1) || (spatial_rank == 2 && interpolation_mode == 2),
+            "unsupported grid_sampler interpolation mode {interpolation_mode}"
+        );
+        anyhow::ensure!(
+            matches!(padding_mode, 0..=2),
+            "unsupported grid_sampler padding mode {padding_mode}"
+        );
+        let output_shape = self.output_meta_shape(node)?;
+        let mut coordinates = Vec::with_capacity(spatial_rank);
+        for spatial in 0..spatial_rank {
+            let lane = spatial_rank - 1 - spatial;
+            let normalized = grid
+                .slice_along(lane..lane + 1, spatial_rank + 1)
+                .squeeze(spatial_rank + 1);
+            coordinates.push(self.grid_source_coordinate(
+                normalized,
+                input.dims()[2 + spatial],
+                if interpolation_mode == 2 {
+                    0
+                } else {
+                    padding_mode
+                },
+                align_corners,
+                if interpolation_mode == 1 {
+                    Some(-1.0)
+                } else if spatial_rank == 3 && padding_mode != 0 {
+                    Some(1.0)
+                } else {
+                    None
+                },
+            ));
+        }
+
+        if interpolation_mode == 1 {
+            let rounded = coordinates
+                .into_iter()
+                .map(|coordinate| self.round_to_even(coordinate))
+                .collect::<Vec<_>>();
+            return Ok(self.gather_grid_point(
+                input,
+                &rounded,
+                &output_shape,
+                padding_mode,
+                align_corners,
+            ));
+        }
+
+        if interpolation_mode == 2 {
+            let bases = coordinates
+                .iter()
+                .copied()
+                .map(|coordinate| self.floor_tensor(coordinate))
+                .collect::<Vec<_>>();
+            let mut result = self.full_tensor(output_shape.clone(), input.dtype, 0.0);
+            for y_offset in -1..=2 {
+                for x_offset in -1..=2 {
+                    let y_index = bases[0] + y_offset as f32;
+                    let x_index = bases[1] + x_offset as f32;
+                    let y_weight = self.cubic_coefficient(coordinates[0] - y_index);
+                    let x_weight = self.cubic_coefficient(coordinates[1] - x_index);
+                    let value = self.gather_grid_point(
+                        input,
+                        &[y_index, x_index],
+                        &output_shape,
+                        padding_mode,
+                        align_corners,
+                    );
+                    result += value * (y_weight * x_weight).expand_dim(1, output_shape[1]);
+                }
+            }
+            return Ok(result);
+        }
+
+        let lower = coordinates
+            .iter()
+            .copied()
+            .map(|coordinate| self.floor_tensor(coordinate))
+            .collect::<Vec<_>>();
+        let fractions = coordinates
+            .iter()
+            .zip(lower.iter())
+            .map(|(&coordinate, &base)| coordinate - base)
+            .collect::<Vec<_>>();
+        let mut result = self.full_tensor(output_shape.clone(), input.dtype, 0.0);
+        for corner in 0..(1usize << spatial_rank) {
+            let mut corner_indices = Vec::with_capacity(spatial_rank);
+            let mut weight = self.full_tensor(fractions[0].dims(), grid.dtype, 1.0);
+            for spatial in 0..spatial_rank {
+                if corner & (1 << spatial) == 0 {
+                    corner_indices.push(lower[spatial]);
+                    weight *= self.constant_like(weight, 1.0) - fractions[spatial];
+                } else {
+                    corner_indices.push(lower[spatial] + 1.0);
+                    weight *= fractions[spatial];
+                }
+            }
+            let value = self.gather_grid_point(
+                input,
+                &corner_indices,
+                &output_shape,
+                padding_mode,
+                align_corners,
+            );
+            result += value * weight.cast(input.dtype).expand_dim(1, output_shape[1]);
+        }
+        Ok(result)
+    }
+}

--- a/crates/luminal_python/rust/src/translator/tensor.rs
+++ b/crates/luminal_python/rust/src/translator/tensor.rs
@@ -19,8 +19,6 @@ const TOPK_K_ARG: usize = 1;
 const TOPK_DIM_ARG: usize = 2;
 
 const SORT_INPUT_ARG: usize = 0;
-const SORT_DIM_ARG: usize = 1;
-const SORT_DESCENDING_ARG: usize = 2;
 
 const WHERE_COND_ARG: usize = 0;
 const WHERE_X_ARG: usize = 1;
@@ -98,6 +96,29 @@ pub(crate) fn copy_tensor(
 }
 
 impl<'a> Translator<'a> {
+    pub(crate) fn translate_trilinear(&mut self, node: &Node) -> Result<GraphTensor> {
+        let mut inputs = [
+            self.get_input_tensor(node, 0)?,
+            self.get_input_tensor(node, 1)?,
+            self.get_input_tensor(node, 2)?,
+        ];
+        for (input, argument) in inputs.iter_mut().zip(3..6) {
+            for raw_dim in self.get_ints_arg(node, argument)? {
+                let dim = normalize_dim(raw_dim, input.legacy_tracker_ref().len() + 1);
+                *input = input.unsqueeze(dim);
+            }
+        }
+        let (left, middle) = broadcast_binary(inputs[0], inputs[1]);
+        let (product, right) = broadcast_binary(left * middle, inputs[2]);
+        let rank = product.legacy_tracker_ref().len();
+        let dimensions = self
+            .get_ints_arg(node, 6)?
+            .into_iter()
+            .map(|dim| normalize_dim(dim, rank))
+            .collect::<Vec<_>>();
+        Ok((product * right).sum(dimensions))
+    }
+
     pub(crate) fn constructor_scalar_arg(
         &self,
         node: &Node,
@@ -293,7 +314,9 @@ impl<'a> Translator<'a> {
         // ATen lists the last dimension first: [last_left, last_right,
         // penultimate_left, ...]. GraphTensor::pad expects tensor-axis order.
         let mut pairs = raw
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| (pair[0], pair[1]))
             .collect::<Vec<_>>();
         pairs.reverse();
@@ -465,6 +488,132 @@ impl<'a> Translator<'a> {
         Ok(matches.cast(out_dtype).sum(1))
     }
 
+    /// Lower bucketize/searchsorted by comparing each query with every entry
+    /// in its sorted row and reducing the boolean insertion predicate. This is
+    /// O(N) per query, but it is exact, fixed-shape, and uses only existing
+    /// broadcast/comparison/reduction primitives.
+    pub(crate) fn translate_searchsorted(&mut self, node: &Node) -> Result<GraphTensor> {
+        let bucketize = node.target == "torch.ops.aten.bucketize.Tensor";
+        let mut sorted = self.get_input_tensor(node, usize::from(bucketize))?;
+        let query_index = usize::from(!bucketize);
+        let query = if let Some(name) = node.inputs[query_index].arg.as_tensor_name() {
+            self.get_tensor(name)?
+        } else {
+            let scalar = self.constructor_scalar_arg(node, query_index)?;
+            self.typed_scalar_constant(&scalar, sorted.dtype)?
+        };
+
+        anyhow::ensure!(
+            !sorted.legacy_tracker_ref().is_empty(),
+            "searchsorted requires a sorted sequence with rank at least one"
+        );
+        let sorted_axis = sorted.legacy_tracker_ref().len() - 1;
+        if let Some(sorter_name) = node
+            .inputs
+            .iter()
+            .find(|input| input.name == "sorter")
+            .and_then(|input| input.arg.as_tensor_name())
+        {
+            let sorter = self.get_tensor(sorter_name)?;
+            sorted = super::movement_dynamic::pt2_gather_elements(sorted, sorter, sorted_axis);
+        }
+
+        let (sorted, query) = ensure_same_dtype(sorted, query);
+        let row_length = sorted.dims()[sorted_axis];
+        let query_rank = query.legacy_tracker_ref().len();
+        let (boundaries, queries) = if sorted.legacy_tracker_ref().len() == 1 {
+            let mut boundaries = sorted;
+            for (axis, size) in query.dims().into_iter().enumerate() {
+                boundaries = boundaries.expand_dim(axis, size);
+            }
+            (boundaries, query.expand_dim(query_rank, row_length))
+        } else {
+            anyhow::ensure!(
+                query_rank == sorted.legacy_tracker_ref().len(),
+                "batched searchsorted requires query and sequence ranks to match"
+            );
+            for axis in 0..sorted_axis {
+                anyhow::ensure!(
+                    query.dims()[axis] == sorted.dims()[axis],
+                    "batched searchsorted prefix dimensions must match"
+                );
+            }
+            let query_width = query.dims()[sorted_axis];
+            (
+                sorted.expand_dim(sorted_axis, query_width),
+                query.expand_dim(query_rank, row_length),
+            )
+        };
+
+        let right = node
+            .inputs
+            .iter()
+            .position(|input| input.name == "right")
+            .and_then(|index| self.get_bool_arg(node, index).ok())
+            .unwrap_or(false)
+            || node.inputs.iter().any(|input| {
+                input.name == "side"
+                    && matches!(&input.arg, Argument::Other(value) if value.as_str() == Some("right") || value.get("as_string").and_then(|v| v.as_str()) == Some("right"))
+            });
+        let before = if right {
+            boundaries.le(queries)
+        } else {
+            boundaries.lt(queries)
+        };
+        let mut result = before.cast(DType::I64).sum(query_rank);
+        if matches!(
+            query.dtype,
+            DType::F16 | DType::Bf16 | DType::F32 | DType::F64
+        ) {
+            let nan = self.is_nan(query);
+            let end = self
+                .graph
+                .constant(row_length)
+                .cast(DType::I64)
+                .expand_rhs(result.dims());
+            result = self.select(nan, end, result);
+        }
+        Ok(result.cast(self.output_meta_dtype(node)?))
+    }
+
+    pub(crate) fn translate_triangular_indices(&mut self, node: &Node) -> Result<GraphTensor> {
+        let rows = self.get_int_arg(node, 0)?;
+        let columns = self.get_int_arg(node, 1)?;
+        anyhow::ensure!(
+            rows >= 0 && columns >= 0,
+            "triangular index dimensions must be nonnegative"
+        );
+        let offset = self.get_int_arg(node, 2).unwrap_or(0);
+        let rows = IntExpr::from(rows);
+        let columns = IntExpr::from(columns);
+        let row = self
+            .graph
+            .arange(rows)
+            .cast(DType::I64)
+            .expand_dim(1, columns);
+        let column = self
+            .graph
+            .arange(columns)
+            .cast(DType::I64)
+            .expand_dim(0, rows);
+        let shifted_row = row + offset;
+        let truth = if node.target == "torch.ops.aten.tril_indices.default" {
+            column.le(shifted_row)
+        } else {
+            column.ge(shifted_row)
+        };
+        let output_shape = self.output_meta_shape(node)?;
+        anyhow::ensure!(
+            output_shape.len() == 2,
+            "triangular indices must have rank two"
+        );
+        let coordinates =
+            super::movement::nonzero_static_from_truth(self, truth, output_shape[1], 0);
+        Ok(coordinates
+            .permute(&[1, 0])
+            .cast(self.output_meta_dtype(node)?))
+    }
+
     /// Lower `aten.empty.memory_format` and `aten.empty_permuted.default`.
     ///
     /// Both allocate an uninitialised tensor; the caller is responsible for
@@ -474,7 +623,12 @@ impl<'a> Translator<'a> {
     /// `aten.empty_permuted` additionally takes a `physical_layout` arg
     /// (the storage permutation); for a zero-filled tensor that's a no-op.
     pub(crate) fn translate_empty(&mut self, node: &Node) -> Result<GraphTensor> {
-        let shape = self.get_exprs_arg(node, FULL_SHAPE_ARG)?;
+        let shape_arg = if node.target == "torch.ops.aten.new_empty_strided.default" {
+            1
+        } else {
+            FULL_SHAPE_ARG
+        };
+        let shape = self.get_exprs_arg(node, shape_arg)?;
         let dtype = self.output_meta_dtype(node)?;
         let zero = self.graph.constant_float(0.0).cast(dtype);
         Ok(if shape.is_empty() {
@@ -755,34 +909,53 @@ impl<'a> Translator<'a> {
 
     pub(crate) fn translate_sort(&mut self, node: &Node) -> Result<()> {
         let a = self.get_input_tensor(node, SORT_INPUT_ARG)?;
-        let dim = if node.inputs.len() > SORT_DIM_ARG {
-            self.get_int_arg(node, SORT_DIM_ARG).unwrap_or(-1)
-        } else {
-            -1
-        };
-        let descending = if node.inputs.len() > SORT_DESCENDING_ARG {
-            self.get_bool_arg(node, SORT_DESCENDING_ARG)
-                .unwrap_or(false)
-        } else {
-            false
-        };
+        // `sort.stable` inserts a keyword-only `stable` argument before dim,
+        // so resolve these by schema name rather than by overload-dependent
+        // position. `stable_argsort` is stable regardless; `stable=None` and
+        // `stable=false` permit stability but do not require instability.
+        let dim = node
+            .inputs
+            .iter()
+            .position(|input| input.name == "dim")
+            .and_then(|index| self.get_int_arg(node, index).ok())
+            .unwrap_or(-1);
+        let descending = node
+            .inputs
+            .iter()
+            .position(|input| input.name == "descending")
+            .and_then(|index| self.get_bool_arg(node, index).ok())
+            .unwrap_or(false);
         let dim = normalize_dim(dim, a.legacy_tracker_ref().len());
 
         // Determine output names (sort returns (values, indices))
-        let values_name = node
+        let tuple_outputs = node
             .outputs
             .first()
-            .and_then(|o| o.as_tensor.as_ref().map(|t| t.name.clone()));
-        let indices_name =
-            if let Some(ts) = node.outputs.first().and_then(|o| o.as_tensors.as_ref()) {
-                ts.get(1).map(|t| t.name.clone())
-            } else if node.outputs.len() > 1 {
-                node.outputs[1].as_tensor.as_ref().map(|t| t.name.clone())
-            } else {
-                None
-            };
+            .and_then(|output| output.as_tensors.as_ref());
+        let values_name = if let Some(outputs) = tuple_outputs {
+            outputs.first().map(|tensor| tensor.name.clone())
+        } else {
+            node.outputs
+                .first()
+                .and_then(|output| output.as_tensor.as_ref().map(|tensor| tensor.name.clone()))
+        };
+        let indices_name = if let Some(outputs) = tuple_outputs {
+            outputs.get(1).map(|tensor| tensor.name.clone())
+        } else if node.outputs.len() > 1 {
+            node.outputs[1]
+                .as_tensor
+                .as_ref()
+                .map(|tensor| tensor.name.clone())
+        } else {
+            None
+        };
 
-        let full_argsort = a.stable_argsort(dim, descending);
+        let sort_key = if a.dtype == DType::Bool {
+            a.cast(DType::F32)
+        } else {
+            a
+        };
+        let full_argsort = sort_key.stable_argsort(dim, descending);
 
         if let Some(val_name) = values_name
             && !val_name.is_empty()

--- a/crates/luminal_python/rust/src/translator/unary.rs
+++ b/crates/luminal_python/rust/src/translator/unary.rs
@@ -20,6 +20,14 @@ const FLOOR_DIVIDE_OTHER_ARG: usize = 1;
 const DIV_MODE_INPUT_ARG: usize = 0;
 const DIV_MODE_OTHER_ARG: usize = 1;
 
+#[derive(Clone, Copy)]
+pub(crate) enum ChebyshevKind {
+    First,
+    Second,
+    Third,
+    Fourth,
+}
+
 impl<'a> Translator<'a> {
     pub(crate) fn translate_argsort(&mut self, node: &Node) -> Result<GraphTensor> {
         let a = self.get_input_tensor(node, ARGSORT_INPUT_ARG)?;
@@ -40,7 +48,12 @@ impl<'a> Translator<'a> {
         // efficient default for native Rust callers). Cast at the
         // PT2↔luminal boundary so the strict output-read path sees
         // an I64 buffer.
-        Ok(a.stable_argsort(dim, descending).cast(DType::I64))
+        let sort_key = if a.dtype == DType::Bool {
+            a.cast(DType::F32)
+        } else {
+            a
+        };
+        Ok(sort_key.stable_argsort(dim, descending).cast(DType::I64))
     }
 
     pub(crate) fn translate_unary_op(
@@ -52,6 +65,1171 @@ impl<'a> Translator<'a> {
             .get_input_tensor(node, 0)?
             .cast(self.output_meta_dtype(node)?);
         Ok(f(a))
+    }
+
+    pub(crate) fn floor_tensor(&mut self, value: GraphTensor) -> GraphTensor {
+        let truncated = value.cast(DType::I64).cast(value.dtype);
+        truncated - value.lt(truncated).cast(value.dtype)
+    }
+
+    /// Round to nearest with ties to even, using only casts, comparisons and
+    /// arithmetic. Integral inputs are already rounded and remain unchanged.
+    pub(crate) fn round_to_even(&mut self, value: GraphTensor) -> GraphTensor {
+        if matches!(
+            value.dtype,
+            DType::Int
+                | DType::I64
+                | DType::I4
+                | DType::U4
+                | DType::I8
+                | DType::U8
+                | DType::I16
+                | DType::U16
+                | DType::Bool
+        ) {
+            return value;
+        }
+
+        let lower = self.floor_tensor(value);
+        let half = self.constant_like(value, 0.5);
+        let fraction = value - lower;
+        let above_half = fraction.gt(half);
+        let exactly_half = fraction.eq(half);
+        let two = self.constant_like(value, 2.0);
+        let odd_lower = (lower % two).ne(self.constant_like(value, 0.0));
+        let increment = self.bool_or(above_half, self.bool_and(exactly_half, odd_lower));
+        let rounded = lower + increment.cast(value.dtype);
+
+        // Integer casts are not meaningful for IEEE exceptional values.
+        let nan = self.is_nan(value);
+        let infinite = self.is_inf(value);
+        let exceptional = self.bool_or(nan, infinite);
+        self.select(exceptional, value, rounded)
+    }
+
+    pub(crate) fn translate_round(&mut self, node: &Node) -> Result<GraphTensor> {
+        let value = self.get_input_tensor(node, 0)?;
+        let decimals = self.named_int_arg(node, "decimals").unwrap_or(0);
+        if decimals == 0
+            || !matches!(
+                value.dtype,
+                DType::F16 | DType::Bf16 | DType::F32 | DType::F64
+            )
+        {
+            return Ok(self.round_to_even(value));
+        }
+        let scale = 10_f64.powi(decimals.unsigned_abs().min(i32::MAX as u64) as i32);
+        let scale = self.constant_like(value, scale);
+        Ok(if decimals > 0 {
+            self.round_to_even(value * scale) / scale
+        } else {
+            self.round_to_even(value / scale) * scale
+        })
+    }
+
+    pub(crate) fn translate_hardtanh(&mut self, node: &Node) -> Result<GraphTensor> {
+        let value = self.get_input_tensor(node, 0)?;
+        let minimum = self.get_float_arg(node, 1).unwrap_or(-1.0);
+        let maximum = self.get_float_arg(node, 2).unwrap_or(1.0);
+        let minimum = self.constant_like(value, minimum);
+        let maximum = self.constant_like(value, maximum);
+        let lower_clamped = self.select(value.lt(minimum), minimum, value);
+        Ok(self.select(lower_clamped.gt(maximum), maximum, lower_clamped))
+    }
+
+    pub(crate) fn translate_leaky_relu(&mut self, node: &Node) -> Result<GraphTensor> {
+        let value = self.unary_input(node)?;
+        let slope = self.get_float_arg(node, 1).unwrap_or(0.01);
+        let zero = self.constant_like(value, 0.0);
+        let negative = value * self.constant_like(value, slope);
+        Ok(self.select(value.gt(zero), value, negative))
+    }
+
+    pub(crate) fn translate_elu(&mut self, node: &Node) -> Result<GraphTensor> {
+        let value = self.unary_input(node)?;
+        let alpha = self.get_float_arg(node, 1).unwrap_or(1.0);
+        let scale = self.get_float_arg(node, 2).unwrap_or(1.0);
+        let input_scale = self.get_float_arg(node, 3).unwrap_or(1.0);
+        let zero = self.constant_like(value, 0.0);
+        let input_scale = self.constant_like(value, input_scale);
+        let one = self.constant_like(value, 1.0);
+        let negative =
+            (self.real_exp(value * input_scale) - one) * self.constant_like(value, alpha);
+        let selected = self.select(value.gt(zero), value, negative);
+        Ok(selected * self.constant_like(value, scale))
+    }
+
+    pub(crate) fn translate_signbit(&mut self, node: &Node) -> Result<GraphTensor> {
+        let value = self.get_input_tensor(node, 0)?;
+        Ok(
+            if matches!(
+                value.dtype,
+                DType::F16 | DType::Bf16 | DType::F32 | DType::F64
+            ) {
+                self.signbit(value)
+            } else {
+                value.lt(self.constant_like(value, 0.0))
+            },
+        )
+    }
+
+    #[allow(clippy::excessive_precision)]
+    pub(crate) fn real_erf(&mut self, value: GraphTensor) -> GraphTensor {
+        // Abramowitz & Stegun 7.1.28 (maximum error about 1.5e-7).
+        let absolute = self.real_abs(value);
+        let t = (absolute * self.constant_like(value, 0.327_591_1)
+            + self.constant_like(value, 1.0))
+        .reciprocal();
+        let polynomial = t
+            * (t * (t
+                * (t * (t * self.constant_like(value, 1.061_405_429)
+                    + self.constant_like(value, -1.453_152_027))
+                    + self.constant_like(value, 1.421_413_741))
+                + self.constant_like(value, -0.284_496_736))
+                + self.constant_like(value, 0.254_829_592));
+        let magnitude =
+            self.constant_like(value, 1.0) - polynomial * self.real_exp(value.square() * -1.0);
+        self.copy_sign(magnitude, value)
+    }
+
+    pub(crate) fn translate_erf(&mut self, node: &Node) -> Result<GraphTensor> {
+        let value = self.unary_input(node)?;
+        Ok(self.real_erf(value))
+    }
+
+    pub(crate) fn translate_erfc(&mut self, node: &Node) -> Result<GraphTensor> {
+        let value = self.unary_input(node)?;
+        Ok(self.real_erfc(value))
+    }
+
+    fn erfcx_positive(&mut self, value: GraphTensor) -> GraphTensor {
+        // This is the positive branch of the Numerical Recipes erfc
+        // approximation after cancelling exp(-x^2). Keeping erfcx in this
+        // scaled form avoids both the underflow and the growing relative error
+        // of computing erfc(x) * exp(x^2) separately.
+        let t =
+            (value * self.constant_like(value, 0.5) + self.constant_like(value, 1.0)).reciprocal();
+        let polynomial = t
+            * (t * (t
+                * (t * (t
+                    * (t * (t
+                        * (t * self.constant_like(value, 0.170_872_77)
+                            + self.constant_like(value, -0.822_152_23))
+                        + self.constant_like(value, 1.488_515_87))
+                        + self.constant_like(value, -1.135_203_98))
+                    + self.constant_like(value, 0.278_868_07))
+                    + self.constant_like(value, -0.186_288_06))
+                + self.constant_like(value, 0.096_784_18))
+                + self.constant_like(value, 0.374_091_96))
+            + self.constant_like(value, 1.000_023_68);
+        let offset = self.constant_like(value, -1.265_512_23);
+        t * self.real_exp(polynomial * t + offset)
+    }
+
+    pub(crate) fn real_erfc(&mut self, value: GraphTensor) -> GraphTensor {
+        let absolute = self.real_abs(value);
+        let positive = self.erfcx_positive(absolute) * self.real_exp(absolute.square() * -1.0);
+        let negative = self.constant_like(value, 2.0) - positive;
+        let zero = self.constant_like(value, 0.0);
+        self.select(value.lt(zero), negative, positive)
+    }
+
+    pub(crate) fn translate_erfcx(&mut self, node: &Node) -> Result<GraphTensor> {
+        let value = self.unary_input(node)?;
+        let absolute = self.real_abs(value);
+        let positive = self.erfcx_positive(absolute);
+        let negative = self.constant_like(value, 2.0) * self.real_exp(value.square()) - positive;
+        let zero = self.constant_like(value, 0.0);
+        Ok(self.select(value.lt(zero), negative, positive))
+    }
+
+    fn chebyshev_evaluate(&mut self, value: GraphTensor, coefficients: &[f64]) -> GraphTensor {
+        debug_assert!(coefficients.len() >= 2);
+        let mut b0 = self.constant_like(value, coefficients[0]);
+        let mut b1 = self.constant_like(value, 0.0);
+        let mut b2 = b1;
+        for coefficient in coefficients.iter().copied().skip(1) {
+            b2 = b1;
+            b1 = b0;
+            b0 = value * b1 - b2 + self.constant_like(value, coefficient);
+        }
+        (b0 - b2) * 0.5
+    }
+
+    #[allow(clippy::excessive_precision)]
+    fn modified_bessel_i0(&mut self, value: GraphTensor, scaled: bool) -> GraphTensor {
+        #[rustfmt::skip]
+        const SMALL: [f64; 30] = [-4.41534164647933937950E-18, 3.33079451882223809783E-17, -2.43127984654795469359E-16, 1.71539128555513303061E-15, -1.16853328779934516808E-14, 7.67618549860493561688E-14, -4.85644678311192946090E-13, 2.95505266312963983461E-12, -1.72682629144155570723E-11, 9.67580903537323691224E-11, -5.18979560163526290666E-10, 2.65982372468238635035E-9, -1.30002500998624804212E-8, 6.04699502254191894932E-8, -2.67079385394061173391E-7, 1.11738753912010371815E-6, -4.41673835845875056359E-6, 1.64484480707288970893E-5, -5.75419501008210370398E-5, 1.88502885095841655729E-4, -5.76375574538582365885E-4, 1.63947561694133579842E-3, -4.32430999505057594430E-3, 1.05464603945949983183E-2, -2.37374148058994688156E-2, 4.93052842396707084878E-2, -9.49010970480476444210E-2, 1.71620901522208775349E-1, -3.04682672343198398683E-1, 6.76795274409476084995E-1,];
+        #[rustfmt::skip]
+        const LARGE: [f64; 25] = [-7.23318048787475395456E-18, -4.83050448594418207126E-18, 4.46562142029675999901E-17, 3.46122286769746109310E-17, -2.82762398051658348494E-16, -3.42548561967721913462E-16, 1.77256013305652638360E-15, 3.81168066935262242075E-15, -9.55484669882830764870E-15, -4.15056934728722208663E-14, 1.54008621752140982691E-14, 3.85277838274214270114E-13, 7.18012445138366623367E-13, -1.79417853150680611778E-12, -1.32158118404477131188E-11, -3.14991652796324136454E-11, 1.18891471078464383424E-11, 4.94060238822496958910E-10, 3.39623202570838634515E-9, 2.26666899049817806459E-8, 2.04891858946906374183E-7, 2.89137052083475648297E-6, 6.88975834691682398426E-5, 3.36911647825569408990E-3, 8.04490411014108831608E-1,];
+
+        self.modified_bessel_i(value, &SMALL, &LARGE, 0, scaled)
+    }
+
+    #[allow(clippy::excessive_precision)]
+    fn modified_bessel_i1(&mut self, value: GraphTensor, scaled: bool) -> GraphTensor {
+        #[rustfmt::skip]
+        const SMALL: [f64; 29] = [2.77791411276104639959E-18, -2.11142121435816608115E-17, 1.55363195773620046921E-16, -1.10559694773538630805E-15, 7.60068429473540693410E-15, -5.04218550472791168711E-14, 3.22379336594557470981E-13, -1.98397439776494371520E-12, 1.17361862988909016308E-11, -6.66348972350202774223E-11, 3.62559028155211703701E-10, -1.88724975172282928790E-9, 9.38153738649577178388E-9, -4.44505912879632808065E-8, 2.00329475355213526229E-7, -8.56872026469545474066E-7, 3.47025130813767847674E-6, -1.32731636560394358279E-5, 4.78156510755005422638E-5, -1.61760815825896745588E-4, 5.12285956168575772895E-4, -1.51357245063125314899E-3, 4.15642294431288815669E-3, -1.05640848946261981558E-2, 2.47264490306265168283E-2, -5.29459812080949914269E-2, 1.02643658689847095384E-1, -1.76416518357834055153E-1, 2.52587186443633654823E-1,];
+        #[rustfmt::skip]
+        const LARGE: [f64; 25] = [7.51729631084210481353E-18, 4.41434832307170791151E-18, -4.65030536848935832153E-17, -3.20952592199342395980E-17, 2.96262899764595013876E-16, 3.30820231092092828324E-16, -1.88035477551078244854E-15, -3.81440307243700780478E-15, 1.04202769841288027642E-14, 4.27244001671195135429E-14, -2.10154184277266431302E-14, -4.08355111109219731823E-13, -7.19855177624590851209E-13, 2.03562854414708950722E-12, 1.41258074366137813316E-11, 3.25260358301548823856E-11, -1.89749581235054123450E-11, -5.58974346219658380687E-10, -3.83538038596423702205E-9, -2.63146884688951950684E-8, -2.51223623787020892529E-7, -3.88256480887769039346E-6, -1.10588938762623716291E-4, -9.76109749136146840777E-3, 7.78576235018280120474E-1,];
+
+        self.modified_bessel_i(value, &SMALL, &LARGE, 1, scaled)
+    }
+
+    fn modified_bessel_i(
+        &mut self,
+        value: GraphTensor,
+        small_coefficients: &[f64],
+        large_coefficients: &[f64],
+        order: usize,
+        scaled: bool,
+    ) -> GraphTensor {
+        let absolute = self.real_abs(value);
+        let small_argument = absolute * 0.5 - self.constant_like(value, 2.0);
+        let mut small = self.chebyshev_evaluate(small_argument, small_coefficients);
+        if order == 1 {
+            small *= absolute;
+        }
+        let large_argument =
+            self.constant_like(value, 32.0) / absolute - self.constant_like(value, 2.0);
+        let mut large =
+            self.chebyshev_evaluate(large_argument, large_coefficients) / absolute.sqrt();
+        if !scaled {
+            let exponential = self.real_exp(absolute);
+            small *= exponential;
+            large *= exponential;
+        }
+        let threshold = self.constant_like(value, 8.0);
+        let magnitude = self.select(absolute.le(threshold), small, large);
+        if order == 0 {
+            magnitude
+        } else {
+            let zero = self.constant_like(value, 0.0);
+            self.select(value.lt(zero), -magnitude, magnitude)
+        }
+    }
+
+    pub(crate) fn translate_modified_bessel(
+        &mut self,
+        node: &Node,
+        order: usize,
+        scaled: bool,
+    ) -> Result<GraphTensor> {
+        let value = self.unary_input(node)?;
+        Ok(if order == 0 {
+            self.modified_bessel_i0(value, scaled)
+        } else {
+            self.modified_bessel_i1(value, scaled)
+        })
+    }
+
+    pub(crate) fn translate_spherical_bessel_j0(&mut self, node: &Node) -> Result<GraphTensor> {
+        let value = self.unary_input(node)?;
+        let zero = self.constant_like(value, 0.0);
+        let one = self.constant_like(value, 1.0);
+        let finite = value.sin() / value;
+        let is_zero = self.is_zero(value);
+        let with_zero = self.select(is_zero, one, finite);
+        let infinite = self.is_inf(value);
+        Ok(self.select(infinite, zero, with_zero))
+    }
+
+    fn polynomial_evaluate(&mut self, value: GraphTensor, coefficients: &[f64]) -> GraphTensor {
+        let mut result = self.constant_like(value, coefficients[0]);
+        for coefficient in coefficients.iter().copied().skip(1) {
+            result = result * value + self.constant_like(value, coefficient);
+        }
+        result
+    }
+
+    fn polynomial_with_leading_one(
+        &mut self,
+        value: GraphTensor,
+        coefficients: &[f64],
+    ) -> GraphTensor {
+        let mut result = value + self.constant_like(value, coefficients[0]);
+        for coefficient in coefficients.iter().copied().skip(1) {
+            result = result * value + self.constant_like(value, coefficient);
+        }
+        result
+    }
+
+    #[allow(clippy::excessive_precision)]
+    fn cylindrical_bessel_asymptotic(
+        &mut self,
+        value: GraphTensor,
+        order: usize,
+        second_kind: bool,
+    ) -> GraphTensor {
+        #[rustfmt::skip]
+        const J0_PP: [f64; 7] = [7.96936729297347051624e-04, 8.28352392107440799803e-02, 1.23953371646414299388e+00, 5.44725003058768775090e+00, 8.74716500199817011941e+00, 5.30324038235394892183e+00, 9.99999999999999997821e-01,];
+        #[rustfmt::skip]
+        const J0_PQ: [f64; 7] = [9.24408810558863637013e-04, 8.56288474354474431428e-02, 1.25352743901058953537e+00, 5.47097740330417105182e+00, 8.76190883237069594232e+00, 5.30605288235394617618e+00, 1.00000000000000000218e+00,];
+        #[rustfmt::skip]
+        const J0_QP: [f64; 8] = [-1.13663838898469149931e-02, -1.28252718670509318512e+00, -1.95539544257735972385e+01, -9.32060152123768231369e+01, -1.77681167980488050595e+02, -1.47077505154951170175e+02, -5.14105326766599330220e+01, -6.05014350600728481186e+00,];
+        #[rustfmt::skip]
+        const J0_QQ: [f64; 7] = [6.43178256118178023184e+01, 8.56430025976980587198e+02, 3.88240183605401609683e+03, 7.24046774195652478189e+03, 5.93072701187316984827e+03, 2.06209331660327847417e+03, 2.42005740240291393179e+02,];
+        #[rustfmt::skip]
+        const J1_PP: [f64; 7] = [7.62125616208173112003e-04, 7.31397056940917570436e-02, 1.12719608129684925192e+00, 5.11207951146807644818e+00, 8.42404590141772420927e+00, 5.21451598682361504063e+00, 1.00000000000000000254e+00,];
+        #[rustfmt::skip]
+        const J1_PQ: [f64; 7] = [5.71323128072548699714e-04, 6.88455908754495404082e-02, 1.10514232634061696926e+00, 5.07386386128601488557e+00, 8.39985554327604159757e+00, 5.20982848682361821619e+00, 9.99999999999999997461e-01,];
+        #[rustfmt::skip]
+        const J1_QP: [f64; 8] = [5.10862594750176621635e-02, 4.98213872951233449420e+00, 7.58238284132545283818e+01, 3.66779609360150777800e+02, 7.10856304998926107277e+02, 5.97489612400613639965e+02, 2.11688757100572135698e+02, 2.52070205858023719784e+01,];
+        #[rustfmt::skip]
+        const J1_QQ: [f64; 7] = [7.42373277035675149943e+01, 1.05644886038262816351e+03, 4.98641058337653607651e+03, 9.56231892404756170795e+03, 7.99704160447350683650e+03, 2.82619278517639096600e+03, 3.36093607810698293419e+02,];
+
+        let (pp, pq, qp, qq, phase): (&[f64], &[f64], &[f64], &[f64], f64) = if order == 0 {
+            (&J0_PP, &J0_PQ, &J0_QP, &J0_QQ, std::f64::consts::FRAC_PI_4)
+        } else {
+            (
+                &J1_PP,
+                &J1_PQ,
+                &J1_QP,
+                &J1_QQ,
+                2.356194490192344928846982537459627163,
+            )
+        };
+        let reciprocal_square = self.constant_like(value, 25.0) / value.square();
+        let p = self.polynomial_evaluate(reciprocal_square, pp)
+            / self.polynomial_evaluate(reciprocal_square, pq);
+        let q = self.constant_like(value, 5.0) / value
+            * self.polynomial_evaluate(reciprocal_square, qp)
+            / self.polynomial_evaluate(reciprocal_square, qq);
+        let angle = value - self.constant_like(value, phase);
+        let cosine = self.real_cos(angle);
+        let sine = angle.sin();
+        let oscillation = if second_kind {
+            p * sine + q * cosine
+        } else {
+            p * cosine - q * sine
+        };
+        oscillation * self.constant_like(value, 0.797884560802865355879892119868763737)
+            / value.sqrt()
+    }
+
+    #[allow(clippy::excessive_precision)]
+    fn cylindrical_bessel_j0(&mut self, value: GraphTensor) -> GraphTensor {
+        #[rustfmt::skip]
+        const RP: [f64; 4] = [-4.79443220978201773821e+09, 1.95617491946556577543e+12, -2.49248344360967716204e+14, 9.70862251047306323952e+15,];
+        #[rustfmt::skip]
+        const RQ: [f64; 8] = [4.99563147152651017219e+02, 1.73785401676374683123e+05, 4.84409658339962045305e+07, 1.11855537045356834862e+10, 2.11277520115489217587e+12, 3.10518229857422583814e+14, 3.18121955943204943306e+16, 1.71086294081043136091e+18,];
+
+        let absolute = self.real_abs(value);
+        let squared = absolute.square();
+        let ratio = self.polynomial_evaluate(squared, &RP) / self.polynomial_evaluate(squared, &RQ);
+        let ordinary = (squared - self.constant_like(value, 5.78318596294678452118))
+            * (squared - self.constant_like(value, 30.4712623436620863991))
+            * ratio;
+        let near_zero = self.constant_like(value, 1.0) - squared * 0.25;
+        let tiny = self.constant_like(value, 1.0e-5);
+        let small = self.select(absolute.lt(tiny), near_zero, ordinary);
+        let large = self.cylindrical_bessel_asymptotic(absolute, 0, false);
+        let threshold = self.constant_like(value, 5.0);
+        self.select(absolute.le(threshold), small, large)
+    }
+
+    #[allow(clippy::excessive_precision)]
+    fn cylindrical_bessel_j1(&mut self, value: GraphTensor) -> GraphTensor {
+        #[rustfmt::skip]
+        const RP: [f64; 4] = [-8.99971225705559398224e+08, 4.52228297998194034323e+11, -7.27494245221818276015e+13, 3.68295732863852883286e+15,];
+        #[rustfmt::skip]
+        const RQ: [f64; 8] = [6.20836478118054335476e+02, 2.56987256757748830383e+05, 8.35146791431949253037e+07, 2.21511595479792499675e+10, 4.74914122079991414898e+12, 7.84369607876235854894e+14, 8.95222336184627338078e+16, 5.32278620332680085395e+18,];
+
+        let absolute = self.real_abs(value);
+        let squared = absolute.square();
+        let small = self.polynomial_evaluate(squared, &RP) / self.polynomial_evaluate(squared, &RQ)
+            * absolute
+            * (squared - self.constant_like(value, 14.6819706421238932572))
+            * (squared - self.constant_like(value, 49.2184563216946036703));
+        let large = self.cylindrical_bessel_asymptotic(absolute, 1, false);
+        let threshold = self.constant_like(value, 5.0);
+        let magnitude = self.select(absolute.le(threshold), small, large);
+        self.copy_sign(magnitude, value)
+    }
+
+    #[allow(clippy::excessive_precision)]
+    fn cylindrical_bessel_y0(&mut self, value: GraphTensor) -> GraphTensor {
+        #[rustfmt::skip]
+        const YP: [f64; 8] = [1.55924367855235737965e+04, -1.46639295903971606143e+07, 5.43526477051876500413e+09, -9.82136065717911466409e+11, 8.75906394395366999549e+13, -3.46628303384729719441e+15, 4.42733268572569800351e+16, -1.84950800436986690637e+16,];
+        #[rustfmt::skip]
+        const YQ: [f64; 7] = [1.04128353664259848412e+03, 6.26107330137134956842e+05, 2.68919633393814121987e+08, 8.64002487103935000337e+10, 2.02979612750105546709e+13, 3.17157752842975028269e+15, 2.50596256172653059228e+17,];
+
+        let squared = value.square();
+        let small = self.polynomial_evaluate(squared, &YP) / self.polynomial_evaluate(squared, &YQ)
+            + self.constant_like(value, std::f64::consts::FRAC_2_PI)
+                * value.log()
+                * self.cylindrical_bessel_j0(value);
+        let large = self.cylindrical_bessel_asymptotic(value, 0, true);
+        let threshold = self.constant_like(value, 5.0);
+        let ordinary = self.select(value.le(threshold), small, large);
+        self.finish_cylindrical_bessel_y(value, ordinary)
+    }
+
+    #[allow(clippy::excessive_precision)]
+    fn cylindrical_bessel_y1(&mut self, value: GraphTensor) -> GraphTensor {
+        #[rustfmt::skip]
+        const YP: [f64; 6] = [1.26320474790178026440e+09, -6.47355876379160291031e+11, 1.14509511541823727583e+14, -8.12770255501325109621e+15, 2.02439475713594898196e+17, -7.78877196265950026825e+17,];
+        #[rustfmt::skip]
+        const YQ: [f64; 8] = [5.94301592346128195359e+02, 2.35564092943068577943e+05, 7.34811944459721705660e+07, 1.87601316108706159478e+10, 3.88231277496238566008e+12, 6.20557727146953693363e+14, 6.87141087355300489866e+16, 3.97270608116560655612e+18,];
+
+        let squared = value.square();
+        let small = value * self.polynomial_evaluate(squared, &YP)
+            / self.polynomial_evaluate(squared, &YQ)
+            + self.constant_like(value, std::f64::consts::FRAC_2_PI)
+                * (self.cylindrical_bessel_j1(value) * value.log() - value.reciprocal());
+        let large = self.cylindrical_bessel_asymptotic(value, 1, true);
+        let threshold = self.constant_like(value, 5.0);
+        let ordinary = self.select(value.le(threshold), small, large);
+        self.finish_cylindrical_bessel_y(value, ordinary)
+    }
+
+    fn finish_cylindrical_bessel_y(
+        &mut self,
+        value: GraphTensor,
+        ordinary: GraphTensor,
+    ) -> GraphTensor {
+        let negative_infinity = self.constant_like(value, f64::NEG_INFINITY);
+        let nan = self.constant_like(value, f64::NAN);
+        let zero = self.is_zero(value);
+        let with_zero = self.select(zero, negative_infinity, ordinary);
+        let zero_value = self.constant_like(value, 0.0);
+        let negative = value.lt(zero_value);
+        let input_nan = self.is_nan(value);
+        let invalid = self.bool_or(negative, input_nan);
+        self.select(invalid, nan, with_zero)
+    }
+
+    pub(crate) fn translate_cylindrical_bessel(
+        &mut self,
+        node: &Node,
+        order: usize,
+        second_kind: bool,
+    ) -> Result<GraphTensor> {
+        let value = self.unary_input(node)?;
+        Ok(match (order, second_kind) {
+            (0, false) => self.cylindrical_bessel_j0(value),
+            (1, false) => self.cylindrical_bessel_j1(value),
+            (0, true) => self.cylindrical_bessel_y0(value),
+            (1, true) => self.cylindrical_bessel_y1(value),
+            _ => unreachable!(),
+        })
+    }
+
+    #[allow(clippy::excessive_precision)]
+    fn modified_bessel_k(&mut self, value: GraphTensor, order: usize, scaled: bool) -> GraphTensor {
+        #[rustfmt::skip]
+        const K0_A: [f64; 10] = [1.37446543561352307156e-16, 4.25981614279661018399e-14, 1.03496952576338420167e-11, 1.90451637722020886025e-09, 2.53479107902614945675e-07, 2.28621210311945178607e-05, 1.26461541144692592338e-03, 3.59799365153615016266e-02, 3.44289899924628486886e-01, -5.35327393233902768720e-01,];
+        #[rustfmt::skip]
+        const K0_B: [f64; 25] = [5.30043377268626276149e-18, -1.64758043015242134646e-17, 5.21039150503902756861e-17, -1.67823109680541210385e-16, 5.51205597852431940784e-16, -1.84859337734377901440e-15, 6.34007647740507060557e-15, -2.22751332699166985548e-14, 8.03289077536357521100e-14, -2.98009692317273043925e-13, 1.14034058820847496303e-12, -4.51459788337394416547e-12, 1.85594911495471785253e-11, -7.95748924447710747776e-11, 3.57739728140030116597e-10, -1.69753450938905987466e-09, 8.57403401741422608519e-09, -4.66048989768794782956e-08, 2.76681363944501510342e-07, -1.83175552271911948767e-06, 1.39498137188764993662e-05, -1.28495495816278026384e-04, 1.56988388573005337491e-03, -3.14481013119645005427e-02, 2.44030308206595545468e+00,];
+        #[rustfmt::skip]
+        const K1_A: [f64; 11] = [-7.02386347938628759343e-18, -2.42744985051936593393e-15, -6.66690169419932900609e-13, -1.41148839263352776110e-10, -2.21338763073472585583e-08, -2.43340614156596823496e-06, -1.73028895751305206302e-04, -6.97572385963986435018e-03, -1.22611180822657148235e-01, -3.53155960776544875667e-01, 1.52530022733894777053e+00,];
+        #[rustfmt::skip]
+        const K1_B: [f64; 25] = [-5.75674448366501715755e-18, 1.79405087314755922667e-17, -5.68946255844285935196e-17, 1.83809354436663880070e-16, -6.05704724837331885336e-16, 2.03870316562433424052e-15, -7.01983709041831346144e-15, 2.47715442448130437068e-14, -8.97670518232499435011e-14, 3.34841966607842919884e-13, -1.28917396095102890680e-12, 5.13963967348173025100e-12, -2.12996783842756842877e-11, 9.21831518760500529508e-11, -4.19035475934189648750e-10, 2.01504975519703286596e-09, -1.03457624656780970260e-08, 5.74108412545004946722e-08, -3.50196060308781257119e-07, 2.40648494783721712015e-06, -1.93619797416608296024e-05, 1.95215518471351631108e-04, -2.85781685962277938680e-03, 1.03923736576817238437e-01, 2.72062619048444266945e+00,];
+
+        let (small_coefficients, large_coefficients): (&[f64], &[f64]) = if order == 0 {
+            (&K0_A, &K0_B)
+        } else {
+            (&K1_A, &K1_B)
+        };
+        let two = self.constant_like(value, 2.0);
+        let small_argument = value.square() - two;
+        let small_series = self.chebyshev_evaluate(small_argument, small_coefficients);
+        let half = self.constant_like(value, 0.5);
+        let small = if order == 0 {
+            small_series - (value * half).log() * self.modified_bessel_i0(value, false)
+        } else {
+            (value * half).log() * self.modified_bessel_i1(value, false) + small_series / value
+        };
+        let eight = self.constant_like(value, 8.0);
+        let large_argument = eight / value - two;
+        let large = self.chebyshev_evaluate(large_argument, large_coefficients) / value.sqrt();
+        let small = if scaled {
+            small * self.real_exp(value)
+        } else {
+            small
+        };
+        let large = if scaled {
+            large
+        } else {
+            self.real_exp(-value) * large
+        };
+        let ordinary = self.select(value.le(two), small, large);
+        let infinity = self.constant_like(value, f64::INFINITY);
+        let nan = self.constant_like(value, f64::NAN);
+        let zero = self.is_zero(value);
+        let with_zero = self.select(zero, infinity, ordinary);
+        let zero_value = self.constant_like(value, 0.0);
+        let negative = value.lt(zero_value);
+        let input_nan = self.is_nan(value);
+        let invalid = self.bool_or(negative, input_nan);
+        self.select(invalid, nan, with_zero)
+    }
+
+    pub(crate) fn translate_modified_bessel_k(
+        &mut self,
+        node: &Node,
+        order: usize,
+        scaled: bool,
+    ) -> Result<GraphTensor> {
+        let value = self.unary_input(node)?;
+        Ok(self.modified_bessel_k(value, order, scaled))
+    }
+
+    #[allow(clippy::excessive_precision)]
+    fn airy_ai(&mut self, value: GraphTensor) -> GraphTensor {
+        #[rustfmt::skip]
+        const AN: [f64; 8] = [3.46538101525629032477e-01, 1.20075952739645805542e+01, 7.62796053615234516538e+01, 1.68089224934630576269e+02, 1.59756391350164413639e+02, 7.05360906840444183113e+01, 1.40264691163389668864e+01, 9.99999999999999995305e-01,];
+        #[rustfmt::skip]
+        const AD: [f64; 8] = [5.67594532638770212846e-01, 1.47562562584847203173e+01, 8.45138970141474626562e+01, 1.77318088145400459522e+02, 1.64234692871529701831e+02, 7.14778400825575695274e+01, 1.40959135607834029598e+01, 1.00000000000000000470e+00,];
+        #[rustfmt::skip]
+        const AFN: [f64; 9] = [-1.31696323418331795333e-01, -6.26456544431912369773e-01, -6.93158036036933542233e-01, -2.79779981545119124951e-01, -4.91900132609500318020e-02, -4.06265923594885404393e-03, -1.59276496239262096340e-04, -2.77649108155232920844e-06, -1.67787698489114633780e-08,];
+        #[rustfmt::skip]
+        const AFD: [f64; 9] = [1.33560420706553243746e+01, 3.26825032795224613948e+01, 2.67367040941499554804e+01, 9.18707402907259625840e+00, 1.47529146771666414581e+00, 1.15687173795188044134e-01, 4.40291641615211203805e-03, 7.54720348287414296618e-05, 4.51850092970580378464e-07,];
+        #[rustfmt::skip]
+        const AGN: [f64; 11] = [1.97339932091685679179e-02, 3.91103029615688277255e-01, 1.06579897599595591108e+00, 9.39169229816650230044e-01, 3.51465656105547619242e-01, 6.33888919628925490927e-02, 5.85804113048388458567e-03, 2.82851600836737019778e-04, 6.98793669997260967291e-06, 8.11789239554389293311e-08, 3.41551784765923618484e-10,];
+        #[rustfmt::skip]
+        const AGD: [f64; 10] = [9.30892908077441974853e+00, 1.98352928718312140417e+01, 1.55646628932864612953e+01, 5.47686069422975497931e+00, 9.54293611618961883998e-01, 8.64580826352392193095e-02, 4.12656523824222607191e-03, 1.01259085116509135510e-04, 1.17166733214413521882e-06, 4.91834570062930015649e-09,];
+
+        let one = self.constant_like(value, 1.0);
+        let negative_value = -value;
+        let negative_root = negative_value.sqrt();
+        let three = self.constant_like(value, 3.0);
+        let negative_phase = self.constant_like(value, -2.0) * value * negative_root / three;
+        let z = negative_phase.reciprocal();
+        let z_squared = z.square();
+        let f = one
+            + z_squared * self.polynomial_evaluate(z_squared, &AFN)
+                / self.polynomial_evaluate(z_squared, &AFD);
+        let g = z * self.polynomial_evaluate(z_squared, &AGN)
+            / self.polynomial_evaluate(z_squared, &AGD);
+        let angle = negative_phase + self.constant_like(value, std::f64::consts::FRAC_PI_4);
+        let negative = self.constant_like(value, 0.564189583547756286948) / negative_root.sqrt()
+            * (angle.sin() * f - self.real_cos(angle) * g);
+
+        let positive_root = value.sqrt();
+        let two_thirds = self.constant_like(value, 2.0 / 3.0);
+        let zeta = value * positive_root * two_thirds;
+        let inverse_zeta = zeta.reciprocal();
+        let positive = self.constant_like(value, 0.564189583547756286948)
+            * (self.polynomial_evaluate(inverse_zeta, &AN)
+                / self.polynomial_evaluate(inverse_zeta, &AD))
+            * self.real_exp(-zeta)
+            / (positive_root.sqrt() * 2.0);
+
+        // The power-series branch is only selected on [-2.09, 2.09), so a
+        // fixed 30 terms uniformly exceeds F64 precision without any runtime
+        // convergence or control-flow requirement.
+        let cubic = value * value * value;
+        let mut series_f = one;
+        let mut series_g = value;
+        let mut m = one;
+        let mut n = value;
+        for iteration in 0..30 {
+            let k = (iteration * 3) as f64;
+            let m_denominator = self.constant_like(value, (k + 2.0) * (k + 3.0));
+            let n_denominator = self.constant_like(value, (k + 3.0) * (k + 4.0));
+            m = m * cubic / m_denominator;
+            n = n * cubic / n_denominator;
+            series_f += m;
+            series_g += n;
+        }
+        let central = self.constant_like(value, 0.355028053887817239260) * series_f
+            - self.constant_like(value, 0.258819403792806798405) * series_g;
+
+        let negative_threshold = self.constant_like(value, -2.09);
+        let positive_threshold = self.constant_like(value, 2.09);
+        let lower_or_central = self.select(value.lt(negative_threshold), negative, central);
+        let ordinary = self.select(value.ge(positive_threshold), positive, lower_or_central);
+        let underflow_threshold = self.constant_like(value, 103.892);
+        let zero = self.constant_like(value, 0.0);
+        let ordinary = self.select(value.gt(underflow_threshold), zero, ordinary);
+        let infinite = self.is_inf(value);
+        let input_nan = self.is_nan(value);
+        let invalid = self.bool_or(infinite, input_nan);
+        let nan = self.constant_like(value, f64::NAN);
+        self.select(invalid, nan, ordinary)
+    }
+
+    pub(crate) fn translate_airy_ai(&mut self, node: &Node) -> Result<GraphTensor> {
+        let value = self.unary_input(node)?;
+        Ok(self.airy_ai(value))
+    }
+
+    #[allow(clippy::excessive_precision)]
+    fn accurate_real_erf(&mut self, value: GraphTensor) -> GraphTensor {
+        #[rustfmt::skip]
+        const T: [f64; 5] = [9.60497373987051638749E0, 9.00260197203842689217E1, 2.23200534594684319226E3, 7.00332514112805075473E3, 5.55923013010394962768E4,];
+        #[rustfmt::skip]
+        const U: [f64; 5] = [3.35617141647503099647E1, 5.21357949780152679795E2, 4.59432382970980127987E3, 2.26290000613890934246E4, 4.92673942608635921086E4,];
+        #[rustfmt::skip]
+        const P: [f64; 9] = [2.46196981473530512524E-10, 5.64189564831068821977E-1, 7.46321056442269912687E0, 4.86371970985681366614E1, 1.96520832956077098242E2, 5.26445194995477358631E2, 9.34528527171957607540E2, 1.02755188689515710272E3, 5.57535335369399327526E2,];
+        #[rustfmt::skip]
+        const Q: [f64; 8] = [1.32281951154744992508E1, 8.67072140885989742329E1, 3.54937778887819891062E2, 9.75708501743205489753E2, 1.82390916687909736289E3, 2.24633760818710981792E3, 1.65666309194161350182E3, 5.57535340817727675546E2,];
+        #[rustfmt::skip]
+        const R: [f64; 6] = [5.64189583547755073984E-1, 1.27536670759978104416E0, 5.01905042251180477414E0, 6.16021097993053585195E0, 7.40974269950448939160E0, 2.97886665372100240670E0,];
+        #[rustfmt::skip]
+        const S: [f64; 6] = [2.26052863220117276590E0, 9.39603524938001434673E0, 1.20489539808096656605E1, 1.70814450747565897222E1, 9.60896809063285878198E0, 3.36907645100081516050E0,];
+
+        let absolute = self.real_abs(value);
+        let squared = absolute.square();
+        let central = absolute * self.polynomial_evaluate(squared, &T)
+            / self.polynomial_with_leading_one(squared, &U);
+        let moderate =
+            self.polynomial_evaluate(absolute, &P) / self.polynomial_with_leading_one(absolute, &Q);
+        let large =
+            self.polynomial_evaluate(absolute, &R) / self.polynomial_with_leading_one(absolute, &S);
+        let eight = self.constant_like(value, 8.0);
+        let erfc_ratio = self.select(absolute.lt(eight), moderate, large);
+        let erfc = self.real_exp(squared * -1.0) * erfc_ratio;
+        let one = self.constant_like(value, 1.0);
+        let tail = one - erfc;
+        let magnitude = self.select(absolute.lt(one), central, tail);
+        let infinite = self.is_inf(value);
+        let magnitude = self.select(infinite, one, magnitude);
+        self.copy_sign(magnitude, value)
+    }
+
+    #[allow(clippy::excessive_precision)]
+    fn inverse_erf(&mut self, value: GraphTensor) -> GraphTensor {
+        const A: [f64; 4] = [-0.140543331, 0.914624893, -1.645349621, 0.886226899];
+        const B: [f64; 4] = [0.012229801, -0.329097515, 1.442710462, -2.118377725];
+        const C: [f64; 4] = [1.641345311, 3.429567803, -1.624906493, -1.970840454];
+        const D: [f64; 2] = [3.543889200, 1.637067800];
+
+        let absolute = self.real_abs(value);
+        let squared = value.square();
+        let central_numerator = self.polynomial_evaluate(squared, &A);
+        let central_denominator =
+            squared * self.polynomial_evaluate(squared, &B) + self.constant_like(value, 1.0);
+        let central = value * central_numerator / central_denominator;
+
+        let one = self.constant_like(value, 1.0);
+        let tail_root = (((one - absolute) * 0.5).log() * -1.0).sqrt();
+        let tail_numerator = self.polynomial_evaluate(tail_root, &C);
+        let tail_denominator = tail_root
+            * (tail_root * self.constant_like(value, D[1]) + self.constant_like(value, D[0]))
+            + one;
+        let tail = self.copy_sign(tail_numerator, value) / tail_denominator;
+        let threshold = self.constant_like(value, 0.7);
+        let mut result = self.select(absolute.le(threshold), central, tail);
+
+        let derivative_scale = self.constant_like(value, std::f64::consts::FRAC_2_SQRT_PI);
+        for _ in 0..2 {
+            let error = self.accurate_real_erf(result) - value;
+            let derivative = derivative_scale * self.real_exp(result.square() * -1.0);
+            result -= error / derivative;
+        }
+
+        let infinity = self.constant_like(value, f64::INFINITY);
+        let nan = self.constant_like(value, f64::NAN);
+        let endpoint = self.is_zero(absolute - one);
+        let signed_infinity = self.copy_sign(infinity, value);
+        result = self.select(endpoint, signed_infinity, result);
+        let outside = absolute.gt(one);
+        let input_nan = self.is_nan(value);
+        let invalid = self.bool_or(outside, input_nan);
+        self.select(invalid, nan, result)
+    }
+
+    #[allow(clippy::excessive_precision)]
+    fn inverse_normal_cdf(&mut self, value: GraphTensor) -> GraphTensor {
+        #[rustfmt::skip]
+        const P0: [f64; 5] = [-5.99633501014107895267E1, 9.80010754185999661536E1, -5.66762857469070293439E1, 1.39312609387279679503E1, -1.23916583867381258016E0,];
+        #[rustfmt::skip]
+        const Q0: [f64; 9] = [1.00000000000000000000E0, 1.95448858338141759834E0, 4.67627912898881538453E0, 8.63602421390890590575E1, -2.25462687854119370527E2, 2.00260212380060660359E2, -8.20372256168333339912E1, 1.59056225126211695515E1, -1.18331621121330003142E0,];
+        #[rustfmt::skip]
+        const P1: [f64; 9] = [4.05544892305962419923E0, 3.15251094599893866154E1, 5.71628192246421288162E1, 4.40805073893200834700E1, 1.46849561928858024014E1, 2.18663306850790267539E0, -1.40256079171354495875E-1, -3.50424626827848203418E-2, -8.57456785154685413611E-4,];
+        #[rustfmt::skip]
+        const Q1: [f64; 9] = [1.00000000000000000000E0, 1.57799883256466749731E1, 4.53907635128879210584E1, 4.13172038254672030440E1, 1.50425385692907503408E1, 2.50464946208309415979E0, -1.42182922854787788574E-1, -3.80806407691578277194E-2, -9.33259480895457427372E-4,];
+        #[rustfmt::skip]
+        const P2: [f64; 9] = [3.23774891776946035970E0, 6.91522889068984211695E0, 3.93881025292474443415E0, 1.33303460815807542389E0, 2.01485389549179081538E-1, 1.23716634817820021358E-2, 3.01581553508235416007E-4, 2.65806974686737550832E-6, 6.23974539184983293730E-9,];
+        #[rustfmt::skip]
+        const Q2: [f64; 9] = [1.00000000000000000000E0, 6.02427039364742014255E0, 3.67983563856160859403E0, 1.37702099489081330271E0, 2.16236993594496635890E-1, 1.34204006088543189037E-2, 3.28014464682127739104E-4, 2.89247864745380683936E-6, 6.79019408009981274425E-9,];
+
+        let zero = self.constant_like(value, 0.0);
+        let one = self.constant_like(value, 1.0);
+        let tail_threshold = self.constant_like(value, 0.13533528323661269189);
+        let upper_tail = value.gt(one - tail_threshold);
+        let tail_probability = self.select(upper_tail, one - value, value);
+
+        let centered = tail_probability - self.constant_like(value, 0.5);
+        let centered_squared = centered.square();
+        let central = centered
+            + centered * centered_squared * self.polynomial_evaluate(centered_squared, &P0)
+                / self.polynomial_evaluate(centered_squared, &Q0);
+        let central = central * self.constant_like(value, 2.50662827463100050242);
+
+        let root = (tail_probability.log() * -2.0).sqrt();
+        let root_reciprocal = root.reciprocal();
+        let leading = root - root.log() / root;
+        let first = root_reciprocal * self.polynomial_evaluate(root_reciprocal, &P1)
+            / self.polynomial_evaluate(root_reciprocal, &Q1);
+        let second = root_reciprocal * self.polynomial_evaluate(root_reciprocal, &P2)
+            / self.polynomial_evaluate(root_reciprocal, &Q2);
+        let eight = self.constant_like(value, 8.0);
+        let correction = self.select(root.lt(eight), first, second);
+        let magnitude = leading - correction;
+        let tail = self.select(upper_tail, magnitude, -magnitude);
+        let ordinary = self.select(tail_probability.gt(tail_threshold), central, tail);
+
+        let negative_infinity = self.constant_like(value, f64::NEG_INFINITY);
+        let positive_infinity = self.constant_like(value, f64::INFINITY);
+        let nan = self.constant_like(value, f64::NAN);
+        let is_zero = self.is_zero(value);
+        let is_one = self.is_zero(value - one);
+        let outside = self.bool_or(value.lt(zero), value.gt(one));
+        let input_nan = self.is_nan(value);
+        let invalid = self.bool_or(outside, input_nan);
+        let endpoints = self.select(is_zero, negative_infinity, ordinary);
+        let endpoints = self.select(is_one, positive_infinity, endpoints);
+        self.select(invalid, nan, endpoints)
+    }
+
+    pub(crate) fn translate_ndtri(&mut self, node: &Node) -> Result<GraphTensor> {
+        let value = self.unary_input(node)?;
+        Ok(self.inverse_normal_cdf(value))
+    }
+
+    pub(crate) fn translate_erfinv(&mut self, node: &Node) -> Result<GraphTensor> {
+        let value = self.unary_input(node)?;
+        Ok(self.inverse_erf(value))
+    }
+
+    fn numeric_tensor_arg(
+        &mut self,
+        node: &Node,
+        index: usize,
+        dtype: DType,
+    ) -> Result<GraphTensor> {
+        if let Some(name) = node.inputs[index].arg.as_tensor_name() {
+            return Ok(self.get_tensor(name)?.cast(dtype));
+        }
+        let value = node.inputs[index]
+            .arg
+            .as_int()
+            .map(|value| value as f64)
+            .or_else(|| node.inputs[index].arg.as_float())
+            .or_else(|| {
+                node.inputs[index]
+                    .arg
+                    .as_bool()
+                    .map(|value| if value { 1.0 } else { 0.0 })
+            })
+            .ok_or_else(|| anyhow::anyhow!("{} input {index} must be numeric", node.target))?;
+        Ok(self.floating_scalar(value, dtype))
+    }
+
+    pub(crate) fn translate_chebyshev_polynomial(
+        &mut self,
+        node: &Node,
+        kind: ChebyshevKind,
+        shifted: bool,
+    ) -> Result<GraphTensor> {
+        let dtype = self.output_meta_dtype(node)?;
+        let value = self.numeric_tensor_arg(node, 0, dtype)?;
+        let degree = self.numeric_tensor_arg(node, 1, dtype)?;
+        let (mut value, mut degree) = broadcast_binary(value, degree);
+        if shifted {
+            value = value * 2.0 - self.constant_like(value, 1.0);
+        }
+
+        let integer_dtype = if dtype == DType::F64 {
+            DType::I64
+        } else {
+            DType::Int
+        };
+        degree = degree.cast(integer_dtype).cast(dtype);
+        let zero = self.constant_like(value, 0.0);
+        let one = self.constant_like(value, 1.0);
+        let two = self.constant_like(value, 2.0);
+        let half = self.constant_like(value, 0.5);
+        let degree_plus_one = degree + one;
+        let twice_degree_plus_one = degree * 2.0 + one;
+        let odd = (degree % two).ne(zero);
+
+        let absolute = self.real_abs(value);
+        let angle = self.real_acos(value);
+        let inside = match kind {
+            ChebyshevKind::First => self.real_cos(degree * angle),
+            ChebyshevKind::Second => (degree_plus_one * angle).sin() / angle.sin(),
+            ChebyshevKind::Third => {
+                self.real_cos((degree + half) * angle) / self.real_cos(angle * 0.5)
+            }
+            ChebyshevKind::Fourth => ((degree + half) * angle).sin() / (angle * 0.5).sin(),
+        };
+
+        let hyperbolic_angle = self.real_acosh(absolute);
+        let positive_outside = match kind {
+            ChebyshevKind::First => self.real_cosh(degree * hyperbolic_angle),
+            ChebyshevKind::Second => {
+                self.real_sinh(degree_plus_one * hyperbolic_angle)
+                    / self.real_sinh(hyperbolic_angle)
+            }
+            ChebyshevKind::Third => {
+                self.real_cosh((degree + half) * hyperbolic_angle)
+                    / self.real_cosh(hyperbolic_angle * 0.5)
+            }
+            ChebyshevKind::Fourth => {
+                self.real_sinh((degree + half) * hyperbolic_angle)
+                    / self.real_sinh(hyperbolic_angle * 0.5)
+            }
+        };
+        let negative_outside_magnitude = match kind {
+            ChebyshevKind::First => self.real_cosh(degree * hyperbolic_angle),
+            ChebyshevKind::Second => {
+                self.real_sinh(degree_plus_one * hyperbolic_angle)
+                    / self.real_sinh(hyperbolic_angle)
+            }
+            ChebyshevKind::Third => {
+                self.real_sinh((degree + half) * hyperbolic_angle)
+                    / self.real_sinh(hyperbolic_angle * 0.5)
+            }
+            ChebyshevKind::Fourth => {
+                self.real_cosh((degree + half) * hyperbolic_angle)
+                    / self.real_cosh(hyperbolic_angle * 0.5)
+            }
+        };
+        let negative_outside =
+            self.select(odd, -negative_outside_magnitude, negative_outside_magnitude);
+        let outside = self.select(value.lt(zero), negative_outside, positive_outside);
+        let mut result = self.select(absolute.lt(one), inside, outside);
+
+        let positive_endpoint = match kind {
+            ChebyshevKind::First | ChebyshevKind::Third => one,
+            ChebyshevKind::Second => degree_plus_one,
+            ChebyshevKind::Fourth => twice_degree_plus_one,
+        };
+        let negative_endpoint_magnitude = match kind {
+            ChebyshevKind::First | ChebyshevKind::Fourth => one,
+            ChebyshevKind::Second => degree_plus_one,
+            ChebyshevKind::Third => twice_degree_plus_one,
+        };
+        let negative_endpoint = self.select(
+            odd,
+            -negative_endpoint_magnitude,
+            negative_endpoint_magnitude,
+        );
+        let endpoint = self.select(value.lt(zero), negative_endpoint, positive_endpoint);
+        let is_endpoint = self.is_zero(absolute - one);
+        result = self.select(is_endpoint, endpoint, result);
+
+        // ATen uses the three-term recurrence for ordinary degrees. Keeping
+        // that path for the common finite range reproduces its rounding while
+        // the closed forms above cover arbitrary runtime degrees without an
+        // unbounded compiler-side loop.
+        let mut previous = one;
+        let mut current = match kind {
+            ChebyshevKind::First => value,
+            ChebyshevKind::Second => value * 2.0,
+            ChebyshevKind::Third => value * 2.0 - one,
+            ChebyshevKind::Fourth => value * 2.0 + one,
+        };
+        let degree_zero = self.is_zero(degree);
+        result = self.select(degree_zero, previous, result);
+        let degree_one = self.is_zero(degree - one);
+        result = self.select(degree_one, current, result);
+        for index in 2..=20 {
+            let next = value * 2.0 * current - previous;
+            let index_value = self.constant_like(value, index as f64);
+            let at_index = self.is_zero(degree - index_value);
+            result = self.select(at_index, next, result);
+            previous = current;
+            current = next;
+        }
+
+        let negative_degree = degree.lt(zero);
+        Ok(self.select(negative_degree, zero, result))
+    }
+
+    #[allow(clippy::excessive_precision)]
+    fn lanczos_lgamma_positive(&mut self, value: GraphTensor) -> GraphTensor {
+        #[rustfmt::skip]
+        const COEFFICIENTS: [f64; 9] = [0.999_999_999_999_809_9, 676.520_368_121_885_1, -1_259.139_216_722_402_8, 771.323_428_777_653_1, -176.615_029_162_140_6, 12.507_343_278_686_905, -0.138_571_095_265_720_12, 9.984_369_578_019_572e-6, 1.505_632_735_149_311_6e-7,];
+        let shifted = value - self.constant_like(value, 1.0);
+        let mut series = self.constant_like(value, COEFFICIENTS[0]);
+        for (index, coefficient) in COEFFICIENTS.iter().copied().enumerate().skip(1) {
+            let denominator = shifted + self.constant_like(value, index as f64);
+            series += self.constant_like(value, coefficient) / denominator;
+        }
+        let t = shifted + self.constant_like(value, 7.5);
+        let half = self.constant_like(value, 0.5);
+        self.constant_like(value, 0.5 * (2.0 * std::f64::consts::PI).ln())
+            + (shifted + half) * t.log()
+            - t
+            + series.log()
+    }
+
+    pub(crate) fn translate_lgamma(&mut self, node: &Node) -> Result<GraphTensor> {
+        let value = self.unary_input(node)?;
+        let direct = self.lanczos_lgamma_positive(value);
+        let one = self.constant_like(value, 1.0);
+        let reflected_positive = self.lanczos_lgamma_positive(one - value);
+        let pi = self.constant_like(value, std::f64::consts::PI);
+        let reflection = pi.log() - self.real_abs((value * pi).sin()).log() - reflected_positive;
+        let half = self.constant_like(value, 0.5);
+        let ordinary = self.select(value.lt(half), reflection, direct);
+        let infinity = self.constant_like(value, f64::INFINITY);
+        let infinite = self.is_inf(value);
+        let zero = self.constant_like(value, 0.0);
+        let nonpositive = value.le(zero);
+        let integral = value.eq(self.floor_tensor(value));
+        let pole = self.bool_and(nonpositive, integral);
+        let exceptional = self.bool_or(infinite, pole);
+        let one = self.constant_like(value, 1.0);
+        let two = self.constant_like(value, 2.0);
+        let equals_one = value.eq(one);
+        let equals_two = value.eq(two);
+        let one_or_two = self.bool_or(equals_one, equals_two);
+        let ordinary = self.select(one_or_two, zero, ordinary);
+        let result = self.select(exceptional, infinity, ordinary);
+        let nan = self.is_nan(value);
+        let nan_value = self.constant_like(value, f64::NAN);
+        Ok(self.select(nan, nan_value, result))
+    }
+
+    fn positive_digamma(&mut self, value: GraphTensor) -> GraphTensor {
+        let mut shifted = value;
+        let mut recurrence = self.constant_like(value, 0.0);
+        let threshold = self.constant_like(value, 8.0);
+        let zero = self.constant_like(value, 0.0);
+        for _ in 0..8 {
+            let active = shifted.lt(threshold);
+            let term = shifted.reciprocal() * -1.0;
+            recurrence += self.select(active, term, zero);
+            shifted += active.cast(value.dtype);
+        }
+        let inverse = shifted.reciprocal();
+        let inverse_squared = inverse.square();
+        let correction = self.constant_like(value, 1.0 / 12.0)
+            - inverse_squared
+                * (self.constant_like(value, 1.0 / 120.0)
+                    - inverse_squared
+                        * (self.constant_like(value, 1.0 / 252.0)
+                            - inverse_squared
+                                * (self.constant_like(value, 1.0 / 240.0)
+                                    - inverse_squared
+                                        * (self.constant_like(value, 5.0 / 660.0)
+                                            - inverse_squared
+                                                * self.constant_like(value, 691.0 / 32_760.0)))));
+        recurrence + shifted.log() - inverse * 0.5 - inverse_squared * correction
+    }
+
+    fn positive_polygamma(&mut self, value: GraphTensor, order: usize) -> GraphTensor {
+        debug_assert!(order >= 1);
+        let factorial = |n: usize| (1..=n).fold(1.0, |product, value| product * value as f64);
+        let sign = if order % 2 == 1 { 1.0 } else { -1.0 };
+        let order_factorial = factorial(order);
+        let mut shifted = value;
+        let mut recurrence = self.constant_like(value, 0.0);
+        let threshold = self.constant_like(value, 8.0);
+        let zero = self.constant_like(value, 0.0);
+        for _ in 0..8 {
+            let active = shifted.lt(threshold);
+            let term = shifted.pow(-((order + 1) as f32))
+                * self.constant_like(value, sign * order_factorial);
+            recurrence += self.select(active, term, zero);
+            shifted += active.cast(value.dtype);
+        }
+
+        const BERNOULLI: [(usize, f64); 6] = [
+            (2, 1.0 / 6.0),
+            (4, -1.0 / 30.0),
+            (6, 1.0 / 42.0),
+            (8, -1.0 / 30.0),
+            (10, 5.0 / 66.0),
+            (12, -691.0 / 2730.0),
+        ];
+        let mut asymptotic =
+            shifted.pow(-(order as f32)) * self.constant_like(value, factorial(order - 1));
+        asymptotic +=
+            shifted.pow(-((order + 1) as f32)) * self.constant_like(value, 0.5 * order_factorial);
+        for (degree, bernoulli) in BERNOULLI {
+            let coefficient = bernoulli * factorial(order + degree - 1) / factorial(degree);
+            asymptotic +=
+                shifted.pow(-((order + degree) as f32)) * self.constant_like(value, coefficient);
+        }
+        recurrence + asymptotic * self.constant_like(value, sign)
+    }
+
+    fn cotangent_derivative_polynomial(order: usize) -> Vec<f64> {
+        // If u = cot(pi*x), then D^n u = pi^n P_n(u), with
+        // P_{n+1}(u) = -(1 + u^2) P'_n(u).
+        let mut coefficients = vec![0.0, 1.0];
+        for _ in 0..order {
+            let mut derivative = vec![0.0; coefficients.len().saturating_sub(1)];
+            for (degree, coefficient) in coefficients.iter().copied().enumerate().skip(1) {
+                derivative[degree - 1] = degree as f64 * coefficient;
+            }
+            let mut next = vec![0.0; derivative.len() + 2];
+            for (degree, coefficient) in derivative.into_iter().enumerate() {
+                next[degree] -= coefficient;
+                next[degree + 2] -= coefficient;
+            }
+            coefficients = next;
+        }
+        coefficients
+    }
+
+    fn real_polygamma(&mut self, value: GraphTensor, order: usize) -> GraphTensor {
+        let positive = if order == 0 {
+            self.positive_digamma(value)
+        } else {
+            self.positive_polygamma(value, order)
+        };
+        let one = self.constant_like(value, 1.0);
+        let reflected_positive = if order == 0 {
+            self.positive_digamma(one - value)
+        } else {
+            self.positive_polygamma(one - value, order)
+        };
+        let pi = self.constant_like(value, std::f64::consts::PI);
+        let angle = value * pi;
+        let cotangent = self.real_cos(angle) / angle.sin();
+        let coefficients = Self::cotangent_derivative_polynomial(order);
+        let mut polynomial = self.constant_like(value, *coefficients.last().unwrap_or(&0.0));
+        for coefficient in coefficients.iter().rev().skip(1) {
+            polynomial = polynomial * cotangent + self.constant_like(value, *coefficient);
+        }
+        let reflected = if order == 1 {
+            // Avoid forming 1 + cot(x)^2 with the cosine approximation. The
+            // equivalent csc(x)^2 form is materially more accurate near poles.
+            let sine = angle.sin();
+            -reflected_positive + pi.square() / sine.square()
+        } else {
+            reflected_positive * if order.is_multiple_of(2) { 1.0 } else { -1.0 }
+                - polynomial
+                    * self.constant_like(value, std::f64::consts::PI.powi((order + 1) as i32))
+        };
+        let zero = self.constant_like(value, 0.0);
+        let nonpositive = value.le(zero);
+        let mut result = self.select(nonpositive, reflected, positive);
+
+        let is_zero = self.is_zero(value);
+        if order >= 1 {
+            let pole = self.constant_like(
+                value,
+                if order % 2 == 1 {
+                    f64::INFINITY
+                } else {
+                    f64::NEG_INFINITY
+                },
+            );
+            result = self.select(is_zero, pole, result);
+            if order >= 2 {
+                let negative = value.lt(zero);
+                let integral = value.eq(self.floor_tensor(value));
+                let negative_pole = self.bool_and(negative, integral);
+                result = self.select(negative_pole, pole, result);
+            }
+        } else {
+            let negative = value.lt(zero);
+            let integral = value.eq(self.floor_tensor(value));
+            let negative_pole = self.bool_and(negative, integral);
+            let nan = self.constant_like(value, f64::NAN);
+            result = self.select(negative_pole, nan, result);
+        }
+
+        let infinite = self.is_inf(value);
+        let negative_sign = self.signbit(value);
+        let positive_sign = self.bool_not(negative_sign);
+        let negative_infinite = self.bool_and(infinite, negative_sign);
+        let positive_infinite = self.bool_and(infinite, positive_sign);
+        let nan = self.constant_like(value, f64::NAN);
+        let infinity_result = if order == 0 {
+            self.constant_like(value, f64::INFINITY)
+        } else if order == 1 {
+            zero
+        } else {
+            nan
+        };
+        result = self.select(positive_infinite, infinity_result, result);
+        let negative_infinity_result = if order >= 2 {
+            self.constant_like(
+                value,
+                if order % 2 == 1 {
+                    f64::INFINITY
+                } else {
+                    f64::NEG_INFINITY
+                },
+            )
+        } else {
+            nan
+        };
+        result = self.select(negative_infinite, negative_infinity_result, result);
+        let input_nan = self.is_nan(value);
+        self.select(input_nan, nan, result)
+    }
+
+    pub(crate) fn translate_digamma(&mut self, node: &Node) -> Result<GraphTensor> {
+        let value = self.unary_input(node)?;
+        let output_dtype = value.dtype;
+        Ok(self
+            .real_polygamma(value.cast(DType::F64), 0)
+            .cast(output_dtype))
+    }
+
+    pub(crate) fn translate_polygamma(&mut self, node: &Node) -> Result<GraphTensor> {
+        let order = self.get_int_arg(node, 0)?;
+        anyhow::ensure!(order >= 0, "polygamma order must be nonnegative");
+        let value = self
+            .get_input_tensor(node, 1)?
+            .cast(self.output_meta_dtype(node)?);
+        let output_dtype = value.dtype;
+        if order == 1 && output_dtype != DType::F64 {
+            // ATen evaluates trigamma reflection in the output dtype. Near
+            // negative poles that dtype-specific sin(pi*x) rounding is visible
+            // in the result, so an internal F64 promotion would not conform.
+            return Ok(self.real_polygamma(value, order as usize));
+        }
+        let accurate = self
+            .real_polygamma(value.cast(DType::F64), order as usize)
+            .cast(output_dtype);
+        Ok(accurate)
+    }
+
+    pub(crate) fn translate_logcumsumexp(&mut self, node: &Node) -> Result<GraphTensor> {
+        let value = self.unary_input(node)?;
+        if value.legacy_tracker_ref().is_empty() {
+            anyhow::ensure!(
+                matches!(self.get_int_arg(node, 1)?, -1 | 0),
+                "logcumsumexp dimension is out of range for a scalar"
+            );
+            return Ok(value);
+        }
+        let axis = crate::pt2_util::normalize_dim(self.get_int_arg(node, 1)?, value.legacy_tracker_ref().len());
+        let rank = value.legacy_tracker_ref().len();
+        let length = value.dims()[axis];
+        let mut padding = vec![(IntExpr::from(0), IntExpr::from(0)); rank];
+        padding[axis] = (length - 1, IntExpr::from(0));
+        let negative_infinity = self.floating_scalar(f64::NEG_INFINITY, value.dtype);
+        let padded = value.pad_with(padding, negative_infinity);
+        let mut kernel = vec![IntExpr::from(1); rank];
+        kernel[axis] = length;
+        let mut windows = padded.unfold(kernel, vec![1usize; rank], vec![1usize; rank]);
+        for kernel_axis in (0..rank).rev() {
+            if kernel_axis != axis {
+                windows = windows.squeeze(rank + kernel_axis);
+            }
+        }
+        let reduction_axis = rank;
+        let maximum = windows.max(reduction_axis);
+        let expanded = maximum.expand_dim(reduction_axis, windows.dims()[reduction_axis]);
+        let ordinary = maximum + (windows - expanded).exp().sum(reduction_axis).log();
+
+        let infinite = self.is_inf(windows);
+        let negative = self.signbit(windows);
+        let positive_infinite = self.bool_and(infinite, self.bool_not(negative));
+        let positive_count = positive_infinite.cast(DType::Int).sum(reduction_axis);
+        let zero = self.graph.constant(0).expand_rhs(positive_count.dims());
+        let has_positive_infinity = positive_count.gt(zero);
+        let infinity = self.constant_like(ordinary, f64::INFINITY);
+        let result = self.select(has_positive_infinity, infinity, ordinary);
+
+        let nan_count = self.is_nan(windows).cast(DType::Int).sum(reduction_axis);
+        let zero = self.graph.constant(0).expand_rhs(nan_count.dims());
+        let has_nan = nan_count.gt(zero);
+        let nan = self.constant_like(result, f64::NAN);
+        Ok(self.select(has_nan, nan, result))
     }
 
     /// Translate `aten.acos.default` into existing elementwise HLIR primitives.
@@ -142,6 +1320,76 @@ impl<'a> Translator<'a> {
     pub(crate) fn real_exp(&mut self, input: GraphTensor) -> GraphTensor {
         let log2_e = self.constant_like(input, std::f64::consts::LOG2_E);
         (input * log2_e).exp2()
+    }
+
+    pub(crate) fn translate_expm1(&mut self, node: &Node) -> Result<GraphTensor> {
+        let input = self.unary_input(node)?;
+        let one = self.constant_like(input, 1.0);
+        Ok(self.real_exp(input) - one)
+    }
+
+    pub(crate) fn translate_log1p(&mut self, node: &Node) -> Result<GraphTensor> {
+        let input = self.unary_input(node)?;
+        let one = self.constant_like(input, 1.0);
+        Ok((input + one).log())
+    }
+
+    pub(crate) fn translate_log10(&mut self, node: &Node) -> Result<GraphTensor> {
+        let input = self.unary_input(node)?;
+        let ln_ten = self.constant_like(input, std::f64::consts::LN_10);
+        Ok(input.log() / ln_ten)
+    }
+
+    pub(crate) fn translate_sinh(&mut self, node: &Node) -> Result<GraphTensor> {
+        let input = self.unary_input(node)?;
+        let output_dtype = input.dtype;
+        let opmath = if matches!(output_dtype, DType::F16 | DType::Bf16) {
+            input.cast(DType::F32)
+        } else {
+            input
+        };
+        Ok(self.real_sinh(opmath).cast(output_dtype))
+    }
+
+    pub(crate) fn real_tan(&mut self, input: GraphTensor) -> GraphTensor {
+        let cosine = self.real_cos(input);
+        input.sin() / cosine
+    }
+
+    pub(crate) fn translate_tan(&mut self, node: &Node) -> Result<GraphTensor> {
+        let input = self.unary_input(node)?;
+        Ok(self.real_tan(input))
+    }
+
+    pub(crate) fn translate_angle(&mut self, node: &Node) -> Result<GraphTensor> {
+        let input = self.unary_input(node)?;
+        let zero = self.constant_like(input, 0.0);
+        Ok(self.real_atan2(zero, input))
+    }
+
+    pub(crate) fn translate_isinf(&mut self, node: &Node) -> Result<GraphTensor> {
+        let input = self.get_input_tensor(node, 0)?;
+        if matches!(
+            input.dtype,
+            DType::F16 | DType::Bf16 | DType::F32 | DType::F64
+        ) {
+            Ok(self.is_inf(input))
+        } else {
+            Ok(self
+                .graph
+                .constant(0)
+                .cast(DType::Bool)
+                .expand_rhs(input.dims()))
+        }
+    }
+
+    pub(crate) fn translate_ldexp(&mut self, node: &Node) -> Result<GraphTensor> {
+        let input = self
+            .get_input_tensor(node, 0)?
+            .cast(self.output_meta_dtype(node)?);
+        let exponent = self.get_input_tensor(node, 1)?.cast(input.dtype);
+        let (input, exponent) = broadcast_binary(input, exponent);
+        Ok(input * exponent.exp2())
     }
 
     pub(crate) fn translate_cos(&mut self, node: &Node) -> Result<GraphTensor> {

--- a/crates/luminal_python/rust/src/typed_data.rs
+++ b/crates/luminal_python/rust/src/typed_data.rs
@@ -234,8 +234,10 @@ impl From<TypedData> for ReferenceData {
             DType::F32 | DType::TF32 => {
                 let data: Vec<f32> = td
                     .bytes
-                    .chunks_exact(4)
-                    .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
+                    .map(|b| f32::from_le_bytes(*b))
                     .collect();
                 ReferenceData::F32(data)
             }
@@ -243,34 +245,40 @@ impl From<TypedData> for ReferenceData {
                 // Downcast f64 -> f32 for the reference runtime (which only has F32 variant for floats > 32-bit)
                 let data: Vec<f32> = td
                     .bytes
-                    .chunks_exact(8)
-                    .map(|b| {
-                        f64::from_le_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]) as f32
-                    })
+                    .as_chunks::<8>()
+                    .0
+                    .iter()
+                    .map(|b| f64::from_le_bytes(*b) as f32)
                     .collect();
                 ReferenceData::F32(data)
             }
             DType::F16 => {
                 let data: Vec<half::f16> = td
                     .bytes
-                    .chunks_exact(2)
-                    .map(|b| half::f16::from_le_bytes([b[0], b[1]]))
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
+                    .map(|b| half::f16::from_le_bytes(*b))
                     .collect();
                 ReferenceData::F16(data)
             }
             DType::Bf16 => {
                 let data: Vec<half::bf16> = td
                     .bytes
-                    .chunks_exact(2)
-                    .map(|b| half::bf16::from_le_bytes([b[0], b[1]]))
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
+                    .map(|b| half::bf16::from_le_bytes(*b))
                     .collect();
                 ReferenceData::Bf16(data)
             }
             DType::Int => {
                 let data: Vec<i32> = td
                     .bytes
-                    .chunks_exact(4)
-                    .map(|b| i32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
+                    .map(|b| i32::from_le_bytes(*b))
                     .collect();
                 ReferenceData::Int(data)
             }
@@ -286,16 +294,20 @@ impl From<TypedData> for ReferenceData {
             DType::I16 => {
                 let data: Vec<i16> = td
                     .bytes
-                    .chunks_exact(2)
-                    .map(|b| i16::from_le_bytes([b[0], b[1]]))
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
+                    .map(|b| i16::from_le_bytes(*b))
                     .collect();
                 ReferenceData::I16(data)
             }
             DType::U16 => {
                 let data: Vec<i32> = td
                     .bytes
-                    .chunks_exact(2)
-                    .map(|b| u16::from_le_bytes([b[0], b[1]]) as i32)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
+                    .map(|b| u16::from_le_bytes(*b) as i32)
                     .collect();
                 ReferenceData::Int(data)
             }

--- a/crates/luminal_python/tests/test_complex.py
+++ b/crates/luminal_python/tests/test_complex.py
@@ -85,6 +85,185 @@ def test_complex_components_and_shape_operations():
         _assert_close(result, reference, rtol=0, atol=0)
 
 
+class ComplexSplitWithSizes(torch.nn.Module):
+    def forward(self, value):
+        return tuple(torch.ops.aten.split_with_sizes.default(value, [1, 3, 2], -1))
+
+
+@pytest.mark.parametrize("dtype", (torch.complex32, torch.complex64, torch.complex128))
+def test_complex_split_with_sizes_preserves_all_outputs(dtype):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        value = torch.randn(6, 4, dtype=dtype).T
+        expected = ComplexSplitWithSizes()(value)
+        actual = _compile_and_run(ComplexSplitWithSizes(), value)
+    for result, reference in zip(actual, expected):
+        _assert_close(result, reference, rtol=0, atol=0)
+
+
+class ComplexPredicateAliases(torch.nn.Module):
+    def forward(self, value, other, condition):
+        return (
+            torch.ops.aten.any.default(value),
+            torch.ops.aten.any.dim(value, -1, True),
+            torch.ops.aten.any.dims(value, [], False),
+            torch.ops.aten.where.self(condition, value, other),
+            torch.ops.aten.angle.default(value),
+            torch.ops.aten.isinf.default(value),
+            torch.ops.aten.isnan.default(value),
+            torch.ops.aten.eq.Scalar(value, 0.5 - 0.25j),
+            torch.ops.aten.ne.Scalar(value, 0.5 - 0.25j),
+            torch.ops.aten.logical_and.default(value, other),
+            torch.ops.aten.logical_not.default(value),
+            torch.ops.aten.logical_or.default(value, other),
+            torch.ops.aten.logical_xor.default(value, other),
+        )
+
+
+class ComplexUnaryAlias(torch.nn.Module):
+    def __init__(self, op):
+        super().__init__()
+        self.op = op
+
+    def forward(self, value):
+        return self.op(value)
+
+
+class ComplexPowerAndScaleAliases(torch.nn.Module):
+    def forward(self, value, other, magnitude, phase, exponent):
+        return (
+            torch.ops.aten.polar.default(magnitude, phase),
+            torch.ops.aten.pow.Tensor_Scalar(value, 1.5 - 0.25j),
+            torch.ops.aten.pow.Tensor_Tensor(value, other),
+            torch.ops.aten.ldexp.Tensor(value, exponent),
+        )
+
+
+class ComplexCopyAliases(torch.nn.Module):
+    def forward(self, value):
+        permuted = torch.ops.aten.permute_copy.default(value, [1, 0])
+        unbound = torch.ops.aten.unbind_copy.int(permuted, 0)
+        return (
+            torch.ops.aten.view_copy.default(value, [3, 2]),
+            permuted,
+            torch.ops.aten.narrow_copy.default(permuted, -1, 0, 1),
+            *unbound,
+        )
+
+
+class ComplexScatterAliases(torch.nn.Module):
+    def forward(self, value, index, source):
+        return (
+            torch.ops.aten.scatter.src(value, 1, index, source),
+            torch.ops.aten.scatter.value(value, 1, index, 0.5 - 0.25j),
+            torch.ops.aten.scatter.reduce(value, 1, index, source, reduce="add"),
+            torch.ops.aten.scatter.reduce(value, 1, index, source, reduce="multiply"),
+            torch.ops.aten.scatter.value_reduce(
+                value, 1, index, 0.5 - 0.25j, reduce="add"
+            ),
+            torch.ops.aten.scatter_add.default(value, 1, index, source),
+        )
+
+
+def _complex_alias_inputs():
+    value = torch.tensor(
+        [
+            [0.5 + 0.25j, 1.0 - 0.5j, -0.25 + 0.75j],
+            [0.75 - 0.2j, 1.5 + 0.1j, 0.2 + 0.4j],
+        ],
+        dtype=torch.complex64,
+    )
+    other = torch.tensor(
+        [[1.25 - 0.5j, 0.5 + 0.3j, 0.75 - 0.1j], [0.4 + 0.6j, 1.1 - 0.7j, 0.8 + 0.2j]],
+        dtype=torch.complex64,
+    )
+    condition = torch.tensor([[True, False, True], [False, True, False]])
+    magnitude = torch.tensor([[0.5, 1.0, 1.5], [2.0, 0.75, 0.25]])
+    phase = torch.tensor([[0.0, 0.5, -0.25], [1.0, -1.5, 2.0]])
+    exponent = torch.tensor([[0, 1, -1], [2, -2, 3]], dtype=torch.int32)
+    return value, other, condition, magnitude, phase, exponent
+
+
+def _assert_complex_alias_module(module, *inputs):
+    expected = module(*inputs)
+    actual = _compile_and_run(module, *inputs)
+    for result, reference in zip(actual, expected):
+        _assert_close(result, reference, rtol=5e-4, atol=5e-5)
+
+
+def test_complex_predicate_aliases_lower_through_real_components():
+    value, other, condition, _, _, _ = _complex_alias_inputs()
+    _assert_complex_alias_module(ComplexPredicateAliases(), value, other, condition)
+
+
+@pytest.mark.parametrize(
+    "op",
+    (
+        torch.ops.aten.exp2.default,
+        torch.ops.aten.expm1.default,
+        torch.ops.aten.log.default,
+        torch.ops.aten.log1p.default,
+        torch.ops.aten.log2.default,
+        torch.ops.aten.log10.default,
+        torch.ops.aten.reciprocal.default,
+        torch.ops.aten.rsqrt.default,
+        torch.ops.aten.sigmoid.default,
+        torch.ops.aten.sin.default,
+        torch.ops.aten.sinh.default,
+        torch.ops.aten.sqrt.default,
+        torch.ops.aten.tan.default,
+        torch.ops.aten.tanh.default,
+    ),
+    ids=lambda op: op.name().replace("aten::", "").replace(".", "_"),
+)
+def test_complex_unary_aliases_lower_through_real_components(op):
+    value, _, _, _, _, _ = _complex_alias_inputs()
+    module = ComplexUnaryAlias(op)
+    expected = module(value)
+    (actual,) = _compile_and_run(module, value)
+    _assert_close(actual, expected, rtol=5e-4, atol=5e-5)
+
+
+def test_complex_power_and_scale_aliases_lower_through_real_components():
+    value, other, _, magnitude, phase, exponent = _complex_alias_inputs()
+    _assert_complex_alias_module(
+        ComplexPowerAndScaleAliases(),
+        value,
+        other,
+        magnitude,
+        phase,
+        exponent,
+    )
+
+
+def test_complex_copy_aliases_materialize_every_output():
+    value = torch.randn(2, 3, dtype=torch.complex64)
+    module = ComplexCopyAliases()
+    expected = module(value)
+    actual = _compile_and_run(module, value)
+    for result, reference in zip(actual, expected):
+        _assert_close(result, reference, rtol=0, atol=0)
+
+
+def test_complex_scatter_aliases_preserve_duplicate_updates():
+    value = torch.tensor(
+        [[2.0 + 0.5j, 3.0 - 0.25j, 5.0 + 1.0j]],
+        dtype=torch.complex64,
+    )
+    index = torch.tensor([[0, 0]])
+    source = torch.tensor(
+        [[2.0 + 1.0j, 3.0 - 0.5j]],
+        dtype=torch.complex64,
+    )
+    module = ComplexScatterAliases()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        expected = module(value, index, source)
+        actual = _compile_and_run(module, value, index, source)
+    for result, reference in zip(actual, expected):
+        _assert_close(result, reference, rtol=3e-4, atol=3e-5)
+
+
 class MixedComplexReal(torch.nn.Module):
     def forward(self, z, x):
         return (

--- a/crates/luminal_python/tests/test_fft.py
+++ b/crates/luminal_python/tests/test_fft.py
@@ -1,0 +1,235 @@
+"""Regression coverage for composed PT2 Fourier transform lowerings."""
+
+import torch
+from luminal.pt2 import compile as luminal_compile
+
+
+def _compile(module: torch.nn.Module, inputs, dynamic_shapes=None):
+    return luminal_compile(
+        module,
+        inputs,
+        search_iterations=1,
+        dynamic_shapes={} if dynamic_shapes is None else dynamic_shapes,
+    )
+
+
+def _outputs(value):
+    return value if isinstance(value, tuple) else (value,)
+
+
+def _assert_compiled_matches(
+    module: torch.nn.Module,
+    inputs,
+    *,
+    rtol=6e-4,
+    atol=7e-5,
+):
+    expected = _outputs(module(*inputs))
+    actual = _compile(module, inputs)(*inputs)
+    assert len(actual) == len(expected)
+    for result, reference in zip(actual, expected):
+        assert result.shape == reference.shape
+        assert result.dtype == reference.dtype
+        torch.testing.assert_close(
+            result,
+            reference,
+            rtol=rtol,
+            atol=atol,
+            equal_nan=True,
+        )
+
+
+class RealOneDimensionalFfts(torch.nn.Module):
+    def forward(self, value):
+        return (
+            torch.fft.fft(value, n=6, norm="backward"),
+            torch.fft.ifft(value, n=4, norm="ortho"),
+            torch.fft.rfft(value, norm="forward"),
+            torch.fft.ihfft(value, n=6, norm="ortho"),
+        )
+
+
+def test_real_one_dimensional_fft_family():
+    value = torch.tensor([1.0, -2.0, 0.5, 3.0, -0.25])
+    _assert_compiled_matches(RealOneDimensionalFfts(), (value,))
+
+
+class ComplexOneDimensionalFfts(torch.nn.Module):
+    def forward(self, value):
+        return (
+            torch.fft.fft(value, norm="ortho"),
+            torch.fft.ifft(value, norm="forward"),
+            torch.fft.irfft(value, n=6),
+            torch.fft.hfft(value, n=6),
+            torch.fft.hfft(value, n=7, norm="ortho"),
+        )
+
+
+def test_complex_one_dimensional_fft_family_even_and_odd_lengths():
+    value = torch.tensor([1 + 2j, -2 + 0.5j, 0.25 - 1j, 3 + 0j], dtype=torch.complex64)
+    _assert_compiled_matches(ComplexOneDimensionalFfts(), (value,))
+
+
+class HermitianEndpointBehavior(torch.nn.Module):
+    def forward(self, value):
+        return torch.fft.irfft(value, n=6, norm="forward")
+
+
+def test_c2r_ignores_dc_and_nyquist_imaginary_components():
+    value = torch.tensor(
+        [1 + 50j, -2 + 0.5j, 0.25 - 1j, 3 - 80j], dtype=torch.complex64
+    )
+    _assert_compiled_matches(HermitianEndpointBehavior(), (value,))
+
+
+class MultiDimensionalFfts(torch.nn.Module):
+    def forward(self, value):
+        return (
+            torch.fft.fftn(value, dim=(0, 2), norm="ortho"),
+            torch.fft.rfftn(value, dim=(0, 2), norm="forward"),
+            torch.fft.fft2(value, s=(3, 5), dim=(1, 2)),
+            torch.fft.ihfftn(value, s=(2, 6), dim=(0, 2)),
+        )
+
+
+def test_multidimensional_fft_family_and_nonfinal_axes():
+    value = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4) - 7
+    _assert_compiled_matches(MultiDimensionalFfts(), (value,), rtol=8e-4, atol=9e-5)
+
+
+class MultiDimensionalInverseFfts(torch.nn.Module):
+    def forward(self, value):
+        return (
+            torch.fft.ifftn(value, dim=(0, 2), norm="forward"),
+            torch.fft.irfftn(value, s=(2, 6), dim=(0, 2), norm="ortho"),
+            torch.fft.hfftn(value, s=(2, 6), dim=(0, 2)),
+        )
+
+
+def test_multidimensional_complex_inverse_and_hermitian_ffts():
+    real = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4) / 5
+    imag = torch.flip(real, dims=(0, 2)) / 7
+    value = torch.complex(real, imag)
+    _assert_compiled_matches(
+        MultiDimensionalInverseFfts(), (value,), rtol=1e-3, atol=1e-4
+    )
+
+
+class ShiftFrequencies(torch.nn.Module):
+    def forward(self, value):
+        return (
+            torch.fft.fftshift(value, dim=(0, 1)),
+            torch.fft.ifftshift(value, dim=(0, 1)),
+        )
+
+
+def test_fft_shifts_for_integer_and_complex_values():
+    for value in (
+        torch.arange(12, dtype=torch.int64).reshape(3, 4),
+        torch.complex(
+            torch.arange(12, dtype=torch.float32).reshape(3, 4),
+            torch.arange(12, dtype=torch.float32).reshape(3, 4).flip(1),
+        ),
+    ):
+        _assert_compiled_matches(ShiftFrequencies(), (value,), rtol=0, atol=0)
+
+
+class DynamicLengthFfts(torch.nn.Module):
+    def forward(self, value):
+        return (
+            torch.fft.fft(value, norm="ortho"),
+            torch.fft.rfft(value),
+        )
+
+
+def test_fft_accepts_symbolic_compile_time_length_expression():
+    module = DynamicLengthFfts()
+    example = torch.arange(4, dtype=torch.float32) - 1
+    length = torch.export.Dim("fft_length", min=2, max=8)
+    compiled = _compile(module, (example,), dynamic_shapes=({0: length},))
+
+    for size in (4, 6):
+        value = torch.linspace(-2, 3, size)
+        expected = module(value)
+        actual = compiled(value)
+        for result, reference in zip(actual, expected):
+            torch.testing.assert_close(
+                result, reference, rtol=6e-4, atol=7e-5, equal_nan=True
+            )
+
+
+class DoublePrecisionFfts(torch.nn.Module):
+    def forward(self, real, complex_value):
+        return (
+            torch.fft.rfft(real, norm="ortho"),
+            torch.fft.fft(complex_value),
+            torch.fft.irfft(complex_value, n=6),
+        )
+
+
+def test_double_precision_fft_accuracy_and_dtype():
+    real = torch.tensor([1.0, -2.0, 0.5, 3.0, -0.25], dtype=torch.float64)
+    complex_value = torch.complex(real[:4], torch.flip(real[:4], dims=(0,)))
+    _assert_compiled_matches(
+        DoublePrecisionFfts(),
+        (real, complex_value),
+        rtol=1e-7,
+        atol=1e-8,
+    )
+
+
+class ShortTimeFourierTransform(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("window", torch.hann_window(6))
+
+    def forward(self, value):
+        return torch.stft(
+            value,
+            n_fft=8,
+            hop_length=3,
+            win_length=6,
+            window=self.window,
+            center=True,
+            normalized=True,
+            onesided=True,
+            return_complex=True,
+        )
+
+
+def test_stft_decomposition_uses_composed_r2c_lowering():
+    value = torch.linspace(-1, 1, 20)
+    _assert_compiled_matches(
+        ShortTimeFourierTransform(), (value,), rtol=8e-4, atol=9e-5
+    )
+
+
+class InverseShortTimeFourierTransform(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("window", torch.hann_window(6))
+
+    def forward(self, value):
+        return torch.istft(
+            value,
+            n_fft=8,
+            hop_length=3,
+            win_length=6,
+            window=self.window,
+            center=True,
+            normalized=True,
+            onesided=True,
+            length=20,
+            return_complex=False,
+        )
+
+
+def test_istft_decomposition_accumulates_overlapping_inverse_fft_frames():
+    generator = torch.Generator().manual_seed(7)
+    value = torch.complex(
+        torch.randn((5, 7), generator=generator),
+        torch.randn((5, 7), generator=generator),
+    )
+    _assert_compiled_matches(
+        InverseShortTimeFourierTransform(), (value,), rtol=8e-4, atol=9e-5
+    )

--- a/crates/luminal_python/tests/test_reduction.py
+++ b/crates/luminal_python/tests/test_reduction.py
@@ -1,5 +1,7 @@
 """Regression coverage for PT2 reduction and scan lowerings."""
 
+import warnings
+
 import torch
 from luminal.pt2 import compile as luminal_compile
 
@@ -59,3 +61,334 @@ def test_cumprod_complex_scalar_and_empty_inputs():
         expected = torch.cumprod(value, 0)
         (actual,) = _compile_and_run(CumulativeProductDimZero(), value)
         torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
+
+
+class ComposedReductions(torch.nn.Module):
+    def forward(self, value):
+        variance, mean = torch.ops.aten.var_mean.correction(
+            value, [0, 2], correction=0.5, keepdim=True
+        )
+        return (
+            torch.ops.aten._log_softmax.default(value, -1, False),
+            torch.ops.aten.linalg_vector_norm.default(value, 0, [1], False),
+            torch.ops.aten.linalg_vector_norm.default(value, 1, [0, 2], True),
+            torch.ops.aten.linalg_vector_norm.default(value, 2, [], False),
+            torch.ops.aten.linalg_vector_norm.default(value, 3.5, [2], False),
+            torch.ops.aten.linalg_vector_norm.default(value, float("inf"), [1], False),
+            torch.ops.aten.linalg_vector_norm.default(value, float("-inf"), [1], False),
+            torch.ops.aten.var.correction(value, [1], correction=1, keepdim=True),
+            variance,
+            mean,
+        )
+
+
+def test_composed_real_reductions_match_eager():
+    value = torch.tensor(
+        [
+            [[-2.0, 0.0, 1.5, 4.0], [3.0, -1.0, 2.0, 0.5], [1.0, 2.0, 3.0, 4.0]],
+            [[0.25, -0.5, 1.0, 2.0], [-3.0, 5.0, 0.0, 1.0], [2.5, -1.5, 0.5, 3.5]],
+        ]
+    )
+    module = ComposedReductions()
+    expected = module(value)
+    actual = _compile_and_run(module, value)
+    assert len(actual) == len(expected)
+    for result, reference in zip(actual, expected):
+        assert result.shape == reference.shape
+        assert result.dtype == reference.dtype
+        torch.testing.assert_close(
+            result, reference, rtol=4e-4, atol=4e-5, equal_nan=True
+        )
+
+
+class ScalarLogSoftmax(torch.nn.Module):
+    def forward(self, value):
+        return torch.ops.aten._log_softmax.default(value, 0, False)
+
+
+def test_scalar_log_softmax_preserves_ieee_behavior():
+    module = ScalarLogSoftmax()
+    for value in (torch.tensor(2.0), torch.tensor(float("inf"))):
+        expected = module(value)
+        (actual,) = _compile_and_run(module, value)
+        torch.testing.assert_close(actual, expected, equal_nan=True)
+
+
+class ComplexComposedReductions(torch.nn.Module):
+    def forward(self, value):
+        variance, mean = torch.ops.aten.var_mean.correction(
+            value, [0], correction=0, keepdim=False
+        )
+        return (
+            torch.ops.aten.linalg_vector_norm.default(value, 2, [1], True),
+            torch.ops.aten.linalg_vector_norm.default(
+                value, 2, [1], False, dtype=torch.complex128
+            ),
+            torch.ops.aten.linalg_vector_norm.default(value, 1.5, [], False),
+            torch.ops.aten.var.correction(value, [1], correction=1, keepdim=False),
+            variance,
+            mean,
+        )
+
+
+def test_composed_complex_reductions_match_eager():
+    real = torch.tensor([[1.0, -2.0, 0.5], [3.0, 0.0, -1.5]])
+    imag = torch.tensor([[0.25, 1.0, -3.0], [-2.0, 4.0, 0.5]])
+    value = torch.complex(real, imag)
+    module = ComplexComposedReductions()
+    expected = module(value)
+    actual = _compile_and_run(module, value)
+    for result, reference in zip(actual, expected):
+        assert result.shape == reference.shape
+        assert result.dtype == reference.dtype
+        torch.testing.assert_close(
+            result, reference, rtol=5e-4, atol=5e-5, equal_nan=True
+        )
+
+
+class VarianceOverloads(torch.nn.Module):
+    def forward(self, value):
+        variance_default = torch.ops.aten.var.default(value, False)
+        variance_dim = torch.ops.aten.var.dim(value, [1], True, True)
+        var_mean_default = torch.ops.aten.var_mean.default(value, False)
+        var_mean_dim = torch.ops.aten.var_mean.dim(value, [0], True, False)
+        return (
+            variance_default,
+            variance_dim,
+            var_mean_default[0],
+            var_mean_default[1],
+            var_mean_dim[0],
+            var_mean_dim[1],
+        )
+
+
+def test_variance_default_and_dim_overloads_match_eager():
+    value = torch.tensor([[-2.0, 0.5, 3.0], [4.0, -1.0, 2.0]], dtype=torch.float64)
+    module = VarianceOverloads()
+    expected = module(value)
+    actual = _compile_and_run(module, value)
+    for result, reference in zip(actual, expected):
+        assert result.shape == reference.shape
+        assert result.dtype == reference.dtype
+        torch.testing.assert_close(
+            result, reference, rtol=1e-7, atol=1e-8, equal_nan=True
+        )
+
+
+class DynamicComposedReductions(torch.nn.Module):
+    def forward(self, value):
+        variance, mean = torch.ops.aten.var_mean.correction(
+            value, [0], correction=1, keepdim=True
+        )
+        return (
+            torch.ops.aten.linalg_vector_norm.default(value, 2, [0], False),
+            torch.ops.aten._log_softmax.default(value, 0, False),
+            variance,
+            mean,
+        )
+
+
+def test_composed_reductions_accept_symbolic_compile_time_extents():
+    module = DynamicComposedReductions()
+    example = torch.arange(6.0).reshape(2, 3)
+    batch = torch.export.Dim("batch", min=2, max=8)
+    compiled = luminal_compile(
+        module,
+        (example,),
+        search_iterations=1,
+        dynamic_shapes=({0: batch},),
+    )
+
+    for rows in (2, 5):
+        value = torch.linspace(-3, 4, rows * 3).reshape(rows, 3)
+        actual = compiled(value)
+        expected = module(value)
+        for result, reference in zip(actual, expected):
+            torch.testing.assert_close(result, reference, rtol=5e-4, atol=5e-5)
+
+
+class ScatterAndIndexReductions(torch.nn.Module):
+    def forward(self, value, scatter_index, scatter_source, index, index_source):
+        return (
+            torch.ops.aten.scatter_reduce.two(
+                value, 1, scatter_index, scatter_source, "sum", include_self=True
+            ),
+            torch.ops.aten.scatter_reduce.two(
+                value, 1, scatter_index, scatter_source, "prod", include_self=False
+            ),
+            torch.ops.aten.scatter_reduce.two(
+                value, 1, scatter_index, scatter_source, "mean", include_self=False
+            ),
+            torch.ops.aten.scatter_reduce.two(
+                value, 1, scatter_index, scatter_source, "amax", include_self=True
+            ),
+            torch.ops.aten.scatter_reduce.two(
+                value, 1, scatter_index, scatter_source, "amin", include_self=False
+            ),
+            torch.ops.aten.index_reduce.default(
+                value, 1, index, index_source, "prod", include_self=True
+            ),
+            torch.ops.aten.index_reduce.default(
+                value, 1, index, index_source, "mean", include_self=False
+            ),
+            torch.ops.aten.index_reduce.default(
+                value, 1, index, index_source, "amax", include_self=False
+            ),
+            torch.ops.aten.index_reduce.default(
+                value, 1, index, index_source, "amin", include_self=True
+            ),
+        )
+
+
+def test_scatter_and_index_reduce_duplicates_and_include_self():
+    value = torch.tensor([[2.0, 3.0, 5.0], [7.0, 11.0, 13.0]])
+    scatter_index = torch.tensor([[0, 0, 2], [1, 1, 1]])
+    scatter_source = torch.tensor([[2.0, 3.0, 4.0], [0.5, 2.0, -1.0]])
+    index = torch.tensor([1, 1, 2])
+    index_source = torch.tensor([[2.0, 4.0, -3.0], [0.5, 2.0, 8.0]])
+    module = ScatterAndIndexReductions()
+    inputs = (value, scatter_index, scatter_source, index, index_source)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        expected = module(*inputs)
+        actual = _compile_and_run(module, *inputs)
+    for result, reference in zip(actual, expected):
+        torch.testing.assert_close(
+            result, reference, rtol=2e-5, atol=2e-6, equal_nan=True
+        )
+
+
+class DynamicScatterAndIndexReductions(torch.nn.Module):
+    def forward(self, value, index, source):
+        return (
+            torch.ops.aten.scatter_reduce.two(
+                value, 0, index, source, "sum", include_self=False
+            ),
+            torch.ops.aten.index_reduce.default(
+                value, 0, index, source, "prod", include_self=True
+            ),
+        )
+
+
+def test_scatter_and_index_reduce_accept_bounded_symbolic_update_extents():
+    module = DynamicScatterAndIndexReductions()
+    example = (
+        torch.tensor([1.0, 2.0, 3.0]),
+        torch.tensor([0, 2]),
+        torch.tensor([4.0, 5.0]),
+    )
+    output_size = torch.export.Dim("output_size", min=2, max=8)
+    update_size = torch.export.Dim("update_size", min=1, max=8)
+    compiled = luminal_compile(
+        module,
+        example,
+        search_iterations=1,
+        dynamic_shapes=(
+            {0: output_size},
+            {0: update_size},
+            {0: update_size},
+        ),
+    )
+
+    runtime_inputs = (
+        example,
+        (
+            torch.tensor([2.0, 3.0, 5.0, 7.0, 11.0]),
+            torch.tensor([1, 1, 4, 0]),
+            torch.tensor([2.0, -3.0, 4.0, 0.5]),
+        ),
+    )
+    for inputs in runtime_inputs:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            actual = compiled(*inputs)
+            expected = module(*inputs)
+        for result, reference in zip(actual, expected):
+            torch.testing.assert_close(result, reference, rtol=2e-5, atol=2e-6)
+
+
+class IntegerScatterMean(torch.nn.Module):
+    def forward(self, value, index, source):
+        return torch.ops.aten.scatter_reduce.two(
+            value, 0, index, source, "mean", include_self=False
+        )
+
+
+def test_scatter_reduce_integer_mean_floors_negative_results():
+    value = torch.tensor([9, 9, 9], dtype=torch.int64)
+    index = torch.tensor([1, 1, 2])
+    source = torch.tensor([-2, -3, 4], dtype=torch.int64)
+    module = IntegerScatterMean()
+    (actual,) = _compile_and_run(module, value, index, source)
+    expected = module(value, index, source)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+class ScatterNaNExtrema(torch.nn.Module):
+    def forward(self, value, index, source):
+        return (
+            torch.ops.aten.scatter_reduce.two(
+                value, 0, index, source, "amax", include_self=True
+            ),
+            torch.ops.aten.scatter_reduce.two(
+                value, 0, index, source, "amin", include_self=False
+            ),
+        )
+
+
+def test_scatter_reduce_extrema_propagate_nan():
+    value = torch.tensor([10.0, 20.0])
+    index = torch.tensor([0, 0])
+    source = torch.tensor([float("nan"), 3.0])
+    module = ScatterNaNExtrema()
+    actual = _compile_and_run(module, value, index, source)
+    expected = module(value, index, source)
+    for result, reference in zip(actual, expected):
+        torch.testing.assert_close(result, reference, equal_nan=True)
+
+
+class BooleanScatterReductions(torch.nn.Module):
+    def forward(self, value, index, source):
+        return tuple(
+            torch.ops.aten.scatter_reduce.two(
+                value, 0, index, source, reduction, include_self=True
+            )
+            for reduction in ("sum", "prod", "amax", "amin")
+        )
+
+
+def test_boolean_scatter_reductions_use_logical_semantics():
+    value = torch.tensor([False, True, False])
+    index = torch.tensor([0, 0, 1])
+    source = torch.tensor([True, True, False])
+    module = BooleanScatterReductions()
+    actual = _compile_and_run(module, value, index, source)
+    expected = module(value, index, source)
+    for result, reference in zip(actual, expected):
+        torch.testing.assert_close(result, reference, rtol=0, atol=0)
+
+
+class ScalarScatterAndIndexReductions(torch.nn.Module):
+    def forward(self, value, scatter_index, index, source):
+        return (
+            torch.ops.aten.scatter_reduce.two(
+                value, 0, scatter_index, source, "sum", include_self=False
+            ),
+            torch.ops.aten.index_reduce.default(
+                value, 0, index, source, "mean", include_self=True
+            ),
+        )
+
+
+def test_scalar_scatter_and_index_reductions():
+    value = torch.tensor(6.0)
+    scatter_index = torch.tensor(0)
+    index = torch.tensor([0])
+    source = torch.tensor(2.0)
+    module = ScalarScatterAndIndexReductions()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        actual = _compile_and_run(module, value, scatter_index, index, source)
+        expected = module(value, scatter_index, index, source)
+    for result, reference in zip(actual, expected):
+        torch.testing.assert_close(result, reference, rtol=0, atol=0)

--- a/crates/luminal_python/tests/test_remaining_existing_hlir_lowerings.py
+++ b/crates/luminal_python/tests/test_remaining_existing_hlir_lowerings.py
@@ -1,0 +1,709 @@
+"""Regression tests for ATen composites built from the existing HLIR."""
+
+import torch
+
+from luminal.pt2 import compile as luminal_compile
+
+
+def _compile(module: torch.nn.Module, *inputs: torch.Tensor, dynamic_shapes=None):
+    return luminal_compile(
+        module,
+        inputs,
+        search_iterations=1,
+        dynamic_shapes={} if dynamic_shapes is None else dynamic_shapes,
+    )
+
+
+def _assert_close(actual, expected, *, rtol=5e-4, atol=5e-5) -> None:
+    actual, actual_spec = torch.utils._pytree.tree_flatten(actual)
+    expected, expected_spec = torch.utils._pytree.tree_flatten(expected)
+    del actual_spec, expected_spec
+    assert len(actual) == len(expected)
+    for index, (result, reference) in enumerate(zip(actual, expected)):
+        approximate = reference.dtype.is_floating_point or reference.is_complex()
+        torch.testing.assert_close(
+            result,
+            reference,
+            rtol=rtol if approximate else 0,
+            atol=atol if approximate else 0,
+            equal_nan=True,
+            check_stride=False,
+            msg=f"output {index}",
+        )
+
+
+def _check(module, *inputs, **tolerances) -> None:
+    _assert_close(_compile(module, *inputs)(*inputs), module(*inputs), **tolerances)
+
+
+class ElementwiseComposites(torch.nn.Module):
+    def forward(self, value, other):
+        return (
+            torch.ops.aten.hardtanh.default(value, -0.5, 0.75),
+            torch.ops.aten.elu.default(value, 1.2, 0.7, 0.8),
+            torch.ops.aten.leaky_relu.default(value, 0.2),
+            torch.ops.aten.round.default(value),
+            torch.ops.aten.round.decimals(value, decimals=2),
+            torch.ops.aten.signbit.default(value),
+            torch.ops.aten.hypot.default(value, other),
+            torch.ops.aten.erfc.default(value),
+            torch.ops.aten.special_erfcx.default(value),
+            torch.ops.aten.lgamma.default(value),
+            torch.ops.aten.digamma.default(value),
+            torch.ops.aten.polygamma.default(1, value),
+            torch.ops.aten.i0.default(value),
+            torch.ops.aten.special_i0e.default(value),
+            torch.ops.aten.special_i1.default(value),
+            torch.ops.aten.special_i1e.default(value),
+            torch.ops.aten.special_modified_bessel_i0.default(value),
+            torch.ops.aten.special_modified_bessel_i1.default(value),
+            torch.ops.aten.special_spherical_bessel_j0.default(value),
+            torch.ops.aten.erfinv.default(value / 4),
+            torch.ops.aten.special_ndtri.default(value.sigmoid()),
+            torch.ops.aten.logcumsumexp.default(value, -1),
+            torch.ops.aten.pow.Scalar(2.0, value),
+        )
+
+
+def test_elementwise_composites_cover_ieee_edges() -> None:
+    value = torch.tensor(
+        [[-2.5, -0.0, 0.5, 1.25], [float("inf"), float("nan"), -0.25, 50.0]]
+    )
+    other = torch.tensor([[4.0], [2.0]])
+    module = ElementwiseComposites()
+    _check(module, value, other)
+
+
+class PolygammaOrders(torch.nn.Module):
+    def forward(self, value):
+        return (
+            torch.ops.aten.digamma.default(value),
+            torch.ops.aten.polygamma.default(0, value),
+            torch.ops.aten.polygamma.default(1, value),
+            torch.ops.aten.polygamma.default(2, value),
+            torch.ops.aten.polygamma.default(3, value),
+            torch.ops.aten.polygamma.default(4, value),
+        )
+
+
+@torch.no_grad()
+def test_polygamma_orders_reflection_poles_and_infinities() -> None:
+    values = [
+        -100.2,
+        -20.5,
+        -10.1,
+        -5.0,
+        -2.5,
+        -1.0,
+        -0.5,
+        -0.1,
+        -0.0,
+        0.0,
+        1e-6,
+        0.01,
+        0.1,
+        0.5,
+        1.0,
+        2.0,
+        10.0,
+        100.0,
+        float("inf"),
+        float("-inf"),
+        float("nan"),
+    ]
+    module = PolygammaOrders()
+    for dtype in (torch.float32, torch.float64):
+        value = torch.tensor(values, dtype=dtype)
+        _check(module, value, rtol=2e-4, atol=2e-5)
+
+
+class ModifiedBesselFamily(torch.nn.Module):
+    def forward(self, value):
+        return (
+            torch.ops.aten.i0.default(value),
+            torch.ops.aten.special_i0e.default(value),
+            torch.ops.aten.special_i1.default(value),
+            torch.ops.aten.special_i1e.default(value),
+            torch.ops.aten.special_modified_bessel_i0.default(value),
+            torch.ops.aten.special_modified_bessel_i1.default(value),
+            torch.ops.aten.special_spherical_bessel_j0.default(value),
+        )
+
+
+@torch.no_grad()
+def test_modified_bessel_family_across_approximation_intervals() -> None:
+    values = [
+        float("-inf"),
+        -100.0,
+        -20.0,
+        -8.0,
+        -1.0,
+        -0.0,
+        0.0,
+        1e-8,
+        1.0,
+        8.0,
+        20.0,
+        100.0,
+        float("inf"),
+        float("nan"),
+    ]
+    module = ModifiedBesselFamily()
+    for dtype, tolerance in ((torch.float32, 1e-5), (torch.float64, 1e-7)):
+        value = torch.tensor(values, dtype=dtype)
+        _check(module, value, rtol=tolerance, atol=tolerance)
+
+
+class CylindricalBesselAndAiryFamily(torch.nn.Module):
+    def forward(self, value):
+        return (
+            torch.ops.aten.special_bessel_j0.default(value),
+            torch.ops.aten.special_bessel_j1.default(value),
+            torch.ops.aten.special_bessel_y0.default(value),
+            torch.ops.aten.special_bessel_y1.default(value),
+            torch.ops.aten.special_modified_bessel_k0.default(value),
+            torch.ops.aten.special_modified_bessel_k1.default(value),
+            torch.ops.aten.special_scaled_modified_bessel_k0.default(value),
+            torch.ops.aten.special_scaled_modified_bessel_k1.default(value),
+            torch.ops.aten.special_airy_ai.default(value),
+        )
+
+
+@torch.no_grad()
+def test_cylindrical_bessel_and_airy_piecewise_approximations() -> None:
+    values = [
+        float("-inf"),
+        -100.0,
+        -10.0,
+        -5.001,
+        -5.0,
+        -2.1001,
+        -2.09,
+        -2.0,
+        -1e-8,
+        -0.0,
+        0.0,
+        1e-8,
+        1.0,
+        2.0,
+        2.09,
+        5.0,
+        5.001,
+        8.3203353,
+        20.0,
+        103.892,
+        103.893,
+        float("inf"),
+        float("nan"),
+    ]
+    module = CylindricalBesselAndAiryFamily()
+    for dtype, tolerance in ((torch.float32, 3e-5), (torch.float64, 3e-7)):
+        value = torch.tensor(values, dtype=dtype)
+        _check(module, value, rtol=tolerance, atol=tolerance / 10)
+
+
+class InverseProbabilityFunctions(torch.nn.Module):
+    def forward(self, erf_value, probability):
+        return (
+            torch.ops.aten.erfinv.default(erf_value),
+            torch.ops.aten.special_ndtri.default(probability),
+        )
+
+
+@torch.no_grad()
+def test_inverse_probability_functions_cover_tails_and_boundaries() -> None:
+    module = InverseProbabilityFunctions()
+    # Older supported PyTorch releases use a less accurate F64 erfinv tail
+    # approximation than Luminal (about 7e-5 relative error at 1 - eps).
+    # Keep the comparison tight enough to catch branch/coefficient mistakes
+    # without requiring Luminal to reproduce that version-specific error.
+    for dtype, tolerance in ((torch.float32, 1e-5), (torch.float64, 1e-4)):
+        epsilon = torch.finfo(dtype).eps
+        erf_value = torch.tensor(
+            [
+                float("-inf"),
+                -2.0,
+                -1.0,
+                -1.0 + epsilon,
+                -0.7,
+                -0.0,
+                0.0,
+                0.7,
+                1.0 - epsilon,
+                1.0,
+                2.0,
+                float("inf"),
+                float("nan"),
+            ],
+            dtype=dtype,
+        )
+        probability = torch.tensor(
+            [
+                float("-inf"),
+                -1.0,
+                -0.0,
+                0.0,
+                torch.finfo(dtype).tiny,
+                epsilon,
+                0.1,
+                0.5,
+                0.9,
+                1.0 - epsilon,
+                1.0,
+                2.0,
+                float("inf"),
+                float("nan"),
+            ],
+            dtype=dtype,
+        )
+        _check(module, erf_value, probability, rtol=tolerance, atol=tolerance)
+
+
+class ChebyshevPolynomial(torch.nn.Module):
+    def __init__(self, index):
+        super().__init__()
+        self.index = index
+
+    def forward(self, value, degree):
+        operations = (
+            torch.ops.aten.special_chebyshev_polynomial_t.default,
+            torch.ops.aten.special_chebyshev_polynomial_u.default,
+            torch.ops.aten.special_chebyshev_polynomial_v.default,
+            torch.ops.aten.special_chebyshev_polynomial_w.default,
+            torch.ops.aten.special_shifted_chebyshev_polynomial_t.default,
+            torch.ops.aten.special_shifted_chebyshev_polynomial_u.default,
+            torch.ops.aten.special_shifted_chebyshev_polynomial_v.default,
+            torch.ops.aten.special_shifted_chebyshev_polynomial_w.default,
+        )
+        return operations[self.index](value, degree)
+
+
+@torch.no_grad()
+def test_chebyshev_families_cover_runtime_degrees_and_domains() -> None:
+    for dtype, tolerance in ((torch.float32, 1e-5), (torch.float64, 1e-7)):
+        value = torch.tensor(
+            [-2.0, -1.0, -0.75, 0.0, 0.3, 1.0, 2.0, -0.2, 0.8, 1.25],
+            dtype=dtype,
+        )
+        degree = torch.tensor(
+            [-2.0, 0.0, 1.0, 2.0, 3.9, 7.0, 9.0, 10.0, 20.0, 25.0],
+            dtype=dtype,
+        )
+        for index in range(8):
+            module = ChebyshevPolynomial(index)
+            _check(module, value, degree, rtol=tolerance, atol=tolerance)
+
+
+class HistogramComposites(torch.nn.Module):
+    def forward(
+        self,
+        value,
+        weight,
+        bin_edges,
+        coordinates,
+        coordinate_weight,
+        first_edges,
+        second_edges,
+    ):
+        count_histogram = torch.ops.aten.histogram.bin_ct(
+            value,
+            4,
+            range=[-2.0, 3.0],
+            weight=weight,
+            density=False,
+        )
+        edge_histogram = torch.ops.aten.histogram.bins_tensor(
+            value,
+            bin_edges,
+            weight=weight,
+            density=True,
+        )
+        generated_edges = torch.ops.aten._histogramdd_bin_edges.default(
+            coordinates,
+            [3, 4],
+            range=[-2.0, 2.0, -1.0, 3.0],
+            weight=coordinate_weight,
+            density=False,
+        )
+        count_histogramdd = torch.ops.aten._histogramdd_from_bin_cts.default(
+            coordinates,
+            [3, 4],
+            range=[-2.0, 2.0, -1.0, 3.0],
+            weight=coordinate_weight,
+            density=True,
+        )
+        edge_histogramdd = torch.ops.aten._histogramdd_from_bin_tensors.default(
+            coordinates,
+            [first_edges, second_edges],
+            weight=coordinate_weight,
+            density=False,
+        )
+        return (
+            count_histogram,
+            edge_histogram,
+            generated_edges,
+            count_histogramdd,
+            edge_histogramdd,
+        )
+
+
+@torch.no_grad()
+def test_histogram_composites_have_fixed_bin_shapes() -> None:
+    module = HistogramComposites()
+    for dtype, tolerance in ((torch.float32, 1e-5), (torch.float64, 1e-7)):
+        inputs = (
+            torch.tensor(
+                [-3.0, -2.0, -1.0, -0.5, 0.0, 1.0, 3.0, 4.0, float("nan")],
+                dtype=dtype,
+            ),
+            torch.tensor([1.0, 2.0, 1.0, 3.0, 1.0, 2.0, 4.0, 1.0, 5.0], dtype=dtype),
+            torch.tensor([-2.0, -0.5, 1.0, 3.0], dtype=dtype),
+            torch.tensor(
+                [
+                    [-2.0, -1.0],
+                    [-1.0, 0.0],
+                    [0.0, 1.0],
+                    [1.0, 2.0],
+                    [2.0, 3.0],
+                    [3.0, 4.0],
+                    [float("nan"), 0.0],
+                ],
+                dtype=dtype,
+            ),
+            torch.tensor([1.0, 2.0, 1.0, 3.0, 4.0, 5.0, 7.0], dtype=dtype),
+            torch.tensor([-2.0, -0.25, 0.5, 2.0], dtype=dtype),
+            torch.tensor([-1.0, 0.0, 1.5, 3.0], dtype=dtype),
+        )
+        _check(module, *inputs, rtol=tolerance, atol=tolerance)
+
+
+class FixedShapeIndexing(torch.nn.Module):
+    def forward(self, value, mask, source, index, repeats, boundaries, queries):
+        return (
+            torch.ops.aten.slice_scatter.default(value, source[:2], 0, 1, 5, 2),
+            torch.ops.aten.masked_scatter.default(value, mask, source),
+            torch.ops.aten.put.default(value, index, source[:3], True),
+            torch.ops.aten.repeat_interleave.Tensor(repeats, output_size=6),
+            torch.ops.aten.nonzero_static.default(value, size=7, fill_value=-2),
+            torch.ops.aten.bucketize.Tensor(queries, boundaries, right=True),
+            torch.ops.aten.searchsorted.Tensor(boundaries, queries, right=False),
+        )
+
+
+def test_fixed_shape_indexing_and_search_composites() -> None:
+    inputs = (
+        torch.tensor([0.0, 1.0, 0.0, 2.0, 3.0, 0.0]),
+        torch.tensor([False, True, False, True, True, False]),
+        torch.tensor([9.0, 8.0, 7.0]),
+        torch.tensor([1, 1, -1]),
+        torch.tensor([2, 0, 1, 3]),
+        torch.tensor([1.0, 3.0, 5.0]),
+        torch.tensor([0.0, 1.0, 2.0, 5.0, float("nan")]),
+    )
+    module = FixedShapeIndexing()
+    _check(module, *inputs)
+
+
+class ComplexMovement(torch.nn.Module):
+    def forward(self, value, source, mask, gather_index, fancy_index):
+        return (
+            torch.ops.aten.gather.default(value, 1, gather_index),
+            torch.ops.aten.index.Tensor(value, [fancy_index]),
+            torch.ops.aten.slice_scatter.default(value, source, 1, 1, 4, 2),
+            torch.ops.aten.masked_scatter.default(value, mask, source.flatten()),
+            torch.ops.aten.put.default(
+                value, torch.tensor([1, 1, -1]), source.flatten()[:3], True
+            ),
+            torch.ops.aten.logcumsumexp.default(value + 80.0, 1),
+            torch.ops.aten.dist.default(value, value * 2.0, 2.0),
+        )
+
+
+def test_complex_movement_is_componentwise() -> None:
+    torch.manual_seed(0)
+    value = torch.randn(3, 4) + 1j * torch.randn(3, 4)
+    source = torch.randn(3, 2) + 1j * torch.randn(3, 2)
+    mask = torch.tensor(
+        [[False, True, False, True], [True, False, False, False], [False] * 4]
+    )
+    gather_index = torch.tensor([[3, 1], [0, 2], [1, 1]])
+    fancy_index = torch.tensor([2, 0])
+    module = ComplexMovement()
+    inputs = (value, source, mask, gather_index, fancy_index)
+    _check(module, *inputs)
+
+
+class PoolingAndResize(torch.nn.Module):
+    def forward(self, value):
+        max_values, max_indices = torch.ops.aten.max_pool2d_with_indices.default(
+            value, [2, 3], [1, 2], [1, 1], [1, 1], True
+        )
+        adaptive_values, adaptive_indices = torch.ops.aten.adaptive_max_pool2d.default(
+            value, [3, 2]
+        )
+        max_backward = torch.ops.aten.max_pool2d_with_indices_backward.default(
+            torch.ones_like(max_values),
+            value,
+            [2, 3],
+            [1, 2],
+            [1, 1],
+            [1, 1],
+            True,
+            max_indices,
+        )
+        return (
+            torch.ops.aten.avg_pool2d.default(
+                value, [3, 2], [2, 1], [1, 1], True, False, None
+            ),
+            torch.ops.aten._adaptive_avg_pool2d.default(value, [3, 2]),
+            max_values,
+            max_indices,
+            adaptive_values,
+            adaptive_indices,
+            max_backward,
+            torch.ops.aten.upsample_bilinear2d.vec(value, [7, 5], False, None),
+            torch.ops.aten._upsample_bilinear2d_aa.default(
+                value, [2, 3], False, None, None
+            ),
+            torch.ops.aten._upsample_bilinear2d_aa.default(
+                value, [7, 3], True, None, None
+            ),
+        )
+
+
+def test_pooling_and_bilinear_resize_composites() -> None:
+    torch.manual_seed(1)
+    value = torch.randn(1, 2, 4, 5)
+    module = PoolingAndResize()
+    _check(module, value)
+
+
+class AntialiasedBilinearResize(torch.nn.Module):
+    def forward(self, value):
+        return (
+            torch.ops.aten._upsample_bilinear2d_aa.default(
+                value, [2, 3], False, 0.5, 0.6
+            ),
+            torch.ops.aten._upsample_bilinear2d_aa.default(
+                value, [7, 8], True, None, None
+            ),
+        )
+
+
+def test_antialiased_bilinear_resize_float_and_uint8() -> None:
+    torch.manual_seed(7)
+    module = AntialiasedBilinearResize()
+    values = (
+        torch.randn(1, 3, 4, 5, dtype=torch.float32),
+        torch.randn(1, 3, 4, 5, dtype=torch.float64),
+        torch.randint(0, 256, (1, 3, 4, 5), dtype=torch.uint8),
+    )
+    for value in values:
+        _check(module, value)
+
+
+class FunctionalBatchNorm(torch.nn.Module):
+    def forward(self, value, weight, bias, running_mean, running_var):
+        return torch.ops.aten._native_batch_norm_legit_functional.default(
+            value,
+            weight,
+            bias,
+            running_mean,
+            running_var,
+            True,
+            0.2,
+            1e-5,
+        )
+
+
+def test_functional_batch_norm_returns_stats_and_updates() -> None:
+    torch.manual_seed(2)
+    inputs = (
+        torch.randn(2, 3, 4, 5),
+        torch.randn(3),
+        torch.randn(3),
+        torch.randn(3),
+        torch.rand(3) + 0.5,
+    )
+    module = FunctionalBatchNorm()
+    _check(module, *inputs)
+
+
+class OrderingAndDistances(torch.nn.Module):
+    def forward(self, value, other, points, points2):
+        return (
+            torch.ops.aten.max.dim(value, 1, False),
+            torch.ops.aten.min.dim(value, 1, True),
+            torch.ops.aten.median.dim(value, 1, False),
+            torch.ops.aten.nanmedian.dim(value, 1, False),
+            torch.ops.aten.dist.default(value, other, 2.5),
+            torch.ops.aten._cdist_forward.default(points, points2, 2.0, None),
+            torch.ops.aten._pdist_forward.default(points, 2.0),
+        )
+
+
+class IntegerGcd(torch.nn.Module):
+    def forward(self, lhs, rhs):
+        return torch.ops.aten.gcd.default(lhs, rhs)
+
+
+def test_integer_gcd_static_euclidean_rounds() -> None:
+    module = IntegerGcd()
+    values = {
+        torch.uint8: ([0, 1, 6, 17, 200, 255], [0, 4, 8, 51, 125, 254]),
+        torch.int8: ([-128, -10, -1, 0, 6, 127], [0, 4, 3, -8, 15, 126]),
+        torch.int16: ([-32768, -144, -1, 0, 610, 32767], [0, 89, 3, -8, 987, 32766]),
+        torch.int32: (
+            [-(2**31), -10946, -1, 0, 46368, 2**31 - 1],
+            [0, 6765, 3, -8, 75025, 2**31 - 2],
+        ),
+        torch.int64: (
+            [-(2**63), -1836311903, -1, 0, 2971215073, 2**63 - 1],
+            [0, 1134903170, 3, -8, 4807526976, 2**63 - 2],
+        ),
+    }
+    for dtype, (lhs_values, rhs_values) in values.items():
+        lhs = torch.tensor(lhs_values, dtype=dtype)
+        rhs = torch.tensor(rhs_values, dtype=dtype)
+        _check(module, lhs, rhs)
+
+
+def test_ordering_and_distance_composites() -> None:
+    value = torch.tensor([[1.0, 4.0, 2.0, 2.0], [float("nan"), 2.0, 3.0, 4.0]])
+    other = torch.tensor([[0.0, 3.0, 1.0, 4.0], [1.0, 2.0, 5.0, 3.0]])
+    points = torch.tensor([[0.0, 1.0], [2.0, 3.0], [-1.0, 4.0]])
+    points2 = torch.tensor([[1.0, 0.0], [3.0, -2.0]])
+    module = OrderingAndDistances()
+    inputs = (value, other, points, points2)
+    _check(module, *inputs)
+
+
+class TrilinearAndEmbeddingBag(torch.nn.Module):
+    def forward(self, left, right, weight, bias, indices, offsets, sample_weights):
+        return (
+            torch.nn.functional.bilinear(left, right, weight, bias),
+            torch.nn.functional.embedding_bag(
+                indices,
+                weight.flatten(1),
+                offsets,
+                mode="sum",
+                per_sample_weights=sample_weights,
+                padding_idx=2,
+            ),
+            torch.nn.functional.embedding_bag(
+                indices,
+                weight.flatten(1),
+                offsets,
+                mode="mean",
+                padding_idx=2,
+            ),
+            torch.nn.functional.embedding_bag(
+                indices,
+                weight.flatten(1),
+                offsets,
+                mode="max",
+                padding_idx=2,
+            ),
+        )
+
+
+def test_trilinear_and_embedding_bag_composites() -> None:
+    torch.manual_seed(3)
+    inputs = (
+        torch.randn(2, 3),
+        torch.randn(2, 4),
+        torch.randn(5, 3, 4),
+        torch.randn(5),
+        torch.tensor([1, 2, 0, 3, 2]),
+        torch.tensor([0, 2, 2, 5]),
+        torch.tensor([0.5, 2.0, -1.0, 1.5, 3.0]),
+    )
+    module = TrilinearAndEmbeddingBag()
+    _check(module, *inputs)
+
+
+class Sampling2d(torch.nn.Module):
+    def forward(self, value, grid, random_samples):
+        return (
+            torch.ops.aten.grid_sampler_2d.default(value, grid, 0, 2, False),
+            torch.ops.aten.grid_sampler_2d.default(value, grid, 2, 1, True),
+            torch.ops.aten.fractional_max_pool2d.default(
+                value, [2, 3], [3, 2], random_samples
+            ),
+        )
+
+
+def test_fixed_shape_2d_sampling_composites() -> None:
+    torch.manual_seed(4)
+    # NaN grid coordinates changed semantics across supported PyTorch
+    # releases; finite out-of-bounds coordinates keep this regression focused
+    # on Luminal's interpolation and padding rather than host-version behavior.
+    inputs = (
+        torch.randn(1, 2, 5, 6),
+        torch.tensor(
+            [
+                [
+                    [[-1.4, -1.2], [-0.5, 0.25], [1.3, 0.8]],
+                    [[-0.75, 0.0], [0.2, -0.9], [1.0, 1.0]],
+                ]
+            ]
+        ),
+        torch.rand(1, 2, 2),
+    )
+    module = Sampling2d()
+    _check(module, *inputs)
+
+
+class Sampling3d(torch.nn.Module):
+    def forward(self, value, grid, random_samples):
+        return (
+            torch.ops.aten.grid_sampler_3d.default(value, grid, 0, 2, False),
+            torch.ops.aten.fractional_max_pool3d.default(
+                value, [2, 2, 3], [2, 3, 2], random_samples
+            ),
+        )
+
+
+def test_fixed_shape_3d_sampling_composites() -> None:
+    torch.manual_seed(5)
+    inputs = (
+        torch.randn(1, 2, 4, 5, 6),
+        torch.tensor(
+            [
+                [
+                    [
+                        [[-1.3, -1.1, -0.7], [0.2, 0.4, 0.6]],
+                        [[1.2, 0.8, 1.4], [float("nan"), 0.0, 0.0]],
+                    ]
+                ]
+            ]
+        ),
+        torch.rand(1, 2, 3),
+    )
+    module = Sampling3d()
+    _check(module, *inputs)
+
+
+class SegmentReductions(torch.nn.Module):
+    def forward(self, value, lengths, offsets):
+        return (
+            torch.segment_reduce(value, "sum", lengths=lengths, axis=1, initial=2.0),
+            torch.segment_reduce(value, "mean", offsets=offsets, axis=1, initial=1.0),
+            torch.segment_reduce(value, "prod", lengths=lengths, axis=1, initial=-1.0),
+            torch.segment_reduce(value, "max", offsets=offsets, axis=1, initial=0.5),
+            torch.segment_reduce(value, "min", lengths=lengths, axis=1),
+        )
+
+
+def test_fixed_shape_segment_reduce_composites() -> None:
+    value = torch.tensor(
+        [
+            [1.0, 3.0, -2.0, 5.0, 4.0],
+            [-1.0, 2.0, 6.0, -3.0, 7.0],
+        ]
+    )
+    lengths = torch.tensor([[0, 1, 2, 2], [2, 0, 3, 0]])
+    offsets = torch.nn.functional.pad(lengths, [1, 0]).cumsum(1)
+    module = SegmentReductions()
+    inputs = (value, lengths, offsets)
+    _check(module, *inputs)

--- a/crates/luminal_python/tests/test_straightforward_lowerings.py
+++ b/crates/luminal_python/tests/test_straightforward_lowerings.py
@@ -38,6 +38,114 @@ def _complex_randn(*shape: int, dtype=torch.complex64) -> torch.Tensor:
     )
 
 
+class SmallAlgebraicAliases(torch.nn.Module):
+    def forward(self, value, exponent, integers):
+        return (
+            torch.ops.aten.any.default(value),
+            torch.ops.aten.any.dim(value, -1, True),
+            torch.ops.aten.any.dims(value, [], False),
+            torch.ops.aten.log1p.default(value),
+            torch.ops.aten.expm1.default(value),
+            torch.ops.aten.log10.default(value + 2.0),
+            torch.ops.aten.sinh.default(value),
+            torch.ops.aten.tan.default(value),
+            torch.ops.aten.angle.default(value),
+            torch.ops.aten.isinf.default(value),
+            torch.ops.aten.isinf.default(integers),
+            torch.ops.aten.ldexp.Tensor(value, exponent),
+        )
+
+
+class CopyAndStableSortAliases(torch.nn.Module):
+    def forward(self, value):
+        permuted = torch.ops.aten.permute_copy.default(value, [1, 0])
+        unbound = torch.ops.aten.unbind_copy.int(permuted, 0)
+        sorted_values, sorted_indices = torch.ops.aten.sort.stable(
+            value, stable=True, dim=-1, descending=True
+        )
+        return (
+            torch.ops.aten.view_copy.default(value, [2, 6]),
+            permuted,
+            torch.ops.aten.narrow_copy.default(permuted, -1, 1, 2),
+            *unbound,
+            sorted_values,
+            sorted_indices,
+        )
+
+
+class ScatterAliases(torch.nn.Module):
+    def forward(self, value, index, source):
+        return (
+            torch.ops.aten.scatter.reduce(value, 1, index, source, reduce="add"),
+            torch.ops.aten.scatter.reduce(value, 1, index, source, reduce="multiply"),
+            torch.ops.aten.scatter.value_reduce(value, 1, index, 1.5, reduce="add"),
+            torch.ops.aten.scatter.value_reduce(
+                value, 1, index, -0.5, reduce="multiply"
+            ),
+            torch.ops.aten.scatter_add.default(value, 1, index, source),
+        )
+
+
+class OptionalIndexPutAccumulate(torch.nn.Module):
+    def forward(self, value, index, source):
+        return torch.ops.aten.index_put.default(
+            value, [None, index], source, accumulate=True
+        )
+
+
+def test_small_algebraic_aliases_use_existing_primitives() -> None:
+    value = torch.tensor([[0.0, 0.25, -0.5], [1.0, 0.0, 0.75]])
+    exponent = torch.tensor([[0, 1, -1], [2, -2, 3]], dtype=torch.int32)
+    integers = torch.tensor([[0, 1, -2], [3, 0, 4]], dtype=torch.int64)
+    module = SmallAlgebraicAliases()
+    _assert_outputs(
+        _compile(module, value, exponent, integers)(value, exponent, integers),
+        module(value, exponent, integers),
+    )
+
+
+def test_copy_aliases_and_stable_sort_preserve_all_outputs() -> None:
+    value = torch.tensor(
+        [[3.0, 1.0, 3.0, 2.0], [0.0, 4.0, 4.0, -1.0], [2.0, 2.0, 1.0, 0.0]]
+    )
+    module = CopyAndStableSortAliases()
+    _assert_outputs(_compile(module, value)(value), module(value))
+
+
+def test_scatter_aliases_accumulate_duplicate_destinations_in_order() -> None:
+    value = torch.tensor([[2.0, 3.0, 5.0], [7.0, 11.0, 13.0]])
+    index = torch.tensor([[0, 0, 2], [1, 1, 1]])
+    source = torch.tensor([[2.0, 3.0, 4.0], [0.5, 2.0, -1.0]])
+    module = ScatterAliases()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        expected = module(value, index, source)
+        actual = _compile(module, value, index, source)(value, index, source)
+    _assert_outputs(actual, expected)
+
+
+def test_optional_index_put_accumulates_real_and_complex_duplicates() -> None:
+    index = torch.tensor([1, 1, 3])
+    module = OptionalIndexPutAccumulate()
+    for value, source in (
+        (
+            torch.arange(10, dtype=torch.float32).reshape(2, 5),
+            torch.tensor([[2.0, 3.0, 4.0], [-1.0, 0.5, 7.0]]),
+        ),
+        (
+            _complex_randn(2, 5),
+            torch.tensor(
+                [[2 + 1j, 3 - 4j, 4 + 0j], [-1 + 2j, 0.5j, 7 - 3j]],
+                dtype=torch.complex64,
+            ),
+        ),
+    ):
+        _assert_outputs(
+            _compile(module, value, index, source)(value, index, source),
+            module(value, index, source),
+        )
+
+
 class LinearComposites(torch.nn.Module):
     def __init__(self, alpha, beta):
         super().__init__()

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -44,6 +44,7 @@ Dispositions:
 | `eb7a5d6e` | #407 | metal: add fused RMSNorm and simd-group reductions | FILE-LEVEL (park) + INTENT-ONLY (CL) | branch `merge/main-407-metal-rmsnorm` | REQUIREMENT FOR CL: the live CUDA `reduce` codegen is a serial per-output loop with NO warp-level reduction, and no fused RMSNorm op exists — main`s `simd_sum`/`simd_max` block reduction is the CUDA-applicable half; see **#407 metal RMSNorm + simd reductions** below |
 | `62d3cc0d` | #406 | Expand PyTorch lowering and complex dtype coverage | MIXED — FILE-LEVEL (24 python files + `docs/design/associative-fold.md`) / FILE-LEVEL (7 files into the `cuda_lite_hlir` park) / RE-EXPRESSED (core: `ne` -> Bool, NaN-safe `pad`) / N/A (`examples/gemma4_moe`, `src/graph.rs`) / DROPPED-AS-INERT (`rowmajor-empty`) | branch `merge/main-406-pt-lowering` (two commits) | LUM-803 (ideal value types) and LUM-804 (native Bool8 select) — see **#406 PyTorch lowering + complex dtypes** below |
 | `b37eea15` | #409 | Compile-time optimization | FILE-LEVEL (26 files into the `cuda_lite_hlir` park, 1 into the metal park) + UNCARRIED (5 core files, intent recorded) + N/A (`examples/llama`) | branch `merge/main-409-compile-time-park` | RULED 2026-09-03: *"move all this stuff to the hlir park and we'll get to it later. We don't actually need to do much here."* The dense-integer e-graph extraction index, the prepare/profile candidate split, and the two `Expression` intern-identity helpers are the pieces worth revisiting — see **#409 compile-time optimization** below |
+| `2f820521` | #414 | Expand PyTorch ATen lowering coverage | FILE-LEVEL (19 python-park files + 2 into the `cuda_lite_hlir` park) + LANDED-BY-EQUIVALENT (`src/frontend/movement.rs`) + N/A (`examples/flux2`) | branch `merge/main-414-aten-coverage` | RULED 2026-09-03: *"we can also do 414 in one go."* ~115 new ATen overloads = M4 translator requirements; the `as_float` non-finite JSON decoding is a correctness nugget worth keeping — see **#414 ATen coverage** below |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -1607,6 +1608,165 @@ at `:306` and passed to the matmul at `:376` — so the size is a compile-time
 constant, never zero, and never derived from a per-spec `workspace_size` that
 a heuristic could return as 0. The recycling half of the fix is a main-side
 allocator concern with no counterpart here.
+
+## #414 ATen coverage — banked in one go
+
+RULED 2026-09-03: *"we can also do 414 in one go."* Main's `2f820521` is
+23 files, +8134/-121, and 19 of them are the python park.
+
+### FILE-LEVEL: 19 files in `crates/luminal_python`
+
+Fourteen Rust files (two of them new — `translator/pooling.rs`, 928 lines, and
+`translator/sampling.rs`, 314) and five pytest files (`test_fft.py` and
+`test_remaining_existing_hlir_lowerings.py` new). Main's content, this
+branch's spellings, per the standing park rule.
+
+**What it adds.** Roughly 115 new `torch.ops.aten.*` overloads reach a
+lowering, in recognizable families:
+
+- **Elementwise + special functions** — `hypot`, `gcd`, `expm1`, `sinh`, `tan`,
+  `log1p`, `log10`, `angle`, `isinf`, `signbit`, `hardtanh`, `elu`,
+  `leaky_relu`, `round.default`/`round.decimals`, `erfc`, `erfinv`,
+  `special_erfcx`, `lgamma`, `digamma`, `polygamma`, `i0`, and the whole Bessel
+  / Chebyshev-polynomial / Airy / `ndtri` block. `erf` itself moves out of the
+  giant `dispatch.rs` match arm into `translate_erf`.
+- **Pooling and normalization** (`translator/pooling.rs`) — `avg_pool2d/3d`,
+  `_adaptive_avg_pool2d/3d`, `max_pool2d/3d_with_indices` (+ the 2d backward),
+  `adaptive_max_pool2d/3d`, `fractional_max_pool2d/3d`, `grid_sampler_2d/3d`,
+  and the `_native_batch_norm_legit` / `_batch_norm_with_update_functional`
+  family.
+- **Reductions and statistics** — `var` / `var_mean` in all three overloads,
+  `any.default/dim/dims`, `max.dim`, `min.dim`, `median`/`nanmedian`,
+  `logcumsumexp`, `linalg_vector_norm`, `dist`, `_cdist_forward`,
+  `_pdist_forward`, `_trilinear`, `segment_reduce`, and the `histogram` /
+  `_histogramdd_*` set.
+- **Scatter/gather with reductions** — `scatter.reduce`,
+  `scatter.value_reduce`, `scatter_add`, `scatter_reduce.two`, `index_reduce`,
+  `slice_scatter`, `masked_scatter`, `put`, `nonzero_static`,
+  `embedding_renorm`, `_embedding_bag_forward_only`.
+- **Sampling and sorting** (`translator/sampling.rs`) — `sort.default` and
+  `sort.stable`.
+- **Constructors and copies** — `empty.memory_format`, `empty_permuted`,
+  `empty_strided`, `new_empty_strided`, `tril_indices`, `triu_indices`,
+  `view_copy`, `permute_copy`, `narrow_copy`, `unbind_copy.int`,
+  `upsample_bilinear2d.vec` and its antialiased form.
+
+Two pieces of the mechanism are worth naming because they are reusable
+requirements, not just op count. First, `translator/mod.rs` grows a
+**by-name argument reader** — `named_input_index` / `named_int_arg` /
+`named_float_arg` / `named_bool_arg` / `named_tensor_arg` — plus
+`tensor_output_names` / `store_tensor_outputs` for multi-output ops and two
+constructors (`axis_positions`, `full_tensor`). Main's own comment on the
+`sort` change says why: *"`sort.stable` inserts a keyword-only `stable`
+argument before dim, so resolve these by schema name rather than by
+overload-dependent position."* Positional argument indices are not stable
+across ATen overloads, and every lowering that used them was one overload away
+from silently reading the wrong argument. Second, `reduce_scatter_elements` is
+a **sequential read/modify/write** lowering shared by `scatter_reduce` and
+`index_reduce`: core `Scatter` is overwrite-only, so preserving duplicate
+update order needs one static graph step per update element, and a symbolic
+update stream is padded to its compile-time upper bound
+(`bounds_of_expr(..).max`, the new `pt2_expr::bounds_of_expr`) with validity
+guards making the padding lanes no-ops. That is an expensive shape, and it is
+the kind of thing an ordered-scatter primitive would collapse — the same
+argument LUM-804 makes for select.
+
+**The correctness nugget, so it is not lost in the bulk.**
+`pt2_schema.rs`'s `Argument::as_float` learns to decode non-finite floats:
+
+```rust
+// PT2 JSON cannot encode IEEE non-finite values as JSON numbers,
+// so torch serializes them as strings inside the usual as_float
+// wrapper (notably linalg_vector_norm's +/-Infinity orders).
+Argument::Other(value) => value.get("as_float").and_then(Value::as_str)
+    .and_then(|value| match value {
+        "Infinity" | "+Infinity" => Some(f64::INFINITY),
+        "-Infinity" => Some(f64::NEG_INFINITY),
+        "NaN" => Some(f64::NAN),
+        _ => value.parse().ok(),
+    }),
+```
+
+Before this, `linalg_vector_norm(x, ord=inf)` — the infinity norm, a perfectly
+ordinary call — did not fail: `as_float` returned `None` and the argument
+silently took whatever default the lowering had. **Any future PT2 boundary on
+this branch inherits the same trap**: JSON has no encoding for `Infinity` or
+`NaN`, so a serializer must use strings, and a reader that only accepts
+`Value::Number` will silently mis-read them. That is a requirement on the M4
+translator re-attachment, and it is not python-specific.
+
+**Application and conflicts.** Applied as one 3-way patch (the "in one go"
+path — no file was taken wholesale). Six hunks conflicted in five files,
+every one because the park has drifted, and every resolution takes main's
+content in the park's spelling:
+
+| file | conflict | resolution |
+| --- | --- | --- |
+| `translator/dispatch.rs` | the park still had `erf` inline in the match arm | main's `self.translate_erf(node)?` |
+| `translator/mod.rs` | the park's `tensor_meta_to_shape` returns `Result<Vec<IntExpr>>` | main's seven new helpers inserted above it, `Expression` -> `IntExpr` |
+| `translator/movement_dynamic.rs` | `row_major_strides` already widened to `pub(super)` at `&[IntExpr]` by #406 | main's new `ScatterReduction` enum ahead of it |
+| `translator/tensor.rs` | `sort`'s dim/descending read (`a.shape.len()` here is `a.legacy_tracker_ref().len()`) | main's by-schema-name resolution, re-spelled |
+| `translator/movement.rs` (x2) | the whole `reduce_scatter_elements` block landed on top of the park's `translate_scatter_value` | main's block, re-spelled |
+
+**Residue** (diff-of-diffs against `2f820521`, per file). All five `.py`
+files, `pt2_schema.rs` and `typed_data.rs` are EMPTY, and so are both new Rust
+files apart from re-spellings. Everything else is exclusively the standing
+park re-spellings — `Expression` -> `IntExpr`, and `X.shape` ->
+`X.legacy_tracker_ref()` / `X.legacy_tracker_mut()` / `X.dims()` by whether the
+tracker is read, mutated, or passed by value. **Drift-invariance check**: for
+every carried file, `diff(main preimage, park before)` and `diff(main
+postimage, park after)` differ ONLY by re-spellings of main's own added lines;
+nothing pre-existing moved. In particular `movement_dynamic.rs` keeps the park
+version of the `pt2_scatter_nd` trailing-offset scaffolding — the #402 row
+recorded main's fix there as SUPERSEDED (this branch fixed the same defect by a
+stronger mechanism in `src/frontend/movement.rs:563`), and this commit does not
+quietly reintroduce main's version.
+
+Two park costs stay as they are, and are noted so nobody "fixes" them by
+accident: the crate's `.gather(` / `.scatter(` calls are still main's spelling
+in 11 places (only the lines earlier batches happened to touch became
+`gather1d` / `scatter1d`), and `ShapeTracker` — which the re-spelled
+`legacy_tracker_ref()` / `legacy_tracker_mut()` return — no longer exists
+anywhere in this branch's `src/`. The park does not build, and this commit does
+not change that.
+
+### FILE-LEVEL: 2 files into the `cuda_lite_hlir` park
+
+`src/runtime.rs` and `src/tests/flashinfer.rs`, path-rewritten. Pure Rust
+1.98 clippy churn: `bytes.chunks_exact(N).map(|c| T::from_ne_bytes([c[0],
+...]))` becomes `bytes.as_chunks::<N>().0.iter().map(|b|
+T::from_ne_bytes(*b))` in `get_i16` / `get_i32` / `get_i64` / `get_f64` and in
+the bf16 test helper. Applied cleanly; residue empty.
+
+**The same pattern exists in the live CL crate** at
+`crates/luminal_cuda_lite/src/device.rs:73`, `:79` and `:85` (three
+`chunks_exact` readers). It is not touched here — nothing in this commit's
+scope reaches the live crate, the workspace clippy gate is green as-is, and
+converting them is a standalone cleanup, not part of this walk.
+
+### LANDED-BY-EQUIVALENT — `src/frontend/movement.rs`
+
+Main's one core hunk (+1/-1) adds `.simplify()` to pad's output dims:
+`new_dims.push((dim + *start + *end).simplify())`. **This branch already does
+exactly that**, at `src/frontend/movement.rs:1121`:
+
+```rust
+let out_dims: Vec<IntExpr> = dims.iter().zip(&padding)
+    .map(|(d, (s, e))| (*d + *s + *e).simplify())
+    .collect();
+```
+
+with the comment on the line above naming its provenance — *"Frontend
+simplification restored (revert ruling 2026-08-27)"*. No edit; live core is
+untouched by this commit.
+
+### N/A — `examples/flux2/src/main.rs`
+
++4/-2, the same `chunks_exact` -> `as_chunks` churn in
+`read_safetensors_f32`. This branch's `examples/flux2` has no `src/main.rs`:
+it is `lib.rs` + `transformer.rs`, because model-zoo members here are
+backend-neutral graph definitions and the executables live under the runtime
+crate. Nothing to patch.
 
 ## #406 pad — the select construction REVERTED (2026-09-03)
 


### PR DESCRIPTION
**Stack.** PR 2 of 4, batch 5 of the main rejoin (main's post-split commits, chronological). Base: `merge/main-409-compile-time-park`. Merge in order; before merging, retarget to `logical-ssa-project` with `gh pr edit --base logical-ssa-project`.

**Gate policy (Austin, 2026-09-03):** run at risk — minimal gate on live-core commits (build, added tests by exact name, lib-only clippy, fmt); parks need no build.

## `2392526e` ATen coverage (#414): the python park banked in one go

Main's 2f820521 lowers ~115 more torch.ops.aten overloads: the special
function block (Bessel/Chebyshev/Airy/erfinv/lgamma/digamma), pooling and
batch norm in a new translator/pooling.rs, var/var_mean/median/histogram/
cdist/pdist reductions, the scatter-with-reduction family, sort in a new
translator/sampling.rs, and the empty_*/tril_indices/*_copy constructors.
Per Austin's ruling ("we can also do 414 in one go") the 19 python files
land as one 3-way application rather than file-by-file.

Six hunks conflicted across five translator files, each on park drift
(IntExpr, legacy_tracker_ref/mut, #406's row_major_strides widening);
each resolves to main's content in the park's spelling. Drift-invariance
checked per file: nothing pre-existing moved, and movement_dynamic.rs
keeps the park's scatter_nd scaffolding rather than reintroducing the
version #402 recorded as superseded.

Two mechanism pieces are recorded in the ledger as M4 requirements rather
than left as op count: the by-schema-name argument readers (positional
indices are not stable across ATen overloads — sort.stable inserts a
keyword-only argument before dim), and Argument::as_float learning to
decode +/-Infinity and NaN, which PT2 serializes as JSON strings because
JSON cannot encode them as numbers.

crates/luminal_cuda_lite/src/{runtime.rs,tests/flashinfer.rs} is
chunks_exact -> as_chunks clippy churn, parked. examples/flux2/src/main.rs
does not exist here (N/A). src/frontend/movement.rs is landed-by-equivalent:
pad already computes (*d + *s + *e).simplify() at movement.rs:1121, so live
core is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
