### PR TITLE
main rejoin: vLLM serving runtime (#418): parks banked; embeddability requirements recorded (parity owed)

### DIFF
--- a/crates/luminal_cuda_lite_hlir/Cargo.toml
+++ b/crates/luminal_cuda_lite_hlir/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 luminal = { path = "../.." }
 luminal_tracing = { path = "../luminal_tracing" }
-cudarc = { version = "0.19.8", features = ["cuda-version-from-build-system", "fallback-latest"] }
+cudarc = { git = "https://github.com/luminal-ai/cudarc.git", rev = "a42f3897b6d00aded8e6ac7ad258c72d8bad5596", features = ["cuda-version-from-build-system", "fallback-latest"] }
 anyhow = "1.0"
 as-any = "0.3.2"
 itertools = "0.12.1"

--- a/crates/luminal_cuda_lite_hlir/src/dyn_backend.rs
+++ b/crates/luminal_cuda_lite_hlir/src/dyn_backend.rs
@@ -19,6 +19,9 @@ impl DynBackend for CudaLiteDynBackend {
     fn device_type(&self) -> &str {
         "cuda"
     }
+    fn device_index(&self) -> Option<usize> {
+        Some(self.runtime.device_index())
+    }
 
     fn set_data_bytes(&mut self, node: NodeIndex, bytes: Vec<u8>, _dtype: DType) {
         self.runtime.set_data(node, bytes);
@@ -56,7 +59,12 @@ impl DynBackend for CudaLiteDynBackend {
     fn get_output_bool(&self, node: NodeIndex) -> Vec<bool> {
         self.runtime.get_bool(node)
     }
-    fn execute(&mut self, dyn_map: &DynMap) {
+    fn execute(&mut self, dyn_map: &DynMap, stream: Option<u64>) {
+        if let Some(stream) = stream {
+            unsafe { self.runtime.use_borrowed_stream(stream) };
+        } else {
+            self.runtime.use_owned_stream();
+        }
         self.runtime.execute(dyn_map);
     }
     fn supports_device_ptrs(&self) -> bool {
@@ -87,12 +95,25 @@ pub fn cuda_lite_factory(
     graph: &mut Graph,
     args: BackendCompileArgs,
 ) -> Result<Box<dyn DynBackend>, String> {
-    let cuda_ctx = CudaContext::new(0).map_err(|e| format!("CUDA init failed: {e}"))?;
+    let device_index = args
+        .device_index
+        .ok_or_else(|| "CUDA backend requires a device index".to_string())?;
+    if device_index != 0 {
+        return Err(format!(
+            "CUDA backend currently supports only logical device 0, got {device_index}"
+        ));
+    }
+    let cuda_ctx = CudaContext::new(device_index).map_err(|e| format!("CUDA init failed: {e}"))?;
     let stream = cuda_ctx.default_stream();
+    let external_cuda_graph = args.external_cuda_graph;
     compile_backend::<CudaRuntime>(
         graph,
         args,
-        || Ok(CudaRuntime::initialize(stream)),
+        || {
+            let mut runtime = CudaRuntime::initialize(stream);
+            runtime.external_cuda_graph = external_cuda_graph;
+            Ok(runtime)
+        },
         |rt, node, bytes, _dtype| {
             rt.set_data(node, bytes);
         },

--- a/crates/luminal_cuda_lite_hlir/src/kernel/to_host.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/to_host.rs
@@ -170,6 +170,29 @@ impl CompiledFlashInferDecode {
             .downcast_ref::<FlashInferAttention>()
             .expect("CompiledFlashInferDecode only stores FlashInfer host ops")
     }
+
+    fn enqueue_prepared(
+        &self,
+        stream: &Arc<CudaStream>,
+        buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
+        dyn_map: &DynMap,
+    ) -> anyhow::Result<()> {
+        let prepared = self
+            .prepared
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("FlashInfer step is not prepared"))?;
+        let resolved =
+            self.flashinfer()
+                .resolve_for_graph(self.node, &self.inputs, buffers, dyn_map)?;
+        let signature = resolved.signature_for_graph_plan(prepared.plan_c());
+        anyhow::ensure!(
+            self.signature
+                .as_ref()
+                .is_some_and(|old| old.spec == signature.spec),
+            "FlashInfer shape changed after warmup"
+        );
+        prepared.enqueue(stream, signature.ptrs, true)
+    }
 }
 
 struct PendingFlashInferDecodeRecapture {
@@ -347,6 +370,29 @@ impl CompiledCuBlasLt {
             .downcast_ref::<CuBlasLt>()
             .expect("CompiledCuBlasLt only stores CuBlasLt host ops")
     }
+
+    fn enqueue_prepared(
+        &self,
+        stream: &Arc<CudaStream>,
+        buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
+        dyn_map: &DynMap,
+    ) -> anyhow::Result<()> {
+        let signature = self
+            .cublaslt()
+            .resolve_for_graph(self.node, &self.inputs, buffers, dyn_map)?
+            .signature();
+        let prepared = self
+            .prepared
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("cuBLASLt step is not prepared"))?;
+        anyhow::ensure!(
+            self.signature
+                .as_ref()
+                .is_some_and(|old| old.spec == signature.spec),
+            "cuBLASLt shape changed after warmup"
+        );
+        prepared.enqueue(stream, signature.ptrs)
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -458,6 +504,123 @@ impl CompiledKernel {
             function_max_threads_per_block: Some(function_facts.max_threads_per_block),
         })
     }
+
+    fn requires_output_buffer(&self, dyn_map: &DynMap) -> bool {
+        self.kernel_op.output_size().exec(dyn_map).unwrap_or(1) != 0
+            && self.kernel_op.output_aliases_input().is_none()
+    }
+
+    fn launch_config(&self, dyn_map: &DynMap) -> anyhow::Result<KernelLaunchConfig> {
+        let config = KernelLaunchConfig {
+            grid: (
+                self.grid.0.exec(dyn_map).unwrap() as u32,
+                self.grid.1.exec(dyn_map).unwrap() as u32,
+                self.grid.2.exec(dyn_map).unwrap() as u32,
+            ),
+            block: (
+                self.block.0.exec(dyn_map).unwrap() as u32,
+                self.block.1.exec(dyn_map).unwrap() as u32,
+                self.block.2.exec(dyn_map).unwrap() as u32,
+            ),
+            shared_mem: self.shared_mem.exec(dyn_map).unwrap() as u32,
+        };
+        if config.grid.0 == 0
+            || config.grid.1 == 0
+            || config.grid.2 == 0
+            || config.block.0 == 0
+            || config.block.1 == 0
+            || config.block.2 == 0
+        {
+            anyhow::bail!(
+                "invalid CUDA launch dimensions for kernel {} at LLIR node {:?}: grid={:?} block={:?}",
+                self.kernel_name,
+                self.node,
+                config.grid,
+                config.block,
+            );
+        }
+        Ok(config)
+    }
+
+    fn validate_pointers(
+        &self,
+        output_ptr: u64,
+        input_ptrs: &[u64],
+        dyn_map: &DynMap,
+    ) -> anyhow::Result<()> {
+        if self.requires_output_buffer(dyn_map) && output_ptr == 0 {
+            anyhow::bail!(
+                "missing output buffer for CUDA kernel {} at LLIR node {:?}",
+                self.kernel_name,
+                self.node,
+            );
+        }
+
+        for (idx, (input_node, input_ptr)) in self.inputs.iter().zip(input_ptrs).enumerate() {
+            if *input_ptr == 0 {
+                anyhow::bail!(
+                    "missing input buffer {idx} for CUDA kernel {} at LLIR node {:?}; input LLIR node {:?}",
+                    self.kernel_name,
+                    self.node,
+                    input_node,
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn enqueue_prepared(
+        &mut self,
+        stream: &Arc<CudaStream>,
+        buffer_ptrs: &FxHashMap<NodeIndex, u64>,
+        dyn_map: &DynMap,
+        dyn_dims_ptr: u64,
+    ) -> anyhow::Result<()> {
+        self.kernel_op.pre_execute(
+            stream,
+            &mut self.internal_bufs,
+            &mut self.constants,
+            buffer_ptrs,
+            dyn_map,
+        );
+        let output_ptr = buffer_ptrs.get(&self.node).copied().unwrap_or(0);
+        let input_ptrs = self
+            .inputs
+            .iter()
+            .map(|node| buffer_ptrs.get(node).copied().unwrap_or(0))
+            .collect_vec();
+        self.validate_pointers(output_ptr, &input_ptrs, dyn_map)?;
+        let kernel_dyn_dims_ptr = if self.has_dyn_dims_param {
+            dyn_dims_ptr
+        } else {
+            0
+        };
+        anyhow::ensure!(
+            !self.has_dyn_dims_param || kernel_dyn_dims_ptr != 0,
+            "dynamic-dimension buffer was not prepared before capture"
+        );
+        let mut params = UnifiedKernelParams::new(self.kernel_op.build_params(
+            stream,
+            output_ptr,
+            &input_ptrs,
+            &self.internal_bufs,
+            kernel_dyn_dims_ptr,
+        ));
+        let function = unsafe { self.function.raw_function() };
+        let launch = self.launch_config(dyn_map)?;
+        unsafe {
+            cudarc::driver::result::launch_kernel(
+                function,
+                launch.grid,
+                launch.block,
+                launch.shared_mem,
+                stream.cu_stream(),
+                &mut params.ptrs,
+            )?;
+        }
+        Ok(())
+    }
 }
 
 /// Unified kernel params that can hold any number of u64 values.
@@ -528,6 +691,8 @@ struct CudaGraphOpState {
     flashinfer_prepare_cache: Vec<CachedFlashInferPrepare>,
     /// Shared device buffer for dynamic dimensions
     dyn_dims_buffer: Option<CudaSlice<i32>>,
+    /// Cached before external capture to avoid CudaSlice's cross-stream event wait.
+    dyn_dims_ptr: u64,
     /// CUDA graph handle
     cuda_graph: Option<CudaGraphHandle>,
     /// CUDA graph exec handle
@@ -576,6 +741,7 @@ impl CudaGraphOpState {
             cublaslt_workspace_pool: Vec::new(),
             flashinfer_prepare_cache: Vec::new(),
             dyn_dims_buffer: None,
+            dyn_dims_ptr: 0,
             cuda_graph: None,
             cuda_graph_exec: None,
             kernel_params: Vec::new(),
@@ -1516,74 +1682,6 @@ impl CudaGraphOp {
         }
     }
 
-    fn kernel_requires_output_buffer(kernel: &CompiledKernel, dyn_map: &DynMap) -> bool {
-        kernel.kernel_op.output_size().exec(dyn_map).unwrap_or(1) != 0
-            && kernel.kernel_op.output_aliases_input().is_none()
-    }
-
-    fn kernel_launch_config(
-        kernel: &CompiledKernel,
-        dyn_map: &DynMap,
-    ) -> anyhow::Result<KernelLaunchConfig> {
-        let config = KernelLaunchConfig {
-            grid: (
-                kernel.grid.0.exec(dyn_map).unwrap() as u32,
-                kernel.grid.1.exec(dyn_map).unwrap() as u32,
-                kernel.grid.2.exec(dyn_map).unwrap() as u32,
-            ),
-            block: (
-                kernel.block.0.exec(dyn_map).unwrap() as u32,
-                kernel.block.1.exec(dyn_map).unwrap() as u32,
-                kernel.block.2.exec(dyn_map).unwrap() as u32,
-            ),
-            shared_mem: kernel.shared_mem.exec(dyn_map).unwrap() as u32,
-        };
-        if config.grid.0 == 0
-            || config.grid.1 == 0
-            || config.grid.2 == 0
-            || config.block.0 == 0
-            || config.block.1 == 0
-            || config.block.2 == 0
-        {
-            anyhow::bail!(
-                "invalid CUDA launch dimensions for kernel {} at LLIR node {:?}: grid={:?} block={:?}",
-                kernel.kernel_name,
-                kernel.node,
-                config.grid,
-                config.block,
-            );
-        }
-        Ok(config)
-    }
-
-    fn validate_kernel_pointers(
-        kernel: &CompiledKernel,
-        output_ptr: u64,
-        input_ptrs: &[u64],
-        dyn_map: &DynMap,
-    ) -> anyhow::Result<()> {
-        if Self::kernel_requires_output_buffer(kernel, dyn_map) && output_ptr == 0 {
-            anyhow::bail!(
-                "missing output buffer for CUDA kernel {} at LLIR node {:?}",
-                kernel.kernel_name,
-                kernel.node,
-            );
-        }
-
-        for (idx, (input_node, input_ptr)) in kernel.inputs.iter().zip(input_ptrs).enumerate() {
-            if *input_ptr == 0 {
-                anyhow::bail!(
-                    "missing input buffer {idx} for CUDA kernel {} at LLIR node {:?}; input LLIR node {:?}",
-                    kernel.kernel_name,
-                    kernel.node,
-                    input_node,
-                );
-            }
-        }
-
-        Ok(())
-    }
-
     /// Forget every memory derived from a dynamic-dimension value, so the next
     /// materialize walks the same staleness paths a real dim change triggers:
     /// dyn-var kernels rebuild params, dyn-shaped cuBLASLt islands re-prepare
@@ -1658,6 +1756,7 @@ impl CudaGraphOp {
             kernel.internal_bufs.clear();
         }
         state.dyn_dims_buffer = None;
+        state.dyn_dims_ptr = 0;
     }
 
     /// Patch a CUDA graph from an exact set of changed bindings without
@@ -1750,7 +1849,7 @@ impl CudaGraphOp {
                         .unwrap_or(0)
                 })
                 .collect_vec();
-            Self::validate_kernel_pointers(kernel, output_ptr, &input_ptrs, dyn_map)?;
+            kernel.validate_pointers(output_ptr, &input_ptrs, dyn_map)?;
             let kernel_dyn_dims_ptr = if kernel.has_dyn_dims_param {
                 dyn_dims_ptr
             } else {
@@ -1901,11 +2000,11 @@ impl CudaGraphOp {
 
         // Allocate dyn_dims_buffer if needed
         if !self.dyn_dims_order.is_empty() && state.dyn_dims_buffer.is_none() {
-            state.dyn_dims_buffer = Some(
-                stream
-                    .alloc_zeros::<i32>(self.dyn_dims_order.len())
-                    .expect("Failed to allocate dyn_dims buffer"),
-            );
+            let buffer = stream
+                .alloc_zeros::<i32>(self.dyn_dims_order.len())
+                .expect("Failed to allocate dyn_dims buffer");
+            state.dyn_dims_ptr = buffer.device_ptr(stream).0;
+            state.dyn_dims_buffer = Some(buffer);
         }
 
         // Update shared dyn_dims buffer if dyn_map changed
@@ -2002,7 +2101,7 @@ impl CudaGraphOp {
             // before touching either the mutable or executable CUDA graph.
             let mut launch_overrides = FxHashMap::default();
             for idx in launch_candidate_set {
-                let launch = Self::kernel_launch_config(&state.kernels[idx], dyn_map)?;
+                let launch = state.kernels[idx].launch_config(dyn_map)?;
                 if state.kernel_launches.get(idx) != Some(&launch) {
                     dirty_kernel_set.insert(idx);
                     launch_overrides.insert(idx, launch);
@@ -2030,7 +2129,7 @@ impl CudaGraphOp {
                     .iter()
                     .map(|inp| current_buffer_ptrs.get(inp).copied().unwrap_or(0))
                     .collect();
-                Self::validate_kernel_pointers(kernel, output_ptr, &input_ptrs, dyn_map)?;
+                kernel.validate_pointers(output_ptr, &input_ptrs, dyn_map)?;
                 let kernel_dyn_dims_ptr = if kernel.has_dyn_dims_param {
                     dyn_dims_ptr
                 } else {
@@ -2485,6 +2584,63 @@ impl CudaGraphOp {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("CUDA graph launch requested before materialization"))?
             .launch(stream)?;
+        Ok(())
+    }
+
+    /// Enqueue prepared work directly so a caller-owned CUDA graph can capture it.
+    pub(crate) fn launch_steps(
+        &self,
+        stream: &Arc<CudaStream>,
+        buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
+        dyn_map: &DynMap,
+    ) -> anyhow::Result<()> {
+        stream.context().bind_to_thread()?;
+        let mut state = self.state.borrow_mut();
+        anyhow::ensure!(
+            state.last_dyn_values == *dyn_map,
+            "external CUDA graph capture requires a same-shape warmup"
+        );
+
+        let mut buffer_ptrs = FxHashMap::default();
+        for &node in &self.buffer_nodes {
+            if let Some(buffer) = buffers.get(&node) {
+                buffer_ptrs.insert(node, buffer.ptr());
+            }
+        }
+        for &(input, output) in &self.output_aliases {
+            if let Some(&ptr) = buffer_ptrs.get(&input) {
+                buffer_ptrs.insert(output, ptr);
+            }
+        }
+        let dyn_dims_ptr = state.dyn_dims_ptr;
+
+        for step_index in 0..state.steps.len() {
+            let (step_name, result) = match state.steps[step_index] {
+                CompiledStep::Kernel(index) => {
+                    let kernel = &mut state.kernels[index];
+                    (
+                        kernel.kernel_name,
+                        kernel.enqueue_prepared(stream, &buffer_ptrs, dyn_map, dyn_dims_ptr),
+                    )
+                }
+                CompiledStep::CuBlasLt(index) => (
+                    "cuBLASLt",
+                    state.cublaslt_ops[index].enqueue_prepared(stream, buffers, dyn_map),
+                ),
+                CompiledStep::FlashInferDecode(index) => (
+                    "FlashInfer",
+                    state.flashinfer_ops[index].enqueue_prepared(stream, buffers, dyn_map),
+                ),
+            };
+            result.map_err(|error| {
+                anyhow::anyhow!("external {step_name} step {step_index} failed: {error}")
+            })?;
+            anyhow::ensure!(
+                stream.capture_status()?
+                    != cudarc::driver::sys::CUstreamCaptureStatus::CU_STREAM_CAPTURE_STATUS_INVALIDATED,
+                "external CUDA capture was invalidated by {step_name} step {step_index}"
+            );
+        }
         Ok(())
     }
 
@@ -2972,7 +3128,7 @@ impl CudaGraphOp {
                     }
 
                     let kernel = &state.kernels[idx];
-                    let launch = Self::kernel_launch_config(kernel, dyn_map)?;
+                    let launch = kernel.launch_config(dyn_map)?;
 
                     let output_ptr = buffer_ptrs.get(&kernel.node).copied().unwrap_or(0);
                     let input_ptrs: Vec<u64> = kernel
@@ -2980,7 +3136,7 @@ impl CudaGraphOp {
                         .iter()
                         .map(|inp| buffer_ptrs.get(inp).copied().unwrap_or(0))
                         .collect();
-                    Self::validate_kernel_pointers(kernel, output_ptr, &input_ptrs, dyn_map)?;
+                    kernel.validate_pointers(output_ptr, &input_ptrs, dyn_map)?;
                     let kernel_dyn_dims_ptr = if kernel.has_dyn_dims_param {
                         dyn_dims_ptr
                     } else {

--- a/crates/luminal_cuda_lite_hlir/src/runtime.rs
+++ b/crates/luminal_cuda_lite_hlir/src/runtime.rs
@@ -397,6 +397,7 @@ pub struct CudaRuntime {
     // Keep this private: every mutation must go through the buffer APIs so
     // `changed_hlir` and resource-input validation stay in sync with the map.
     hlir_buffers: FxHashMap<NodeIndex, CudaInput>,
+    owned_stream: Arc<CudaStream>,
     cuda_stream: Arc<CudaStream>,
     changed_hlir: FxHashSet<NodeIndex>,
     pub(crate) cuda_graph_timings: Vec<(CudaGraphTiming, Uuid)>,
@@ -420,6 +421,11 @@ pub struct CudaRuntime {
     /// Resource-relevant input state covered by the most recent aggregate
     /// retained-bucket validation.
     last_resource_input_signature: FxHashMap<NodeIndex, ResourceInputFootprint>,
+    /// Owned-stream execution is blocking; borrowed-stream execution leaves
+    /// completion ordered on the caller's stream.
+    synchronize_stream: bool,
+    /// Launch kernels directly so an enclosing runtime can capture them.
+    pub(crate) external_cuda_graph: bool,
     /// High-water intermediate allocation reused across candidate loads and
     /// bucket switches. At most one compiled bucket may borrow it at a time.
     persistent_arena: Option<PersistentArena>,
@@ -471,6 +477,36 @@ impl CudaRuntime {
         let stream = ctx.default_stream();
 
         Ok(Self::initialize(stream))
+    }
+
+    pub fn device_index(&self) -> usize {
+        self.owned_stream.context().ordinal()
+    }
+
+    /// # Safety
+    ///
+    /// `raw_stream` must be a live CUDA stream on this runtime's context. Its
+    /// owner must keep it alive while this runtime may retain or use it.
+    pub unsafe fn use_borrowed_stream(&mut self, raw_stream: u64) {
+        let context = self.owned_stream.context();
+        let raw_stream = raw_stream as usize as sys::CUstream;
+        let stream = unsafe { context.wrap_borrowed_stream(raw_stream) };
+        self.select_execution_stream(stream);
+        self.synchronize_stream = false;
+    }
+
+    pub fn use_owned_stream(&mut self) {
+        self.select_execution_stream(Arc::clone(&self.owned_stream));
+        self.synchronize_stream = true;
+    }
+
+    fn select_execution_stream(&mut self, stream: Arc<CudaStream>) {
+        self.cuda_stream = Arc::clone(&stream);
+        for bucket in &mut self.compiled_buckets {
+            for op in bucket.exec_graph.node_weights_mut() {
+                op.stream = Arc::clone(&stream);
+            }
+        }
     }
 
     /// Read-only view of installed HLIR inputs.
@@ -1246,13 +1282,14 @@ impl CudaRuntime {
         unsafe { self.copy_outputs_to_device_ptrs(&[(id.to_id(), dest_ptr, n_bytes)]) };
     }
 
-    /// Copy several output tensors to external CUDA device pointers and wait once.
+    /// Copy several output tensors to external CUDA device pointers.
     ///
     /// Resolving every source before submitting any work makes the operation
     /// all-or-nothing with respect to runtime lookup failures. More importantly,
     /// callers which need to commit many functionalized mutations (for example
-    /// every K/V tensor in a StaticCache) do not pay one stream synchronization
-    /// per tensor.
+    /// every K/V tensor in a StaticCache) enqueue one batch. Owned-stream mode
+    /// waits once for the batch; borrowed-stream mode leaves it on the caller's
+    /// stream.
     ///
     /// # Safety
     /// Every destination pointer must name a live CUDA allocation with at least
@@ -1285,7 +1322,9 @@ impl CudaRuntime {
                 .expect("cuMemcpyDtoDAsync failed");
             }
         }
-        self.cuda_stream.synchronize().unwrap();
+        if self.synchronize_stream {
+            self.cuda_stream.synchronize().unwrap();
+        }
     }
 
     fn restore_external_output_node(&mut self, data_node: NodeIndex) {
@@ -1767,6 +1806,7 @@ impl CudaRuntime {
         bucket: &mut CompiledBucket,
         stream: &Arc<CudaStream>,
         dyn_dims: &DynMap,
+        external_output_nodes: &FxHashSet<NodeIndex>,
     ) {
         let profile_alloc = std::env::var_os("LUMINAL_CUDA_PROFILE_RECAPTURE").is_some();
         let alloc_profile_start = std::time::Instant::now();
@@ -1893,9 +1933,11 @@ impl CudaRuntime {
             bucket.materialization_fully_dirty = true;
         }
         let arena_ptr = bucket.arena.as_ref().unwrap().device_ptr(stream).0;
+        // Don't allow arena allocation to overwrite a user-provided output pointer.
         let buffer_updates = bucket
             .logical_buffer_offsets
             .iter()
+            .filter(|(logical_node, _)| !external_output_nodes.contains(logical_node))
             .filter_map(|(logical_node, offset)| {
                 let len = bucket.logical_buffer_bytes.get(logical_node).copied()?;
                 let ptr = arena_ptr.checked_add(*offset as u64)?;
@@ -2789,6 +2831,19 @@ impl CudaRuntime {
             new_arena_bytes,
             cached_ptrs_after_alloc,
         ) = {
+            // Preserve caller-provided output pointers for this bucket.
+            // Arena allocation must not replace them with internal buffer pointers.
+            let external_output_nodes = if self.resolved_output_bucket == Some(bucket_idx) {
+                self.resolved_output_registrations
+                    .values()
+                    .filter_map(|resolved| match resolved {
+                        ResolvedOutputRegistration::External { data_node } => Some(*data_node),
+                        _ => None,
+                    })
+                    .collect()
+            } else {
+                FxHashSet::default()
+            };
             let bucket = &mut self.compiled_buckets[bucket_idx];
             let stabilize_intermediate_pointers = bucket.stabilize_intermediate_pointers;
             let was_hlir_synced = bucket.hlir_synced;
@@ -2804,6 +2859,7 @@ impl CudaRuntime {
                         bucket,
                         &self.cuda_stream,
                         &allocation_dyn_map,
+                        &external_output_nodes,
                     );
                     bucket.last_allocation_dyn_map = allocation_dyn_map.clone();
                 }
@@ -2825,7 +2881,12 @@ impl CudaRuntime {
                     bucket.cached_buffer_ptrs.len(),
                 )
             } else {
-                Self::allocate_intermediate_buffers(bucket, &self.cuda_stream, dyn_map);
+                Self::allocate_intermediate_buffers(
+                    bucket,
+                    &self.cuda_stream,
+                    dyn_map,
+                    &external_output_nodes,
+                );
                 (
                     stabilize_intermediate_pointers,
                     was_hlir_synced,
@@ -4394,6 +4455,7 @@ impl Runtime for CudaRuntime {
             .expect("failed to create CUDA profiling end event");
         Self {
             hlir_buffers: FxHashMap::default(),
+            owned_stream: Arc::clone(&stream),
             cuda_stream: stream,
             changed_hlir: FxHashSet::default(),
             cuda_graph_timings: vec![],
@@ -4410,6 +4472,8 @@ impl Runtime for CudaRuntime {
             max_kernel_source_bytes: Some(DEFAULT_MAX_KERNEL_SOURCE_BYTES),
             device_resource_limits,
             last_resource_input_signature: FxHashMap::default(),
+            synchronize_stream: true,
+            external_cuda_graph: false,
             persistent_arena: None,
             resource_length_sensitive_hlir: FxHashSet::default(),
             validated_resource_signatures: FxHashSet::default(),
@@ -4585,11 +4649,20 @@ impl Runtime for CudaRuntime {
         self.apply_output_ptr_registrations();
         output_registration_time += timer.elapsed();
 
-        // Materialize CUDA graphs before timed execution. The first real launch
-        // should only patch an already-instantiated graph, not build it from scratch.
+        let external_capture = self.external_cuda_graph
+            && !self.profiling
+            && self.cuda_stream.capture_status().is_ok_and(|status| {
+                status
+                    == cudarc::driver::sys::CUstreamCaptureStatus::CU_STREAM_CAPTURE_STATUS_ACTIVE
+            });
+
+        // vLLM warms up each shape before capture. Reuse those prepared
+        // resources while capturing instead of touching Luminal's private graph.
         let timer = std::time::Instant::now();
-        self.materialize_bucket_cuda_graphs(self.active_bucket, dyn_map, false)
-            .unwrap_or_else(|e| panic!("CUDA graph materialization failed: {e}"));
+        if !external_capture {
+            self.materialize_bucket_cuda_graphs(self.active_bucket, dyn_map, false)
+                .unwrap_or_else(|e| panic!("CUDA graph materialization failed: {e}"));
+        }
         materialize_time += timer.elapsed();
         if self.profiling {
             self.last_profile_device_duration = None;
@@ -4612,14 +4685,22 @@ impl Runtime for CudaRuntime {
             .entered();
             if let Some(cuda_graph) = exec_op.internal.as_any().downcast_ref::<CudaGraphOp>() {
                 let timer = std::time::Instant::now();
-                cuda_graph
-                    .launch_materialized(&exec_op.stream)
-                    .unwrap_or_else(|e| {
-                        panic!(
-                            "CUDA graph launch error in {:?}: {e}",
-                            exec_op.internal.stats_name().unwrap_or("unknown")
-                        );
-                    });
+                let result = if self.external_cuda_graph && !self.profiling {
+                    // allow vLLM to capture kernels
+                    let buffers = self
+                        .buffer_map_for_exec_op(bucket, exec_op, false)
+                        .unwrap_or_else(|e| panic!("CUDA execute buffer resolution failed: {e}"))
+                        .expect("CUDA execute requires all CudaGraphOp buffers");
+                    cuda_graph.launch_steps(&exec_op.stream, &buffers, dyn_map)
+                } else {
+                    cuda_graph.launch_materialized(&exec_op.stream)
+                };
+                result.unwrap_or_else(|e| {
+                    panic!(
+                        "CUDA launch error in {:?}: {e}",
+                        exec_op.internal.stats_name().unwrap_or("unknown")
+                    );
+                });
                 graph_launch_time += timer.elapsed();
                 graph_launches += 1;
             } else {
@@ -4688,9 +4769,12 @@ impl Runtime for CudaRuntime {
                 .expect("failed to record CUDA profiling end event");
         }
 
-        // Single sync at end - CUDA stream ordering guarantees sequential execution
+        // Standalone execution is blocking. Embedded callers already use
+        // stream ordering and must not be synchronized here.
         let timer = std::time::Instant::now();
-        self.cuda_stream.synchronize().unwrap();
+        if self.synchronize_stream {
+            self.cuda_stream.synchronize().unwrap();
+        }
         sync_time += timer.elapsed();
         self.last_total_time_us = total_start.elapsed().as_secs_f64() * 1_000_000.0;
         if self.profiling {

--- a/crates/luminal_metal/src/dyn_backend.rs
+++ b/crates/luminal_metal/src/dyn_backend.rs
@@ -28,7 +28,7 @@ impl DynBackend for MetalDynBackend {
     fn get_output_f32(&self, node: NodeIndex) -> Vec<f32> {
         self.runtime.get_f32(node)
     }
-    fn execute(&mut self, dyn_map: &DynMap) {
+    fn execute(&mut self, dyn_map: &DynMap, _stream: Option<u64>) {
         self.runtime.execute(dyn_map);
     }
 }

--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -191,6 +191,8 @@ impl CompiledGraph {
         weight_data: WeightData,
         factory: BackendFactory,
         search_iters: usize,
+        device_index: Option<usize>,
+        external_cuda_graph: bool,
     ) -> Result<CompiledGraph, String> {
         let GraphTranslation {
             mut graph,
@@ -215,6 +217,8 @@ impl CompiledGraph {
         // Build compile args from WeightData.
         let compile_args = BackendCompileArgs {
             search_iters,
+            device_index,
+            external_cuda_graph,
             weights: weights
                 .iter()
                 .map(|(label, td)| (label.clone(), td.bytes.clone(), td.dtype))
@@ -338,6 +342,12 @@ impl CompiledGraph {
     #[getter]
     fn device_type(&self) -> &str {
         self.runtime.device_type()
+    }
+
+    /// The logical CUDA device used by this backend, or None for CPU.
+    #[getter]
+    fn device_index(&self) -> Option<usize> {
+        self.runtime.device_index()
     }
 
     /// Whether the active backend supports device pointer operations (zero-copy GPU I/O).
@@ -600,8 +610,9 @@ impl CompiledGraph {
     }
 
     /// Execute the graph.
-    fn run(&mut self) {
-        self.runtime.execute(&self.graph.dyn_map);
+    #[pyo3(signature = (stream=None))]
+    fn run(&mut self, stream: Option<u64>) {
+        self.runtime.execute(&self.graph.dyn_map, stream);
     }
 
     /// Return the HLIR graph as a DOT string for visualization.

--- a/crates/luminal_python/rust/src/pt2_compiled_model.rs
+++ b/crates/luminal_python/rust/src/pt2_compiled_model.rs
@@ -127,13 +127,23 @@ pub fn translate_module(
 }
 
 #[pyfunction]
-#[pyo3(signature = (pt2_path, weights_path, search_iters, factory_capsule, weight_device_ptrs=None))]
+#[pyo3(signature = (
+    pt2_path,
+    weights_path,
+    search_iters,
+    factory_capsule,
+    weight_device_ptrs=None,
+    device_index=None,
+    external_cuda_graph=false,
+))]
 pub fn process_pt2(
     pt2_path: &str,
     weights_path: &str,
     search_iters: usize,
     factory_capsule: &Bound<'_, PyCapsule>,
     weight_device_ptrs: Option<HashMap<String, (u64, usize)>>,
+    device_index: Option<usize>,
+    external_cuda_graph: bool,
 ) -> PyResult<CompiledGraph> {
     let factory: BackendFactory = {
         let expected = ::luminal::dyn_backend::BACKEND_FACTORY_CAPSULE_NAME;
@@ -152,9 +162,10 @@ pub fn process_pt2(
                 }
             }
             None => {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "factory_capsule has no name; expected \"luminal.backend_factory\"",
-                ));
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "factory_capsule has no name; expected {:?}",
+                    expected
+                )));
             }
         }
         let wrapper_ptr = factory_capsule
@@ -175,6 +186,8 @@ pub fn process_pt2(
         search_iters,
         weight_device_ptrs.unwrap_or_default(),
         factory,
+        device_index,
+        external_cuda_graph,
     )
     .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#}")))
 }
@@ -185,12 +198,21 @@ fn compile_pt2(
     search_iters: usize,
     weight_device_ptrs: HashMap<String, (u64, usize)>,
     factory: BackendFactory,
+    device_index: Option<usize>,
+    external_cuda_graph: bool,
 ) -> anyhow::Result<CompiledGraph> {
     let (translation, mut weights) = translate_pt2(pt2_path, weights_path)?;
     weights.device_ptrs = weight_device_ptrs;
 
-    CompiledGraph::parse_graph(translation, weights, factory, search_iters)
-        .map_err(|e| anyhow::anyhow!(e))
+    CompiledGraph::parse_graph(
+        translation,
+        weights,
+        factory,
+        search_iters,
+        device_index,
+        external_cuda_graph,
+    )
+    .map_err(|e| anyhow::anyhow!(e))
 }
 
 /// Translate a PT2 exported model into a format-neutral GraphTranslation + WeightData.

--- a/crates/luminal_python/src/luminal/__init__.py
+++ b/crates/luminal_python/src/luminal/__init__.py
@@ -2,6 +2,7 @@
 
 # Import Python components
 # Register DynamicCache pytree serialization once at import time
+from .artifact_cache import ArtifactCacheStats, artifact_cache_stats
 from .cache_utils import _register_cache_serialization
 from .compiled_model import CompiledModel
 
@@ -15,6 +16,8 @@ _register_cache_serialization()
 # Re-export everything for clean package interface
 __all__ = [
     "CompiledModel",
+    "ArtifactCacheStats",
+    "artifact_cache_stats",
     "luminal_backend",
     "register_backend",
     "CompiledGraph",

--- a/crates/luminal_python/src/luminal/artifact_cache.py
+++ b/crates/luminal_python/src/luminal/artifact_cache.py
@@ -1,0 +1,130 @@
+"""Process-local reuse for structurally identical compiled regions."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+
+import torch
+import torch.fx as fx
+
+from .compiled_model import CompiledModel
+
+_SYMBOL = re.compile(r"\b[su]\d+\b")
+_artifacts: dict[str, CompiledArtifact] = {}
+_reuse_hits = 0
+_searches = 0
+
+
+@dataclass(frozen=True)
+class ArtifactCacheStats:
+    unique_artifacts: int
+    reuse_hits: int
+    searches: int
+
+
+class CompiledArtifact:
+    """Compiled runtime shared by separate positional tensor bindings."""
+
+    def __init__(self, graph, weight_refs=()):
+        self.graph = graph
+        self.weight_refs = tuple(weight_refs)
+        self._active_binding = None
+
+    def bind(self, **kwargs):
+        return CompiledModel(
+            self.graph,
+            weight_refs=self.weight_refs,
+            artifact=self,
+            **kwargs,
+        )
+
+    def activate(self, binding) -> bool:
+        changed = self._active_binding is not binding
+        self._active_binding = binding
+        return changed
+
+
+def region_artifact_key(program, **options) -> str | None:
+    """Return None when the program contains weights that cannot be rebound."""
+
+    if program.state_dict or program.constants:
+        return None
+
+    nodes = list(program.graph_module.graph.nodes)
+    indices = {node: index for index, node in enumerate(nodes)}
+    symbols = {}
+
+    def normalize_symbol(value):
+        def replace(match):
+            name = match.group(0)
+            return symbols.setdefault(name, f"s{len(symbols)}")
+
+        return _SYMBOL.sub(replace, str(value))
+
+    def normalize(value):
+        if isinstance(value, fx.Node):
+            return ("node", indices[value])
+        if isinstance(value, torch.Tensor):
+            return (
+                "tensor",
+                tuple(normalize_symbol(dim) for dim in value.shape),
+                tuple(normalize_symbol(dim) for dim in value.stride()),
+                str(value.dtype),
+                value.device.type,
+                str(value.layout),
+                normalize_symbol(value.storage_offset()),
+            )
+        if isinstance(value, (tuple, list)):
+            return tuple(normalize(item) for item in value)
+        if isinstance(value, dict):
+            items = ((str(key), normalize(item)) for key, item in value.items())
+            return tuple(sorted(items))
+        if isinstance(value, (str, torch.SymInt, torch.SymFloat, torch.SymBool)):
+            return normalize_symbol(value)
+        if value is None or isinstance(value, (bool, int, float)):
+            return value
+        return str(value)
+
+    graph = []
+    for node in nodes:
+        graph.append(
+            (
+                node.op,
+                None if node.op == "placeholder" else str(node.target),
+                normalize(node.args),
+                normalize(node.kwargs),
+                normalize(node.meta.get("val")),
+            )
+        )
+
+    ranges = sorted(
+        (normalize_symbol(symbol), normalize_symbol(bounds))
+        for symbol, bounds in program.range_constraints.items()
+    )
+    payload = repr((graph, ranges, sorted(options.items()))).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def get_or_compile(key, compile_artifact):
+    global _reuse_hits, _searches
+    artifact = _artifacts.get(key)
+    if artifact is not None:
+        _reuse_hits += 1
+        return artifact
+    artifact = compile_artifact()
+    _artifacts[key] = artifact
+    _searches += 1
+    return artifact
+
+
+def artifact_cache_stats() -> ArtifactCacheStats:
+    return ArtifactCacheStats(len(_artifacts), _reuse_hits, _searches)
+
+
+def clear_artifact_cache() -> None:
+    global _reuse_hits, _searches
+    _artifacts.clear()
+    _reuse_hits = 0
+    _searches = 0

--- a/crates/luminal_python/src/luminal/compiled_model.py
+++ b/crates/luminal_python/src/luminal/compiled_model.py
@@ -6,6 +6,7 @@ import torch
 
 from .dtype_util import code_to_torch_dtype
 from .dtype_util import torch_dtype_code as _torch_dtype_code
+from .main import _cuda_device_index
 
 
 def _cuda_input_binding_signature(tensor, n_bytes: int) -> tuple:
@@ -41,7 +42,11 @@ class CompiledModel:
         weight_refs=None,
         input_names=None,
         user_indices=None,
+        output_spec=None,
         scalar_output_positions=(),
+        use_current_stream=False,
+        static_outputs=False,
+        artifact=None,
     ):
         """Initialize with a compiled CompiledGraph from Rust.
 
@@ -52,6 +57,11 @@ class CompiledModel:
             user_indices: When torch.compile lifts model parameters into extra args,
                 this tells __call__ which arg positions are actual user inputs.
                 None means all args are user inputs (PT2 path).
+            output_spec: Optional pytree structure expected by the caller.
+            use_current_stream: Run CUDA work on PyTorch's current stream instead
+                of the backend's owned stream.
+            static_outputs: Reuse maximum-capacity CUDA output buffers across
+                calls and return views with the current runtime shapes.
         """
         self._graph = graph_result
         self._input_names = input_names or graph_result.input_names
@@ -70,12 +80,23 @@ class CompiledModel:
         self._has_dynamic_dims = getattr(graph_result, "has_dynamic_dims", False)
         self._weight_refs = weight_refs or []
         self._user_indices = user_indices
+        self._output_spec = output_spec
         self._scalar_output_positions = frozenset(scalar_output_positions)
+        self._use_current_stream = use_current_stream
+        self._static_outputs = static_outputs
+        self._static_output_tensors = None
+        self._artifact = artifact
+        self._binding = object()
         self.skip_input_names = frozenset()
         self._is_gpu = getattr(graph_result, "device_type", "cpu") != "cpu"
+        self._device_index = getattr(graph_result, "device_index", None)
+        if self._is_gpu and self._device_index is None:
+            raise RuntimeError("CUDA CompiledGraph did not report a device index")
         self._supports_device_ptrs = getattr(
             graph_result, "supports_device_ptrs", False
         )
+        if static_outputs and not (self._is_gpu and self._supports_device_ptrs):
+            raise ValueError("static outputs require CUDA device-pointer support")
         # name -> (device, pointer, required bytes, dtype, strong tensor ref).
         # CUDA bindings are persistent in the runtime; only changed metadata
         # needs to cross PyO3 on subsequent calls.
@@ -130,6 +151,10 @@ class CompiledModel:
         Returns:
             Tuple of PyTorch tensors containing the model outputs
         """
+        binding_changed = self._artifact is not None and self._artifact.activate(
+            self._binding
+        )
+
         # Drop stripped SymInt args, if any.
         if self._user_indices is not None:
             user_inputs = [inputs[i] for i in self._user_indices]
@@ -141,13 +166,11 @@ class CompiledModel:
                 f"Expected {len(self._input_names)} inputs, got {len(user_inputs)}"
             )
 
-        # Device for outputs: prefer any CUDA input — inputs include lifted
-        # weights, and user_inputs[0] may be a CPU-resident weight (offloaded
-        # models) while activations live on the GPU.
-        input_device = next(
-            (t.device for t in user_inputs if t.is_cuda),
-            user_inputs[0].device if user_inputs else torch.device("cpu"),
-        )
+        if self._is_gpu:
+            _cuda_device_index(user_inputs, expected=self._device_index)
+            input_device = torch.device("cuda", self._device_index)
+        else:
+            input_device = user_inputs[0].device if user_inputs else torch.device("cpu")
 
         # Auto-detect dynamic dims from input shapes
         if self._has_dynamic_dims:
@@ -186,7 +209,7 @@ class CompiledModel:
                 n_bytes = t.numel() * t.element_size()
                 signature = _cuda_input_binding_signature(t, n_bytes)
                 previous = self._cuda_input_bindings.get(name)
-                if previous is None or previous[:4] != signature:
+                if binding_changed or previous is None or previous[:4] != signature:
                     self._graph.set_input_device_ptr(name, t.data_ptr(), n_bytes)
                 # Commit only after a changed registration succeeds. Retaining
                 # the tensor prevents allocator reuse while Rust holds its
@@ -260,6 +283,32 @@ class CompiledModel:
             torch.bool: ("get_output_bool", torch.bool),
         }
 
+        if self._static_outputs:
+            for i in self._writeback_by_pos:
+                name = self._output_names[i]
+                target = user_inputs[self._writeback_input_pos[i]]
+                out_dtype = output_torch_dtypes[i]
+                expected_numel = math.prod(output_shapes[i])
+                if not (
+                    hasattr(self._graph, "copy_outputs_to_device_ptrs_at")
+                    and target.is_cuda
+                    and target.is_contiguous()
+                    and target.dtype == out_dtype
+                    and target.numel() == expected_numel
+                ):
+                    raise ValueError(
+                        f"static writeback '{name}' requires a contiguous CUDA "
+                        f"tensor with dtype {out_dtype} and {expected_numel} elements"
+                    )
+                n_bytes = target.numel() * target.element_size()
+                signature = _cuda_input_binding_signature(target, n_bytes)
+                previous = self._cuda_writeback_bindings.get(i)
+                if previous is not None and previous[:4] != signature:
+                    raise ValueError(
+                        f"static writeback '{name}' target allocation changed"
+                    )
+                self._cuda_writeback_bindings[i] = (*signature, target)
+
         def _read_typed_output(
             position: int, name: str, shape, out_dtype
         ) -> torch.Tensor:
@@ -320,6 +369,22 @@ class CompiledModel:
         _use_zero_copy = self._supports_device_ptrs
         output_tensors = []
         if _use_zero_copy:
+            if self._static_outputs and self._static_output_tensors is None:
+                self._static_output_tensors = []
+                for i, (shape, out_dtype) in enumerate(
+                    zip(self._output_shapes, output_torch_dtypes)
+                ):
+                    if i in self._writeback_by_pos:
+                        self._static_output_tensors.append(None)
+                        continue
+                    if out_dtype not in _zero_copy_native_floats:
+                        raise TypeError(
+                            f"static output '{self._output_names[i]}' has "
+                            f"unsupported dtype {out_dtype}"
+                        )
+                    out = torch.empty(shape, dtype=out_dtype, device=input_device)
+                    self._static_output_tensors.append(out)
+
             for i, (name, shape) in enumerate(zip(self._output_names, output_shapes)):
                 out_dtype = output_torch_dtypes[i]
                 if i in self._writeback_by_pos:
@@ -329,19 +394,36 @@ class CompiledModel:
                     # front can redirect one cache writeback into another.
                     # Preserve positional semantics with the batched post-run
                     # device copies below.
-                    if i in self._cuda_writeback_bindings:
-                        self._graph.clear_output_device_ptr_at(i)
-                        del self._cuda_writeback_bindings[i]
                     output_tensors.append(None)
                     continue
-                out = torch.empty(shape, dtype=out_dtype, device=input_device)
+                if self._static_outputs:
+                    out = self._static_output_tensors[i]
+                    capacity_shape = tuple(out.shape)
+                    shape = tuple(shape)
+                    if len(shape) != len(capacity_shape) or any(
+                        current > capacity
+                        for current, capacity in zip(shape, capacity_shape)
+                    ):
+                        raise ValueError(
+                            f"output '{name}' shape {shape} exceeds static "
+                            f"capacity {capacity_shape}"
+                        )
+                    out = out.view(-1)[: math.prod(shape)].view(shape)
+                else:
+                    out = torch.empty(shape, dtype=out_dtype, device=input_device)
                 if out_dtype in _zero_copy_native_floats:
+                    # The allocation has maximum capacity, but the runtime
+                    # needs the current logical byte length for dynamic shapes.
                     self._graph.set_output_device_ptr_at(
                         i, out.data_ptr(), out.numel() * out.element_size()
                     )
                 output_tensors.append(out)
 
-        self._graph.run()
+        if self._use_current_stream:
+            stream = torch.cuda.current_stream(self._device_index)
+            self._graph.run(stream.cuda_stream)
+        else:
+            self._graph.run()
 
         outputs = []
         gpu_writebacks = []
@@ -385,7 +467,10 @@ class CompiledModel:
         if gpu_writebacks:
             self._graph.copy_outputs_to_device_ptrs_at(gpu_writebacks)
 
-        return tuple(
+        flat_outputs = tuple(
             output.item() if i in self._scalar_output_positions else output
             for i, output in enumerate(outputs)
         )
+        if self._output_spec is not None:
+            return torch.utils._pytree.tree_unflatten(flat_outputs, self._output_spec)
+        return flat_outputs

--- a/crates/luminal_python/src/luminal/main.py
+++ b/crates/luminal_python/src/luminal/main.py
@@ -9,6 +9,34 @@ from .dtype_util import torch_dtype_code as _torch_dtype_code
 # ---------------------------------------------------------------------------
 
 
+def _cuda_device_index(tensors, expected=None):
+    """Return one CUDA device index and enforce the current cuda:0 contract."""
+    indices = {
+        tensor.device.index
+        for tensor in tensors
+        if torch.is_tensor(tensor) and tensor.device.type == "cuda"
+    }
+    if None in indices:
+        raise ValueError("CUDA tensor metadata must include a logical device index")
+    if len(indices) > 1:
+        raise ValueError(
+            f"CUDA tensors span multiple logical devices: {sorted(indices)}"
+        )
+
+    observed = next(iter(indices), None)
+    if expected is not None and observed is not None and observed != expected:
+        raise ValueError(
+            f"CUDA tensor is on logical device {observed}, but the compiled "
+            f"runtime uses logical device {expected}"
+        )
+    selected = expected if expected is not None else observed
+    if selected not in (None, 0):
+        raise ValueError(
+            f"Luminal currently supports only logical CUDA device 0, got {selected}"
+        )
+    return selected
+
+
 def _detect_factory_capsule(example_inputs):
     """Pick the best built-in factory capsule based on input device."""
     # Dynamo can prefix `example_inputs` with SymInt entries when shapes are
@@ -31,7 +59,7 @@ def _detect_factory_capsule(example_inputs):
     return _reference_factory_capsule()
 
 
-def _collect_weight_pointers(weights):
+def _collect_weight_pointers(weights, device_index=None):
     """Partition weight tensors into CUDA device pointers and CPU host pointers.
 
     Preserves native dtype — no forced conversion to float32.
@@ -45,6 +73,7 @@ def _collect_weight_pointers(weights):
         - device_ptrs: {name: (device_ptr, n_bytes)}
         - cpu_ptrs: {name: (host_ptr, n_bytes, dtype_code)}
     """
+    _cuda_device_index(weights.values(), expected=device_index)
     keep_alive = []
     device_ptrs = {}
     cpu_ptrs = {}

--- a/crates/luminal_python/src/luminal/pt2.py
+++ b/crates/luminal_python/src/luminal/pt2.py
@@ -9,12 +9,18 @@ import inspect
 import os
 import shutil
 import tempfile
+from functools import partial
 
 import torch
 
-from .compiled_model import CompiledModel
+from .artifact_cache import CompiledArtifact, get_or_compile
 from .luminal import process_pt2
-from .main import _collect_weight_pointers, _detect_factory_capsule, _load_cpu_weights
+from .main import (
+    _collect_weight_pointers,
+    _cuda_device_index,
+    _detect_factory_capsule,
+    _load_cpu_weights,
+)
 
 # ---------------------------------------------------------------------------
 # DynamicCache <> pytree registration
@@ -198,7 +204,7 @@ def _decomp_table():
     return table
 
 
-def _collect_input_device_ptrs(ep, user_inputs):
+def _collect_input_device_ptrs(ep, user_inputs, device_index):
     """Map user-input placeholder names to (device_ptr, n_bytes) for live,
     contiguous CUDA nn.Parameters. Parameters are read-only in inference
     graphs, so the search can safely alias their memory; buffers and
@@ -208,6 +214,7 @@ def _collect_input_device_ptrs(ep, user_inputs):
     search's ones-buffer seeding."""
     from torch.export.graph_signature import InputKind
 
+    _cuda_device_index(user_inputs, expected=device_index)
     user_specs = [
         s for s in ep.graph_signature.input_specs if s.kind == InputKind.USER_INPUT
     ]
@@ -287,32 +294,20 @@ def _lower_sym_sum(ep) -> None:
         gm.recompile()
 
 
-def _save_and_compile(
+def _compile_artifact(
     ep_or_path,
     factory,
     search_iterations,
-    user_indices=None,
-    input_device_ptrs=None,
-    scalar_output_positions=(),
+    input_device_ptrs,
+    device_index,
+    external_cuda_graph,
 ):
-    """Compile a PT2 model via Rust, return CompiledModel.
-
-    Args:
-        ep_or_path: Either an ExportedProgram (will be saved to a temp file) or
-            a path to an already-saved .pt2 file. Baked weights come from
-            ep.state_dict (the AOT compile() path); torch.compile graphs carry
-            weights as ordinary inputs and have an empty state_dict.
-        factory: PyCapsule wrapping the BackendFactory to use.
-    """
     owns_tmpdir = not isinstance(ep_or_path, str)
     tmpdir = tempfile.mkdtemp(prefix="luminal_") if owns_tmpdir else None
     try:
         if owns_tmpdir:
             pt2_path = os.path.join(tmpdir, "model.pt2")
-            # `_example_inputs` is an optional copy of the arguments used to create an
-            # ExportedProgram and is not part of the executable graph's semantics. vLLM
-            # invokes compiler backends during torch.compile tracing, so these inputs may
-            # be FakeTensors, which Luminal does not currently serialize or consume.
+            # Fake example inputs are not part of the executable program.
             ep_or_path._example_inputs = None
             _lower_sym_sum(ep_or_path)  # serde gap workaround; see docstring
             torch.export.save(ep_or_path, pt2_path)
@@ -321,30 +316,69 @@ def _save_and_compile(
             pt2_path = ep_or_path
             weight_source = {}
 
-        # Collect weight pointers for Rust (avoids duplicate GPU buffer allocation)
+        resolved_device = _cuda_device_index(
+            weight_source.values(), expected=device_index
+        )
         keep_alive, weight_device_ptrs, cpu_weights = _collect_weight_pointers(
-            weight_source
+            weight_source, device_index=resolved_device
         )
         if input_device_ptrs:
             weight_device_ptrs.update(input_device_ptrs)
 
-        # Compile with device pointers — search uses actual weight memory (zero-copy)
         compiled = process_pt2(
-            pt2_path, "", search_iterations, factory, weight_device_ptrs
+            pt2_path,
+            "",
+            search_iterations,
+            factory,
+            weight_device_ptrs,
+            resolved_device,
+            external_cuda_graph,
         )
-
-        # Load CPU weights after compilation
         _load_cpu_weights(compiled, cpu_weights)
-
-        return CompiledModel(
-            compiled,
-            weight_refs=keep_alive,
-            user_indices=user_indices,
-            scalar_output_positions=scalar_output_positions,
-        )
+        return CompiledArtifact(compiled, keep_alive)
     finally:
         if owns_tmpdir and tmpdir:
             shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _save_and_compile(
+    ep_or_path,
+    factory,
+    search_iterations,
+    user_indices=None,
+    output_spec=None,
+    input_device_ptrs=None,
+    scalar_output_positions=(),
+    device_index=None,
+    use_current_stream=False,
+    static_outputs=False,
+    external_cuda_graph=False,
+    artifact_key=None,
+):
+    """Compile a PT2 model via Rust, return CompiledModel."""
+
+    compile_artifact = partial(
+        _compile_artifact,
+        ep_or_path,
+        factory,
+        search_iterations,
+        input_device_ptrs,
+        device_index,
+        external_cuda_graph,
+    )
+
+    artifact = (
+        get_or_compile(artifact_key, compile_artifact)
+        if artifact_key is not None
+        else compile_artifact()
+    )
+    return artifact.bind(
+        user_indices=user_indices,
+        output_spec=output_spec,
+        scalar_output_positions=scalar_output_positions,
+        use_current_stream=use_current_stream,
+        static_outputs=static_outputs,
+    )
 
 
 def _safe_int_bound(value):
@@ -582,6 +616,7 @@ def compile(
         example_args = tuple(example_input)
     else:
         example_args = (example_input,)
+    device_index = _cuda_device_index(example_args)
 
     kwargs = export_kwargs or {}
     extra = _export_kwargs()
@@ -627,7 +662,7 @@ def compile(
         )
         ep = ep.run_decompositions(_decomp_table())
 
-    return _save_and_compile(ep, factory, search_iterations)
+    return _save_and_compile(ep, factory, search_iterations, device_index=device_index)
 
 
 def _drop_input_guards(ep):
@@ -810,6 +845,7 @@ def _eager_pt2_compile(
     factory,
     search_iterations,
     scalar_output_positions=(),
+    device_index=None,
 ):
     """Run torch.export → save → Rust compile end-to-end. Returns CompiledModel.
 
@@ -853,7 +889,8 @@ def _eager_pt2_compile(
     # duplicating the full parameter set on device (OOM at ~2x weights for
     # whole-model compiles) and profiling with synthetic data. Nothing is
     # baked: the runtime still takes pointers per call.
-    input_device_ptrs = _collect_input_device_ptrs(ep, user_inputs)
+    device_index = _cuda_device_index(user_inputs, expected=device_index)
+    input_device_ptrs = _collect_input_device_ptrs(ep, user_inputs, device_index)
 
     del ep, gm
     gc.collect()
@@ -868,6 +905,7 @@ def _eager_pt2_compile(
             user_indices=user_indices,
             input_device_ptrs=input_device_ptrs,
             scalar_output_positions=scalar_output_positions,
+            device_index=device_index,
         )
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
@@ -907,6 +945,7 @@ class _LazyDynamicCompiledModel:
         factory,
         search_iterations,
         scalar_output_positions=(),
+        device_index=None,
     ):
         self._gm = gm
         self._user_inputs = user_inputs
@@ -914,6 +953,7 @@ class _LazyDynamicCompiledModel:
         self._dynamic_shapes = dynamic_shapes
         self._search_iterations = search_iterations
         self._scalar_output_positions = scalar_output_positions
+        self._device_index = device_index
         self._factory = factory
         self._compiled = None
 
@@ -927,6 +967,7 @@ class _LazyDynamicCompiledModel:
                 self._factory,
                 self._search_iterations,
                 self._scalar_output_positions,
+                self._device_index,
             )
             # Drop references we no longer need post-compile.
             self._gm = None
@@ -986,6 +1027,7 @@ def pt2_backend(gm, example_inputs, factory=None, search_iterations=None):
     user_inputs, post_strip_subindices, strip_ok = _strip_symint_placeholders(
         gm, user_inputs
     )
+    device_index = _cuda_device_index(user_inputs)
     dynamic_shapes = _build_dynamic_shapes_from_gm(gm) if strip_ok else None
 
     # Arg positions surviving the SymInt strip; None when nothing was
@@ -1009,6 +1051,7 @@ def pt2_backend(gm, example_inputs, factory=None, search_iterations=None):
             factory,
             search_iterations,
             scalar_output_positions,
+            device_index,
         )
 
     return _eager_pt2_compile(
@@ -1019,4 +1062,5 @@ def pt2_backend(gm, example_inputs, factory=None, search_iterations=None):
         factory,
         search_iterations,
         scalar_output_positions,
+        device_index,
     )

--- a/crates/luminal_python/src/luminal/region_compile.py
+++ b/crates/luminal_python/src/luminal/region_compile.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .artifact_cache import region_artifact_key
 from .compiled_model import CompiledModel
 from .pt2 import _save_and_compile
 from .region_export import RegionExport
@@ -12,6 +13,8 @@ def compile_region(
     *,
     device_type: str = "cuda",
     search_iterations: int = 1,
+    static_outputs: bool = False,
+    external_cuda_graph: bool = False,
 ) -> CompiledModel:
     """Compile a region without borrowing storage from its example inputs.
 
@@ -22,6 +25,13 @@ def compile_region(
 
     if device_type != "cuda":
         raise ValueError(f"unsupported region device type: {device_type!r}")
+    if region.device_index is None:
+        raise ValueError("CUDA region compilation requires CUDA tensor inputs")
+    if region.device_index != 0:
+        raise ValueError(
+            "Luminal currently supports only logical CUDA device 0, "
+            f"got {region.device_index}"
+        )
 
     try:
         from .luminal import _cuda_lite_factory_capsule
@@ -30,10 +40,24 @@ def compile_region(
             "region compilation requires luminal_python built with CUDA support"
         ) from error
 
+    artifact_key = region_artifact_key(
+        region.program,
+        device_type=device_type,
+        device_index=region.device_index,
+        search_iterations=search_iterations,
+        external_cuda_graph=external_cuda_graph,
+    )
+
     return _save_and_compile(
         region.program,
         _cuda_lite_factory_capsule(),
         search_iterations,
         user_indices=region.input_indices,
+        output_spec=region.output_spec,
         input_device_ptrs=None,
+        device_index=region.device_index,
+        use_current_stream=True,
+        static_outputs=static_outputs,
+        external_cuda_graph=external_cuda_graph,
+        artifact_key=artifact_key,
     )

--- a/crates/luminal_python/src/luminal/region_export.py
+++ b/crates/luminal_python/src/luminal/region_export.py
@@ -18,6 +18,7 @@ from .pt2 import (
     _export_kwargs,
     _strip_symint_placeholders,
 )
+from .main import _cuda_device_index
 from .region_abi import DynamicRange
 
 
@@ -25,7 +26,9 @@ from .region_abi import DynamicRange
 class RegionExport:
     program: torch.export.ExportedProgram
     input_indices: tuple[int, ...]
+    output_spec: Any
     dynamic_ranges: tuple[DynamicRange, ...]
+    device_index: int | None
 
 
 def export_region(
@@ -42,6 +45,8 @@ def export_region(
     """
 
     graph = copy.deepcopy(graph).eval()
+    output = next(node for node in graph.graph.nodes if node.op == "output")
+    _, output_spec = torch.utils._pytree.tree_flatten(output.args[0])
     _strip_data_attr(graph)
     inputs, input_indices, strip_ok = _strip_symint_placeholders(
         graph, list(example_inputs)
@@ -51,6 +56,7 @@ def export_region(
             "cannot export region: a SymInt input could not be derived from "
             "a tensor dimension"
         )
+    device_index = _cuda_device_index(inputs)
 
     dynamic_shapes = _build_dynamic_shapes_from_gm(graph, dynamic_range)
     export_inputs = _fresh_export_inputs(inputs)
@@ -76,7 +82,13 @@ def export_region(
         exported = exported.run_decompositions(_decomp_table())
         _drop_input_guards(exported)
         ranges = _set_range_constraints(exported, dynamic_range)
-        return RegionExport(exported, tuple(input_indices), ranges)
+        return RegionExport(
+            program=exported,
+            input_indices=tuple(input_indices),
+            output_spec=output_spec,
+            dynamic_ranges=ranges,
+            device_index=device_index,
+        )
     except Exception as error:
         raise RuntimeError(
             "torch.export failed for compiler-owned FX region: "

--- a/crates/luminal_python/tests/test_capsule_validation.py
+++ b/crates/luminal_python/tests/test_capsule_validation.py
@@ -12,6 +12,7 @@ import ctypes
 import pytest
 
 from luminal import process_pt2
+from luminal.luminal import _reference_factory_capsule
 
 
 def _new_capsule(name: bytes):
@@ -20,6 +21,14 @@ def _new_capsule(name: bytes):
     PyCapsule_New.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]
     dummy = ctypes.c_void_p(0xDEADBEEF)
     return PyCapsule_New(ctypes.byref(dummy), name, None)
+
+
+def test_factory_capsule_uses_versioned_abi_name():
+    get_name = ctypes.pythonapi.PyCapsule_GetName
+    get_name.restype = ctypes.c_char_p
+    get_name.argtypes = [ctypes.py_object]
+
+    assert get_name(_reference_factory_capsule()) == b"luminal.backend_factory.v2"
 
 
 def test_process_pt2_rejects_capsule_with_wrong_name():

--- a/crates/luminal_python/tests/test_region_compile.py
+++ b/crates/luminal_python/tests/test_region_compile.py
@@ -1,10 +1,21 @@
 from __future__ import annotations
 
+import time
+
 import pytest
 import torch
 from torch import fx
 
 import luminal.region_compile as region_compile_module
+from luminal.artifact_cache import (
+    ArtifactCacheStats,
+    CompiledArtifact,
+    artifact_cache_stats,
+    clear_artifact_cache,
+    get_or_compile,
+    region_artifact_key,
+)
+from luminal.compiled_model import CompiledModel
 from luminal.region_compile import compile_region
 from luminal.region_export import export_region
 
@@ -19,10 +30,11 @@ def _add_graph() -> fx.GraphModule:
 
 
 def test_compile_region_preserves_runtime_input_indices(monkeypatch) -> None:
-    region = export_region(
-        _add_graph(),
-        [torch.randn(2, 4), torch.randn(2, 4)],
-    )
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        inputs = [torch.randn(2, 4, device="cuda") for _ in range(2)]
+        region = export_region(_add_graph(), inputs)
     sentinel = object()
     factory = object()
     received = {}
@@ -50,8 +62,211 @@ def test_compile_region_preserves_runtime_input_indices(monkeypatch) -> None:
         "capsule": factory,
         "iterations": 3,
         "user_indices": region.input_indices,
+        "output_spec": region.output_spec,
         "input_device_ptrs": None,
+        "device_index": 0,
+        "use_current_stream": True,
+        "static_outputs": False,
+        "external_cuda_graph": False,
+        "artifact_key": region_artifact_key(
+            region.program,
+            device_type="cuda",
+            device_index=0,
+            search_iterations=3,
+            external_cuda_graph=False,
+        ),
     }
+
+
+def _key_program(input_name: str, op=torch.ops.aten.relu.default):
+    from types import SimpleNamespace
+
+    graph = fx.Graph()
+    value = graph.placeholder(input_name)
+    value.meta["val"] = torch.empty(2, 4)
+    result = graph.call_function(op, (value,))
+    result.meta["val"] = torch.empty(2, 4)
+    graph.output((result,))
+    return SimpleNamespace(
+        constants={},
+        state_dict={},
+        range_constraints={},
+        graph_module=fx.GraphModule(torch.nn.Module(), graph),
+    )
+
+
+def test_artifact_key_ignores_input_names() -> None:
+    options = {"device_type": "cuda", "search_iterations": 1}
+
+    assert region_artifact_key(_key_program("layer_0"), **options) == (
+        region_artifact_key(_key_program("layer_1"), **options)
+    )
+    assert region_artifact_key(_key_program("layer_0"), **options) != (
+        region_artifact_key(
+            _key_program("layer_0", torch.ops.aten.sigmoid.default), **options
+        )
+    )
+
+
+def test_artifact_cache_compiles_once() -> None:
+    clear_artifact_cache()
+    artifact = object()
+    calls = 0
+
+    def compile_artifact():
+        nonlocal calls
+        calls += 1
+        return artifact
+
+    assert get_or_compile("region", compile_artifact) is artifact
+    assert get_or_compile("region", compile_artifact) is artifact
+    assert calls == 1
+    assert artifact_cache_stats() == ArtifactCacheStats(
+        unique_artifacts=1,
+        reuse_hits=1,
+        searches=1,
+    )
+    clear_artifact_cache()
+
+
+def test_shared_artifact_rebinds_inputs_between_models() -> None:
+    from types import SimpleNamespace
+
+    class CudaTensor(torch.Tensor):
+        @staticmethod
+        def __new__(cls):
+            return torch.Tensor._make_subclass(cls, torch.empty(2), False)
+
+        @property
+        def device(self):
+            return torch.device("cuda:0")
+
+        @property
+        def is_cuda(self):
+            return True
+
+    registrations = []
+    graph = SimpleNamespace(
+        input_names=["x"],
+        input_dtypes=[7],
+        output_names=[],
+        output_dtypes=[],
+        output_shapes=[],
+        writeback_outputs=[],
+        has_dynamic_dims=False,
+        device_type="cuda",
+        device_index=0,
+        supports_device_ptrs=True,
+        set_input_device_ptr=lambda _, ptr, __: registrations.append(ptr),
+        run=lambda: None,
+    )
+    artifact = CompiledArtifact(graph)
+    first = artifact.bind()
+    second = artifact.bind()
+    first_input = CudaTensor()
+    second_input = CudaTensor()
+
+    first(first_input)
+    second(second_input)
+    first(first_input)
+
+    assert registrations == [
+        first_input.data_ptr(),
+        second_input.data_ptr(),
+        first_input.data_ptr(),
+    ]
+
+
+def test_compile_region_rejects_nonzero_device() -> None:
+    from dataclasses import replace
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        inputs = [torch.randn(2, 4, device="cuda") for _ in range(2)]
+        region = export_region(_add_graph(), inputs)
+
+    with pytest.raises(ValueError, match="only logical CUDA device 0"):
+        compile_region(replace(region, device_index=1))
+
+
+def test_compiled_model_rejects_wrong_cuda_device() -> None:
+    from types import SimpleNamespace
+
+    class CudaOneTensor(torch.Tensor):
+        @staticmethod
+        def __new__(cls):
+            return torch.Tensor._make_subclass(cls, torch.empty(2), require_grad=False)
+
+        @property
+        def device(self):
+            return torch.device("cuda:1")
+
+    graph = SimpleNamespace(
+        input_names=["x"],
+        input_dtypes=[7],
+        output_names=[],
+        output_shapes=[],
+        writeback_outputs=[],
+        has_dynamic_dims=False,
+        device_type="cuda",
+        device_index=0,
+        supports_device_ptrs=True,
+    )
+    model = CompiledModel(graph)
+
+    with pytest.raises(ValueError, match="compiled runtime uses logical device 0"):
+        model(CudaOneTensor())
+
+
+def test_compiled_model_passes_current_stream(monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    calls = []
+    graph = SimpleNamespace(
+        input_names=[],
+        input_dtypes=[],
+        output_names=[],
+        output_dtypes=[],
+        output_shapes=[],
+        writeback_outputs=[],
+        has_dynamic_dims=False,
+        device_type="cuda",
+        device_index=0,
+        supports_device_ptrs=True,
+        run=lambda *args: calls.append(args),
+    )
+    monkeypatch.setattr(
+        torch.cuda,
+        "current_stream",
+        lambda device: SimpleNamespace(cuda_stream=1234),
+    )
+
+    assert CompiledModel(graph, use_current_stream=True)() == ()
+    assert calls == [(1234,)]
+
+
+def test_compiled_model_restores_region_output_structure() -> None:
+    from types import SimpleNamespace
+
+    graph = SimpleNamespace(
+        input_names=[],
+        input_dtypes=[],
+        output_names=["result"],
+        output_dtypes=[7],
+        output_shapes=[[1]],
+        writeback_outputs=[],
+        has_dynamic_dims=False,
+        device_type="cpu",
+        device_index=None,
+        supports_device_ptrs=False,
+        run=lambda: None,
+        get_output_at=lambda position: [3.0],
+    )
+    _, output_spec = torch.utils._pytree.tree_flatten(torch.tensor(0))
+
+    output = CompiledModel(graph, output_spec=output_spec)()
+
+    assert torch.equal(output, torch.tensor([3.0]))
 
 
 def _cuda_skip_reason() -> str | None:
@@ -67,6 +282,49 @@ def _cuda_skip_reason() -> str | None:
 
 
 _CUDA_SKIP_REASON = _cuda_skip_reason()
+
+
+def _cuda_sleep_ms(stream: torch.cuda.Stream) -> float:
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    with torch.cuda.stream(stream):
+        start.record()
+        torch.cuda._sleep(1_000_000_000)
+        end.record()
+    end.synchronize()
+    return start.elapsed_time(end)
+
+
+@pytest.mark.skipif(
+    _CUDA_SKIP_REASON is not None, reason=_CUDA_SKIP_REASON or "CUDA is unavailable"
+)
+def test_non_static_writeback_accepts_changed_target() -> None:
+    from types import SimpleNamespace
+
+    copies = []
+    graph = SimpleNamespace(
+        input_names=["target"],
+        input_dtypes=[7],
+        output_names=["mutation"],
+        output_dtypes=[7],
+        output_shapes=[[2]],
+        writeback_outputs=[(0, "target")],
+        has_dynamic_dims=False,
+        device_type="cuda",
+        device_index=0,
+        supports_device_ptrs=True,
+        set_input_device_ptr=lambda *args: None,
+        run=lambda *args: None,
+        copy_outputs_to_device_ptrs_at=lambda value: copies.append(value),
+    )
+    model = CompiledModel(graph)
+    first = torch.zeros(2, device="cuda")
+    second = torch.zeros(2, device="cuda")
+
+    model(first)
+    model(second)
+
+    assert [copy[0][1] for copy in copies] == [first.data_ptr(), second.data_ptr()]
 
 
 @pytest.mark.skipif(
@@ -90,6 +348,141 @@ def test_compile_region_from_fake_cuda_metadata() -> None:
     ]
     (actual,) = compiled(*real_inputs)
     torch.testing.assert_close(actual, real_inputs[0] + real_inputs[1])
+
+
+@pytest.mark.skipif(
+    _CUDA_SKIP_REASON is not None, reason=_CUDA_SKIP_REASON or "CUDA is unavailable"
+)
+def test_compile_region_uses_current_cuda_stream() -> None:
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        fake_inputs = [
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+        ]
+        region = export_region(_add_graph(), fake_inputs)
+
+    compiled = compile_region(region, search_iterations=1, static_outputs=True)
+    left = torch.empty((2, 4), device="cuda", dtype=torch.float16)
+    right = torch.empty((2, 4), device="cuda", dtype=torch.float16)
+    stream = torch.cuda.Stream()
+
+    # Warm up one-time compilation and allocation work on this stream.
+    with torch.cuda.stream(stream):
+        (actual,) = compiled(left, right)
+    stream.synchronize()
+
+    # `_sleep` cycles do not have a portable wall-clock duration, so measure the
+    # delay on this GPU before using it to test whether the host call blocks.
+    sleep_ms = _cuda_sleep_ms(stream)
+    assert sleep_ms > 10, f"CUDA delay is too short to test blocking: {sleep_ms} ms"
+
+    with torch.cuda.stream(stream):
+        torch.cuda._sleep(1_000_000_000)
+        left.fill_(1)
+        right.fill_(2)
+        call_start = time.perf_counter()
+        (actual,) = compiled(left, right)
+        call_ms = (time.perf_counter() - call_start) * 1_000
+
+    assert call_ms < sleep_ms / 2, (
+        "Luminal blocked on the borrowed CUDA stream "
+        f"(call={call_ms:.3f} ms, queued_delay={sleep_ms:.3f} ms)"
+    )
+    stream.synchronize()
+    torch.testing.assert_close(actual, torch.full_like(actual, 3))
+
+
+@pytest.mark.skipif(
+    _CUDA_SKIP_REASON is not None, reason=_CUDA_SKIP_REASON or "CUDA is unavailable"
+)
+def test_compile_region_can_be_captured_by_pytorch() -> None:
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        fake_inputs = [
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+        ]
+        region = export_region(_add_graph(), fake_inputs)
+
+    compiled = compile_region(
+        region,
+        search_iterations=1,
+        static_outputs=True,
+        external_cuda_graph=True,
+    )
+    left = torch.ones((2, 4), device="cuda", dtype=torch.float16)
+    right = torch.full((2, 4), 2, device="cuda", dtype=torch.float16)
+
+    # Prepare every Luminal resource before capture.
+    compiled(left, right)
+    torch.cuda.synchronize()
+
+    # vLLM's capture buffers need not have the same addresses as warmup.
+    capture_left = torch.full_like(left, 3)
+    capture_right = torch.full_like(right, 4)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        (actual,) = compiled(capture_left, capture_right)
+
+    capture_left.fill_(5)
+    capture_right.fill_(6)
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(actual, torch.full_like(actual, 11))
+
+
+@pytest.mark.skipif(
+    _CUDA_SKIP_REASON is not None, reason=_CUDA_SKIP_REASON or "CUDA is unavailable"
+)
+def test_static_writeback_uses_stable_target_on_current_stream() -> None:
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    graph = fx.Graph()
+    target = graph.placeholder("target")
+    update = graph.placeholder("update")
+    result = graph.call_function(torch.ops.aten.add_.Tensor, (target, update))
+    graph.output(result)
+    graph_module = fx.GraphModule(torch.nn.Module(), graph)
+
+    with FakeTensorMode():
+        fake_inputs = [
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+        ]
+        region = export_region(graph_module, fake_inputs)
+
+    compiled = compile_region(region, search_iterations=1, static_outputs=True)
+    target_value = torch.zeros((2, 4), device="cuda", dtype=torch.float16)
+    stream = torch.cuda.Stream()
+
+    with torch.cuda.stream(stream):
+        compiled(target_value, torch.ones_like(target_value))
+    stream.synchronize()
+    torch.testing.assert_close(target_value, torch.ones_like(target_value))
+
+    sleep_ms = _cuda_sleep_ms(stream)
+    assert sleep_ms > 10, f"CUDA delay is too short to test blocking: {sleep_ms} ms"
+    with torch.cuda.stream(stream):
+        torch.cuda._sleep(1_000_000_000)
+        call_start = time.perf_counter()
+        compiled(target_value, torch.full_like(target_value, 2))
+        call_ms = (time.perf_counter() - call_start) * 1_000
+
+    assert call_ms < sleep_ms / 2, (
+        "Luminal writeback blocked on the borrowed CUDA stream "
+        f"(call={call_ms:.3f} ms, queued_delay={sleep_ms:.3f} ms)"
+    )
+    stream.synchronize()
+    torch.testing.assert_close(target_value, torch.full_like(target_value, 3))
+
+    with pytest.raises(ValueError, match="requires a contiguous CUDA tensor"):
+        compiled(target_value.t(), torch.ones_like(target_value.t()))
+
+    with pytest.raises(ValueError, match="target allocation changed"):
+        compiled(torch.zeros_like(target_value), torch.ones_like(target_value))
 
 
 @pytest.mark.skipif(
@@ -122,15 +515,18 @@ def test_compile_region_enforces_dynamic_range() -> None:
         [fake_left, fake_right],
         dynamic_range=(1, 8),
     )
-    compiled = compile_region(region, search_iterations=1)
+    compiled = compile_region(region, search_iterations=1, static_outputs=True)
     assert compiled._graph.output_shapes == [[16, 8]]
 
+    output_ptrs = set()
     for size in (2, 3, 5, 8):
         left_value = torch.randn((size, 8), device="cuda", dtype=torch.float16)
         right_value = torch.randn((size, 8), device="cuda", dtype=torch.float16)
         (actual,) = compiled(left_value, right_value)
+        output_ptrs.add(actual.data_ptr())
         assert actual.shape == (size * 2, 8)
         torch.testing.assert_close(actual, torch.cat((left_value, right_value)))
+    assert len(output_ptrs) == 1
 
     for size in (1, 9):
         value = torch.randn((size, 8), device="cuda", dtype=torch.float16)

--- a/crates/luminal_python/tests/test_region_export.py
+++ b/crates/luminal_python/tests/test_region_export.py
@@ -10,6 +10,19 @@ from torch import fx
 from luminal.region_export import _fresh_export_inputs, export_region
 
 
+def _tensor_reporting_device(device: str) -> torch.Tensor:
+    class DeviceTensor(torch.Tensor):
+        @staticmethod
+        def __new__(cls):
+            return torch.Tensor._make_subclass(cls, torch.empty(1), require_grad=False)
+
+        @property
+        def device(self):
+            return torch.device(device)
+
+    return DeviceTensor()
+
+
 def _linear_graph() -> fx.GraphModule:
     graph = fx.Graph()
     x = graph.placeholder("x")
@@ -290,3 +303,29 @@ def test_export_region_surfaces_export_error(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="ValueError: original export failure"):
         export_region(_linear_graph(), [torch.randn(3, 8)] * 3)
+
+
+def test_export_region_records_fake_cuda_device() -> None:
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        inputs = [torch.randn(2, 4, device="cuda:0") for _ in range(2)]
+        graph = fx.symbolic_trace(lambda left, right: left + right)
+        region = export_region(graph, inputs)
+
+    assert region.device_index == 0
+
+
+def test_export_region_rejects_multiple_cuda_devices() -> None:
+    inputs = [
+        _tensor_reporting_device("cuda:0"),
+        _tensor_reporting_device("cuda:1"),
+    ]
+    with pytest.raises(ValueError, match="span multiple logical devices"):
+        export_region(fx.symbolic_trace(lambda left, right: left + right), inputs)
+
+
+def test_export_region_rejects_nonzero_cuda_device() -> None:
+    inputs = [_tensor_reporting_device("cuda:1") for _ in range(2)]
+    with pytest.raises(ValueError, match="only logical CUDA device 0"):
+        export_region(fx.symbolic_trace(lambda left, right: left + right), inputs)

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -48,6 +48,7 @@ Dispositions:
 | `b745d102` | #413 | metal: emit constants by f32 bit pattern | FILE-LEVEL (2 metal-park files) | branch `merge/main-413-metal-constants` | RULED 2026-09-03: *"same 413 is fine. we can just merge this and check later."* The CHECK is done and the answer is NO: live CUDA constant codegen has the same defect — see **#413 metal constants** below |
 | `38640588` | #416 | Allow vLLM FX region compilation | FILE-LEVEL (11 python-park files + 1 into the `cuda_lite_hlir` park) + DROPPED (the zero-extent slice special case, by ruling) + RE-EXPRESSED (one recording-only pin) | branch `merge/main-416-vllm-regions` | RULED 2026-09-03: *"let's not special case slices producing extent zero for now"* — and the answer to *"nothing bad should happen?"* is: nothing does; the shared-destination invariant is already enforced by the conflict engine — see **#416 vLLM regions** below |
 | `477d3626` | #417 | Preserve concrete dtypes through loop rolling | INTENT-ONLY (the law written into the estate beside `dtype-of`) | branch `merge/main-417-dtype-contract` | RULED 2026-09-03: *"This is good, let's merge it."* Nothing is file-mergeable — `src/hlir.rs` and `src/op.rs` are deleted and `src/graph.rs` is a different file (the recorder). The principle main paid for is already this branch's design and is now written down; the `output_dtype` table, `concrete_node_dtypes` and the marker assertions are uncarried — see **#417 dtype contracts** below |
+| `6681720b` | #418 | Add CUDA serving runtime support for vLLM integration | FILE-LEVEL (12 python-park files + 4 into the `cuda_lite_hlir` park + 1 metal-park file) + UNCARRIED (`src/dyn_backend.rs`, deleted on this branch) | branch `merge/main-418-serving-parks` | RULED 2026-09-03: *"we'll record only, we'll eventually have to get to parity."* Five EMBEDDABILITY REQUIREMENTS on the live CL executor, each checked against today's `crates/luminal_cuda_lite/src/device.rs`: device selection, a caller-owned borrowed stream with a synchronize-or-not policy, fixed-capacity caller-owned output buffers, functionalized mutation writebacks, and a versioned FFI seam — see **#418 vLLM serving** below |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -2098,6 +2099,194 @@ reader does not mistake an empty ruleset for a live propagation.
 not name a future requirement: main's end state is this branch's starting
 state. What is owed is only that it stay that way, which is what the comment is
 for.
+
+## #418 vLLM serving — parks banked; embeddability requirements recorded (parity owed)
+
+RULED 2026-09-03: *"we'll record only, we'll eventually have to get to
+parity."* Main's `6681720b` (+1249/-171, 18 files) is the commit that makes
+luminal EMBEDDABLE: a host process (vLLM) selects the device, hands luminal its
+own CUDA stream, supplies the output allocations, captures luminal's kernels
+into the host's own CUDA graph, and reuses one compiled artifact across
+rebindings. Seventeen of the eighteen files are park files and went across
+untouched. The eighteenth is core and does not exist here.
+
+### FILE-LEVEL: 17 files, residue EMPTY on every one
+
+Twelve `crates/luminal_python/**` (`rust/src/{compiled_graph,
+pt2_compiled_model}.rs`, `src/luminal/{__init__,artifact_cache,compiled_model,
+main,pt2,region_compile,region_export}.py`, `tests/{test_capsule_validation,
+test_region_compile,test_region_export}.py` — `artifact_cache.py` is new,
++130), four into the `cuda_lite_hlir` park (`Cargo.toml`, `src/runtime.rs`,
+`src/dyn_backend.rs`, `src/kernel/to_host.rs`, path-rewritten from
+`crates/luminal_cuda_lite/`), and one metal-park file
+(`crates/luminal_metal/src/dyn_backend.rs`, +1/-1, the `execute` signature).
+
+**Every one applied cleanly — no conflicts, and NO re-spelling was needed.**
+The diff-of-diffs check (main's per-file hunk set, path-rewritten, versus the
+hunk set actually banked, normalized for line offsets) is byte-IDENTICAL for
+all 17. The park conventions were re-checked afterwards and hold:
+`named_tensor_dtyped` is still 0 occurrences in `crates/luminal_python`; no
+added line reintroduces `Expression` or a Rust `.shape` field access (the two
+`.shape` hits in the added Python are `torch.Tensor.shape`); and the park's own
+drift survives untouched (`early_stop_exceeded` still at
+`crates/luminal_cuda_lite_hlir/src/runtime.rs:55`, `IntExpr` still spelled in
+`runtime.rs` and `kernel/to_host.rs`). None of the three crates is a workspace
+member, so nothing was built.
+
+What the park now carries, in main's terms: `CudaRuntime` gains an
+`owned_stream` beside its execution `cuda_stream` plus
+`use_borrowed_stream(raw: u64)` / `use_owned_stream()` /
+`select_execution_stream()`, and a `synchronize_stream` flag that makes the
+terminal `self.cuda_stream.synchronize()` — and the batched writeback sync in
+`copy_outputs_to_device_ptrs` — CONDITIONAL: owned-stream execution stays
+blocking, borrowed-stream execution leaves completion ordered on the caller's
+stream. `external_cuda_graph` makes `execute` detect an ACTIVE capture on the
+caller's stream and, in that case, skip luminal's own graph materialization and
+launch the individual steps (`CudaGraphOp::launch_steps`, the `enqueue_prepared`
+/ `validate_pointers` / `requires_output_buffer` split in
+`kernel/to_host.rs`) so the host's capture picks them up. Arena allocation
+learns to EXCLUDE caller-registered output nodes
+(`external_output_nodes` threaded into `allocate_intermediate_buffers`), so a
+reallocation cannot silently overwrite a pointer the host owns. `Cargo.toml`
+re-points `cudarc` at the `luminal-ai` fork.
+On the Python side `CompiledModel` gains `use_current_stream`,
+`static_outputs` (fixed max-capacity CUDA output buffers reused across calls,
+returned as views at the current runtime shapes), `device_index` enforcement
+via `_cuda_device_index`, and an `artifact` handle whose `activate(binding)`
+returns True when the shared compiled artifact was last used by a DIFFERENT
+binding — the signal to re-register every input device pointer.
+`artifact_cache.py` keys structurally identical FX regions (symbol names
+normalized) so separate positional bindings share one search.
+
+### UNCARRIED: `src/dyn_backend.rs` (+18/-5)
+
+The file was deleted on this branch; there is no `DynBackend` trait, no
+`BackendCompileArgs`, and no PyCapsule seam (`grep -rn 'pyo3\|PyCapsule\|
+BackendFactory' src/` returns nothing — the python crate is parked, not
+attached to the recorder). Main's five changes there, recorded for the
+re-attachment:
+
+- `fn device_index(&self) -> Option<usize>` on the trait, defaulting to `None`.
+- `fn execute(&mut self, dyn_map: &DynMap, stream: Option<u64>)` — the raw
+  borrowed stream is threaded through the trait itself, and
+  `ReferenceDynBackend::execute` asserts `stream.is_none()`.
+- `BackendCompileArgs` gains `device_index: Option<usize>` and
+  `external_cuda_graph: bool`.
+- `BACKEND_FACTORY_CAPSULE_NAME` bumped `"luminal.backend_factory"` ->
+  `"luminal.backend_factory.v2"`, with the reason stated in the doc comment:
+  *"The version is part of the ABI: `BackendCompileArgs` crosses this boundary
+  by value, so an older plugin must be rejected rather than reading a changed
+  struct layout."* Note this REPLACES the previous comment, which promised the
+  name would never change for compatibility with older producers — main
+  deliberately reversed that promise, and the versioned form is the one worth
+  copying.
+
+### THE FIVE EMBEDDABILITY REQUIREMENTS (recorded, nothing acted on)
+
+Each is stated as a requirement on the live CL executor — `execute_plan` in
+`crates/luminal_cuda_lite/src/device.rs`, called from
+`CudaRuntime::execute` (`crates/luminal_cuda_lite/src/runtime.rs:299-307`) —
+with today's state verified in the tree, not assumed.
+
+**(1) Explicit CUDA device selection.** *Today: device 0 is hardcoded, and the
+context is created per call.* `crates/luminal_cuda_lite/src/device.rs:156`:
+
+```rust
+let ctx = CudaContext::new(0).context("no CUDA device 0")?;
+```
+
+`execute_plan` takes only `(plan, staged)`; `CudaRuntime::execute(&mut self)`
+(`runtime.rs:299`) takes nothing at all, and `CudaRuntime` holds no context or
+device field. Main's shape is the parameterized one: the device index arrives
+in `BackendCompileArgs`, the factory refuses a missing index outright
+(*"CUDA backend requires a device index"*), the runtime reports it back through
+`device_index()`, and the Python side cross-checks that every input tensor
+lives on that logical device (`main.py::_cuda_device_index`). Requirement: the
+device is an argument of the call, reported back to the host, and a mismatch
+between the host's tensors and the executor's device is a loud refusal. (Main
+still restricts to logical device 0 — the multi-device work is the plumbing,
+not the capability.)
+
+**(2) Execution on a caller-owned stream the executor neither destroys nor
+synchronizes.** *Today: the context's default stream, created per call, with an
+unconditional terminal synchronize.* `device.rs:157`
+(`let stream = ctx.default_stream();`) and `device.rs:456`
+(`stream.synchronize().context("stream sync")?;`), followed by blocking
+`memcpy_dtoh` per output slot (`device.rs:472`). There is no way to pass a
+stream in and no flag that suppresses the sync. Requirement, in two halves:
+(a) an entry point that takes a raw `CUstream` from the host, wraps it BORROWED
+(main: `context.wrap_borrowed_stream`, behind an `unsafe fn` whose contract is
+that the owner keeps it alive), and re-points every launch at it — the executor
+must never destroy it; and (b) an explicit SYNCHRONIZE-OR-NOT policy tied to
+that choice: owned stream => blocking, as today; borrowed stream => return with
+the work merely enqueued, completion ordered on the caller's stream, and the
+D2H readback path must then be optional too, because a host that supplied its
+own output buffers does not want the copy at all. Main spells the policy as one
+bool, `synchronize_stream`, set by whichever of `use_owned_stream` /
+`use_borrowed_stream` was called.
+
+**(3) Fixed-capacity, stable-address, caller-owned output buffers the planner
+must not reuse.** *Today: the executor allocates every buffer itself, fresh,
+per call, and hands back host copies.* Phase 1 allocates one `alloc_zeros` per
+plan buffer including the ones backing output slots (`device.rs:198`); Phase 4
+copies each output slot's backing buffer D2H into a fresh `Vec<u8>` and returns
+owned `TypedBuffer`s keyed by slot index (`device.rs:466-476`), which
+`CudaRuntime` stores in `outputs_host` (`runtime.rs:51`, `:307`). So output
+storage is neither caller-owned nor stable across calls, and its address is not
+even stable across two executions of the same plan. The requirement has three
+parts a host needs simultaneously: the host supplies the output pointer; that
+pointer is FIXED-CAPACITY (allocated once at the maximum shape and re-viewed at
+the current runtime shape, which is main's `static_outputs` — CUDA-graph
+capture demands a stable address, so a per-shape allocation is not an option);
+and the planner/allocator must be forbidden from handing that buffer's range to
+anything else (main's fix is literally a filter — `external_output_nodes`
+excluded from `logical_buffer_offsets` before arena assignment).
+**The seam already exists and already says so.** `device.rs:215-222`, the
+CONTRACT-1 bind-time check, is written for exactly this future:
+
+> distinct BufferIds must be backed by disjoint device ranges … Fresh
+> `alloc_zeros` per buffer makes this hold by construction today; the assert is
+> the contract's enforcement face for when raw caller pointers arrive at this
+> binding surface. Loud refusal, never mistranslation.
+
+That is where a caller pointer table would be bound, and the disjointness
+assert is what would catch a host handing in two overlapping ranges.
+
+**(4) Functionalized mutation writebacks.** *Today: absent from the executor,
+though the PLAN ontology already has the vocabulary.* A serving host's KV
+cache is a caller tensor that the graph logically returns a new value for and
+the host wants written back in place; main batches every such copy into one
+`copy_outputs_to_device_ptrs` submission and (post-#418) syncs it only in
+owned-stream mode, with `CompiledModel` refusing a writeback target that is not
+a contiguous CUDA tensor of the right dtype and element count, and refusing
+outright if the target's allocation CHANGED between calls. Here, `grep -rni
+'writeback\|donat' crates/luminal_cuda_lite/src/*.rs` finds exactly one hit,
+and it is a comment: the escape guard at `device.rs:126-132`, which reasons
+about DONATED boundary storage while refusing a plan whose output is backed by
+`FreedBy::Program`. The plan level is genuinely ready — `Owner::{Caller,
+System}` (`src/bufferize.rs:115-120`), `Access::{ReadOnly, ReadWrite}` and
+`FreedBy::{Caller, Program}` (`src/layout_ir/mod.rs:704-721`, deliberately
+orthogonal: *"permission to clobber bytes never implies responsibility to
+destroy storage"*) are exactly the facts a writeback needs. What is missing is
+only the executor seam: a way to name the caller's destination pointer for an
+output slot, and a batched, once-synchronized (or not-synchronized) copy to it.
+
+**(5) A versioned FFI seam.** *Today: none, and none is owed yet — but the
+version discipline is.* There is no python attachment on this branch at all
+(see UNCARRIED above), so nothing crosses a C boundary from live core. When one
+is built, main's rule is the one to adopt: the capsule name CARRIES the ABI
+version (`luminal.backend_factory.v2`) precisely because the argument struct
+crosses by value, so bumping the name is how an older producer gets a clean
+rejection instead of a reinterpreted struct — and #418 is itself the proof, a
+commit that added two fields to `BackendCompileArgs` and one parameter to
+`DynBackend::execute` in the same breath. Note the python park's
+`test_capsule_validation.py` already pins name-mismatch rejection, so the test
+shape is banked even though the seam is not.
+
+**Nothing here is a defect.** The CL executor is a correct standalone executor;
+every gap above is a capability it was never asked for. This section exists so
+that when it IS asked for, the list is already written and already measured
+against the code.
 
 ## #406 pad — the select construction REVERTED (2026-09-03)
 


### PR DESCRIPTION
**Stack.** PR 2 of 2, batch 6 of the main rejoin. Base: `merge/main-417-dtype-contract`. Merge in order; before merging, retarget to `logical-ssa-project` with `gh pr edit --base logical-ssa-project`.

**Ruling (Austin, 2026-09-03):** #418 "we'll record only, we'll eventually have to get to parity." — parks banked; embeddability requirements recorded against the live executor; no live code.

## `7e9ef8b4` vLLM serving runtime (#418): parks banked; embeddability requirements recorded

Main's 6681720b is the commit that makes luminal embeddable in a serving host:
the host selects the device, hands luminal its own CUDA stream, supplies
fixed-capacity output allocations, captures luminal's kernels into its own CUDA
graph, and reuses one compiled artifact across rebindings.

Seventeen of its eighteen files are park files and are banked verbatim: 12 in
crates/luminal_python (artifact_cache.py is new), 4 path-rewritten from main's
crates/luminal_cuda_lite into crates/luminal_cuda_lite_hlir, and 1 metal-park
signature change. Every one applied cleanly with no conflicts and no
re-spelling -- the diff-of-diffs residue is EMPTY on all 17, named_tensor_dtyped
stays at 0 occurrences in the python park, no added line reintroduces
Expression or a Rust .shape access, and the hlir park's own drift
(early_stop_exceeded, IntExpr) survives untouched. None of the three crates is
a workspace member, so nothing was built.

The eighteenth file, src/dyn_backend.rs, is deleted on this branch: no
DynBackend trait, no BackendCompileArgs, no PyCapsule seam. UNCARRIED, with its
five changes written out -- device_index() on the trait, the stream parameter
threaded through execute(), the two new BackendCompileArgs fields, and the
BACKEND_FACTORY_CAPSULE_NAME bump to .v2 (main deliberately reversing its own
earlier never-change-this-name promise, because the argument struct crosses the
boundary by value).

Per Austin -- "we'll record only, we'll eventually have to get to parity" --
the ledger section states the five embeddability requirements as requirements
on the live CL executor, each with today's state verified in the tree: device 0
hardcoded per call at device.rs:156; the context's default stream with an
unconditional terminal synchronize at device.rs:157/:456; every buffer
including output-backing ones freshly allocated per call and returned as host
copies (device.rs:198, :466-476), with the CONTRACT-1 bind-time check at
device.rs:215-222 already written as the seam where caller pointers would
arrive; no writeback machinery at all, though Owner/Access/FreedBy
(bufferize.rs:115-120, layout_ir/mod.rs:704-721) are already the right
vocabulary; and no FFI seam yet, so only the version discipline is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
