### PR TITLE
rejoin P2: the CL op registry is chosen at runtime initialization (load_with_registry, cuda_registry_filtered, RegisteredOp::new/label)

### DIFF
--- a/crates/luminal_cuda_lite/src/extractor.rs
+++ b/crates/luminal_cuda_lite/src/extractor.rs
@@ -40,7 +40,7 @@ struct Extractor<'a> {
     /// structural plumbing — inputs, outputs, buffer lists — is never
     /// filtered). This registry is the ONLY dispatch: an enode whose label
     /// has no entry here simply offers no implementation candidate.
-    matchers: HashMap<&'static str, Box<dyn OpMatcher>>,
+    matchers: HashMap<&'static str, &'a dyn OpMatcher>,
     class_nodes: HashMap<ClassId, Vec<NodeId>>,
     /// The shared rendering state: the render-time class index and the
     /// per-(class, depth, preference) render memo, behind an `Rc` so the
@@ -180,7 +180,7 @@ struct ProducerRef {
 /// TestRuntime seam — see `Extractor::new_with_matchers`).
 pub fn extract_layout_ir_with_matchers(
     egraph: &EGraph,
-    matchers: Vec<Box<dyn luminal::layout_ir::OpMatcher>>,
+    matchers: &[Box<dyn luminal::layout_ir::OpMatcher>],
 ) -> Result<Option<ExtractedGraph>> {
     Extractor::new_with_matchers(egraph, None, None, matchers).extract()
 }
@@ -200,7 +200,7 @@ impl<'a> ExtractionSession<'a> {
     pub fn new_with_matcher_set(
         egraph: &'a EGraph,
         allowed_ops: Option<&[&str]>,
-        matchers: Vec<Box<dyn luminal::layout_ir::OpMatcher>>,
+        matchers: &'a [Box<dyn luminal::layout_ir::OpMatcher>],
     ) -> Self {
         let allowed = allowed_ops.map(|ops| ops.iter().map(|op| op.to_string()).collect());
         let mut extractor = Extractor::new_with_matchers(egraph, allowed, None, matchers);
@@ -497,7 +497,7 @@ impl<'a> ExtractionSession<'a> {
 pub fn extract_layout_ir_with_ops_and_matchers(
     egraph: &EGraph,
     allowed_ops: Option<&[&str]>,
-    matchers: Vec<Box<dyn luminal::layout_ir::OpMatcher>>,
+    matchers: &[Box<dyn luminal::layout_ir::OpMatcher>],
 ) -> Result<Option<ExtractedGraph>> {
     let allowed = allowed_ops.map(|ops| ops.iter().map(|op| op.to_string()).collect());
     let mut extractor = Extractor::new_with_matchers(egraph, allowed, None, matchers);
@@ -535,7 +535,7 @@ pub struct Genome {
 pub fn extract_layout_ir_with_genome_and_matchers(
     egraph: &EGraph,
     genome: &Genome,
-    matchers: Vec<Box<dyn luminal::layout_ir::OpMatcher>>,
+    matchers: &[Box<dyn luminal::layout_ir::OpMatcher>],
 ) -> Result<Option<ExtractedGraph>> {
     let mut extractor = Extractor::new_with_matchers(egraph, None, Some(genome), matchers);
     extractor.apply_viability_filter();
@@ -549,7 +549,7 @@ pub fn extract_layout_ir_with_genome_and_matchers(
 /// from. Classes with no producers (boundary inputs) are absent.
 pub fn producer_index_with_matchers(
     egraph: &EGraph,
-    matchers: Vec<Box<dyn luminal::layout_ir::OpMatcher>>,
+    matchers: &[Box<dyn luminal::layout_ir::OpMatcher>],
 ) -> std::collections::BTreeMap<ClassId, Vec<(String, ProducerChoice)>> {
     let mut extractor = Extractor::new_with_matchers(egraph, None, None, matchers);
     extractor.apply_viability_filter();
@@ -885,10 +885,18 @@ impl<'a> Extractor<'a> {
         egraph: &'a EGraph,
         allowed_ops: Option<HashSet<String>>,
         genome: Option<&Genome>,
-        matcher_set: Vec<Box<dyn OpMatcher>>,
+        matcher_set: &'a [Box<dyn OpMatcher>],
     ) -> Self {
-        let matchers: HashMap<&'static str, Box<dyn OpMatcher>> = matcher_set
-            .into_iter()
+        // THE MATCHER SET IS LENT, NOT OWNED (Phase 2, 2026-09-03): the
+        // vocabulary belongs to the runtime INSTANCE that was loaded
+        // with it, and one instance runs many extractions (every genome
+        // of every bucket). Borrowing is what lets the runtime hold the
+        // list once instead of rebuilding it per call — `dyn OpMatcher`
+        // is not `Clone` and the registry is chosen at `load`, so there
+        // is nothing to rebuild it FROM down here.
+        let matchers: HashMap<&'static str, &'a dyn OpMatcher> = matcher_set
+            .iter()
+            .map(|matcher| matcher.as_ref())
             .filter(|matcher| {
                 allowed_ops
                     .as_ref()

--- a/crates/luminal_cuda_lite/src/lib.rs
+++ b/crates/luminal_cuda_lite/src/lib.rs
@@ -6,6 +6,13 @@
 //! allow-list seam — but executing on a CUDA device with
 //! NVRTC-compiled kernels instead of host loops.
 //!
+//! THE OP SET IS CHOSEN AT INITIALIZATION (ruling 2026-09-03, #420/#422
+//! rejoin Phase 2): a runtime's matcher vocabulary and its derived allow
+//! list come from the `Vec<RegisteredOp>` handed to
+//! [`CudaRuntime::load_with_registry`] — [`cuda_registry`] and
+//! [`cuda_registry_with_cublaslt`] are presets, and
+//! [`cuda_registry_filtered`] narrows either without editing this crate.
+//!
 //! THIS CRATE OWNS ITS SEARCH (ruling 2026-09-03, #420/#422 rejoin
 //! Phase 1): [`extractor`] and [`search`] are this runtime's own copies
 //! — core keeps the shared machinery (program, assembly, `dps_rewrite`,
@@ -50,6 +57,7 @@ pub mod device;
 pub use bindings::CudaBindings;
 pub use host_buffer::HostBuffer;
 pub use layouts::CudaPlan;
+pub use ops::{cuda_registry, cuda_registry_filtered, cuda_registry_with_cublaslt, RegisteredOp};
 pub use runtime::CudaRuntime;
 pub use search::{harness_search_options, CompileOptions, SearchOutcome};
 
@@ -76,12 +84,18 @@ pub fn plan_transparent(op: &dyn luminal::layout_ir::LayoutIrOp) -> bool {
         && op.to_dps().is_none()
 }
 
-/// The op labels this runtime claims — the CUDA analogue of
-/// `reference_allow_list()`: search may only elect ops the backend can
+/// The op labels the DEFAULT registry preset claims — the CUDA analogue
+/// of `reference_allow_list()`: search may only elect ops the backend can
 /// actually EXECUTE (a codegen row in the kernel table) or provably
 /// FOLD (the plan-transparent class above). Labels follow house policy:
 /// the egglog constructor minus the `LayoutTensorOp` prefix, nothing
 /// else added or stripped.
+///
+/// A LOADED RUNTIME'S OWN claim set is
+/// [`CudaRuntime::active_allow_list`], derived from the registry it was
+/// initialized with ([`CudaRuntime::load_with_registry`]); this
+/// crate-level function is the preset's, for callers with no graph in
+/// hand.
 pub fn cuda_allow_list() -> Vec<&'static str> {
     CudaRuntime::allow_list()
         .into_iter()

--- a/crates/luminal_cuda_lite/src/ops/cublaslt/election.rs
+++ b/crates/luminal_cuda_lite/src/ops/cublaslt/election.rs
@@ -26,7 +26,7 @@ type ProducerOrdering<'a> =
 /// over the CALLER's matcher set via the genome seam.)
 pub fn genome_preferring(
     egraph: &luminal::prelude::egraph_serialize::EGraph,
-    matchers: Vec<Box<dyn OpMatcher>>,
+    matchers: &[Box<dyn OpMatcher>],
     preferences: &[&str],
 ) -> crate::extractor::Genome {
     let preferences: Vec<String> = preferences.iter().map(|s| s.to_string()).collect();
@@ -81,7 +81,7 @@ pub fn level_admits(level: usize) -> impl Fn(&str) -> bool {
 /// (dead rows are legal and free).
 pub fn genome_with_ordering(
     egraph: &luminal::prelude::egraph_serialize::EGraph,
-    matchers: Vec<Box<dyn OpMatcher>>,
+    matchers: &[Box<dyn OpMatcher>],
     ordered: ProducerOrdering<'_>,
 ) -> crate::extractor::Genome {
     use luminal::prelude::egraph_serialize::ClassId;

--- a/crates/luminal_cuda_lite/src/ops/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/mod.rs
@@ -8,6 +8,31 @@
 //! FUNCTIONAL forms only in CL-1 — the runtime is out-of-place by
 //! design, so the mutating/alias-safe family is deliberately absent
 //! from this assembly (it arrives with the in-place ties in CL-4).
+//!
+//! THE REGISTRY IS A VALUE, NOT A CONSTANT (ruling 2026-09-03, #420/#422
+//! rejoin Phase 2: *"you should select the allowed ops when you
+//! initialize the runtime ... You should not need to edit CL in order to
+//! modify this. It should be configurable."*). [`cuda_registry`] and
+//! [`cuda_registry_with_cublaslt`] are just the two PRESETS this crate
+//! ships; what a [`crate::CudaRuntime`] assembles, saturates, searches
+//! and claims with is the `Vec<RegisteredOp>` it was handed at
+//! [`crate::CudaRuntime::load_with_registry`]. A caller narrows the
+//! vocabulary with [`cuda_registry_filtered`] over
+//! [`RegisteredOp::label`] / [`RegisteredOp::constructor`], or extends it
+//! with [`RegisteredOp::new`] — from OUTSIDE this crate, with no edit
+//! here.
+//!
+//! WHAT IS STILL CL-ONLY: adding a KERNEL-BEARING op. Claim derivation
+//! reads three classes (see [`crate::CudaRuntime::allow_list`]); the
+//! matcher-only ones — plan-transparent and host-dispatchable — are
+//! trait answers on the prototype and travel with a `RegisteredOp`, but
+//! a row that must actually be EXECUTED needs a codegen row in
+//! [`crate::kernels`], which is keyed by `TypeId` inside this crate.
+//! An outside row without one is simply not claimable: search never
+//! elects it (it is absent from the derived allow list), so the failure
+//! is a refusal, never a wrong plan. Composing an external kernel
+//! superset onto Lite's codegen ("cuda heavy") is PUNTED — no execution
+//! face on `RegisteredOp`, no change to the kernel table's keying.
 
 pub mod add;
 pub mod cast;
@@ -47,6 +72,38 @@ use luminal::layout_ir::{LayoutIrOp, OpMatcher};
 pub struct RegisteredOp {
     pub matcher: Box<dyn OpMatcher>,
     pub prototype: Box<dyn LayoutIrOp>,
+}
+
+impl RegisteredOp {
+    /// Register a matcher with a prototype of the op its `extract`
+    /// produces — the public constructor, so a registry row can be built
+    /// from outside this crate (see the module header for what such a
+    /// row can and cannot claim).
+    pub fn new(matcher: Box<dyn OpMatcher>, prototype: Box<dyn LayoutIrOp>) -> Self {
+        Self { matcher, prototype }
+    }
+
+    /// This row's egglog constructor — the name the estate mints and the
+    /// name the derived allow list carries.
+    pub fn constructor(&self) -> &'static str {
+        self.matcher.egglog_constructor()
+    }
+
+    /// This row's op LABEL: the egglog constructor minus the
+    /// `LayoutTensorOp` prefix and NOTHING else (house policy — op names
+    /// are IR identity: never add `Dps`, never strip `Generic`). It is
+    /// the same string the prototype's own `LayoutIrOp::label` returns,
+    /// which the `labels_agree_with_the_prototypes` pin states outright.
+    ///
+    /// So the `Generic` suffix IS part of a label: filter on
+    /// `"ReduceMaxGeneric"`, not `"ReduceMax"`. (The kernel table's
+    /// `label` column is a different, Generic-less vocabulary; the allow
+    /// list's kernel-bearing test tolerates the difference, callers of
+    /// this method should not have to guess about it.)
+    pub fn label(&self) -> &'static str {
+        let ctor = self.constructor();
+        ctor.strip_prefix("LayoutTensorOp").unwrap_or(ctor)
+    }
 }
 
 /// The registry this runtime assembles, extracts, and derives claims
@@ -137,6 +194,13 @@ pub fn cuda_registry() -> Vec<RegisteredOp> {
 /// assembly through this EXPLICIT seam
 /// ([`crate::CudaRuntime::load_with_cublaslt`]), and the 2D
 /// canonical-form election pin runs marker-enabled.
+///
+/// AS OF PHASE 2 this preset is nothing but a registry VALUE: it is what
+/// [`crate::CudaRuntime::load_with_cublaslt`] hands to
+/// [`crate::CudaRuntime::load_with_registry`], and any caller can build
+/// the same list (or half of it) with [`cuda_registry_filtered`]. The
+/// default's Train-2 set is a BUDGET decision, not a capability one, and
+/// it now costs a caller one argument to overrule.
 pub fn cuda_registry_with_cublaslt() -> Vec<RegisteredOp> {
     let mut registry = cuda_registry();
     for form in cublaslt::CublasLtForm::ALL {
@@ -148,8 +212,42 @@ pub fn cuda_registry_with_cublaslt() -> Vec<RegisteredOp> {
     registry
 }
 
-/// The matcher set this runtime assembles and extracts with — the
-/// registry's matcher column.
+/// THE CONFIGURATION SEAM: the FULL registry (every row this crate
+/// ships, cuBLASLt markers included) narrowed by the caller's own
+/// predicate. This is how a vocabulary is chosen without editing CL:
+///
+/// ```no_run
+/// # use luminal_cuda_lite::{cuda_registry_filtered, CudaRuntime};
+/// # let cx = luminal::graph::Graph::new();
+/// // Everything except the max reduction:
+/// let rt = CudaRuntime::load_with_registry(
+///     &cx,
+///     cuda_registry_filtered(|op| op.label() != "ReduceMaxGeneric"),
+/// )?;
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+///
+/// It starts from the marker-enabled superset ON PURPOSE, so one
+/// predicate can opt a row IN as easily as OUT — `keep` sees every row
+/// that exists. The two presets remain available whole
+/// ([`cuda_registry`], [`cuda_registry_with_cublaslt`]).
+///
+/// A PREDICATE THAT MATCHES NOTHING IS SILENT — it returns the full
+/// registry, and the search then simply has the op available. Assert on
+/// the resulting length (or on
+/// [`crate::CudaRuntime::active_allow_list`]) if the narrowing is
+/// load-bearing; labels carry their `Generic` suffix (see
+/// [`RegisteredOp::label`]).
+pub fn cuda_registry_filtered(keep: impl Fn(&RegisteredOp) -> bool) -> Vec<RegisteredOp> {
+    cuda_registry_with_cublaslt()
+        .into_iter()
+        .filter(|entry| keep(entry))
+        .collect()
+}
+
+/// The matcher set the DEFAULT preset assembles and extracts with — the
+/// registry's matcher column. An instance's own column is derived from
+/// the registry it was loaded with, never from this.
 pub fn cuda_matchers() -> Vec<Box<dyn OpMatcher>> {
     cuda_registry()
         .into_iter()

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -33,15 +33,30 @@ struct NativeParts {
     binding_seeds: String,
 }
 
+/// A `Default` instance holds NO program and NO op vocabulary: every
+/// ladder method past `load` refuses it by name (`load before search`),
+/// so the empty registry a default carries is never the thing a caller
+/// searches under. `load`/`load_with_cublaslt`/`load_with_registry` are
+/// the only ways to get a usable one.
 #[derive(Default)]
 pub struct CudaRuntime {
     native: Option<NativeParts>,
-    /// Train 3: assemble/search with the cuBLASLt marker vocabulary.
-    /// RULED always-on (2026-09-01); still OFF by default only until the
-    /// search budget/sampler catches up with the collapse's
-    /// re-description 2-cycle (see [`crate::ops::cuda_registry_with_cublaslt`]);
-    /// enabled through [`CudaRuntime::load_with_cublaslt`].
-    cublaslt: bool,
+    /// THE INSTANCE'S OP VOCABULARY (Phase 2, 2026-09-03): the matcher
+    /// column of the registry this runtime was LOADED with, and the
+    /// allow list derived from that same registry. Both are decided once,
+    /// at [`CudaRuntime::load_with_registry`], and never consulted from a
+    /// crate-level constant again — which op set a runtime assembles,
+    /// saturates, searches and claims with is a property of the instance,
+    /// selectable by its caller.
+    ///
+    /// The matchers are HELD rather than rebuilt because `dyn OpMatcher`
+    /// is not clonable and one instance runs many extractions (every
+    /// genome, and with buckets every Cartesian combination); everything
+    /// downstream borrows this slice.
+    matchers: Vec<Box<dyn luminal::layout_ir::OpMatcher>>,
+    /// The claim set derived from that same registry — see
+    /// [`CudaRuntime::allow_list_over`] for the three classes.
+    allow: Vec<&'static str>,
     plan: Option<BufferIrGraph<DecodedLayout>>,
     /// Host-staged input payloads by BufferLit id, H2D'd at execute.
     staged: FxHashMap<i64, HostBuffer>,
@@ -65,24 +80,11 @@ pub struct CudaRuntime {
 }
 
 impl CudaRuntime {
-    /// Record the graph's native program. Saturation happens in
+    /// Record the graph's native program under the DEFAULT op registry
+    /// ([`crate::ops::cuda_registry`]). Saturation happens in
     /// [`CudaRuntime::search`].
     pub fn load(graph: &graph::Graph) -> Result<Self> {
-        let (pre_schedule, input_slots, output_slots, post_checks, labeled_checks) = graph
-            .logical
-            .bound_parts(&crate::bindings::CudaBindings)
-            .map_err(|e| anyhow!(e))?;
-        Ok(Self {
-            native: Some(NativeParts {
-                pre_schedule,
-                input_slots,
-                output_slots,
-                post_checks,
-                labeled_checks,
-                binding_seeds: String::new(),
-            }),
-            ..Self::default()
-        })
+        Self::load_with_registry(graph, crate::ops::cuda_registry())
     }
 
     /// [`CudaRuntime::load`] with the cuBLASLt marker vocabulary
@@ -94,19 +96,70 @@ impl CudaRuntime {
     /// re-description 2-cycle — loudly, never a wrong plan. The 2D
     /// canonical matmul form searches and elects green; real graphs
     /// elect at 12×16.
+    ///
+    /// It is now exactly [`CudaRuntime::load_with_registry`] over the
+    /// [`crate::ops::cuda_registry_with_cublaslt`] preset — a named
+    /// convenience, not a mode.
     pub fn load_with_cublaslt(graph: &graph::Graph) -> Result<Self> {
-        let mut rt = Self::load(graph)?;
-        rt.cublaslt = true;
-        Ok(rt)
+        Self::load_with_registry(graph, crate::ops::cuda_registry_with_cublaslt())
     }
 
-    /// The matcher vocabulary this instance assembles/searches with.
-    fn matchers(&self) -> Vec<Box<dyn luminal::layout_ir::OpMatcher>> {
-        if self.cublaslt {
-            crate::ops::cuda_matchers_with_cublaslt()
-        } else {
-            crate::ops::cuda_matchers()
-        }
+    /// THE CONFIGURABLE LOAD (ruling 2026-09-03: *"you should select the
+    /// allowed ops when you initialize the runtime ... You should not
+    /// need to edit CL in order to modify this"*): record the graph's
+    /// native program and FIX this instance's op vocabulary to the given
+    /// registry. Everything downstream — the assembled egglog preamble,
+    /// the saturation, the extraction matcher set, and the derived allow
+    /// list the search claims through — reads that registry and nothing
+    /// else, so two runtimes in one process may hold different op sets.
+    ///
+    /// Build the argument with [`crate::ops::cuda_registry_filtered`]
+    /// (narrow either preset by label or constructor) or by pushing
+    /// [`crate::ops::RegisteredOp::new`] rows onto one. A row whose op
+    /// is neither kernel-bearing, plan-transparent, nor host-dispatchable
+    /// is simply not claimable — it never reaches the allow list, so the
+    /// search refuses loudly instead of electing something the device
+    /// cannot run.
+    pub fn load_with_registry(
+        graph: &graph::Graph,
+        registry: Vec<crate::ops::RegisteredOp>,
+    ) -> Result<Self> {
+        let (pre_schedule, input_slots, output_slots, post_checks, labeled_checks) = graph
+            .logical
+            .bound_parts(&crate::bindings::CudaBindings)
+            .map_err(|e| anyhow!(e))?;
+        // Derive the claim set BEFORE the rows are consumed: the allow
+        // list reads the prototypes, the search reads the matchers.
+        let allow = Self::allow_list_over(&registry);
+        let matchers = registry.into_iter().map(|entry| entry.matcher).collect();
+        Ok(Self {
+            native: Some(NativeParts {
+                pre_schedule,
+                input_slots,
+                output_slots,
+                post_checks,
+                labeled_checks,
+                binding_seeds: String::new(),
+            }),
+            matchers,
+            allow,
+            ..Self::default()
+        })
+    }
+
+    /// The matcher vocabulary this instance assembles/searches with —
+    /// LENT, never rebuilt (see the field's note).
+    fn matchers(&self) -> &[Box<dyn luminal::layout_ir::OpMatcher>] {
+        &self.matchers
+    }
+
+    /// The claim set THIS instance searches under — the allow list
+    /// derived from the registry it was loaded with. Named
+    /// `active_allow_list` because the static
+    /// [`CudaRuntime::allow_list`] (the default preset's) already owns
+    /// the plain name and inherent methods may not share one.
+    pub fn active_allow_list(&self) -> &[&'static str] {
+        &self.allow
     }
 
     /// Seed interval bounds for a dynamic dimension (facts, never pins:
@@ -238,6 +291,11 @@ impl CudaRuntime {
     ///    (`cublasLtMatmul`) — claimable because the device runs them
     ///    without any NVRTC kernel (see
     ///    [`crate::ops::cublaslt::host_dispatchable`]).
+    ///
+    /// THIS STATIC IS THE DEFAULT PRESET'S claim set — the same
+    /// derivation over [`crate::ops::cuda_registry`], for callers with no
+    /// graph in hand. A LOADED instance claims what its own registry
+    /// derives: [`CudaRuntime::active_allow_list`].
     pub fn allow_list() -> Vec<&'static str> {
         Self::allow_list_over(&crate::ops::cuda_registry())
     }
@@ -310,7 +368,7 @@ impl CudaRuntime {
         };
         let full = format!(
             "{}\n\n{}",
-            luminal::egglog_snippet::assembled_program_for(&self.matchers()),
+            luminal::egglog_snippet::assembled_program_for(self.matchers()),
             program.text
         );
         let mut egraph = luminal::egglog_snippet::new_egraph();
@@ -320,7 +378,7 @@ impl CudaRuntime {
             let mut doors = Vec::new();
             let unchecked = format!(
                 "{}\n\n{}\n{}\n{}",
-                luminal::egglog_snippet::assembled_program_for(&self.matchers()),
+                luminal::egglog_snippet::assembled_program_for(self.matchers()),
                 native.pre_schedule,
                 native.binding_seeds,
                 crate::bindings::CudaBindings::SCHEDULE
@@ -372,11 +430,9 @@ impl CudaRuntime {
             );
         }
 
-        let allow = Some(if self.cublaslt {
-            Self::allow_list_with_cublaslt()
-        } else {
-            Self::allow_list()
-        });
+        // THIS INSTANCE's claim set, derived at load from THIS
+        // instance's registry — no crate-level default is consulted.
+        let allow = Some(self.allow.clone());
 
         // Own matchers, own allow list, own ranking: nothing in this
         // search touches another runtime.
@@ -395,9 +451,7 @@ impl CudaRuntime {
             // per-bucket caller data — the ranking is device-free — so
             // the ordinary `search` entry serves both shapes.
             let assembly = crate::search::BucketAssembly {
-                assembled_program: &luminal::egglog_snippet::assembled_program_for(
-                    &self.matchers(),
-                ),
+                assembled_program: &luminal::egglog_snippet::assembled_program_for(self.matchers()),
                 pre_schedule: &native.pre_schedule,
                 binding_seeds: &native.binding_seeds,
                 schedule: crate::bindings::CudaBindings::SCHEDULE,
@@ -411,7 +465,7 @@ impl CudaRuntime {
                 &self.dim_buckets,
                 options,
                 allow,
-                || self.matchers(),
+                self.matchers(),
             )?;
             let first = plans
                 .first()

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -604,8 +604,13 @@ fn bufferize_cycle_tripwire(
 }
 
 /// THE SELECTION LOOP for this backend: the caller supplies its OWN
-/// matcher vocabulary (the cuBLASLt marker set is an instance option)
-/// and its OWN allow list. Deterministic for a fixed seed.
+/// matcher vocabulary and its OWN allow list — both are properties of
+/// the runtime INSTANCE, chosen when it was loaded (see
+/// [`crate::CudaRuntime::load_with_registry`]), not of this crate. The
+/// vocabulary is BORROWED: one instance runs many extractions (every
+/// genome, and with buckets every combination), and `dyn OpMatcher` is
+/// not clonable, so the list lives in the runtime and is lent here.
+/// Deterministic for a fixed seed.
 ///
 /// NO CALLER DATA (D6, 2026-09-03): candidates are ranked by
 /// [`crate::heuristic::heuristic_cost_of`], which never runs anything,
@@ -617,7 +622,7 @@ pub fn search_implementations(
     program: &LogicalProgram,
     options: &CompileOptions,
     allow_override: Option<Vec<&'static str>>,
-    matchers: Vec<Box<dyn luminal::layout_ir::OpMatcher>>,
+    matchers: &[Box<dyn luminal::layout_ir::OpMatcher>],
 ) -> Result<SearchOutcome> {
     let mut timings = SearchTimings::default();
     let analysis_start = Instant::now();
@@ -921,7 +926,7 @@ pub fn bucketed_search_implementations(
     dim_buckets: &BTreeMap<luminal::shape::Symbol, Vec<luminal::graph::DimBucket>>,
     options: &CompileOptions,
     allow_override: Option<Vec<&'static str>>,
-    matchers: impl Fn() -> Vec<Box<dyn luminal::layout_ir::OpMatcher>>,
+    matchers: &[Box<dyn luminal::layout_ir::OpMatcher>],
 ) -> Result<Vec<BucketPlan>> {
     ensure!(!dim_buckets.is_empty(), "no dim buckets supplied");
     let mut plans = Vec::new();
@@ -939,7 +944,7 @@ pub fn bucketed_search_implementations(
             &program,
             options,
             allow_override.clone(),
-            matchers(),
+            matchers,
         )?;
         plans.push(BucketPlan {
             ranges,

--- a/crates/luminal_cuda_lite/tests/input_producer_cleanup.rs
+++ b/crates/luminal_cuda_lite/tests/input_producer_cleanup.rs
@@ -296,7 +296,7 @@ fn the_producer_index_offers_no_producer_for_an_input_terminal() {
 
     let index = luminal_cuda_lite::extractor::producer_index_with_matchers(
         &egraph,
-        luminal_cuda_lite::ops::cuda_matchers_with_cublaslt(),
+        &luminal_cuda_lite::ops::cuda_matchers_with_cublaslt(),
     );
 
     // Holds under #444's retain alone; pinned here because the stratum

--- a/crates/luminal_cuda_lite/tests/registry_selection.rs
+++ b/crates/luminal_cuda_lite/tests/registry_selection.rs
@@ -1,0 +1,219 @@
+//! THE OP REGISTRY IS AN INSTANCE CHOICE (#420/#422 rejoin Phase 2,
+//! ruling 2026-09-03: *"you should select the allowed ops when you
+//! initialize the runtime ... You should not need to edit CL in order to
+//! modify this. It should be configurable."*).
+//!
+//! Everything here runs on the host: the board is `load` (which registry
+//! an instance holds), `active_allow_list` (what it derives from that
+//! registry), and `search` (what it will and will not elect). No device.
+//!
+//! The pins locate ops STRUCTURALLY — by egglog constructor and by the
+//! `RegisteredOp` API — never by class id or registry position.
+
+use luminal::dtype::DType;
+use luminal::prelude::FxHashMap;
+use luminal_cuda_lite::ops::cublaslt::{CublasLt, CublasLtForm, CublasLtMarkerMatcher};
+use luminal_cuda_lite::{
+    cuda_registry, cuda_registry_filtered, cuda_registry_with_cublaslt, harness_search_options,
+    CudaRuntime, RegisteredOp,
+};
+
+const ADD: &str = "LayoutTensorOpAddFunctionalGeneric";
+
+/// The smallest graph that CANNOT be planned without the add op.
+fn add_graph() -> (
+    luminal::graph::Graph,
+    luminal::prelude::GraphTensor,
+    luminal::prelude::GraphTensor,
+) {
+    let mut cx = luminal::graph::Graph::new();
+    let a = cx.tensor((2usize, 3usize), DType::F32);
+    let b = cx.tensor((2usize, 3usize), DType::F32);
+    let _out = (a + b).output();
+    (cx, a, b)
+}
+
+fn payloads(
+    a: luminal::prelude::GraphTensor,
+    b: luminal::prelude::GraphTensor,
+) -> FxHashMap<luminal::prelude::NodeIndex, luminal_cuda_lite::HostBuffer> {
+    [
+        (a.id, vec![1.0f32, 2., 3., 4., 5., 6.].into()),
+        (b.id, vec![10.0f32, 20., 30., 40., 50., 60.].into()),
+    ]
+    .into_iter()
+    .collect()
+}
+
+/// (b) The two shipped presets are ordinary registry VALUES: `load` is
+/// `load_with_registry(cuda_registry())` and `load_with_cublaslt` is the
+/// marker preset — in the claim set each instance actually derives, not
+/// merely by construction.
+#[test]
+fn the_presets_are_just_registries() {
+    let (cx, _a, _b) = add_graph();
+
+    let default = CudaRuntime::load(&cx).expect("load");
+    let explicit = CudaRuntime::load_with_registry(&cx, cuda_registry()).expect("load explicit");
+    assert_eq!(
+        default.active_allow_list(),
+        explicit.active_allow_list(),
+        "`load` must be `load_with_registry(cuda_registry())`"
+    );
+    assert_eq!(
+        default.active_allow_list(),
+        CudaRuntime::allow_list(),
+        "the instance claim set must be the default preset's static one"
+    );
+
+    let marker = CudaRuntime::load_with_cublaslt(&cx).expect("load marker");
+    let marker_explicit =
+        CudaRuntime::load_with_registry(&cx, cuda_registry_with_cublaslt()).expect("load explicit");
+    assert_eq!(
+        marker.active_allow_list(),
+        marker_explicit.active_allow_list(),
+        "`load_with_cublaslt` must be `load_with_registry(cuda_registry_with_cublaslt())`"
+    );
+    assert_eq!(
+        marker.active_allow_list(),
+        CudaRuntime::allow_list_with_cublaslt(),
+    );
+
+    // The marker preset is the default plus the four host-call
+    // contracts, and nothing is lost on the way.
+    for claimed in default.active_allow_list() {
+        assert!(
+            marker.active_allow_list().contains(claimed),
+            "the marker preset dropped {claimed}"
+        );
+    }
+    for form in CublasLtForm::ALL {
+        assert!(
+            marker
+                .active_allow_list()
+                .contains(&form.constructor_name()),
+            "the marker preset does not claim {}",
+            form.constructor_name()
+        );
+        assert!(
+            !default
+                .active_allow_list()
+                .contains(&form.constructor_name()),
+            "the DEFAULT preset claims {} — it is opt-in",
+            form.constructor_name()
+        );
+    }
+}
+
+/// (a) A REGISTRY CHOSEN AT INITIALIZATION IS THE SEARCH'S VOCABULARY:
+/// drop the add row and the same graph, searched by the same runtime
+/// type with the same options, refuses — loudly, naming the blockage —
+/// while the default registry plans it.
+#[test]
+fn a_filtered_registry_withholds_the_op_and_the_search_refuses() {
+    let (cx, a, b) = add_graph();
+    let data = payloads(a, b);
+
+    let without_add = cuda_registry_filtered(|op| op.label() != "AddFunctionalGeneric");
+    // The narrowing is REAL, not a predicate that matched nothing.
+    assert_eq!(
+        without_add.len() + 1,
+        cuda_registry_with_cublaslt().len(),
+        "the filter must have removed exactly the add row"
+    );
+
+    let mut narrowed = CudaRuntime::load_with_registry(&cx, without_add).expect("load");
+    assert!(
+        !narrowed.active_allow_list().contains(&ADD),
+        "a withheld op must not be claimable: {:?}",
+        narrowed.active_allow_list()
+    );
+    let err = narrowed
+        .search(&data, &harness_search_options())
+        .expect_err("a graph that needs add must not plan without the add op");
+    let text = err.to_string();
+    assert!(
+        text.contains("no candidate genome produced an executable plan"),
+        "the refusal must be the search's exhaustion, got: {text}"
+    );
+    assert!(
+        text.contains("dead-ends: 1") && text.contains("choice-cycles: 0"),
+        "the blockage must be diagnosed as a DEAD END (nothing produces the sum), \
+         not a choice cycle, got: {text}"
+    );
+
+    // The SAME graph, the default registry: green.
+    let mut default = CudaRuntime::load(&cx).expect("load");
+    assert!(default.active_allow_list().contains(&ADD));
+    let outcome = default
+        .search(&data, &harness_search_options())
+        .expect("the default registry plans a + b");
+    assert!(outcome.plans_profiled > 0, "no plans profiled");
+}
+
+/// (c) A ROW REGISTERED FROM OUTSIDE THIS CRATE joins the instance's
+/// claim set: `RegisteredOp::new` over a matcher/prototype pair the
+/// caller assembles itself. The row here is a matcher-only one (a
+/// cuBLASLt marker: host-dispatchable, no kernel-table row), which is
+/// exactly the class an external caller can add today — a kernel-bearing
+/// row still needs a codegen entry inside CL (the punted "cuda heavy"
+/// composition story).
+#[test]
+fn a_row_registered_from_outside_joins_the_claim_set() {
+    let (cx, _a, _b) = add_graph();
+
+    let mut registry = cuda_registry();
+    registry.push(RegisteredOp::new(
+        Box::new(CublasLtMarkerMatcher {
+            form: CublasLtForm::Base,
+        }),
+        Box::new(CublasLt {
+            form: CublasLtForm::Base,
+            spec: None,
+        }),
+    ));
+
+    let rt = CudaRuntime::load_with_registry(&cx, registry).expect("load");
+    let default = CudaRuntime::load(&cx).expect("load default");
+
+    assert!(
+        rt.active_allow_list()
+            .contains(&CublasLtForm::Base.constructor_name()),
+        "the hand-registered row is not claimed: {:?}",
+        rt.active_allow_list()
+    );
+    // Exactly one row more than the default, and the other three marker
+    // forms stayed out — the caller chose the vocabulary row by row.
+    assert_eq!(
+        rt.active_allow_list().len(),
+        default.active_allow_list().len() + 1
+    );
+    for form in [
+        CublasLtForm::Bias,
+        CublasLtForm::Accumulate,
+        CublasLtForm::AccumulateBias,
+    ] {
+        assert!(!rt.active_allow_list().contains(&form.constructor_name()));
+    }
+}
+
+/// `RegisteredOp::label` is the house label — the constructor minus the
+/// `LayoutTensorOp` prefix and nothing else — so it is the same string
+/// the registered PROTOTYPE answers with. Callers filter on it; the two
+/// must not drift.
+#[test]
+fn registry_labels_agree_with_the_prototypes() {
+    for entry in cuda_registry_with_cublaslt() {
+        assert!(
+            entry.constructor().starts_with("LayoutTensorOp"),
+            "{} is not a LayoutTensorOp constructor",
+            entry.constructor()
+        );
+        assert_eq!(
+            entry.label(),
+            entry.prototype.label(),
+            "row {} disagrees with its prototype's label",
+            entry.constructor()
+        );
+    }
+}

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -2405,6 +2405,80 @@ coalescing, library dispatch); the arena allocator behind the runtimes'
 `bufferize` call; whatever consolidation the three copies eventually
 earn, which is a question to ask after the runtimes diverge, not before.
 
+## Program: #420/#422 rejoin — Phase 2 (configurable registry)
+
+**The ruling** (Austin, 2026-09-03): *"you should select the allowed ops
+when you initialize the runtime. we should have a function for filtering
+which ops, which matchers are present, etc. You should not need to edit
+CL in order to modify this. It should be configurable."*
+
+**What changed.** `CudaRuntime`'s private `cublaslt: bool` is gone. An
+instance now HOLDS its op vocabulary: the matcher column of the registry
+it was loaded with, plus the allow list derived from that same registry,
+both fixed once in `load_with_registry(graph, Vec<RegisteredOp>)`.
+`load` is that call over `cuda_registry()`; `load_with_cublaslt` is it
+over `cuda_registry_with_cublaslt()` — the marker preset is a registry
+VALUE now, not a mode, and its default-off status stays a budget
+decision that costs a caller one argument to overrule. Assembly,
+saturation, extraction and search all read the instance's list;
+`active_allow_list()` is what a loaded runtime claims. The static
+`CudaRuntime::allow_list()` / `allow_list_with_cublaslt()` /
+`cuda_allow_list()` survive unchanged as the PRESETS' claim sets, for
+callers with no graph in hand.
+
+**The configuration surface** (all outside-callable, no CL edit):
+`cuda_registry_filtered(|op| ...)` narrows the FULL registry (marker rows
+included, so a predicate can opt a row in as easily as out);
+`RegisteredOp::new(matcher, prototype)` builds a row from outside;
+`RegisteredOp::constructor()` / `RegisteredOp::label()` are what a
+predicate reads. `label()` is the house label — the egglog constructor
+minus the `LayoutTensorOp` prefix and nothing else, so it keeps its
+`Generic` suffix and equals the prototype's own `LayoutIrOp::label`
+(pinned).
+
+**Decisions inside the latitude.**
+
+- *The matcher list is LENT, not rebuilt.* `dyn OpMatcher` is not
+  clonable and the registry is a value the caller hands over once, so
+  there is nothing to rebuild it from; the runtime holds
+  `Vec<Box<dyn OpMatcher>>` and `search_implementations` /
+  `bucketed_search_implementations` / the extractor's
+  `new_with_matcher_set` take `&[Box<dyn OpMatcher>]`. The extractor's
+  dispatch map became `HashMap<&'static str, &'a dyn OpMatcher>` — the
+  `'a` it already carried for the e-graph. The bucketed entry's
+  `impl Fn() -> Vec<..>` factory parameter collapsed into that slice.
+  The alternative, a `boxed_clone` supertrait on core's `OpMatcher`,
+  would have forced `#[derive(Clone)]` onto every matcher in three
+  crates for nothing. NO CORE EDIT was needed.
+- *The instance accessor is `active_allow_list`,* not `allow_list`:
+  inherent methods may not share a name, and the static one is the
+  documented preset seam with existing callers. It returns
+  `&[&'static str]` — the instance owns the vector, and nothing needs a
+  copy.
+- *Kernel-bearing rows stay CL-only.* An outside `RegisteredOp` reaches
+  the allow list through the two DERIVED matcher-only classes
+  (plan-transparent, host-dispatchable); a row that must actually be
+  executed needs a codegen entry in `kernels`, keyed by `TypeId` inside
+  this crate. A row without one is simply never claimed, so the failure
+  is a refusal at search, never a wrong plan.
+
+**The punt, recorded.** Composing an external kernel superset onto
+Lite's codegen ("cuda heavy") is NOT started: no execution face on
+`RegisteredOp`, no change to the kernel table's `TypeId` keying, no
+change to cuBLASLt's dispatch arm. Value-level registry rows are the
+whole extension axis for now, which is the same call the Phase 1 park
+made about `CudaRuntimeImpl<O: IntoEgglogOp>`.
+
+**Pinned** (`crates/luminal_cuda_lite/tests/registry_selection.rs`, host
+only): the two presets equal their `load_with_registry` spellings and
+the marker preset is the default plus exactly the four host-call
+contracts; a registry filtered of the add row makes `a + b` REFUSE at
+search with the exhaustion message diagnosing a dead end (choice-cycles
+0), while the same graph under the default registry plans; a marker row
+pushed on from the test crate through `RegisteredOp::new` joins the
+instance claim set and the other three forms stay out; every row's
+`label()` agrees with its prototype's.
+
 ## #420 search into the runtime — parks banked, the boundary move scheduled
 
 RULED 2026-09-03: *"we're going to ignore all the loop unrolling, loop rolling

--- a/tests/test_runtime/src/lib.rs
+++ b/tests/test_runtime/src/lib.rs
@@ -174,7 +174,7 @@ pub fn genome_preferring(
     adopt_genome(
         luminal_cuda_lite::ops::cublaslt::election::genome_preferring(
             egraph,
-            matchers(),
+            &matchers(),
             preferences,
         ),
     )
@@ -233,7 +233,7 @@ pub fn genome_with_ordering(
     adopt_genome(
         luminal_cuda_lite::ops::cublaslt::election::genome_with_ordering(
             egraph,
-            matchers(),
+            &matchers(),
             &bridge,
         ),
     )


### PR DESCRIPTION
**Program:** #420/#422 rejoin, Phase 2 of the stack — base `rejoin/p1-runtime-owned-search` (PR #481). Plan page: https://claude.ai/code/artifact/6b5d25e3-94cf-4089-8977-8e44f971b8a5. Merge in order; retarget to `logical-ssa-project` before merging.

**Ruling (Austin, 2026-09-03):** "you should select the allowed ops when you initialize the runtime. we should have a function for filtering which ops, which matchers are present, etc. You should not need to edit CL in order to modify this. It should be configurable." The cuda-heavy composition story and any execution-face/trait refactor are punted: no execution face on `RegisteredOp`, the kernel table's `TypeId` keying and cuBLASLt dispatch are untouched.

## What changed (one commit, `8d0fc208`, CL only)
- `CudaRuntime::load_with_registry(&Graph, Vec<RegisteredOp>)`; `load` and `load_with_cublaslt` are now presets over `cuda_registry()` / `cuda_registry_with_cublaslt()`. The private `cublaslt: bool` is replaced by two instance fields set at load: the registry's matcher list and the allow list derived from it by the existing three-class rule. `active_allow_list(&self)` exposes the instance's claim set; the static `allow_list`/`cuda_allow_list` remain as the presets' claim sets.
- `RegisteredOp::{new, constructor, label}` and `cuda_registry_filtered(keep)` over the marker-enabled superset, so one predicate opts any row in or out by name: `CudaRuntime::load_with_registry(&cx, cuda_registry_filtered(|r| r.label() != "ReduceMaxGeneric"))`. A row from outside CL is possible for matcher-only / plan-transparent ops via `RegisteredOp::new`; kernel-bearing ops still need a kernel-table row (the punted story), documented.
- Matcher lists are lent (`&[Box<dyn OpMatcher>]`) through CL's search and extractor entry points instead of rebuilt or cloned, so no core trait change was needed.
- New tests `tests/registry_selection.rs`: presets equal their registries; a filtered registry withholds the op and the search refuses with `dead-ends: 1`; an outside row joins the claim set; registry labels agree with the prototypes' labels for every row.

**Gate:** CL all-targets build, workspace build, `cargo test -p luminal_cuda_lite` every suite ok (cuBLASLt election 9 passed in 40.7 s), `cargo test -p test_runtime` 42 suites ok, clippy clean, fmt clean.

**Judgment calls:** instance accessor named `active_allow_list` (the static name has callers); `label()` keeps the `Generic` suffix per the op-names-are-identity doctrine, pinned against the prototypes; the filter helper starts from the marker-enabled superset; the outside-row test uses a hand-built cuBLASLt marker row because duplicate rows would collide silently in the constructor-keyed map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
