### PR TITLE
pad: revert the select_by_index construction; arithmetic masking is back (LUM-805)

### DIFF
--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -1389,3 +1389,45 @@ exists here.
 **Owed** (the same debt #398 booked for `LogicalConstant`): give `LogicalIota` a
 dtype instead of pinning `(Int)`, and `constant_i64` becomes
 `constant(value).cast(DType::I64)` — one node instead of nine.
+## #406 pad — the select construction REVERTED (2026-09-03)
+
+Ruling 4b's "option i" (`select_by_index`: packed 2N iota + two `scatter1d` +
+`gather1d`, landed in PR #471 / `0e6e7868`) was measured and reverted the same
+day. The core lib test suite went from ~15 s to >76 minutes (killed); a
+`sample` of the live binary put every surviving thread — the rank-≥2 pad
+consumers `test_pad_2d`, `test_concat`, `test_slice_pad`, `test_unfold`,
+`test_cumulative`, `test_stack` — inside `egglog::EGraph::run_schedule` with
+the time in `luminal::subst_primitive::{substitute, Walk::collect, Walk::build}`.
+The study (opus agent, worktree pad-study, AFTER state): rank-1 pad saturates
+in 72 ms (670 classes / 1238 e-nodes vs 177 / 321 for a bare multiply; 7
+applies instead of 1; winning plan 18 buffers instead of 4); a rank-2 pad of
+`(4,8)` by one cell per axis does not finish saturation in 15 minutes. Padding
+width and tensor size are irrelevant; RANK is everything. Mechanism: each
+`scatter1d`/`gather1d` flattens and `unflatten_to`s, minting
+`LogicalIndexMapApply` chains whose entries are `IntTruncDiv`/`IntTruncRem`
+(6 at rank 1, 23 at rank 2, nested at rank 2); native affine composition has
+no arm for div/rem entries (`egglog_preamble.egg` ~4066-4079), so every link
+falls through to the `:naive` subst-walk rule (~4007-4015) whose `Walk::collect`
+copies the whole reachable region per generation and re-mints a
+`LayoutTensorLit` per parent layout per apply. The gather coordinate
+`even + index` is an add of two iotas that no rule folds back into an iota,
+so `gather/unification_4.egg` (all-iota coordinates ≡ view) can never fire —
+pad's read cannot fold back into the views-stage seam. The rank-1 tests the
+commit pinned could not see any of this.
+
+**What this revert does.** `pad` and `pad_with` return to the clamped-view ×
+mask arithmetic; `pad(padding, 0.0)` records NO fill term (the graph is the
+pre-#406 one in the common case); `pad_with` keeps the typed scalar fill
+through `masked + (1 - mask) * fill` with the `1` minted as an Int constant
+cast to the input dtype. `select_by_index` is deleted. The NaN test
+`pad_fill_is_exact_beside_non_finite_values` is deleted because the leak is
+back: `0 * NaN` / `0 * Inf` poisons the padding. The typed-fill test is F32:
+an Int tensor pads through the same arithmetic but Int add/mul are
+proof-gated and refuse without a `bind_value_range` attestation. `ne → Bool`
+and `constant_i64` from the same commit are untouched.
+
+**Tickets.** LUM-805 (Bug) records this blowup, the measurements and the full
+analysis; LUM-804 still owns the fix — a native `Bool8` select op, never a
+gather construction. Any future pad construction is gated by the rank-≥2
+pad-family proptests actually finishing, not by named rank-1 tests.
+

--- a/src/frontend/movement.rs
+++ b/src/frontend/movement.rs
@@ -3,91 +3,6 @@ use itertools::Itertools;
 use crate::graph::{MapEntry, Movement, movement_entries};
 use crate::prelude::*;
 
-/// Select elementwise WITHOUT arithmetic masking.
-///
-/// Multiplying an inactive branch by zero lets non-finite values leak
-/// through — `0.0 * NaN` is NaN and `0.0 * Inf` is NaN — which is exactly
-/// what padding a tensor that contains them exposes. So instead of a mask
-/// product, both branches are PACKED into one buffer carrying a trailing
-/// extent-2 axis (`if_false` in the even slots, `if_true` in the odd ones)
-/// and the branch the indicator names is GATHERED out. No arithmetic ever
-/// touches the value that is not selected.
-///
-/// `index` is an Int indicator over the branch shape: `0` selects
-/// `if_false`, `1` selects `if_true`.
-///
-/// STOPGAP — LUM-804. This costs one iota for the packed zero dest, two
-/// scatters, one gather and one Int add per call, and it materializes a
-/// buffer of twice the output size. A native `Bool8`-driven select op
-/// would be a single node reading both branches lazily; until that op
-/// exists this is the only NaN-safe construction available in the
-/// recorded vocabulary.
-fn select_by_index(index: GraphTensor, if_true: GraphTensor, if_false: GraphTensor) -> GraphTensor {
-    assert_eq!(
-        if_true.dims(),
-        if_false.dims(),
-        "select_by_index: branches share a shape"
-    );
-    assert_eq!(
-        if_true.dtype, if_false.dtype,
-        "select_by_index: branches share a dtype"
-    );
-    assert_eq!(
-        index.dims(),
-        if_true.dims(),
-        "select_by_index: the indicator shares the branch shape"
-    );
-    assert_eq!(
-        index.dtype,
-        DType::Int,
-        "select_by_index: the indicator must be Int"
-    );
-
-    let shape = if_true.dims();
-    assert!(
-        !shape.is_empty(),
-        "select_by_index: rank-0 branches have no gather axis"
-    );
-    let mut packed_shape = shape.clone();
-    packed_shape.push(IntExpr::from(2));
-
-    // Slot `2*i` holds `if_false[i]` and slot `2*i + 1` holds `if_true[i]`,
-    // so the packed positions are the row-major flat index over `shape`
-    // with every stride DOUBLED. A pure coordinate function, one iota
-    // (ruling 2026-08-07), never a flat div/mod chain.
-    let doubled_strides: Vec<IntExpr> = (0..shape.len())
-        .map(|axis| {
-            shape[axis + 1..]
-                .iter()
-                .fold(IntExpr::from(2), |acc, d| acc * *d)
-        })
-        .collect();
-    let even_strides = doubled_strides.clone();
-    let even = if_true.graph().iota(shape.clone(), move |c| {
-        (0..c.len()).fold(IntExpr::from(0), |acc, axis| {
-            acc + c[axis] * even_strides[axis]
-        })
-    });
-    let odd = if_true.graph().iota(shape, move |c| {
-        (0..c.len()).fold(IntExpr::from(1), |acc, axis| {
-            acc + c[axis] * doubled_strides[axis]
-        })
-    });
-
-    // The scatter dest. An expanded scalar would alias one element across
-    // the whole buffer, and scatter's dest is copied-then-written, so the
-    // dest is a real materialized zero tensor.
-    let dest = if_true
-        .graph()
-        .iota(packed_shape, |_| IntExpr::from(0))
-        .cast(if_true.dtype);
-    let packed = if_true.scatter1d(odd, if_false.scatter1d(even, dest));
-
-    // `even` is reused as the base rather than minted a second time: it is
-    // the same coordinate function over the same shape.
-    packed.gather1d(even + index)
-}
-
 /// ONE-APPLY view composer for macro interiors (Austin's ratified rule
 /// 2026-08-26: "one user call = one view node; macro interiors also mint
 /// ONE apply per logical construct, never per-axis loops"). A chain of
@@ -1102,6 +1017,13 @@ impl GraphTensor {
             "padding value dtype must match the input's ({:?} vs {:?})",
             elem.dtype, self.dtype
         );
+        self.pad_impl(padding, Some(elem))
+    }
+
+    /// The shared pad body. `elem == None` is the zero fill: the masked
+    /// read alone, with no fill term recorded (zero padding of an F32
+    /// tensor is by far the common case and must not grow the graph).
+    fn pad_impl(self, padding: impl ToPad, elem: Option<GraphTensor>) -> GraphTensor {
         let mut padding = padding.to_pad_vec();
         padding.extend(vec![(0.into(), 0.into()); self.rank() - padding.len()]); // Make sure we have a padding per dim
         if padding.iter().all(|(s, e)| *s == 0 && *e == 0) {
@@ -1169,26 +1091,44 @@ impl GraphTensor {
             .logical
             .record_mask_iota(&befores, &afters, &dims)
             .unwrap_or_else(crate::graph::unrecorded_value);
-        // The mask STAYS Int: it is the select indicator, not a factor.
-        // `clamped * mask` was the NaN leak — the clamped view repeats edge
-        // values into the pad region and `0.0 * NaN` is NaN, so a padded
-        // tensor containing NaN or Inf poisoned its own padding.
-        let mask = GraphTensor::from_id(mask_id, out_dims.clone(), self.graph_ref, DType::Int);
-        let fill = elem.expand_rhs(out_dims);
-        select_by_index(mask, clamped, fill)
+        // ARITHMETIC MASKING, restored 2026-09-03. Main #406's select_by_index
+        // (packed 2N iota + two scatter1d + gather1d, PR #471) was NaN-safe
+        // but made egglog saturation stop converging for rank >= 2 pads
+        // (core lib tests 15 s -> >76 min; LUM-805). KNOWN LEAK, tracked as
+        // LUM-804: the clamped view repeats edge values into the pad region
+        // and `0 * NaN` / `0 * Inf` is NaN, so padding a tensor that holds
+        // non-finite values poisons its padding. The fix owed is a native
+        // Bool8 select op, not a gather construction.
+        let mask = GraphTensor::from_id(mask_id, out_dims.clone(), self.graph_ref, DType::Int)
+            .cast(self.dtype);
+        let masked = clamped * mask;
+        match elem {
+            None => masked,
+            Some(elem) => {
+                let one = self
+                    .graph()
+                    .constant(1)
+                    .cast(self.dtype)
+                    .expand_rhs(out_dims.clone());
+                masked + (one - mask) * elem.expand_rhs(out_dims)
+            }
+        }
     }
 
     /// Pad out dimensions of a tensor with an `f32` convenience value.
     pub fn pad(self, padding: impl ToPad, elem: f32) -> GraphTensor {
         let padding = padding.to_pad_vec();
-        // Early-return BEFORE minting the fill constant: zero padding is the
+        // Early-return BEFORE minting any fill constant: zero padding is the
         // identity, and a dead constant would still be a node in the
         // recorded graph.
         if padding.iter().all(|(s, e)| *s == 0 && *e == 0) {
             return self;
         }
+        if elem == 0.0 {
+            return self.pad_impl(padding, None);
+        }
         let fill = self.graph().constant_float(elem).cast(self.dtype);
-        self.pad_with(padding, fill)
+        self.pad_impl(padding, Some(fill))
     }
 
     /// Pad along an existing dimension
@@ -1558,74 +1498,26 @@ mod tests {
         );
     }
 
-    /// Pad's fill must be the fill, not `0 * x`. The clamped read half
-    /// repeats EDGE values into the pad region, so the old
-    /// `clamped * mask` construction computed `0.0 * NaN` (= NaN) and
-    /// `0.0 * Inf` (= NaN) there and handed back a padded tensor whose
-    /// padding was poisoned by its own contents.
-    #[test]
-    fn pad_fill_is_exact_beside_non_finite_values() {
-        for data in [
-            vec![1.0f32, f32::NAN],
-            vec![f32::INFINITY, 2.0],
-            vec![f32::NEG_INFINITY, f32::NAN],
-        ] {
-            let mut cx = Graph::new();
-            let a = cx.tensor(2, DType::F32);
-            let b = a.pad((1, 1), 0.0).output();
-
-            let rt = luminal_reference::harness::run_reference(&cx, &[(a.id, data.clone().into())]);
-            let out = rt.get_f32(b.id).unwrap();
-            assert_eq!(out.len(), 4, "padded length: {out:?}");
-
-            // BIT equality, not `== 0.0`: a NaN would fail `==` anyway, but
-            // `-0.0 == 0.0` is true and a sign-flipped fill is still wrong.
-            assert_eq!(
-                out[0].to_bits(),
-                0.0f32.to_bits(),
-                "left pad is not exactly +0.0 for {data:?}: {out:?}"
-            );
-            assert_eq!(
-                out[3].to_bits(),
-                0.0f32.to_bits(),
-                "right pad is not exactly +0.0 for {data:?}: {out:?}"
-            );
-
-            // The interior is untouched, NaN included.
-            for (i, expected) in data.iter().enumerate() {
-                if expected.is_nan() {
-                    assert!(
-                        out[i + 1].is_nan(),
-                        "interior NaN lost for {data:?}: {out:?}"
-                    );
-                } else {
-                    assert_eq!(
-                        out[i + 1].to_bits(),
-                        expected.to_bits(),
-                        "interior changed for {data:?}: {out:?}"
-                    );
-                }
-            }
-        }
-    }
-
-    /// `pad_with` takes the fill as a TYPED scalar tensor, so an Int tensor
-    /// pads with an exact Int and never round-trips through `f32`.
+    /// `pad_with` takes the fill as a TYPED scalar tensor, so the fill's
+    /// dtype is the caller's declaration rather than an implied one. F32
+    /// here: an Int tensor pads through the same arithmetic, but Int add and
+    /// mul are proof-gated (non-wrapping ruling 2026-08-11) and refuse
+    /// without a `bind_value_range` attestation on the input.
     #[test]
     fn pad_with_uses_a_typed_scalar_fill() {
         let mut cx = Graph::new();
-        let a = cx.tensor(3, DType::Int);
-        let fill = cx.constant(-7);
+        let a = cx.tensor(3, DType::F32);
+        let fill = cx.constant_float(-7.0);
         let b = a.pad_with((1, 2), fill).output();
 
         let rt = luminal_reference::harness::run_reference(
             &cx,
-            &[(
-                a.id,
-                luminal::buffer_tensor_ir::TypedBuffer::I32(vec![1, 2, 3]),
-            )],
+            &[(a.id, vec![1.0f32, 2.0, 3.0].into())],
         );
-        assert_eq!(rt.get_i32(b.id).unwrap(), &vec![-7, 1, 2, 3, -7, -7]);
+        assert_exact(
+            rt.get_f32(b.id).unwrap(),
+            &[-7.0, 1.0, 2.0, 3.0, -7.0, -7.0],
+        );
     }
 
     #[test]


### PR DESCRIPTION
Reverts the `select_by_index` pad construction from PR #471 (main #406, "option i") and restores clamped-view × mask arithmetic. Keeps `pad_with` (typed scalar fill), `ne → Bool`, and `constant_i64` from that commit.

**Why.** The select construction made egglog saturation stop converging for every rank ≥ 2 pad: the core lib test suite went from ~15 s to >76 minutes (killed). A stack sample put every surviving test thread (`test_pad_2d`, `test_concat`, `test_slice_pad`, `test_unfold`, `test_cumulative`, `test_stack`) inside `egglog::EGraph::run_schedule`, in the index-map substitution walk. The study measured: rank-1 pad 72 ms saturation (670 classes vs 177 for a bare multiply, 7 applies instead of 1, 18 buffers instead of 4); a `(4,8)` pad by one cell per axis does not finish saturation in 15 minutes. Padding width and tensor size are irrelevant, rank is everything. Mechanism, tickets and the full analysis: **LUM-805**. The NaN/Inf padding leak this reintroduces stays tracked as **LUM-804** (native Bool8 select op owed).

**Gate.** Build clean; the pad-family tests (`test_pad_1d`, `test_pad_2d`, `test_slice_pad`, `test_concat`, `test_unfold`, `test_cumulative`, `test_stack`, `pad_with_uses_a_typed_scalar_fill`) 9 passed in 9.92 s, where before this revert they did not finish; lib clippy clean; fmt clean. The NaN test `pad_fill_is_exact_beside_non_finite_values` is deleted (the leak is back by design); the typed-fill test is F32 because Int add/mul are proof-gated and refuse without `bind_value_range`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
