### PR TITLE
rejoin P3: persistent CudaDevice and the arena module — bufferize's Alloc/Free mapped to slab slices; 3x smaller interior footprint on the A100

### DIFF
--- a/crates/luminal_cuda_lite/src/arena.rs
+++ b/crates/luminal_cuda_lite/src/arena.rs
@@ -1,0 +1,760 @@
+//! THE ARENA: one runtime-owned slab of device bytes, and the
+//! DEVICE-FREE pass that decides who lives where in it.
+//!
+//! # Why this module exists (#422, superseding #401)
+//!
+//! CL-2's executor materialized EVERY plan buffer up front — one
+//! `alloc_zeros` per `BufferId`, all of them live for the whole call.
+//! That is the sum of every buffer the plan ever names, whether or not
+//! two of them are ever live at the same instant. The bufferizer
+//! already computes the lifetimes (`BufferAlloc` brings storage into
+//! existence, `BufferFree` ends it, and the containment certificate
+//! guarantees every toucher sits between the two); nothing consumed
+//! them. This pass does.
+//!
+//! Austin's division of labour (2026-09-03): "first produce the
+//! bufferizer, this will do the allocations / frees. Then a separate
+//! thing will map those allocation / frees to slices on memory in the
+//! arena allocator." This IS the separate thing. It reads a bufferized
+//! plan and answers two questions:
+//!
+//!  1. **In what order should the runtime issue the plan's nodes?**
+//!     Any topological order is legal (the plan supplies dependency
+//!     structure only — see the BufferCopy contract); the order chosen
+//!     here is LIVENESS-AWARE, because the order is what sets the
+//!     high-water mark.
+//!  2. **Which slab range backs each buffer, over that order?** A
+//!     first-fit free-list walk of the alloc/free events.
+//!
+//! # The three ownership rows (`Owner` × `FreedBy`), and why only one is in the slab
+//!
+//! | row | `Owner` | `FreedBy` | alloc? | free? | arena treatment |
+//! |---|---|---|---|---|---|
+//! | BOUNDARY | `Caller` | `Caller` | no | no | `standalone` |
+//! | DONATED | `Caller` | `Program` | no | yes | `donated` |
+//! | ESCAPING | `System` | `Caller` | yes | no | `standalone` |
+//! | INTERIOR | `System` | `Program` | yes | yes | **slab member** |
+//!
+//! Only the INTERIOR row has BOTH ends of a lifetime inside the
+//! program, which is exactly the precondition for handing its bytes to
+//! a later buffer. An ESCAPING buffer's bytes are the caller's from
+//! return on — recycling them would hand the caller a range the next
+//! call overwrites. A DONATED buffer's storage came from the caller;
+//! the program's free RELEASES it, it does not license the arena to
+//! re-let it. BOUNDARY storage is never the program's at all.
+//!
+//! # Sizing
+//!
+//! `bytes_of` is the caller's, so tests can plan with mock sizes and
+//! the executor can pass the one real rule (`literal_span_elements() *
+//! dtype_bytes(dtype)` — see `crate::device`). Symbolic extents are the
+//! caller's error to raise. Buckets are always concrete (D7), so the
+//! slab is always a number.
+//!
+//! # What is NOT here
+//!
+//! No device types, no cudarc: this file compiles and its tests run on
+//! a laptop. Search-time slab policy (sizing the slab across the
+//! candidate plans a search evaluates) is Phase 4's; this pass sizes
+//! ONE installed plan.
+
+use anyhow::{bail, Result};
+use luminal::bufferize::{Buffer, BufferId, BufferIrGraph, BufferNode, Owner, PlanLayout};
+use luminal::layout_ir::FreedBy;
+use luminal::prelude::{petgraph, FxHashMap, NodeIndex};
+use petgraph::visit::{EdgeRef, NodeIndexable};
+use std::collections::{BTreeMap, BinaryHeap};
+
+/// Device allocations are 256-byte aligned, so every slab range is too:
+/// a sub-range handed to a kernel must satisfy the same alignment the
+/// driver would have given it for its own allocation (vectorized loads
+/// and cuBLASLt's `ld` arithmetic both assume it).
+pub const ARENA_ALIGN: usize = 256;
+
+fn align_up(bytes: usize) -> usize {
+    bytes.div_ceil(ARENA_ALIGN) * ARENA_ALIGN
+}
+
+/// One buffer's home in the slab. `bytes` is the buffer's TRUE size
+/// (what a memcpy of it moves); the range RESERVED is `align_up(bytes)`,
+/// which is what disjointness is checked over.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArenaSlice {
+    pub offset: usize,
+    pub bytes: usize,
+}
+
+impl ArenaSlice {
+    /// The reserved (aligned) extent — `bytes` rounded up to
+    /// [`ARENA_ALIGN`].
+    pub fn reserved(&self) -> usize {
+        align_up(self.bytes)
+    }
+}
+
+/// The answer: an issue order, a slab size, and who sits where.
+#[derive(Debug, Clone, Default)]
+pub struct ArenaPlan {
+    /// The order the runtime issues plan nodes in — a topological order
+    /// of the dag (Data and Anti edges alike), chosen for a small
+    /// high-water mark. Every node of the dag appears exactly once.
+    pub order: Vec<NodeIndex>,
+    /// The high-water mark: how many bytes the slab must hold for this
+    /// plan under this order.
+    pub slab_bytes: usize,
+    /// Slab members (the INTERIOR row) and their ranges.
+    pub slices: FxHashMap<BufferId, ArenaSlice>,
+    /// Buffers that live OUTSIDE the slab in their own allocations: the
+    /// BOUNDARY row (inputs and caller-bound outputs) and the ESCAPING
+    /// row (minted storage handed to the caller).
+    pub standalone: Vec<BufferId>,
+    /// The DONATED row: caller storage the program frees. Its bytes are
+    /// the caller's staged storage; it gets no slab range, and its free
+    /// releases rather than recycles.
+    pub donated: Vec<BufferId>,
+}
+
+/// Which of the four rows a buffer is in, as the arena treats it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Row {
+    Slab,
+    Standalone,
+    Donated,
+}
+
+/// Node kinds, for the order policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Kind {
+    Free,
+    Ordinary,
+    Alloc,
+}
+
+fn kind_of<L: PlanLayout>(node: &BufferNode<L>) -> Kind {
+    match node {
+        BufferNode::Compute { op, .. } => match op.label() {
+            "BufferAlloc" => Kind::Alloc,
+            "BufferFree" => Kind::Free,
+            _ => Kind::Ordinary,
+        },
+        _ => Kind::Ordinary,
+    }
+}
+
+/// The buffer a `BufferAlloc` brings into existence (its single result).
+fn allocated<L: PlanLayout>(node: &BufferNode<L>) -> Option<&BufferId> {
+    match node {
+        BufferNode::Compute { op, writes, .. } if op.label() == "BufferAlloc" => writes.first(),
+        _ => None,
+    }
+}
+
+/// The buffer a `BufferFree` ends (its single operand).
+fn freed<L: PlanLayout>(node: &BufferNode<L>) -> Option<&BufferId> {
+    match node {
+        BufferNode::Compute { op, reads, .. } if op.label() == "BufferFree" => reads.first(),
+        _ => None,
+    }
+}
+
+/// THE ISSUE ORDER — a topological order chosen for a small high-water
+/// mark.
+///
+/// A raw `petgraph::algo::toposort` is a legal order and a terrible
+/// one: `BufferAlloc` nodes have in-degree zero (they consume nothing),
+/// so Kahn's queue hoists EVERY alloc to the front, every buffer is
+/// live from the first instant, and the high-water mark equals the sum
+/// of all of them — the very number this pass exists to beat (verdict
+/// C7 of the #420/#422 soundness review).
+///
+/// The fix is a priority among the READY nodes, not a different
+/// algorithm:
+///
+///  1. a `BufferFree` whose in-edges are all discharged goes FIRST —
+///     its range returns to the free list at the earliest instant the
+///     dependency structure allows;
+///  2. then any ordinary node (compute, copy, boundary);
+///  3. a `BufferAlloc` goes LAST, only when nothing else can run — so
+///     a buffer is born at the latest instant, immediately before the
+///     first node that needed it to exist.
+///
+/// Ties inside a class break on node index, which is the bufferizer's
+/// own emission order ("synthesized allocs slot in before their
+/// buffer's first toucher, frees after its last toucher"), so among
+/// equally-ready allocs we mint the one the planner placed first.
+fn issue_order<L: PlanLayout>(plan: &BufferIrGraph<L>) -> Result<Vec<NodeIndex>> {
+    let mut indegree: Vec<usize> = vec![0; plan.dag.node_bound()];
+    for index in plan.dag.node_indices() {
+        indegree[index.index()] = plan
+            .dag
+            .edges_directed(index, petgraph::Direction::Incoming)
+            .count();
+    }
+    // Three ready queues, each min-ordered by node index (`Reverse`).
+    let mut frees: BinaryHeap<std::cmp::Reverse<usize>> = BinaryHeap::new();
+    let mut ordinary: BinaryHeap<std::cmp::Reverse<usize>> = BinaryHeap::new();
+    let mut allocs: BinaryHeap<std::cmp::Reverse<usize>> = BinaryHeap::new();
+    let push = |index: NodeIndex,
+                frees: &mut BinaryHeap<std::cmp::Reverse<usize>>,
+                ordinary: &mut BinaryHeap<std::cmp::Reverse<usize>>,
+                allocs: &mut BinaryHeap<std::cmp::Reverse<usize>>| {
+        match kind_of(&plan.dag[index]) {
+            Kind::Free => frees.push(std::cmp::Reverse(index.index())),
+            Kind::Ordinary => ordinary.push(std::cmp::Reverse(index.index())),
+            Kind::Alloc => allocs.push(std::cmp::Reverse(index.index())),
+        }
+    };
+    for index in plan.dag.node_indices() {
+        if indegree[index.index()] == 0 {
+            push(index, &mut frees, &mut ordinary, &mut allocs);
+        }
+    }
+    let mut order = Vec::with_capacity(plan.dag.node_count());
+    loop {
+        let next = frees
+            .pop()
+            .or_else(|| ordinary.pop())
+            .or_else(|| allocs.pop());
+        let Some(std::cmp::Reverse(raw)) = next else {
+            break;
+        };
+        let index = NodeIndex::new(raw);
+        order.push(index);
+        for edge in plan
+            .dag
+            .edges_directed(index, petgraph::Direction::Outgoing)
+        {
+            let target = edge.target();
+            indegree[target.index()] -= 1;
+            if indegree[target.index()] == 0 {
+                push(target, &mut frees, &mut ordinary, &mut allocs);
+            }
+        }
+    }
+    if order.len() != plan.dag.node_count() {
+        bail!("plan dag has a cycle");
+    }
+    Ok(order)
+}
+
+/// The free list: holes strictly below `top`, plus the wilderness above
+/// it. First fit in offset order (cheap, and it keeps low addresses
+/// busy so the tail stays coalesced).
+#[derive(Debug, Default)]
+struct FreeList {
+    /// offset -> length, disjoint and never adjacent (always coalesced).
+    holes: BTreeMap<usize, usize>,
+    /// The high-water mark: everything at or above this is virgin.
+    top: usize,
+}
+
+impl FreeList {
+    fn alloc(&mut self, need: usize) -> usize {
+        if let Some((&offset, &len)) = self.holes.iter().find(|(_, &len)| len >= need) {
+            self.holes.remove(&offset);
+            if len > need {
+                self.holes.insert(offset + need, len - need);
+            }
+            return offset;
+        }
+        // No hole fits. If the LAST hole runs right up to the top, grow
+        // through it instead of stranding it (coalescing with the
+        // wilderness — the classic dlmalloc move).
+        if let Some((&offset, &len)) = self.holes.iter().next_back() {
+            if offset + len == self.top {
+                self.holes.remove(&offset);
+                self.top = offset + need;
+                return offset;
+            }
+        }
+        let offset = self.top;
+        self.top += need;
+        offset
+    }
+
+    fn free(&mut self, offset: usize, len: usize) {
+        let mut offset = offset;
+        let mut len = len;
+        // Coalesce with the predecessor hole, if it ends here.
+        if let Some((&prev, &prev_len)) = self.holes.range(..offset).next_back() {
+            if prev + prev_len == offset {
+                self.holes.remove(&prev);
+                offset = prev;
+                len += prev_len;
+            }
+        }
+        // …and with the successor, if it starts where we end.
+        if let Some((&next, &next_len)) = self.holes.range(offset + len..).next() {
+            if next == offset + len {
+                self.holes.remove(&next);
+                len += next_len;
+            }
+        }
+        self.holes.insert(offset, len);
+    }
+}
+
+/// Plan the arena for one bufferized plan.
+///
+/// `bytes_of` sizes a buffer (the executor passes the span-of-layout
+/// rule; tests pass whatever they like). It is called for SLAB MEMBERS
+/// only — standalone and donated buffers are the executor's to size, in
+/// its own allocation phase, exactly as before.
+pub fn plan_arena<L: PlanLayout>(
+    plan: &BufferIrGraph<L>,
+    bytes_of: impl Fn(&Buffer<L>) -> Result<usize>,
+) -> Result<ArenaPlan> {
+    plan_arena_over(plan, bytes_of, issue_order(plan)?)
+}
+
+/// [`plan_arena`] over a CALLER-SUPPLIED issue order — the seam the
+/// order-policy comparison test uses to price one order against
+/// another. The order must be a topological order of `plan.dag`
+/// covering every node; nothing here re-checks that.
+pub(crate) fn plan_arena_over<L: PlanLayout>(
+    plan: &BufferIrGraph<L>,
+    bytes_of: impl Fn(&Buffer<L>) -> Result<usize>,
+    order: Vec<NodeIndex>,
+) -> Result<ArenaPlan> {
+    // ---- classification: the ownership rows -------------------------
+    //
+    // A slab member needs BOTH ends of its lifetime in the program. The
+    // rows say which buffers those are; the dag says whether the nodes
+    // that mark the ends are actually there. A plan built by hand (or
+    // an older plan loaded from disk) may carry an INTERIOR buffer with
+    // no alloc/free pair — bufferize's `optimize` always mints them,
+    // but nothing here re-derives them. Such a buffer is DEMOTED to
+    // standalone: it gets its own allocation for the whole call, which
+    // is precisely CL-2's pre-arena behaviour, and the plan still runs.
+    let mut alloc_node: FxHashMap<BufferId, NodeIndex> = FxHashMap::default();
+    let mut free_node: FxHashMap<BufferId, NodeIndex> = FxHashMap::default();
+    for index in plan.dag.node_indices() {
+        if let Some(buffer) = allocated(&plan.dag[index]) {
+            if alloc_node.insert(buffer.clone(), index).is_some() {
+                bail!(
+                    "arena: buffer {buffer:?} is allocated twice — one \
+                     BufferAlloc per buffer is the plan's invariant, and a \
+                     second one would re-let a live range"
+                );
+            }
+        }
+        if let Some(buffer) = freed(&plan.dag[index]) {
+            if free_node.insert(buffer.clone(), index).is_some() {
+                bail!(
+                    "arena: buffer {buffer:?} is freed twice — one BufferFree \
+                     per buffer is the plan's invariant, and a second one \
+                     would hand a live range to the next allocation"
+                );
+            }
+        }
+    }
+
+    let mut rows: Vec<(BufferId, Row)> = Vec::with_capacity(plan.buffers.len());
+    for (id, buffer) in &plan.buffers {
+        let row = match (buffer.owner, buffer.freed_by) {
+            // INTERIOR — the only recyclable row, and only with both
+            // lifetime ends present in the dag.
+            (Owner::System, FreedBy::Program)
+                if alloc_node.contains_key(id) && free_node.contains_key(id) =>
+            {
+                Row::Slab
+            }
+            (Owner::System, FreedBy::Program) => Row::Standalone,
+            // DONATED — caller storage the program frees.
+            (Owner::Caller, FreedBy::Program) => Row::Donated,
+            // BOUNDARY and ESCAPING — the caller's bytes after the call.
+            (_, FreedBy::Caller) => Row::Standalone,
+        };
+        rows.push((id.clone(), row));
+    }
+    // `plan.buffers` is a hash map; sort so the reported vectors read
+    // the same on every run (the slab LAYOUT is already deterministic —
+    // it follows `order`, not this iteration).
+    rows.sort_by_key(|(id, _)| format!("{id:?}"));
+
+    let mut arena = ArenaPlan {
+        order,
+        ..Default::default()
+    };
+    let mut sizes: FxHashMap<BufferId, usize> = FxHashMap::default();
+    for (id, row) in &rows {
+        match row {
+            Row::Slab => {
+                let buffer = &plan.buffers[id];
+                sizes.insert(id.clone(), bytes_of(buffer)?);
+            }
+            Row::Standalone => arena.standalone.push(id.clone()),
+            Row::Donated => arena.donated.push(id.clone()),
+        }
+    }
+
+    // ---- the walk: first-fit over the issue order -------------------
+    let mut free_list = FreeList::default();
+    // CONTRACT-1, LIVE-RANGE FORM. The whole-plan disjointness assert
+    // the executor used to run at bind time is vacuous under a slab
+    // (every range is a sub-range of one allocation) — and it was never
+    // the right question anyway: what folded-view reads and WAR
+    // ordering need is that two SIMULTANEOUSLY BOUND BufferIds do not
+    // share a byte. That is a property of THIS walk, so it is checked
+    // here, once per allocation, against the live set's neighbours (a
+    // sorted disjoint set stays disjoint iff each insertion clears its
+    // two neighbours). The executor keeps `binding_check::assert_disjoint`
+    // for the allocations it makes itself.
+    let mut live: BTreeMap<usize, (usize, BufferId)> = BTreeMap::new();
+    for &index in &arena.order {
+        if let Some(buffer) = allocated(&plan.dag[index]) {
+            let Some(&bytes) = sizes.get(buffer) else {
+                continue; // not a slab member (demoted, escaping, …)
+            };
+            let need = align_up(bytes.max(1));
+            let offset = free_list.alloc(need);
+            if let Some((&prev, (prev_len, prev_id))) = live.range(..offset).next_back() {
+                if prev + prev_len > offset {
+                    bail!(
+                        "CONTRACT-1 violation (arena): {prev_id:?} holds \
+                         [{prev}, {}) and {buffer:?} was given [{offset}, {}) \
+                         — simultaneously bound BufferIds must be disjoint",
+                        prev + prev_len,
+                        offset + need
+                    );
+                }
+            }
+            if let Some((&next, (_, next_id))) = live.range(offset..).next() {
+                if offset + need > next {
+                    bail!(
+                        "CONTRACT-1 violation (arena): {buffer:?} was given \
+                         [{offset}, {}) and {next_id:?} holds [{next}, …) — \
+                         simultaneously bound BufferIds must be disjoint",
+                        offset + need
+                    );
+                }
+            }
+            live.insert(offset, (need, buffer.clone()));
+            arena
+                .slices
+                .insert(buffer.clone(), ArenaSlice { offset, bytes });
+        }
+        if let Some(buffer) = freed(&plan.dag[index]) {
+            if let Some(slice) = arena.slices.get(buffer) {
+                let need = align_up(slice.bytes.max(1));
+                live.remove(&slice.offset);
+                free_list.free(slice.offset, need);
+            }
+        }
+    }
+    arena.slab_bytes = free_list.top;
+    Ok(arena)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use luminal::index_expr::IotaExpr;
+    use luminal::layout_ir::Access;
+    use luminal::test_support::{bufferize_mock, MockLayout, MockOp, MockViewWithMap, TestGraph};
+
+    /// Every buffer is the same size, so the numbers below are counts of
+    /// buffers and nothing else.
+    const UNIT: usize = 1000;
+    const RESERVED: usize = 1024; // align_up(1000)
+
+    fn unit_bytes(_buffer: &Buffer<MockLayout>) -> Result<usize> {
+        Ok(UNIT)
+    }
+
+    /// A straight chain: input `x`, then `steps` out-of-place reads, the
+    /// last pinned to an output slot. Every intermediate result gets its
+    /// own System buffer with a synthesized alloc/free pair, and no two
+    /// non-adjacent results are ever live together.
+    fn chain(steps: usize) -> luminal::bufferize::BufferIrGraph<MockLayout> {
+        let mut g = TestGraph::new();
+        let mut value = g.input("x", "xb", Access::ReadOnly, "rm");
+        for step in 0..steps {
+            value = g.op(
+                Box::new(MockOp {
+                    reads: vec![true],
+                    ..Default::default()
+                }),
+                &[&value],
+                &[(&format!("v{step}"), "rm")],
+            )[0]
+            .clone();
+        }
+        g.output(&value, "out");
+        bufferize_mock(&g.build()).expect("chain bufferizes")
+    }
+
+    fn positions(arena: &ArenaPlan) -> FxHashMap<NodeIndex, usize> {
+        arena
+            .order
+            .iter()
+            .enumerate()
+            .map(|(at, &index)| (index, at))
+            .collect()
+    }
+
+    /// Every node that READS OR WRITES `buffer` for real — allocs and
+    /// frees excluded (they mark the lifetime, they do not touch bytes).
+    fn touchers<L: PlanLayout>(
+        plan: &luminal::bufferize::BufferIrGraph<L>,
+        buffer: &BufferId,
+    ) -> Vec<NodeIndex> {
+        plan.dag
+            .node_indices()
+            .filter(|&index| match &plan.dag[index] {
+                BufferNode::Compute {
+                    op, reads, writes, ..
+                } => {
+                    !matches!(op.label(), "BufferAlloc" | "BufferFree")
+                        && (reads.contains(buffer) || writes.contains(buffer))
+                }
+                BufferNode::BufferCopy { src, dst } => src == buffer || dst == buffer,
+                BufferNode::BufferInput { slots } => slots.iter().any(|s| &s.buffer == buffer),
+                BufferNode::BufferOutput { slots } => slots.iter().any(|s| &s.buffer == buffer),
+            })
+            .collect()
+    }
+
+    /// t1 — RECYCLING: a chain of interior buffers costs the PEAK, not
+    /// the SUM. Only producer and consumer are ever live together, so
+    /// however long the chain, two ranges suffice.
+    #[test]
+    fn chain_of_interior_buffers_costs_the_peak_not_the_sum() {
+        let plan = chain(5);
+        let arena = plan_arena(&plan, unit_bytes).expect("arena plans");
+        let members = arena.slices.len();
+        assert!(
+            members >= 3,
+            "want at least three interior buffers to recycle, got {members}:\n{}",
+            plan.summary()
+        );
+        let sum: usize = arena.slices.values().map(|s| align_up(s.bytes)).sum();
+        assert_eq!(
+            arena.slab_bytes,
+            2 * RESERVED,
+            "producer + consumer are the only pair ever live together \
+             ({members} members, sum {sum}):\n{}",
+            plan.summary()
+        );
+        assert!(
+            arena.slab_bytes < sum,
+            "peak {} must be under the sum {sum}",
+            arena.slab_bytes
+        );
+        // …and the order policy is why. The bufferizer's own node-index
+        // order is a legal topological order here; a raw `toposort`
+        // hoists every in-degree-zero alloc to the front (verdict C7).
+        let by_index = plan_arena_over(
+            &plan,
+            unit_bytes,
+            plan.dag.node_indices().collect::<Vec<_>>(),
+        )
+        .expect("node-index order plans");
+        let raw = plan_arena_over(
+            &plan,
+            unit_bytes,
+            petgraph::algo::toposort(&plan.dag, None).expect("acyclic"),
+        )
+        .expect("raw toposort plans");
+        println!(
+            "high-water: liveness-aware {} | bufferizer node index {} | raw toposort {} \
+             | sum-of-members {sum}",
+            arena.slab_bytes, by_index.slab_bytes, raw.slab_bytes
+        );
+        assert!(
+            arena.slab_bytes <= by_index.slab_bytes,
+            "the liveness-aware order is never worse than emission order"
+        );
+        assert_eq!(
+            raw.slab_bytes, sum,
+            "a raw toposort really does pay the sum"
+        );
+    }
+
+    /// t2 — ESCAPING (`Owner::System` + `FreedBy::Caller`): minted
+    /// storage the caller receives. It has an alloc and NO free, so its
+    /// bytes must outlive the call: outside the slab.
+    #[test]
+    fn escaping_minted_storage_stays_out_of_the_slab() {
+        let mut g = TestGraph::new();
+        let x = g.input("x", "B", Access::ReadWrite, "rm");
+        let p = g.op(
+            Box::new(MockOp {
+                reads: vec![true],
+                ..Default::default()
+            }),
+            &[&x],
+            &[("p", "rm")],
+        )[0]
+        .clone();
+        let v = g.op(
+            Box::new(MockViewWithMap {
+                entries: vec![IotaExpr::Coord(0), IotaExpr::Coord(1)],
+            }),
+            &[&p],
+            &[("v", "t")],
+        )[0]
+        .clone();
+        g.output(&v, "E");
+        let plan = bufferize_mock(&g.build()).expect("escape bufferizes");
+        let escaping = plan
+            .buffers
+            .iter()
+            .find(|(_, b)| b.owner == Owner::System && b.freed_by == FreedBy::Caller)
+            .map(|(id, _)| id.clone())
+            .unwrap_or_else(|| panic!("no escaping buffer:\n{}", plan.summary()));
+        let arena = plan_arena(&plan, unit_bytes).expect("arena plans");
+        assert!(
+            !arena.slices.contains_key(&escaping),
+            "escaping storage must not be a slab member:\n{}",
+            plan.summary()
+        );
+        assert!(
+            arena.standalone.contains(&escaping),
+            "escaping storage is standalone:\n{}",
+            plan.summary()
+        );
+    }
+
+    /// t3 — DONATED (`Owner::Caller` + `FreedBy::Program`): the caller's
+    /// bytes, released by the program. No slab range; the free lands
+    /// after every toucher.
+    #[test]
+    fn donated_caller_storage_gets_no_slab_range_and_frees_last() {
+        let mut g = TestGraph::new();
+        let x = g.input_binding(
+            "x",
+            "xb",
+            Some(Access::ReadWrite),
+            Some(FreedBy::Program),
+            "rm",
+        );
+        let y = g.op(
+            Box::new(MockOp {
+                reads: vec![true],
+                ..Default::default()
+            }),
+            &[&x],
+            &[("y", "rm")],
+        )[0]
+        .clone();
+        g.output(&y, "out");
+        let plan = bufferize_mock(&g.build()).expect("donation bufferizes");
+        let donated = plan
+            .buffers
+            .iter()
+            .find(|(_, b)| b.owner == Owner::Caller && b.freed_by == FreedBy::Program)
+            .map(|(id, _)| id.clone())
+            .unwrap_or_else(|| panic!("no donated buffer:\n{}", plan.summary()));
+        let arena = plan_arena(&plan, unit_bytes).expect("arena plans");
+        assert!(
+            arena.donated.contains(&donated),
+            "donated storage is its own row:\n{}",
+            plan.summary()
+        );
+        assert!(
+            !arena.slices.contains_key(&donated),
+            "donated storage gets no slab range:\n{}",
+            plan.summary()
+        );
+        let at = positions(&arena);
+        let free = plan
+            .dag
+            .node_indices()
+            .find(|&i| freed(&plan.dag[i]) == Some(&donated))
+            .unwrap_or_else(|| panic!("donated storage is freed:\n{}", plan.summary()));
+        for toucher in touchers(&plan, &donated) {
+            assert!(
+                at[&toucher] < at[&free],
+                "the free must follow every toucher of the donated buffer:\n{}",
+                plan.summary()
+            );
+        }
+    }
+
+    /// t4 — THE RECYCLING CONTRACT: a range is only re-let after its
+    /// previous occupant is done with it. Every toucher of the old
+    /// occupant precedes every toucher of the new one in the issue
+    /// order — which, on one stream, is execution order.
+    #[test]
+    fn a_recycled_range_is_only_re_let_after_its_occupant_is_finished() {
+        let plan = chain(5);
+        let arena = plan_arena(&plan, unit_bytes).expect("arena plans");
+        let at = positions(&arena);
+        let mut sharing = 0usize;
+        let members: Vec<(&BufferId, &ArenaSlice)> = arena.slices.iter().collect();
+        for (a, sa) in &members {
+            for (b, sb) in &members {
+                if a == b || sa.offset != sb.offset {
+                    continue;
+                }
+                // Same range, two buffers: order them by their allocs.
+                let alloc_a = plan
+                    .dag
+                    .node_indices()
+                    .find(|&i| allocated(&plan.dag[i]) == Some(a))
+                    .expect("slab member has an alloc");
+                let alloc_b = plan
+                    .dag
+                    .node_indices()
+                    .find(|&i| allocated(&plan.dag[i]) == Some(b))
+                    .expect("slab member has an alloc");
+                if at[&alloc_a] > at[&alloc_b] {
+                    continue; // handled from the other side
+                }
+                sharing += 1;
+                let last_old = touchers(&plan, a)
+                    .into_iter()
+                    .map(|n| at[&n])
+                    .max()
+                    .expect("an occupant is touched");
+                let first_new = touchers(&plan, b)
+                    .into_iter()
+                    .map(|n| at[&n])
+                    .min()
+                    .expect("an occupant is touched");
+                assert!(
+                    last_old < first_new,
+                    "range {} was re-let to {b:?} at position {first_new} while \
+                     {a:?} was still touching it at {last_old}:\n{}",
+                    sa.offset,
+                    plan.summary()
+                );
+            }
+        }
+        assert!(
+            sharing > 0,
+            "the chain must actually recycle a range:\n{}",
+            plan.summary()
+        );
+    }
+
+    /// t5 — the issue order is a real topological order: every edge,
+    /// Data and Anti alike, points forward in it.
+    #[test]
+    fn the_issue_order_respects_every_data_and_anti_edge() {
+        let plan = chain(4);
+        let arena = plan_arena(&plan, unit_bytes).expect("arena plans");
+        assert_eq!(
+            arena.order.len(),
+            plan.dag.node_count(),
+            "every node is issued exactly once"
+        );
+        let at = positions(&arena);
+        let mut anti = 0usize;
+        for edge in plan.dag.edge_references() {
+            if edge.weight().kind == luminal::bufferize::EdgeKind::Anti {
+                anti += 1;
+            }
+            assert!(
+                at[&edge.source()] < at[&edge.target()],
+                "edge {:?} -> {:?} ({:?}) points backwards in the issue order:\n{}",
+                edge.source(),
+                edge.target(),
+                edge.weight().kind,
+                plan.summary()
+            );
+        }
+        println!("{} anti edges honoured", anti);
+    }
+}

--- a/crates/luminal_cuda_lite/src/arena.rs
+++ b/crates/luminal_cuda_lite/src/arena.rs
@@ -307,17 +307,19 @@ struct FreeList {
 
 impl FreeList {
     fn alloc(&mut self, need: usize) -> usize {
-        // BEST fit, not first fit: the tightest hole that holds `need`,
-        // ties to the lowest address. Measured on the two-layer
-        // mini-llama block, first fit left 20% of the slab in holes
-        // nothing fit into (596480 B against a 498176 B peak live);
-        // best fit is the one-line answer to that.
-        if let Some((&offset, &len)) = self
-            .holes
-            .iter()
-            .filter(|(_, &len)| len >= need)
-            .min_by_key(|(offset, &len)| (len, **offset))
-        {
+        // FIRST fit, in offset order — MEASURED against the obvious
+        // alternative and kept. First fit leaves about a fifth of the
+        // slab in holes on the two-layer mini-llama block (596480 B
+        // high-water against a 498176 B peak live, which is the
+        // fragmentation-free lower bound over the same order), and BEST
+        // fit — the tightest hole that holds the request — is WORSE:
+        // 663040 B on the same plan, because it shaves every large hole
+        // down into slivers nothing later fits into. If this is ever
+        // revisited, the thing to try is not another fit rule but
+        // offset assignment over whole lifetimes (the greedy-by-size
+        // arena planners), which is a different pass, not a different
+        // line.
+        if let Some((&offset, &len)) = self.holes.iter().find(|(_, &len)| len >= need) {
             self.holes.remove(&offset);
             if len > need {
                 self.holes.insert(offset + need, len - need);

--- a/crates/luminal_cuda_lite/src/arena.rs
+++ b/crates/luminal_cuda_lite/src/arena.rs
@@ -307,7 +307,17 @@ struct FreeList {
 
 impl FreeList {
     fn alloc(&mut self, need: usize) -> usize {
-        if let Some((&offset, &len)) = self.holes.iter().find(|(_, &len)| len >= need) {
+        // BEST fit, not first fit: the tightest hole that holds `need`,
+        // ties to the lowest address. Measured on the two-layer
+        // mini-llama block, first fit left 20% of the slab in holes
+        // nothing fit into (596480 B against a 498176 B peak live);
+        // best fit is the one-line answer to that.
+        if let Some((&offset, &len)) = self
+            .holes
+            .iter()
+            .filter(|(_, &len)| len >= need)
+            .min_by_key(|(offset, &len)| (len, **offset))
+        {
             self.holes.remove(&offset);
             if len > need {
                 self.holes.insert(offset + need, len - need);

--- a/crates/luminal_cuda_lite/src/arena.rs
+++ b/crates/luminal_cuda_lite/src/arena.rs
@@ -173,67 +173,118 @@ fn freed<L: PlanLayout>(node: &BufferNode<L>) -> Option<&BufferId> {
 /// of all of them — the very number this pass exists to beat (verdict
 /// C7 of the #420/#422 soundness review).
 ///
-/// The fix is a priority among the READY nodes, not a different
-/// algorithm:
+/// Two changes to Kahn's algorithm, both aimed at the same thing —
+/// keeping a buffer's lifetime as short as the dependency structure
+/// allows:
 ///
-///  1. a `BufferFree` whose in-edges are all discharged goes FIRST —
-///     its range returns to the free list at the earliest instant the
-///     dependency structure allows;
-///  2. then any ordinary node (compute, copy, boundary);
-///  3. a `BufferAlloc` goes LAST, only when nothing else can run — so
-///     a buffer is born at the latest instant, immediately before the
-///     first node that needed it to exist.
+///  1. A `BufferFree` whose in-edges are all discharged goes FIRST. Its
+///     in-edges are Data from the final resident's producer plus Anti
+///     from every other toucher, so this is precisely "free the instant
+///     the last toucher has run".
+///  2. A `BufferAlloc` IS NEVER QUEUED AT ALL. It is PULLED: its edge to
+///     its first toucher is left out of that toucher's in-degree, and
+///     when the toucher is popped, its not-yet-issued alloc predecessors
+///     are emitted immediately before it. So an alloc lands where
+///     bufferize meant it to land — "before its buffer's first toucher"
+///     — no matter which of the ready nodes the frontier happens to
+///     pick.
 ///
-/// Ties inside a class break on node index, which is the bufferizer's
-/// own emission order ("synthesized allocs slot in before their
-/// buffer's first toucher, frees after its last toucher"), so among
-/// equally-ready allocs we mint the one the planner placed first.
+/// The pull is what makes the difference on real plans. QUEUEING allocs
+/// at the lowest priority is not enough, and the failure mode is worth
+/// recording: when the frontier stalls (every compute node waits on its
+/// own destination's alloc), the scheduler must issue SOME alloc, and a
+/// node-index tie-break issues one whose toucher is nowhere near ready.
+/// Measured on a two-layer mini-llama block (d=128, 484 nodes) under the
+/// queued policy: the six d x ff weight materializations were allocated
+/// at positions 1..27 and first touched at 447..475, and the high-water
+/// mark came to 99% of the naive sum. Pulling instead of queueing is
+/// what closes that gap.
+///
+/// An alloc that is dead (no outgoing edge) or that somehow carries
+/// in-edges of its own cannot be pulled; it stays an ordinary queued
+/// node, which is the pre-arena behaviour for it and always correct.
+///
+/// Ties inside a queue break on node index, which is the bufferizer's
+/// own emission order, so equally-ready work runs in the order the
+/// planner wrote it.
 fn issue_order<L: PlanLayout>(plan: &BufferIrGraph<L>) -> Result<Vec<NodeIndex>> {
-    let mut indegree: Vec<usize> = vec![0; plan.dag.node_bound()];
+    let bound = plan.dag.node_bound();
+    let incoming = |index: NodeIndex| {
+        plan.dag
+            .edges_directed(index, petgraph::Direction::Incoming)
+            .count()
+    };
+    // An alloc is PULLABLE iff it depends on nothing and something
+    // depends on it: then it can be emitted, always legally, at the
+    // moment its first consumer is emitted.
+    let mut pullable = vec![false; bound];
+    for index in plan.dag.node_indices() {
+        pullable[index.index()] = kind_of(&plan.dag[index]) == Kind::Alloc
+            && incoming(index) == 0
+            && plan
+                .dag
+                .edges_directed(index, petgraph::Direction::Outgoing)
+                .next()
+                .is_some();
+    }
+    // In-degrees COUNT ONLY non-pulled predecessors: a pulled alloc's
+    // edge is discharged by the pull itself.
+    let mut indegree: Vec<usize> = vec![0; bound];
     for index in plan.dag.node_indices() {
         indegree[index.index()] = plan
             .dag
             .edges_directed(index, petgraph::Direction::Incoming)
+            .filter(|edge| !pullable[edge.source().index()])
             .count();
     }
-    // Three ready queues, each min-ordered by node index (`Reverse`).
+    // Two ready queues, each min-ordered by node index (`Reverse`).
     let mut frees: BinaryHeap<std::cmp::Reverse<usize>> = BinaryHeap::new();
     let mut ordinary: BinaryHeap<std::cmp::Reverse<usize>> = BinaryHeap::new();
-    let mut allocs: BinaryHeap<std::cmp::Reverse<usize>> = BinaryHeap::new();
     let push = |index: NodeIndex,
                 frees: &mut BinaryHeap<std::cmp::Reverse<usize>>,
-                ordinary: &mut BinaryHeap<std::cmp::Reverse<usize>>,
-                allocs: &mut BinaryHeap<std::cmp::Reverse<usize>>| {
+                ordinary: &mut BinaryHeap<std::cmp::Reverse<usize>>| {
         match kind_of(&plan.dag[index]) {
             Kind::Free => frees.push(std::cmp::Reverse(index.index())),
-            Kind::Ordinary => ordinary.push(std::cmp::Reverse(index.index())),
-            Kind::Alloc => allocs.push(std::cmp::Reverse(index.index())),
+            _ => ordinary.push(std::cmp::Reverse(index.index())),
         }
     };
     for index in plan.dag.node_indices() {
-        if indegree[index.index()] == 0 {
-            push(index, &mut frees, &mut ordinary, &mut allocs);
+        if !pullable[index.index()] && indegree[index.index()] == 0 {
+            push(index, &mut frees, &mut ordinary);
         }
     }
     let mut order = Vec::with_capacity(plan.dag.node_count());
+    let mut issued = vec![false; bound];
     loop {
-        let next = frees
-            .pop()
-            .or_else(|| ordinary.pop())
-            .or_else(|| allocs.pop());
-        let Some(std::cmp::Reverse(raw)) = next else {
+        let Some(std::cmp::Reverse(raw)) = frees.pop().or_else(|| ordinary.pop()) else {
             break;
         };
         let index = NodeIndex::new(raw);
+        // THE PULL: this node's storage comes into existence right here,
+        // not at the top of the program.
+        for edge in plan
+            .dag
+            .edges_directed(index, petgraph::Direction::Incoming)
+        {
+            let source = edge.source();
+            if pullable[source.index()] && !issued[source.index()] {
+                issued[source.index()] = true;
+                order.push(source);
+            }
+        }
+        issued[index.index()] = true;
         order.push(index);
         for edge in plan
             .dag
             .edges_directed(index, petgraph::Direction::Outgoing)
         {
             let target = edge.target();
+            if pullable[target.index()] {
+                continue; // an alloc is never unlocked; it is pulled
+            }
             indegree[target.index()] -= 1;
             if indegree[target.index()] == 0 {
-                push(target, &mut frees, &mut ordinary, &mut allocs);
+                push(target, &mut frees, &mut ordinary);
             }
         }
     }

--- a/crates/luminal_cuda_lite/src/arena.rs
+++ b/crates/luminal_cuda_lite/src/arena.rs
@@ -102,6 +102,12 @@ pub struct ArenaPlan {
     /// The high-water mark: how many bytes the slab must hold for this
     /// plan under this order.
     pub slab_bytes: usize,
+    /// The FRAGMENTATION-FREE lower bound: the largest total of
+    /// simultaneously-live reservations over the same order. A perfect
+    /// allocator would need exactly this; `slab_bytes - peak_live_bytes`
+    /// is what first-fit's holes cost. Diagnostic only — nothing binds
+    /// to it.
+    pub peak_live_bytes: usize,
     /// Slab members (the INTERIOR row) and their ranges.
     pub slices: FxHashMap<BufferId, ArenaSlice>,
     /// Buffers that live OUTSIDE the slab in their own allocations: the
@@ -401,6 +407,7 @@ pub(crate) fn plan_arena_over<L: PlanLayout>(
     // two neighbours). The executor keeps `binding_check::assert_disjoint`
     // for the allocations it makes itself.
     let mut live: BTreeMap<usize, (usize, BufferId)> = BTreeMap::new();
+    let mut live_bytes = 0usize;
     for &index in &arena.order {
         if let Some(buffer) = allocated(&plan.dag[index]) {
             let Some(&bytes) = sizes.get(buffer) else {
@@ -430,6 +437,8 @@ pub(crate) fn plan_arena_over<L: PlanLayout>(
                 }
             }
             live.insert(offset, (need, buffer.clone()));
+            live_bytes += need;
+            arena.peak_live_bytes = arena.peak_live_bytes.max(live_bytes);
             arena
                 .slices
                 .insert(buffer.clone(), ArenaSlice { offset, bytes });
@@ -438,6 +447,7 @@ pub(crate) fn plan_arena_over<L: PlanLayout>(
             if let Some(slice) = arena.slices.get(buffer) {
                 let need = align_up(slice.bytes.max(1));
                 live.remove(&slice.offset);
+                live_bytes -= need;
                 free_list.free(slice.offset, need);
             }
         }

--- a/crates/luminal_cuda_lite/src/device.rs
+++ b/crates/luminal_cuda_lite/src/device.rs
@@ -641,10 +641,11 @@ fn arena_report(
         .filter_map(|b| buffer_bytes(b).ok())
         .sum();
     eprintln!(
-        "[cl-arena] slab high-water {} B (resident {} B) for {} interior buffers \
-         summing {} B; standalone+donated {} B over {} buffers; whole-plan sum \
-         (the CL-2 cost) {} B; total now {} B",
+        "[cl-arena] slab high-water {} B (peak live {} B, resident {} B) for {} \
+         interior buffers summing {} B; standalone+donated {} B over {} buffers; \
+         whole-plan sum (the CL-2 cost) {} B; total now {} B",
         arena.slab_bytes,
+        arena.peak_live_bytes,
         slab_now,
         arena.slices.len(),
         slab_sum,

--- a/crates/luminal_cuda_lite/src/device.rs
+++ b/crates/luminal_cuda_lite/src/device.rs
@@ -2,28 +2,85 @@
 //! phases reimplemented over cudarc, consuming the identical
 //! `BufferIrGraph`.
 //!
-//! Phase 1 materializes every plan buffer on the device up front
-//! (loud on missing geometry/dtype, exactly like the reference; alloc
-//! and free plan ops are no-ops in this first cut). Phase 2 toposorts
-//! the dag — `Anti` (WAR) edges ride petgraph, so the order is
-//! load-bearing for free. Phase 3 dispatches: D2D for copies,
-//! NVRTC-compiled launches for compute (out-of-place: inputs are the
-//! operand buffers, the destination is a fresh zeroed slice swapped in
-//! after the launch — mirroring the reference's alias-safety
-//! convention; `ties` are ordering-only in CL-2). Phase 4 copies each
-//! output SLOT's backing buffer back to a host `HostBuffer`, keyed by
-//! slot index and paired with the slot's [`OutputBinding`] — the
-//! escape-and-disclose contract (ruling 2026-08-27): the caller gets
-//! the backing bytes (possibly parent-sized, for an escaped view
-//! election) plus the layout to interpret them under.
+//! PHASE 3 OF THE #420/#422 REJOIN (2026-09-03) rebuilt two things
+//! here:
+//!
+//! * THE DEVICE IS PERSISTENT. [`CudaDevice`] holds the context, the
+//!   one stream, the NVRTC module cache, and the arena slab, and the
+//!   runtime owns it across calls. Before, every `execute` built a
+//!   fresh context and a fresh kernel cache and recompiled every
+//!   kernel.
+//! * MEMORY COMES FROM AN ARENA. Phase 1 used to `alloc_zeros` one
+//!   slice per plan buffer, all live for the whole call — the sum of
+//!   every buffer the plan names. Now [`crate::arena`] reads the
+//!   plan's own `BufferAlloc`/`BufferFree` lifetimes, picks an issue
+//!   order that keeps few buffers live at once, and assigns each
+//!   INTERIOR buffer a range of ONE runtime-owned slab, sized to the
+//!   high-water mark and grown (never shrunk) across calls. Boundary,
+//!   escaping and donated storage keep their own allocations — see the
+//!   ownership-row table on [`crate::arena`].
+//!
+//! The phases themselves are unchanged in kind. Phase 1 materializes
+//! the standalone rows and stages inputs (loud on missing
+//! geometry/dtype, exactly like the reference). Phase 2 is the arena's
+//! issue order — a topological order over Data AND Anti edges, so WAR
+//! ordering is enforced by construction, chosen for a small high-water
+//! mark. Phase 3 dispatches: `BufferAlloc` binds its buffer to its slab
+//! range, `BufferFree` drops the binding, D2D for copies,
+//! NVRTC-compiled launches for compute (the destination is the range
+//! the planner assigned — no longer a fresh zeroed slice; every CL
+//! kernel writes every element it owns, see the KERNEL INVARIANT note
+//! below). Phase 4 copies each output SLOT's backing buffer back to a
+//! host `HostBuffer`, keyed by slot index and paired with the slot's
+//! [`OutputBinding`] — the escape-and-disclose contract (ruling
+//! 2026-08-27): the caller gets the backing bytes (possibly
+//! parent-sized, for an escaped view election) plus the layout to
+//! interpret them under.
+//!
+//! # THE KERNEL INVARIANT (why an unzeroed destination is safe)
+//!
+//! A recycled slab range arrives holding the previous occupant's
+//! bytes. That is sound iff no kernel READS its destination before
+//! writing it, and every kernel writes every element it owns. Audited
+//! 2026-09-03, one family at a time:
+//!
+//! * ELEMENTWISE (`kernels::binary`/`unary` and every op that lowers
+//!   through them), CAST, CONSTANT, IOTA, GATHER,
+//!   INDEXMAPAPPLYMATERIALIZE, COPY: one thread per destination
+//!   element, `out[i] = <expr>` over `n = numel(dest_dims)`. The
+//!   destination is never an operand of the launch (the executor
+//!   passes `reads[..reads.len()-writes.len()]`, dropping the DPS dest
+//!   operand), so it cannot even be read.
+//! * REDUCE: `out[i] = acc` over `n = outer*inner` — the whole
+//!   destination, `acc` seeded from `init` and folded over the input.
+//! * SCATTER: TWO launches. The first is `out[i] = init[...]` over the
+//!   FULL destination numel (`init_dims != dest_dims` is a bail), so
+//!   the destination is completely written before the second launch
+//!   scatters into it. Same stream, so the phases are ordered.
+//! * CUBLASLT D: `beta = 0` on the non-fold forms, which is the BLAS
+//!   skip — C (aliased to D) is not read, D is fully written. The
+//!   C-fold forms read a separate C OPERAND buffer with `beta = 1`,
+//!   never the destination's prior bytes.
+//!
+//! So no memset is emitted anywhere. The one standing assumption is
+//! that a destination's `numel(dest_dims)` covers its buffer's SPAN:
+//! true for every codegen'd kernel because the elected destination
+//! layout must be right-major contiguous (the egglog write-capability
+//! guard, 2026-09-01) and for cuBLASLt because `bind_destination`
+//! refuses anything but the two dense orders. A future non-dense
+//! destination would leave the span's tail holding the previous
+//! occupant's bytes, and would need the memset this note says we do
+//! not do.
 
+use crate::arena::{plan_arena, ArenaPlan};
 use crate::host_buffer::{dtype_bytes, HostBuffer};
 use anyhow::{anyhow, bail, Context, Result};
 use cudarc::driver::{
-    CudaContext, CudaFunction, CudaModule, CudaSlice, DevicePtr, LaunchConfig, PushKernelArg,
+    result as cu, CudaContext, CudaFunction, CudaModule, CudaSlice, CudaStream, DevicePtr,
+    LaunchConfig, PushKernelArg,
 };
 use cudarc::nvrtc::compile_ptx;
-use luminal::bufferize::{BufferId, BufferIrGraph, BufferNode, EdgeKind, OutputBinding};
+use luminal::bufferize::{Buffer, BufferId, BufferIrGraph, BufferNode, EdgeKind, OutputBinding};
 use luminal::dtype::PlanDtype;
 use luminal::prelude::FxHashMap;
 use std::collections::HashMap;
@@ -74,11 +131,126 @@ impl KernelCache {
     }
 }
 
-/// Execute a bufferized plan on device 0. Returns, per output slot
+/// THE PERSISTENT DEVICE: everything an execution needs that should
+/// outlive one call — the context, the one stream every kernel and
+/// copy is issued on, the compiled-module cache, and the arena slab.
+/// The runtime owns exactly one of these and hands it to
+/// [`execute_plan`] by `&mut`.
+///
+/// The slab is GROW-ONLY and never parked (#401 as amended by #422):
+/// one runtime-owned allocation, resized upward when an installed plan
+/// needs more than it holds, never released between calls. Nothing has
+/// to be invalidated on a grow — CL captures no CUDA graphs and holds
+/// no device pointers across calls.
+pub struct CudaDevice {
+    #[allow(dead_code)]
+    ctx: Arc<CudaContext>,
+    stream: Arc<CudaStream>,
+    cache: KernelCache,
+    slab: Option<CudaSlice<u8>>,
+}
+
+impl CudaDevice {
+    /// Bind device `ordinal` and take its default stream.
+    pub fn new(ordinal: usize) -> Result<Self> {
+        let ctx = CudaContext::new(ordinal).with_context(|| format!("no CUDA device {ordinal}"))?;
+        let stream = ctx.default_stream();
+        Ok(CudaDevice {
+            cache: KernelCache {
+                ctx: ctx.clone(),
+                modules: HashMap::new(),
+            },
+            ctx,
+            stream,
+            slab: None,
+        })
+    }
+
+    /// Grow the slab to at least `bytes`. The old slab is released
+    /// BEFORE the new one is taken, so a grow never needs both at once.
+    fn ensure_slab(&mut self, bytes: usize) -> Result<()> {
+        if bytes == 0 || self.slab.as_ref().map(|slab| slab.len()).unwrap_or(0) >= bytes {
+            return Ok(());
+        }
+        self.slab = None;
+        self.slab = Some(
+            self.stream
+                .alloc_zeros::<u8>(bytes)
+                .with_context(|| format!("arena slab alloc, {bytes} bytes"))?,
+        );
+        Ok(())
+    }
+
+    /// The slab's current size in bytes (0 before the first plan needs
+    /// one) — the runtime's resident device footprint.
+    pub fn slab_bytes(&self) -> usize {
+        self.slab.as_ref().map(|slab| slab.len()).unwrap_or(0)
+    }
+}
+
+/// A bound buffer: where its bytes are and how many there are. Derived
+/// either from an owned [`CudaSlice`] (the standalone and donated rows)
+/// or from the slab base plus an [`crate::arena::ArenaSlice`] offset.
+///
+/// The executor works in raw device pointers rather than cudarc's
+/// slices/views because a slab range is a BORROW of one allocation:
+/// with many ranges live at once — several read by a launch that also
+/// writes one — no set of `CudaView`/`CudaViewMut` handles can coexist
+/// under the borrow checker. Pushing the pointer as a kernel argument
+/// is ABI-identical to pushing a `&CudaSlice` (cudarc pushes exactly
+/// this `CUdeviceptr`), and the stream-event bookkeeping those handles
+/// carry is inert here: CL issues everything on one stream, so
+/// `is_managing_stream_synchronization()` is false and no event is ever
+/// recorded. A multi-stream executor would owe those events.
+#[derive(Debug, Clone, Copy)]
+struct Bound {
+    ptr: u64,
+    bytes: usize,
+}
+
+fn bound_of(bindings: &FxHashMap<BufferId, Bound>, id: &BufferId, who: &str) -> Result<Bound> {
+    bindings.get(id).copied().ok_or_else(|| {
+        anyhow!(
+            "{who}: buffer {id:?} has no live binding — it was never allocated, \
+             or its BufferFree already ran"
+        )
+    })
+}
+
+/// The one sizing rule: the buffer backs one tensor, its carried layout
+/// gives the span in elements and the dtype fact gives the byte width
+/// (ALLOCATION BY ASSIGNMENT LOOKUP, corrected contract 2026-08-31 — no
+/// walk, no voting). Shared by the arena planner and Phase 1 so the two
+/// can never disagree about a buffer's size.
+fn buffer_bytes(buffer: &Buffer<luminal::layouts::DecodedLayout>) -> Result<usize> {
+    let numel = buffer
+        .layout
+        .mirror
+        .literal_span_elements()
+        .ok_or_else(|| {
+            anyhow!(
+                "buffer {:?} (backing {}) has no literal span — symbolic or \
+                 undisclosed-reach layouts are not executable",
+                buffer.label,
+                buffer.backs
+            )
+        })?;
+    let dtype = buffer.layout.dtype.ok_or_else(|| {
+        anyhow!(
+            "buffer {:?} (backing {}) carries no dtype fact",
+            buffer.label,
+            buffer.backs
+        )
+    })?;
+    Ok(numel * dtype_bytes(dtype)?)
+}
+
+/// Execute a bufferized plan on `device`. Returns, per output slot
 /// index, a host copy of the slot's BACKING buffer plus its
 /// [`OutputBinding`] (the elected layout) — the escape-and-disclose
 /// fetch, universal over dense and view elections.
 pub fn execute_plan(
+    device: &mut CudaDevice,
     plan: &BufferIrGraph<luminal::layouts::DecodedLayout>,
     staged: &FxHashMap<i64, HostBuffer>,
 ) -> Result<FxHashMap<usize, (HostBuffer, OutputBinding<luminal::layouts::DecodedLayout>)>> {
@@ -113,39 +285,34 @@ pub fn execute_plan(
         }
     }
 
-    let ctx = CudaContext::new(0).context("no CUDA device 0")?;
-    let stream = ctx.default_stream();
-    let mut cache = KernelCache {
-        ctx: ctx.clone(),
-        modules: HashMap::new(),
+    // Phase 2, hoisted: the arena decides the issue order AND the slab
+    // layout in one device-free pass (Anti edges ride it, so WAR
+    // ordering is enforced by construction). Everything below walks
+    // `arena.order`.
+    let arena = plan_arena(plan, buffer_bytes).context("arena planning")?;
+    debug_assert!(plan
+        .dag
+        .edge_weights()
+        .all(|e| matches!(e.kind, EdgeKind::Data | EdgeKind::Anti)));
+    device.ensure_slab(arena.slab_bytes)?;
+    let stream = device.stream.clone();
+    let slab_base = match &device.slab {
+        Some(slab) => {
+            let (base, _record) = slab.device_ptr(&stream);
+            base
+        }
+        None => 0,
     };
 
-    // Phase 1: materialize every buffer on device — ALLOCATION BY
-    // ASSIGNMENT LOOKUP (corrected contract, 2026-08-31): the buffer
-    // backs one tensor, its carried layout gives the span in elements
-    // and the dtype fact gives the byte width. No walk, no voting.
-    let mut storage: FxHashMap<BufferId, CudaSlice<u8>> = FxHashMap::default();
-    let mut geometry: FxHashMap<BufferId, (Vec<usize>, PlanDtype)> = FxHashMap::default();
+    // Phase 1: materialize the buffers that do NOT come from the slab —
+    // the BOUNDARY and ESCAPING rows (their bytes are the caller's after
+    // the call) and the DONATED row (the caller's bytes, which in CL
+    // means the staged payload's device copy). Slab members stay unbound
+    // until their `BufferAlloc` is issued.
+    let mut owned: FxHashMap<BufferId, CudaSlice<u8>> = FxHashMap::default();
+    let mut bindings: FxHashMap<BufferId, Bound> = FxHashMap::default();
+    let mut geometry: FxHashMap<BufferId, PlanDtype> = FxHashMap::default();
     for (id, buffer) in &plan.buffers {
-        let dims = buffer.layout.mirror.literal_extents().ok_or_else(|| {
-            anyhow!(
-                "buffer {:?} (backing {}) has symbolic layout extents — not executable",
-                buffer.label,
-                buffer.backs
-            )
-        })?;
-        let numel = buffer
-            .layout
-            .mirror
-            .literal_span_elements()
-            .ok_or_else(|| {
-                anyhow!(
-                    "buffer {:?} (backing {}) has no literal span — symbolic or \
-                 undisclosed-reach layouts are not executable",
-                    buffer.label,
-                    buffer.backs
-                )
-            })?;
         let dtype = buffer.layout.dtype.ok_or_else(|| {
             anyhow!(
                 "buffer {:?} (backing {}) carries no dtype fact",
@@ -153,7 +320,11 @@ pub fn execute_plan(
                 buffer.backs
             )
         })?;
-        let bytes = numel * dtype_bytes(dtype)?;
+        geometry.insert(id.clone(), dtype);
+    }
+    for id in arena.standalone.iter().chain(arena.donated.iter()) {
+        let buffer = &plan.buffers[id];
+        let bytes = buffer_bytes(buffer)?;
         let mut slice = stream
             .alloc_zeros::<u8>(bytes.max(1))
             .with_context(|| format!("device alloc {} bytes for {:?}", bytes, buffer.label))?;
@@ -170,42 +341,43 @@ pub fn execute_plan(
                 stream.memcpy_htod(host, &mut slice).context("H2D")?;
             }
         }
-        storage.insert(id.clone(), slice);
-        geometry.insert(id.clone(), (dims, dtype));
+        let ptr = {
+            let (ptr, _record) = slice.device_ptr(&stream);
+            ptr
+        };
+        bindings.insert(id.clone(), Bound { ptr, bytes });
+        owned.insert(id.clone(), slice);
     }
 
-    // CONTRACT-1 (bind-time): distinct BufferIds must be backed by
-    // disjoint device ranges — folded-view reads and WAR ordering are
-    // both keyed on BufferId identity. Fresh `alloc_zeros` per buffer
-    // makes this hold by construction today; the assert is the
-    // contract's enforcement face for when raw caller pointers arrive
-    // at this binding surface. Loud refusal, never mistranslation.
+    // CONTRACT-1 (bind-time), NARROWED. Distinct BufferIds must be
+    // backed by disjoint device ranges — folded-view reads and WAR
+    // ordering are both keyed on BufferId identity. This assert covers
+    // the allocations the EXECUTOR makes (the standalone and donated
+    // rows), which is the surface it was written for: "when raw caller
+    // pointers arrive at this binding surface". It can no longer be a
+    // whole-plan check, because slab members are sub-ranges of ONE
+    // allocation by design — for them the question is whether two
+    // SIMULTANEOUSLY LIVE ranges overlap, which is decidable at
+    // planning time and is checked there (see the CONTRACT-1 live-range
+    // note in `crate::arena`).
     {
-        let bound: Vec<crate::binding_check::BoundRange> = storage
+        let bound: Vec<crate::binding_check::BoundRange> = owned
             .iter()
-            .map(|(id, slice)| {
-                let (base, _sync) = slice.device_ptr(&stream);
-                crate::binding_check::BoundRange {
-                    buffer: format!("{id:?}"),
-                    base: base as u64,
-                    bytes: slice.len() as u64,
-                }
+            .map(|(id, slice)| crate::binding_check::BoundRange {
+                buffer: format!("{id:?}"),
+                base: bindings[id].ptr,
+                bytes: slice.len() as u64,
             })
             .collect();
         crate::binding_check::assert_disjoint(&bound).context("CONTRACT-1 bind-time check")?;
     }
 
-    // Phase 2: toposort — Anti edges are ordinary edges here, so WAR
-    // ordering is enforced by construction.
-    let order = luminal::prelude::petgraph::algo::toposort(&plan.dag, None)
-        .map_err(|_| anyhow!("plan dag has a cycle"))?;
-    debug_assert!(plan
-        .dag
-        .edge_weights()
-        .all(|e| matches!(e.kind, EdgeKind::Data | EdgeKind::Anti)));
+    if std::env::var_os("LUMINAL_CL_ARENA").is_some() {
+        arena_report(plan, &arena, device.slab_bytes());
+    }
 
-    // Phase 3: dispatch.
-    for node in order {
+    // Phase 3: dispatch, in the arena's issue order.
+    for node in arena.order.iter().copied() {
         match &plan.dag[node] {
             BufferNode::BufferInput { .. } | BufferNode::BufferOutput { .. } => {}
             BufferNode::BufferCopy { src, dst } => {
@@ -217,36 +389,26 @@ pub fn execute_plan(
                 //   `memcpy_dtod` of the whole slice, no layout awareness,
                 //   no element walk. "If a runtime chooses to do resource
                 //   reuse and do unequal sized buffer that is an entirely
-                //   runtime owned choice"; CL-2 pre-materializes exactly
-                //   sized slices and makes no such choice, so unequal
-                //   lengths are a bug HERE and bail loudly (this is the
-                //   executor's own discipline over bufferizer-authored
+                //   runtime owned choice"; CL sizes both ends from the same
+                //   span-of-layout rule and makes no such choice, so
+                //   unequal lengths are a bug HERE and bail loudly (this is
+                //   the executor's own discipline over bufferizer-authored
                 //   nodes, NOT a type fence re-checking an e-graph premise).
                 // * ORDERING IS THIS RUNTIME'S OBLIGATION. The plan supplied
                 //   dependency structure only (data + WAR anti-edges); we
-                //   discharge it by issuing in toposort order onto ONE
-                //   stream, which serializes the copy against every op that
-                //   depends on it and every prior reader of `dst`. A
+                //   discharge it by issuing in the arena's topological order
+                //   onto ONE stream, which serializes the copy against every
+                //   op that depends on it and every prior reader of `dst`. A
                 //   multi-stream executor would owe events/barriers here.
                 // * The three causes (conflict repair, boundary placement,
                 //   lifetime repair) are the bufferizer's business; all
                 //   three execute identically.
-                let src_slice = storage
-                    .get(src)
-                    .ok_or_else(|| anyhow!("copy src unknown"))?
-                    .clone();
-                let dst_slice = storage
-                    .get_mut(dst)
-                    .ok_or_else(|| anyhow!("copy dst unknown"))?;
-                if src_slice.len() != dst_slice.len() {
-                    bail!(
-                        "copy length mismatch: {} -> {} bytes",
-                        src_slice.len(),
-                        dst_slice.len()
-                    );
+                let from = bound_of(&bindings, src, "copy src")?;
+                let to = bound_of(&bindings, dst, "copy dst")?;
+                if from.bytes != to.bytes {
+                    bail!("copy length mismatch: {} -> {} bytes", from.bytes, to.bytes);
                 }
-                stream
-                    .memcpy_dtod(&src_slice, dst_slice)
+                unsafe { cu::memcpy_dtod_async(to.ptr, from.ptr, from.bytes, stream.cu_stream()) }
                     .context("D2D copy")?;
             }
             BufferNode::Compute {
@@ -258,27 +420,64 @@ pub fn execute_plan(
                 ..
             } => {
                 let label = op.label();
-                if label == "BufferAlloc" || label == "BufferFree" {
-                    continue; // storage is pre-materialized in CL-2
+                // THE ARENA'S TWO EVENTS. An alloc binds its buffer to
+                // the range the planner assigned it (nothing is zeroed —
+                // see the KERNEL INVARIANT note at the top of this
+                // module); a free drops the binding, and the range is
+                // already back on the planner's free list, waiting for
+                // the next alloc that fits. A buffer the planner did not
+                // put in the slab (standalone, donated, or an interior
+                // buffer demoted for want of a lifetime pair) is bound
+                // from Phase 1 and its alloc is a no-op.
+                if label == "BufferAlloc" {
+                    if let Some(buffer) = writes.first() {
+                        if let Some(slice) = arena.slices.get(buffer) {
+                            bindings.insert(
+                                buffer.clone(),
+                                Bound {
+                                    ptr: slab_base + slice.offset as u64,
+                                    bytes: slice.bytes,
+                                },
+                            );
+                        }
+                    }
+                    continue;
                 }
+                if label == "BufferFree" {
+                    if let Some(buffer) = reads.first() {
+                        bindings.remove(buffer);
+                    }
+                    continue;
+                }
+                if writes.len() != 1 {
+                    bail!(
+                        "{label}: CL handles single-destination ops, got {}",
+                        writes.len()
+                    );
+                }
+                let dest = bound_of(&bindings, &writes[0], label)?;
+                let input_count = reads.len().saturating_sub(writes.len());
+                let inputs: Vec<Bound> = reads[..input_count]
+                    .iter()
+                    .map(|id| bound_of(&bindings, id, label))
+                    .collect::<Result<_>>()?;
+
                 // Train 3: the HOST-CALL arm — cuBLASLt contracts
                 // dispatch as one `cublasLtMatmul` library call on the
                 // SAME stream as the surrounding kernels, never an
-                // NVRTC kernel. The destination follows the executor's
-                // out-of-place convention (fresh zeroed slice, swapped
-                // into storage after the call), so the C-fold forms
-                // read their C operand buffer and write fresh D
-                // (C != D pointers, beta = 1.0f — legal, identical
-                // layouts by the marker's rule guard).
+                // NVRTC kernel. The destination is the arena range the
+                // planner assigned (it was a fresh zeroed slice before
+                // Phase 3 of the rejoin); the C-fold forms read their C
+                // operand buffer and write D (C != D pointers, beta =
+                // 1.0f — legal, identical layouts by the marker's rule
+                // guard), and the non-fold forms run beta = 0, which is
+                // the BLAS skip, so D's prior bytes are never read.
                 if let Some(dps) = op
                     .as_any()
                     .downcast_ref::<crate::ops::cublaslt::CublasLtDps>()
                 {
                     let mut call = crate::ops::cublaslt::exec::plan_call(&dps.op)
                         .with_context(|| format!("cuBLASLt call planning for {label}"))?;
-                    if writes.len() != 1 {
-                        bail!("{label}: single-destination contract, got {}", writes.len());
-                    }
                     // THE PLAN/CALL-FRAME COHERENCE FENCE — restored,
                     // strengthened, and CLASSIFIED (2026-08-31; the full
                     // taxonomy lives on `exec::bind_destination`).
@@ -319,12 +518,6 @@ pub fn execute_plan(
                         label,
                     )
                     .with_context(|| format!("cuBLASLt destination frame binding for {label}"))?;
-                    let input_count = reads.len().saturating_sub(writes.len());
-                    let inputs: Vec<CudaSlice<u8>> = reads[..input_count]
-                        .iter()
-                        .map(|id| storage.get(id).unwrap().clone())
-                        .collect();
-                    let operand_refs: Vec<&CudaSlice<u8>> = inputs.iter().collect();
                     // E-GRAPH RE-CHECKS STAY DEAD (corrected contract,
                     // 2026-08-31, correction 4): the F32 end-to-end
                     // re-check and the C-operand dims/fold re-checks
@@ -334,29 +527,33 @@ pub fn execute_plan(
                     // guard). They are REMOVED and stay removed. The
                     // frame check that stood alongside them was NOT one
                     // of them — see the coherence fence above.
-                    let (dest_dims, dest_dtype) = geometry.get(&writes[0]).unwrap().clone();
-                    let dest_bytes = dest_dims.iter().product::<usize>() * dtype_bytes(dest_dtype)?;
-                    let mut dest = stream
-                        .alloc_zeros::<u8>(dest_bytes.max(1))
-                        .context("dest alloc")?;
+                    let operand_spans: Vec<crate::ops::cublaslt::device_call::DeviceRange> = inputs
+                        .iter()
+                        .map(|b| crate::ops::cublaslt::device_call::DeviceRange {
+                            ptr: b.ptr,
+                            bytes: b.bytes,
+                        })
+                        .collect();
                     crate::ops::cublaslt::device_call::dispatch(
                         &call,
-                        &operand_refs,
-                        &mut dest,
+                        &operand_spans,
+                        crate::ops::cublaslt::device_call::DeviceRange {
+                            ptr: dest.ptr,
+                            bytes: dest.bytes,
+                        },
                         &stream,
                     )
                     .with_context(|| format!("cuBLASLt dispatch for {label}"))?;
-                    storage.insert(writes[0].clone(), dest);
                     continue;
                 }
                 let Some(kernel) = codegen_for(op.as_ref()) else {
                     bail!("no cuda codegen for {label}");
                 };
                 // Phase 3: codegen geometry comes from the node's OWN slot
-                // descriptors, never the shared buffer table — `geometry`
-                // stays for allocation sizing and the copy check only. A
-                // compute node arriving without its descriptors is
-                // malformed: bail loudly (mirror of the None-dims bail).
+                // descriptors, never the shared buffer table — the buffer
+                // table sizes ALLOCATIONS and nothing else. A compute node
+                // arriving without its descriptors is malformed: bail
+                // loudly (mirror of the None-dims bail).
                 if operand_info.len() != reads.len() || result_info.len() != writes.len() {
                     bail!(
                         "{label}: compute node lacks slot descriptors \
@@ -372,44 +569,28 @@ pub fn execute_plan(
                     .with_context(|| format!("codegen for {label}"))?;
 
                 // Kernel inputs are the non-destination operands; the
-                // destination is a fresh zeroed slice (out-of-place),
-                // swapped into storage after the sequence. Launches in
-                // one sequence share the stream, so phase ordering
-                // (e.g. scatter's init-copy then writes) is free.
-                if writes.len() != 1 {
-                    bail!(
-                        "{label}: CL-2 handles single-destination ops, got {}",
-                        writes.len()
-                    );
-                }
-                let input_count = reads.len().saturating_sub(writes.len());
-                let inputs: Vec<CudaSlice<u8>> = reads[..input_count]
-                    .iter()
-                    .map(|id| storage.get(id).unwrap().clone())
-                    .collect();
-                let (dest_dims, dest_dtype) = geometry.get(&writes[0]).unwrap().clone();
-                let dest_bytes = dest_dims.iter().product::<usize>() * dtype_bytes(dest_dtype)?;
-                let mut dest = stream
-                    .alloc_zeros::<u8>(dest_bytes.max(1))
-                    .context("dest alloc")?;
-
+                // destination is the buffer the planner assigned, in
+                // place. Launches in one sequence share the stream, so
+                // phase ordering (e.g. scatter's init-copy then writes)
+                // is free.
+                let input_ptrs: Vec<u64> = inputs.iter().map(|b| b.ptr).collect();
+                let dest_ptr = dest.ptr;
                 for generated in &launches {
-                    let func = cache.function(&generated.source)?;
+                    let func = device.cache.function(&generated.source)?;
                     let n = generated.n as u64;
                     let cfg = LaunchConfig {
-                        grid_dim: (((generated.n as u32).max(1) + 255) / 256, 1, 1),
+                        grid_dim: ((generated.n as u32).max(1).div_ceil(256), 1, 1),
                         block_dim: (256, 1, 1),
                         shared_mem_bytes: 0,
                     };
                     let mut builder = stream.launch_builder(&func);
-                    for input in &inputs {
-                        builder.arg(input);
+                    for ptr in &input_ptrs {
+                        builder.arg(ptr);
                     }
-                    builder.arg(&mut dest);
+                    builder.arg(&dest_ptr);
                     builder.arg(&n);
                     unsafe { builder.launch(cfg) }.with_context(|| format!("launch {label}"))?;
                 }
-                storage.insert(writes[0].clone(), dest);
             }
         }
     }
@@ -420,20 +601,56 @@ pub fn execute_plan(
     // keyed by slot index and paired with the binding's layout. (The
     // declared-but-unused Boundary buffer of an escaped slot never
     // reaches this plan: buffer DCE dropped it, so Phase 1 never
-    // allocated it; and no free node exists for an escaping buffer.)
+    // allocated it; and no free node exists for an escaping buffer, so
+    // every output slot is still bound here.)
     let mut outputs = FxHashMap::default();
     for node in plan.dag.node_weights() {
         if let BufferNode::BufferOutput { slots } = node {
             for slot in slots {
-                let slice = storage
-                    .get(&slot.buffer)
-                    .ok_or_else(|| anyhow!("output slot {} names unknown buffer", slot.index))?;
-                let mut host = vec![0u8; slice.len()];
-                stream.memcpy_dtoh(slice, &mut host).context("D2H")?;
-                let (_, dtype) = geometry.get(&slot.buffer).unwrap();
-                outputs.insert(slot.index, (bytes_to_typed(&host, *dtype)?, slot.clone()));
+                let bound = bound_of(&bindings, &slot.buffer, "output slot")?;
+                let mut host = vec![0u8; bound.bytes];
+                unsafe { cu::memcpy_dtoh_async(&mut host, bound.ptr, stream.cu_stream()) }
+                    .context("D2H")?;
+                let dtype = geometry[&slot.buffer];
+                outputs.insert(slot.index, (bytes_to_typed(&host, dtype)?, slot.clone()));
             }
         }
     }
     Ok(outputs)
+}
+
+/// The arena's cost, on demand (`LUMINAL_CL_ARENA=1`): the high-water
+/// mark this plan needs against the sum CL-2 used to pay — one
+/// allocation per plan buffer, all live for the whole call.
+fn arena_report(
+    plan: &BufferIrGraph<luminal::layouts::DecodedLayout>,
+    arena: &ArenaPlan,
+    slab_now: usize,
+) {
+    let sum_all: usize = plan
+        .buffers
+        .values()
+        .filter_map(|b| buffer_bytes(b).ok())
+        .sum();
+    let slab_sum: usize = arena.slices.values().map(|s| s.bytes).sum();
+    let standalone: usize = arena
+        .standalone
+        .iter()
+        .chain(arena.donated.iter())
+        .filter_map(|id| plan.buffers.get(id))
+        .filter_map(|b| buffer_bytes(b).ok())
+        .sum();
+    eprintln!(
+        "[cl-arena] slab high-water {} B (resident {} B) for {} interior buffers \
+         summing {} B; standalone+donated {} B over {} buffers; whole-plan sum \
+         (the CL-2 cost) {} B; total now {} B",
+        arena.slab_bytes,
+        slab_now,
+        arena.slices.len(),
+        slab_sum,
+        standalone,
+        arena.standalone.len() + arena.donated.len(),
+        sum_all,
+        arena.slab_bytes + standalone,
+    );
 }

--- a/crates/luminal_cuda_lite/src/lib.rs
+++ b/crates/luminal_cuda_lite/src/lib.rs
@@ -40,6 +40,7 @@
 //! alias-safety convention; `ties` and `Anti` edges are honored in the
 //! toposort order but no in-place claim is made.
 
+pub mod arena;
 pub mod binding_check;
 pub mod bindings;
 pub mod extractor;

--- a/crates/luminal_cuda_lite/src/ops/cublaslt/device_call.rs
+++ b/crates/luminal_cuda_lite/src/ops/cublaslt/device_call.rs
@@ -25,7 +25,7 @@
 use anyhow::{anyhow, Context, Result};
 use cudarc::cublaslt::result as lt;
 use cudarc::cublaslt::sys;
-use cudarc::driver::{CudaSlice, CudaStream, DevicePtr, DevicePtrMut};
+use cudarc::driver::{CudaStream, DevicePtr};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use super::exec::{CSource, LtCall, LtDesc, LtOrder};
@@ -181,16 +181,29 @@ impl Drop for Desc {
     }
 }
 
+/// One bound device range: base pointer and extent in bytes. The
+/// executor binds buffers to ARENA SLAB RANGES (#422, Phase 3 of the
+/// rejoin), which are sub-ranges of one allocation, so it can no longer
+/// hand this call `&CudaSlice` handles — several ranges are live at
+/// once and the borrow checker admits at most one mutable view of the
+/// slab. A pointer plus a length is exactly what `cublasLtMatmul`
+/// consumes anyway.
+#[derive(Debug, Clone, Copy)]
+pub struct DeviceRange {
+    pub ptr: u64,
+    pub bytes: usize,
+}
+
 /// Dispatch one resolved call, stream-ordered on `stream` (the same
 /// stream the surrounding kernels use). `operands` are the Lit operand
-/// buffers `[a, b, c?, bias?]`; `dest` is the (fresh, executor-owned)
-/// D buffer. The caller has ALREADY run `call.validate_against` — this
-/// function re-checks (defense in depth) and then never re-derives a
-/// number the `LtCall` carries.
+/// buffers `[a, b, c?, bias?]`; `dest` is the D buffer — the range the
+/// arena assigned it. The caller has ALREADY run
+/// `call.validate_against` — this function re-checks (defense in depth)
+/// and then never re-derives a number the `LtCall` carries.
 pub fn dispatch(
     call: &LtCall,
-    operands: &[&CudaSlice<u8>],
-    dest: &mut CudaSlice<u8>,
+    operands: &[DeviceRange],
+    dest: DeviceRange,
     stream: &Arc<CudaStream>,
 ) -> Result<()> {
     // BIAS/ORDER TRIPWIRE, DEFENSE IN DEPTH (ruling 2026-09-01): a
@@ -203,8 +216,8 @@ pub fn dispatch(
     super::exec::assert_bias_destination_order(call, "dispatch")?;
     // Pre-dispatch bounds gate (contract 4) — LOUD, before any library
     // call, byte counts converted to f32 element counts.
-    let elems: Vec<usize> = operands.iter().map(|s| s.len() / 4).collect();
-    call.validate_against(&elems, dest.len() / 4)
+    let elems: Vec<usize> = operands.iter().map(|r| r.bytes / 4).collect();
+    call.validate_against(&elems, dest.bytes / 4)
         .context("cuBLASLt pre-dispatch bounds validation")?;
 
     let handle = handle()?;
@@ -260,16 +273,11 @@ pub fn dispatch(
         (&epilogue) as *const _ as *const _,
         std::mem::size_of::<sys::cublasLtEpilogue_t>(),
     )?;
-    // Held to function scope: the use-tracking record must cover the
-    // enqueued matmul, not just the descriptor write below.
-    let mut _bias_use_record = None;
     if let Some(bias_idx) = call.bias_operand {
-        let bias_slice = operands
+        let bias_ptr = operands
             .get(bias_idx)
-            .ok_or_else(|| anyhow!("bias operand {bias_idx} missing"))?;
-        let (bias_ptr, record) = bias_slice.device_ptr(stream);
-        _bias_use_record = Some(record);
-        let bias_ptr = bias_ptr as u64;
+            .ok_or_else(|| anyhow!("bias operand {bias_idx} missing"))?
+            .ptr;
         set_desc(
             sys::cublasLtMatmulDescAttributes_t::CUBLASLT_MATMUL_DESC_BIAS_POINTER,
             (&bias_ptr) as *const _ as *const _,
@@ -344,15 +352,14 @@ pub fn dispatch(
     // Pointers. Literal HOST scalars (contract 2): alpha = 1.0f const;
     // beta structural. C pointer: the c operand on the C-fold forms,
     // the D pointer otherwise (beta = 0.0f, C never read — contract 3).
-    let (a_ptr, _ra) = operands[0].device_ptr(stream);
-    let (b_ptr, _rb) = operands[1].device_ptr(stream);
-    let (d_ptr, _rd) = dest.device_ptr_mut(stream);
+    let a_ptr = operands[0].ptr;
+    let b_ptr = operands[1].ptr;
+    let d_ptr = dest.ptr;
     let (c_ptr, beta): (u64, &'static f32) = match call.c_source {
         CSource::AliasD => (d_ptr, &BETA_ZERO),
         CSource::Operand(i) => {
-            let (p, _rc) = operands[i].device_ptr(stream);
             debug_assert!(call.beta_is_one);
-            (p, &BETA_ONE)
+            (operands[i].ptr, &BETA_ONE)
         }
     };
     let (w_ptr, _rw) = workspace.device_ptr(stream);

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -77,6 +77,14 @@ pub struct CudaRuntime {
     /// `bind_dyn_range` pin plus whatever [`Self::set_dim`] sets. With
     /// buckets bound this is what picks the plan at execute time.
     dims: shape::DynMap,
+    /// THE PERSISTENT DEVICE (#422, rejoin Phase 3): context, stream,
+    /// NVRTC module cache and the arena slab, created on the first
+    /// [`Self::execute`] and kept for the runtime's life — "each runtime
+    /// remembers its own buffer hygiene". `None` until then, so
+    /// `Default` still gives a device-free runtime that plans and
+    /// searches on any host.
+    #[cfg(feature = "device")]
+    device: Option<crate::device::CudaDevice>,
 }
 
 impl CudaRuntime {
@@ -518,19 +526,32 @@ impl CudaRuntime {
         if !self.bucket_plans.is_empty() {
             self.select_bucket_plan()?;
         }
-        let plan = self
-            .plan
-            .as_ref()
-            .ok_or_else(|| anyhow!("search before execute"))?;
         #[cfg(feature = "device")]
         {
-            let outputs = crate::device::execute_plan(plan, &self.staged)?;
+            // The device is created ONCE and reused: the module cache
+            // keeps every NVRTC compilation from the previous calls, and
+            // the arena slab keeps the bytes (grow-only, never parked).
+            if self.device.is_none() {
+                self.device = Some(crate::device::CudaDevice::new(0)?);
+            }
+            let plan = self
+                .plan
+                .as_ref()
+                .ok_or_else(|| anyhow!("search before execute"))?;
+            let device = self
+                .device
+                .as_mut()
+                .expect("the device was just created if it was missing");
+            let outputs = crate::device::execute_plan(device, plan, &self.staged)?;
             self.outputs_host = outputs;
             Ok(())
         }
         #[cfg(not(feature = "device"))]
         {
-            let _ = plan;
+            let _ = self
+                .plan
+                .as_ref()
+                .ok_or_else(|| anyhow!("search before execute"))?;
             bail!(
                 "cuda-lite built without the `device` feature: plans can be \
                  searched and inspected but not executed on this host"

--- a/crates/luminal_cuda_lite/tests/cublaslt_contracts.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_contracts.rs
@@ -144,6 +144,22 @@ fn to_device(stream: &Arc<cudarc::driver::CudaStream>, host: &[f32]) -> CudaSlic
     slice
 }
 
+/// The executor binds buffers to ARENA RANGES now (#422 Phase 3), so
+/// `device_call::dispatch` takes pointer+length pairs rather than
+/// `&CudaSlice` handles. These tests own whole slices; this is the
+/// one-line adapter.
+fn as_range(
+    stream: &Arc<cudarc::driver::CudaStream>,
+    slice: &CudaSlice<u8>,
+) -> device_call::DeviceRange {
+    use cudarc::driver::DevicePtr;
+    let (ptr, _record) = slice.device_ptr(stream);
+    device_call::DeviceRange {
+        ptr,
+        bytes: slice.len(),
+    }
+}
+
 fn from_device(stream: &Arc<cudarc::driver::CudaStream>, slice: &CudaSlice<u8>) -> Vec<f32> {
     let mut host = vec![0u8; slice.len()];
     stream.memcpy_dtoh(slice, &mut host).expect("D2H");
@@ -224,16 +240,16 @@ fn all_four_contract_forms_execute_green() {
 
         let dev_a = to_device(&stream, &a);
         let dev_b = to_device(&stream, &b);
-        let mut operands: Vec<&CudaSlice<u8>> = vec![&dev_a, &dev_b];
+        let mut operands = vec![as_range(&stream, &dev_a), as_range(&stream, &dev_b)];
         let dev_c = c.as_ref().map(|c| to_device(&stream, c));
         let dev_bias = bias.as_ref().map(|v| to_device(&stream, v));
         if let Some(dc) = dev_c.as_ref() {
-            operands.push(dc);
+            operands.push(as_range(&stream, dc));
         }
         if let Some(db) = dev_bias.as_ref() {
-            operands.push(db);
+            operands.push(as_range(&stream, db));
         }
-        let mut dest = stream.alloc_zeros::<u8>(m * n * 4).expect("dest alloc");
+        let dest = stream.alloc_zeros::<u8>(m * n * 4).expect("dest alloc");
 
         // Bias forms: COL D (ld = m), the order the library supports for
         // BIAS/RELU_BIAS; the epilogue adds bias[row] along D's rows.
@@ -245,7 +261,7 @@ fn all_four_contract_forms_execute_green() {
                 LtOrder::Row
             }
         );
-        device_call::dispatch(&call, &operands, &mut dest, &stream)
+        device_call::dispatch(&call, &operands, as_range(&stream, &dest), &stream)
             .unwrap_or_else(|e| panic!("{form:?} dispatch: {e:#}"));
         stream.synchronize().expect("sync");
 
@@ -283,9 +299,14 @@ fn ld_bounds_violation_refuses_before_dispatch() {
     };
     let dev_a = to_device(&stream, &weights(2, 1));
     let dev_b = to_device(&stream, &weights(16, 2));
-    let mut dest = stream.alloc_zeros::<u8>(4 * 4).expect("short dest"); // 4 f32s, needs 8
-    let err = device_call::dispatch(&call, &[&dev_a, &dev_b], &mut dest, &stream)
-        .expect_err("the short D buffer must be refused BEFORE dispatch");
+    let dest = stream.alloc_zeros::<u8>(4 * 4).expect("short dest"); // 4 f32s, needs 8
+    let err = device_call::dispatch(
+        &call,
+        &[as_range(&stream, &dev_a), as_range(&stream, &dev_b)],
+        as_range(&stream, &dest),
+        &stream,
+    )
+    .expect_err("the short D buffer must be refused BEFORE dispatch");
     let msg = format!("{err:#}");
     assert!(msg.contains("refused BEFORE dispatch"), "{msg}");
     stream.synchronize().expect("sync");
@@ -313,15 +334,15 @@ fn bias_form_with_a_row_d_is_refused_before_dispatch() {
         let b = weights(k * n, 2);
         let dev_a = to_device(&stream, &a);
         let dev_b = to_device(&stream, &b);
-        let mut operands: Vec<&CudaSlice<u8>> = vec![&dev_a, &dev_b];
+        let mut operands = vec![as_range(&stream, &dev_a), as_range(&stream, &dev_b)];
         let dev_c = form.has_c().then(|| to_device(&stream, &weights(m * n, 3)));
         let dev_bias = to_device(&stream, &weights(m, 4));
         if let Some(dc) = dev_c.as_ref() {
-            operands.push(dc);
+            operands.push(as_range(&stream, dc));
         }
-        operands.push(&dev_bias);
-        let mut dest = stream.alloc_zeros::<u8>(m * n * 4).expect("dest alloc");
-        let err = device_call::dispatch(&call, &operands, &mut dest, &stream)
+        operands.push(as_range(&stream, &dev_bias));
+        let dest = stream.alloc_zeros::<u8>(m * n * 4).expect("dest alloc");
+        let err = device_call::dispatch(&call, &operands, as_range(&stream, &dest), &stream)
             .expect_err("a ROW-order D under a bias form must trip the fence");
         let msg = format!("{err:#}");
         assert!(msg.contains("unreachable"), "{form:?}: {msg}");

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -2792,6 +2792,242 @@ shape of the target; nothing here yet has a downstream to serve.
 - **`detach_dirty_external_output_bindings`**: not reachable; folded into #418
   requirement 3 as a sentence (above).
 
+## Program: #420/#422 rejoin — Phase 3 (persistent device + arena)
+
+**The move.** The CUDA-lite runtime got a device that outlives a call and
+a memory plan. Before this, every `execute` built a fresh `CudaContext`,
+a fresh `KernelCache` (so every kernel was recompiled from source), and
+one `alloc_zeros` per plan buffer — every buffer live for the whole call,
+which is the SUM of everything the plan names. The bufferizer had been
+computing lifetimes (`BufferAlloc` opens storage, `BufferFree` closes it,
+the containment certificate puts every toucher between the two) and
+nothing consumed them. #422's arena consumes them.
+
+**Austin's rulings this implements** (2026-09-03). "The arena lives in
+the cuda runtime… first produce the bufferizer, this will do the
+allocations / frees. Then a separate thing will map those allocation /
+frees to slices on memory in the arena allocator." "Runtime owns this
+code. Try to factor it into a reasonable module." "Buckets will always be
+concrete, not symbolic, so we should be good on sizing." #401 as
+superseded by #422: ONE runtime-owned slab, grow-only, never parked.
+Zero-copy rebinding: "let's not implement any checks in the runtime… I
+don't want to touch this code unnecessarily, let's keep it simple" — no
+new invariant checks were added; the one existing check was re-scoped
+(below). Each runtime remembers its own buffer hygiene.
+
+### What landed
+
+| Where | What |
+| --- | --- |
+| `crates/luminal_cuda_lite/src/arena.rs` (new) | The device-free planning pass. `plan_arena(plan, bytes_of) -> ArenaPlan`, generic over `L: PlanLayout`, no cudarc — it compiles and its five tests run on a laptop. |
+| `crates/luminal_cuda_lite/src/device.rs` | `CudaDevice` (context + one stream + module cache + slab), `execute_plan(&mut CudaDevice, plan, staged)`, arena-bound storage, the kernel-invariant record. |
+| `crates/luminal_cuda_lite/src/runtime.rs` | One field: `device: Option<CudaDevice>`, created on the first `execute`. `CudaRuntime: Default` unchanged. |
+| `crates/luminal_cuda_lite/src/ops/cublaslt/device_call.rs` | `dispatch` takes `DeviceRange` (pointer + length) instead of `&CudaSlice`/`&mut CudaSlice`. |
+| `crates/luminal_cuda_lite/src/lib.rs` | `pub mod arena;` |
+
+`ArenaPlan` is `{ order: Vec<NodeIndex>, slab_bytes, peak_live_bytes,
+slices: FxHashMap<BufferId, ArenaSlice{offset, bytes}>, standalone:
+Vec<BufferId>, donated: Vec<BufferId> }`. `bytes_of` is the caller's, so
+tests plan with mock sizes and the executor passes the one real rule
+(`literal_span_elements() * dtype_bytes`) — the same closure the arena
+and Phase 1 both call, so the two can never disagree about a size.
+Alignment is 256 bytes. `peak_live_bytes` is diagnostic: the largest
+total of simultaneously-live reservations, i.e. what a perfect allocator
+would need, so the gap against `slab_bytes` prices fragmentation.
+
+### The ownership rows: only one is recyclable
+
+| row | `Owner` | `FreedBy` | alloc | free | arena |
+| --- | --- | --- | --- | --- | --- |
+| BOUNDARY | `Caller` | `Caller` | — | — | `standalone` |
+| DONATED | `Caller` | `Program` | — | yes | `donated` |
+| ESCAPING | `System` | `Caller` | yes | — | `standalone` |
+| INTERIOR | `System` | `Program` | yes | yes | **slab member** |
+
+Only INTERIOR has both ends of its lifetime inside the program, which is
+the precondition for handing its bytes to a later buffer. ESCAPING bytes
+are the caller's from return on — re-letting them would hand the caller a
+range the next call overwrites. DONATED storage came from the caller and
+the program's free RELEASES it; that is not a licence to re-let it (in CL
+the "caller's slice" is the device copy of the staged host payload, so it
+is allocated in Phase 1 like the standalone rows and simply never
+recycled). An INTERIOR buffer whose alloc/free pair is missing from the
+dag — a hand-built or externally loaded plan — is DEMOTED to standalone,
+which is exactly CL-2's behaviour, so those plans still run and
+`slab_bytes` is 0.
+
+### The order policy, and the thing that was measured
+
+The issue order is the arena's, not `petgraph::algo::toposort`'s. Raw
+toposort is legal and terrible: allocs have in-degree zero, Kahn hoists
+every one of them to the front, and the high-water mark equals the sum
+(verdict C7). The policy is:
+
+1. a `BufferFree` whose in-edges are discharged goes FIRST (its in-edges
+   are Data from the final resident's producer plus Anti from every other
+   toucher, so this is "free the instant the last toucher has run");
+2. a `BufferAlloc` **is never queued at all — it is PULLED**: its edge to
+   its first toucher is left out of that toucher's in-degree, and popping
+   the toucher emits its not-yet-issued alloc predecessors immediately
+   before it;
+3. ties break on node index — the bufferizer's own emission order.
+
+**Rule 2 is the finding.** Queueing allocs at the LOWEST priority is not
+enough, and the first cut did exactly that. The frontier stalls
+constantly (every compute node waits on its own destination's alloc), so
+the scheduler must issue *some* alloc, and a node-index tie-break issues
+one whose toucher is nowhere near ready. Measured on a two-layer
+mini-llama block (d=128, 484 plan nodes) on the A100: the six d×ff weight
+materializations were allocated at positions 1..27 and first TOUCHED at
+447..475; median lifetime was 233 of 484 nodes; the high-water mark came
+to 1 823 744 B against a naive sum of 1 845 482 B — a 1% saving. Peak-live
+equalled the high-water almost exactly, so it was never fragmentation:
+the order really was holding everything live. With the pull, on the same
+plan: median lifetime 6 nodes, high-water 596 480 B.
+
+Against bufferize's own node-index placement (the alternative the brief
+named): on the CPU chain fixture both give the peak (2 048 B for five
+1 000 B buffers; raw toposort gives 5 120 B = the sum). The pulled order
+is never worse there, and unlike node-index order it is a topological
+order by construction on any plan, so it ships. The test asserts all
+three numbers.
+
+The allocator is first fit over the free list in offset order, coalescing
+both neighbours on a free and growing through a tail hole rather than
+stranding it. **Best fit was tried and is WORSE** — 663 040 B against
+596 480 B on the same plan, because it shaves every large hole into
+slivers nothing later fits into. Recorded at the allocator. The next move,
+if this is ever worth more, is offset assignment over whole lifetimes
+(the greedy-by-size arena planners), which is a different pass rather
+than a different line.
+
+### The kernel invariant
+
+A recycled range arrives holding the previous occupant's bytes, so NO
+memset is emitted anywhere and every family had to be audited (the record
+lives at the top of `device.rs`):
+
+- **elementwise / cast / constant / iota / gather / index-map
+  materialize / copy** — one thread per destination element, `out[i] =
+  <expr>` over `n = numel(dest_dims)`; and the destination is not even
+  passed to the launch (the executor hands the kernel
+  `reads[..reads.len()-writes.len()]`, which drops the DPS dest operand),
+  so it cannot be read;
+- **reduce** — `out[i] = acc` over `n = outer*inner`, the whole
+  destination, `acc` seeded from `init`;
+- **scatter** — two launches: the first is `out[i] = init[...]` over the
+  FULL destination numel (a rank/extent mismatch bails), so the
+  destination is completely written before the second launch scatters
+  into it; same stream, so the phases are ordered;
+- **cuBLASLt D** — `beta = 0` on the non-fold forms, which is the BLAS
+  skip (C, aliased to D, is not read); the C-fold forms read a separate C
+  OPERAND buffer at `beta = 1`, never the destination's prior bytes.
+
+Standing assumption, recorded rather than checked: a destination's
+`numel(dest_dims)` covers its buffer's SPAN. True for every codegen'd
+kernel because the elected destination layout must be right-major
+contiguous (the egglog write-capability guard, 2026-09-01) and for
+cuBLASLt because `bind_destination` admits only the two dense orders. A
+future non-dense destination would leave the span's tail holding the
+previous occupant's bytes and would need the memset this note says we do
+not do.
+
+### CONTRACT-1: re-scoped, not dropped, not duplicated
+
+The whole-plan `binding_check::assert_disjoint` at bind time would now
+fire BY DESIGN — every slab member is a sub-range of one allocation. It
+was not the right question for them either: what folded-view reads and
+WAR ordering need is that two SIMULTANEOUSLY BOUND `BufferId`s do not
+share a byte. So the check splits along the same seam as the memory:
+
+- the executor still runs `assert_disjoint` over the allocations IT makes
+  (the standalone and donated rows) — the raw-pointer binding surface the
+  module was written for, one call per execute;
+- the slab's half is decided at PLANNING time, in `arena.rs`, as each
+  range is carved: the live set is kept sorted by offset and the new
+  range is checked against its two neighbours (a sorted disjoint set stays
+  disjoint iff every insertion clears its neighbours). O(log k) per alloc,
+  device-free, and it refuses with the same CONTRACT-1 vocabulary.
+
+No other check was added. `BufferFree` drops the binding, so a plan that
+reads a freed buffer gets a loud "no live binding" instead of stale bytes;
+that is the absence of stale state, not a new fence. The owned
+allocations themselves are held to the end of the call.
+
+### Bindings are pointers now
+
+A slab range is a BORROW of one allocation, and no set of
+`CudaView`/`CudaViewMut` handles can coexist under the borrow checker
+when a launch reads several ranges and writes another. Storage is
+therefore `(pointer, length)`: pushing the pointer as a kernel argument
+is ABI-identical to pushing a `&CudaSlice` (cudarc pushes exactly that
+`CUdeviceptr`), copies go through `cudarc::driver::result::memcpy_*_async`
+on the one stream — the same calls cudarc's own safe wrappers make — and
+the stream-event bookkeeping those handles carry is inert here, because
+CL issues everything on one stream and
+`is_managing_stream_synchronization()` is false. A multi-stream executor
+would owe those events; that is written down at the type.
+
+### Measurements (A100, `LUMINAL_CL_ARENA=1`)
+
+mini-llama blocks through the real ladder (load → search at the harness
+budget → execute), all numbers in bytes:
+
+| plan | nodes | interior buffers | interior SUM | slab high-water | peak live | whole-plan sum (CL-2) | total now |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| L1 d128 | 257 | 84 | 907 730 | 298 496 | 296 192 | 1 404 382 | 795 148 |
+| L2 d128 | 484 | 159 | 1 845 482 | 596 480 | 498 176 | 2 837 750 | 1 588 748 |
+| L4 d256 | 872 | 287 | 15 892 710 | 5 254 656 | 5 254 144 | 23 791 858 | 13 153 804 |
+
+The interior row shrinks by 3.0–3.1× and the whole device footprint by
+1.77–1.81× (weights and boundary storage are most of what is left, and
+they are not the arena's to shrink). Fragmentation is under 1% at L1 and
+L4 and 20% at L2. Median buffer lifetime is 6 plan nodes at every size.
+The device_fidelity fixtures are all under 1 KB, so 256-byte alignment
+dominates there and the slab reads LARGER than the sum; the signal at
+that scale is the slot count (5 interior buffers into 3 slots, 3 into 2).
+
+Device suites at `0446476b`, A100-SXM4-40GB: unit 10/10, codegen_identity
+13/13, composed_read_families 5/5, cublaslt_bias_premise 3/3,
+cublaslt_contracts_cpu 19/19, cublaslt_election 9/9, **device_fidelity
+6/6**, **device_view_differentials 4/4**, dim_buckets 4/4, example_smoke
+1/1, input_producer_cleanup 5/5, ladder_refusals 3/3 (3 ignored),
+plan_smoke 2/2, scc_sampler_marker 1/1, view_admission 4/4.
+cublaslt_contracts 5/6: `marker_elected_bias_plan_matches_decomposed_
+route_tolerance_based` fails on its ELECTION assert (seed 0 no longer
+elects `CublasLtBias`), which is PRE-EXISTING — reproduced at the Phase 1
+tip and on a laptop with no GPU, i.e. entirely in the device-free search
+path. It is the pin class the 2026-09-02 permutation-invariance ruling
+already parked. `all_four_contract_forms_execute_green` passes, so the
+`DeviceRange` dispatch is device-verified.
+
+**Also carried** (separate commit): `--features device --all-targets` did
+not build at the Phase 1 tip — Step B's `TypedBuffer`→`HostBuffer` swap
+left `HostBuffer::F32(values)` in the example support module and the
+cuBLASLt contract test, plus a `Vec<f32> == &Vec<f32>` in plan_smoke's
+device arm. cudarc builds fine on macOS (dynamic loading), so this is a
+laptop gate, not a box-only one.
+
+### Deferred
+
+- **Search-time slab policy** → Phase 4. This pass sizes ONE installed
+  plan; sizing across the candidate plans a search evaluates (and whether
+  the search should rank on arena footprint at all) is that phase's.
+- **Zero-copy outputs.** Phase 4 D2Hs every output slot into a fresh host
+  vector, as before. Handing the caller device memory it can keep is the
+  ESCAPING row's whole point and nothing here consumes it yet.
+- **Symbolic sizing.** `bytes_of` refuses a symbolic span. Buckets are
+  concrete by ruling, so nothing needs it today.
+- **The 32 MiB cuBLASLt workspace** is still allocated per call inside
+  `device_call::dispatch`. Now that the device is persistent it should
+  live on `CudaDevice`; it is untouched here because the file belongs to
+  the cuBLASLt estate.
+- **Multi-stream.** Everything is issued on one stream and the
+  recycling's soundness rests on that: issue order IS execution order.
+  Events/barriers are owed the day a second stream appears.
+- **Kernel-count printing** in the examples' support module counts
+  `Compute` nodes including `BufferAlloc`/`BufferFree`; left as is.
+
 ## #406 pad — the select construction REVERTED (2026-09-03)
 
 Ruling 4b's "option i" (`select_by_index`: packed 2N iota + two `scatter1d` +


### PR DESCRIPTION
**Program:** #420/#422 rejoin, Phase 3 of the stack — base `rejoin/p2-configurable-registry` (PR #482). Plan page: https://claude.ai/code/artifact/6b5d25e3-94cf-4089-8977-8e44f971b8a5. Merge in order; retarget to `logical-ssa-project` before merging.

**Rulings (Austin, 2026-09-03):** "The arena lives in the cuda runtime… first produce the bufferizer, this will do the allocations / frees. Then a separate thing will map those allocation / frees to slices on memory in the arena allocator… buckets will always be concrete." "runtime owns this code. Try to factor it into a reasonable module." #401 superseded by #422's form (one grow-only slab). No new runtime checks.

## What landed (7 commits)
- `8e639233` carry-fix: Phase 1's device-feature build (`examples/support`, `cublaslt_contracts`, `plan_smoke`) used a stale `HostBuffer::F32` spelling.
- `490f7f6d` **`crates/luminal_cuda_lite/src/arena.rs`** — device-free planning pass `plan_arena(plan, bytes_of) -> ArenaPlan { order, slab_bytes, peak_live_bytes, slices, standalone, donated }` (256-byte alignment; the same size closure the executor uses). **`CudaDevice { ctx, stream, cache, slab }`** created once, owned by `CudaRuntime`; slab grow-only. The executor binds `(ptr, bytes)` ranges, computes write into their assigned destinations (the fresh-destination-per-compute convention is gone), `BufferAlloc`/`BufferFree` are honoured, cuBLASLt dispatch takes a `DeviceRange`.
- `3c51ac15` `peak_live_bytes`: the perfect-allocator bound, so the gap to `slab_bytes` prices fragmentation.
- `ce2a17c5` **Issue order: allocations are pulled**, emitted immediately before whichever consumer pops first. Queuing them at lowest priority stalls the frontier and gave a 1% saving; pulling gives 3×.
- `1acc2cda` / `78495f80` best fit tried and **measured worse** (663,040 vs 596,480 B); first fit stays, finding recorded.
- `0b3a6077` ledger section.

**Ownership rows:** only interior buffers (`Owner::System` + `FreedBy::Program`) join the slab; escaping and boundary buffers stay standalone; donated buffers have their own row and are never recycled; an interior buffer missing its alloc/free pair is demoted to standalone so hand-built plans still run.

**Kernel invariant verified (no memset needed):** every kernel family writes its whole destination before any read; scatter's first launch copies `init`; cuBLASLt runs `beta=0` on non-fold forms.

**CONTRACT-1 re-scoped, not dropped:** the executor keeps disjointness over the allocations it makes; the slab's half is checked at planning time against live-set neighbours. No other checks added.

## A100 (`LUMINAL_CL_ARENA=1`, mini-llama through the real ladder)
| plan | interior sum | slab high-water | peak live | whole plan before | whole plan now |
|---|---|---|---|---|---|
| L1 d128 | 907,730 | 298,496 | 296,192 | 1,404,382 | 795,148 |
| L2 d128 | 1,845,482 | 596,480 | 498,176 | 2,837,750 | 1,588,748 |
| L4 d256 | 15,892,710 | 5,254,656 | 5,254,144 | 23,791,858 | 13,153,804 |

Device suites: `device_fidelity` 6 passed, `device_view_differentials` 4 passed, every CPU suite ok, arena unit tests 5, builds clean with and without `--features device`, clippy and fmt clean. One failure, **pre-existing and unattributed**: `cublaslt_contracts::marker_elected_bias_plan_matches_decomposed_route_tolerance_based` fails its election assert at seed 0, reproduced at the Phase 1 tip and device-free on macOS; it is the pin class the 2026-09-02 permutation-invariance ruling parked. Not re-swept; Phase 4 checks whether trunk passes it on the box.

**Deferred (ledger):** search-time slab policy (Phase 4), zero-copy outputs, symbolic sizing, the per-call 32 MiB cuBLASLt workspace (belongs to that estate), multi-stream events, the example kernel count still counting Alloc/Free nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
