### PR TITLE
main rejoin: Metal constants by bit pattern (#413): banked; same defect found live in CUDA

### DIFF
--- a/crates/luminal_metal/src/kernel/ops.rs
+++ b/crates/luminal_metal/src/kernel/ops.rs
@@ -2785,12 +2785,14 @@ impl MetalKernelOp for MetalConstant {
         _input_dtypes: &[DType],
         _output_dtype: DType,
     ) -> Option<ComputePipelineState> {
-        // Ensure value is formatted with decimal point for Metal (e.g., -1.0f not -1f)
-        let value_str = if self.value.fract() == 0.0 {
-            format!("{:.1}", self.value)
-        } else {
-            format!("{}", self.value)
-        };
+        // Emit the constant by its f32 bit pattern rather than as a decimal
+        // literal. Decimal formatting is not total over f32: `Display` renders
+        // the infinities as `inf` and NaNs as `NaN`, which with the `f` literal
+        // suffix produced `-inff` / `NaNf` and failed MSL compilation. Round-
+        // tripping the bits reproduces every f32 exactly, including the
+        // non-finite ones, with no value-dependent branch.
+        let value_bits = self.value.to_bits();
+        let value_str = format!("as_type<float>(0x{value_bits:08x}u)");
 
         let source = format!(
             r#"
@@ -2803,7 +2805,7 @@ impl MetalKernelOp for MetalConstant {
                 uint idx [[thread_position_in_grid]]
             ) {{
                 if (idx == 0) {{
-                    out[0] = {value}f;
+                    out[0] = {value};
                 }}
             }}
             "#,

--- a/crates/luminal_metal/src/tests.rs
+++ b/crates/luminal_metal/src/tests.rs
@@ -1877,3 +1877,98 @@ fn test_gather_preserves_data_dtype() {
 
     assert_close(&rt.get_f32(out), &[2.5], 0.001);
 }
+
+/// Run `f` on both the Metal and reference runtimes over the same input and
+/// return `(metal, reference)` outputs.
+fn metal_and_reference(
+    build: impl Fn(&mut Graph) -> (GraphTensor, GraphTensor),
+    input: &[f32],
+) -> (Vec<f32>, Vec<f32>) {
+    let mut cx = Graph::default();
+    let (a, output) = build(&mut cx);
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
+    let mut metal = MetalRuntime::initialize(());
+    metal.set_data(a, input);
+    let mut metal = cx.search(metal, CompileOptions::default().search_graph_limit(5));
+    metal.allocate_intermediate_buffers(&cx.dyn_map);
+    metal.execute(&cx.dyn_map);
+    let metal_out = metal.get_f32(output);
+
+    let mut cx = Graph::default();
+    let (a, output) = build(&mut cx);
+    cx.build_search_space::<ReferenceRuntime>(CompileOptions::default());
+    let mut reference = cx.search(
+        ReferenceRuntime::default(),
+        CompileOptions::default().search_graph_limit(1),
+    );
+    reference.set_data(a.id, input.to_vec());
+    reference.execute(&cx.dyn_map);
+    let reference_out = reference.get_f32(output).to_vec();
+
+    (metal_out, reference_out)
+}
+
+/// Bit-exact comparison, so NaN matches NaN and the two infinities stay
+/// distinct. `assert_close` cannot express this: every comparison against a
+/// NaN is false, so a NaN mismatch would pass silently.
+fn assert_bit_equal(actual: &[f32], expected: &[f32]) {
+    assert_eq!(actual.len(), expected.len(), "length mismatch");
+    for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+        assert_eq!(
+            a.to_bits(),
+            e.to_bits(),
+            "index {i}: got {a} (0x{:08x}), expected {e} (0x{:08x})",
+            a.to_bits(),
+            e.to_bits()
+        );
+    }
+}
+
+#[test]
+fn metal_constant_reproduces_every_f32_bit_pattern() {
+    // Spans the classes decimal formatting could not render: both infinities,
+    // a NaN, both zeros, and a subnormal — plus ordinary finite values.
+    const VALUES: [f32; 10] = [
+        f32::NEG_INFINITY,
+        f32::INFINITY,
+        f32::NAN,
+        0.0,
+        -0.0,
+        f32::MIN_POSITIVE,
+        -1.0,
+        3.5,
+        1e-8,
+        f32::MAX,
+    ];
+    let input = [1.0f32, 2.0, 3.0, 4.0];
+
+    for value in VALUES {
+        let (metal, reference) = metal_and_reference(
+            |cx| {
+                let a = cx.tensor(4);
+                (a, (a * value).output())
+            },
+            &input,
+        );
+        assert_bit_equal(&metal, &reference);
+    }
+}
+
+#[test]
+fn metal_constant_negative_infinity_mask_matches_reference() {
+    // The shape an attention mask takes: adding -inf drives masked positions to
+    // -inf, and softmax over them must agree with the reference backend.
+    let input = [1.0f32, 2.0, 3.0, 4.0];
+    let (metal, reference) = metal_and_reference(
+        |cx| {
+            let a = cx.tensor(4);
+            (a, (a + f32::NEG_INFINITY).output())
+        },
+        &input,
+    );
+    assert_bit_equal(&metal, &reference);
+    assert!(
+        metal.iter().all(|v| *v == f32::NEG_INFINITY),
+        "expected all -inf, got {metal:?}"
+    );
+}

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -45,6 +45,7 @@ Dispositions:
 | `62d3cc0d` | #406 | Expand PyTorch lowering and complex dtype coverage | MIXED — FILE-LEVEL (24 python files + `docs/design/associative-fold.md`) / FILE-LEVEL (7 files into the `cuda_lite_hlir` park) / RE-EXPRESSED (core: `ne` -> Bool, NaN-safe `pad`) / N/A (`examples/gemma4_moe`, `src/graph.rs`) / DROPPED-AS-INERT (`rowmajor-empty`) | branch `merge/main-406-pt-lowering` (two commits) | LUM-803 (ideal value types) and LUM-804 (native Bool8 select) — see **#406 PyTorch lowering + complex dtypes** below |
 | `b37eea15` | #409 | Compile-time optimization | FILE-LEVEL (26 files into the `cuda_lite_hlir` park, 1 into the metal park) + UNCARRIED (5 core files, intent recorded) + N/A (`examples/llama`) | branch `merge/main-409-compile-time-park` | RULED 2026-09-03: *"move all this stuff to the hlir park and we'll get to it later. We don't actually need to do much here."* The dense-integer e-graph extraction index, the prepare/profile candidate split, and the two `Expression` intern-identity helpers are the pieces worth revisiting — see **#409 compile-time optimization** below |
 | `2f820521` | #414 | Expand PyTorch ATen lowering coverage | FILE-LEVEL (19 python-park files + 2 into the `cuda_lite_hlir` park) + LANDED-BY-EQUIVALENT (`src/frontend/movement.rs`) + N/A (`examples/flux2`) | branch `merge/main-414-aten-coverage` | RULED 2026-09-03: *"we can also do 414 in one go."* ~115 new ATen overloads = M4 translator requirements; the `as_float` non-finite JSON decoding is a correctness nugget worth keeping — see **#414 ATen coverage** below |
+| `b745d102` | #413 | metal: emit constants by f32 bit pattern | FILE-LEVEL (2 metal-park files) | branch `merge/main-413-metal-constants` | RULED 2026-09-03: *"same 413 is fine. we can just merge this and check later."* The CHECK is done and the answer is NO: live CUDA constant codegen has the same defect — see **#413 metal constants** below |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -1767,6 +1768,73 @@ untouched by this commit.
 it is `lib.rs` + `transformer.rs`, because model-zoo members here are
 backend-neutral graph definitions and the executables live under the runtime
 crate. Nothing to patch.
+
+## #413 metal constants — banked, and the same defect is live in CUDA
+
+RULED 2026-09-03: *"same 413 is fine. we can just merge this and check
+later."* Two files, `crates/luminal_metal/src/{kernel/ops.rs, tests.rs}`,
+applied cleanly at file level; residue EMPTY for both (drift-invariance check:
+the park's 320- and 205-line drift sets are identical before and after). No
+re-spelling was needed.
+
+**The bug main fixed.** `MetalConstant` rendered its value as a decimal literal
+with an `f` suffix, with a `fract() == 0.0` branch to force a decimal point.
+`Display` is not total over `f32`: it renders the infinities as `inf` and NaNs
+as `NaN`, so `-f32::INFINITY` became `-inff` and a NaN became `NaNf`, neither
+of which is valid MSL. Shader compilation failed and the runtime PANICKED,
+while `ReferenceRuntime` evaluated the same graph fine — a backend-only
+divergence on perfectly ordinary values. The fix emits the bit pattern,
+`as_type<float>(0x{bits:08x}u)`, an idiom already used for the RMSNorm epsilon
+in that same file: exact for every `f32`, with no value-dependent branch. The
+tests compare `MetalRuntime` against `ReferenceRuntime` over both infinities, a
+NaN, both zeros, a subnormal and ordinary finite values using BIT equality,
+because NaN compares false under `assert_close` and a NaN mismatch would
+otherwise pass silently.
+
+### CHECK (recorded, NOT acted on): the live CUDA constant has the same defect
+
+The question asked was whether `crates/luminal_cuda_lite/src/ops/constant/`
+renders non-finite `f32` safely — bit pattern or literal. **It renders a
+literal, and it is not safe.** `crates/luminal_cuda_lite/src/ops/constant/mod.rs:96`:
+
+```rust
+let value = constant.value;                       // ConstantDps::value: f64, mod.rs:46
+let source = format!(
+    r#"extern "C" __global__ void k({to}* out, unsigned long long n) {{
+    unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) out[i] = ({to}){value};
+}}"#
+);
+```
+
+`{value}` is `Display` on an `f64`, so `f32::INFINITY` emits
+`out[i] = (float)inf;` and a NaN emits `out[i] = (float)NaN;`. Neither `inf`
+nor `NaN` is a defined identifier in CUDA C++ (the spellings are `INFINITY` and
+`NAN`, from `<cmath>`), so NVRTC fails to compile the kernel. It is the same
+failure mode as Metal's, one layer down: the literal is not a valid token
+rather than a valid token with the wrong value.
+
+**It is reachable.** Nothing between the frontend and the kernel rejects a
+non-finite constant: `Graph::constant_float` (`src/frontend/other.rs:37`)
+records `LogicalOp::Constant(i as f64)` with no finiteness check, and the
+matcher reads it straight back as `site.child_f64(0)`
+(`crates/luminal_cuda_lite/src/ops/constant/mod.rs`, `ConstantMatcher::extract`).
+Non-finite values are already ordinary traffic on this branch — the pad
+NaN-safety tests landed under #406 build tensors containing `f32::INFINITY`,
+`f32::NEG_INFINITY` and NaN (`src/frontend/movement.rs:1570`, `:1571`) — and
+`pad_with` mints its fill through `constant_float`, so a `pad(.., f32::NEG_INFINITY)`
+(the natural fill for a max-pool or a masked softmax) is exactly the call that
+would produce an uncompilable kernel on CUDA while passing on the reference
+runtime.
+
+**Not acted on, per the ruling.** The fix is the same one-liner main used and
+would be smaller here — CUDA has `__int_as_float(0x...)` as the direct analogue
+of MSL's `as_type<float>` — but it needs a decision about which dtype the bits
+belong to (`ConstantDps::value` is `f64` while the destination dtype comes from
+`ctx.dest_dtypes[0]`, so the emitted literal has to be reinterpreted at the
+DESTINATION width, not at f32 unconditionally), and it wants a
+reference-vs-CUDA bit-equality test of the shape main added on the Metal side.
+Recorded here as an open pin.
 
 ## #406 pad — the select construction REVERTED (2026-09-03)
 


### PR DESCRIPTION
**Stack.** PR 3 of 4, batch 5 of the main rejoin (main's post-split commits, chronological). Base: `merge/main-414-aten-coverage`. Merge in order; before merging, retarget to `logical-ssa-project` with `gh pr edit --base logical-ssa-project`.

**Gate policy (Austin, 2026-09-03):** run at risk — minimal gate on live-core commits (build, added tests by exact name, lib-only clippy, fmt); parks need no build.

## `db218a2f` Metal constants by bit pattern (#413): banked, CUDA checked

MetalConstant rendered its value as a decimal literal with an `f` suffix.
Display is not total over f32 -- the infinities render as `inf` and NaNs as
`NaN` -- so -inf became `-inff` and NaN became `NaNf`, neither valid MSL:
shader compilation failed and the runtime panicked while ReferenceRuntime
evaluated the same graph fine. Main emits the bit pattern instead, an idiom
already used for the RMSNorm epsilon in that file. Two files, file-level
into the metal park, residue empty.

Austin asked for a CHECK, not an action, on the live CUDA constant. The
answer is in the ledger and it is NO: ops/constant/mod.rs:96 interpolates
the f64 value with Display into the kernel source, so a non-finite constant
emits `(float)inf` or `(float)NaN`, neither a defined identifier in CUDA
C++, and NVRTC fails. It is reachable -- constant_float applies no
finiteness check and pad_with mints its fill through it, so pad(.., -inf)
is the natural way in. Recorded as an open pin, not fixed here.

## Reviewer flag

**The same defect is live in the CUDA crate.** `crates/luminal_cuda_lite/src/ops/constant/mod.rs:96` interpolates the f64 constant with `Display` into kernel source, so a non-finite constant emits `(float)inf` / `(float)NaN`, which NVRTC rejects. Reachable via `Graph::constant_float` (no finiteness check) and therefore via `pad(.., f32::NEG_INFINITY)`. Not acted on per the ruling ("merge and check later"); recorded as an open pin in the ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
