### PR TITLE
rejoin P4: CL ranks candidates by measured device time (profile_on_device, run-only candidate timeout, timed_out counter); heuristic stays for CPU

### DIFF
--- a/crates/luminal_cuda_lite/examples/support/mod.rs
+++ b/crates/luminal_cuda_lite/examples/support/mod.rs
@@ -127,9 +127,16 @@ pub mod device {
     /// The full-size CUDA run shared by every model application:
     ///
     /// 1. CUDA-lite `load → bind dyn pins → search` on the shared harness
-    ///    budget,
+    ///    budget, PROFILED ON DEVICE (Phase 4, 2026-09-03): these
+    ///    applications run on a real GPU by construction, so their search
+    ///    ranks candidates by measured time rather than by the byte-move
+    ///    prior. The winner's measurement and its heuristic cost are
+    ///    printed side by side.
     /// 2. plan stats + refusal counters (all zero expected — the ladder
-    ///    acceptance from `tests/ladder_refusals.rs`; nonzero FAILS),
+    ///    acceptance from `tests/ladder_refusals.rs`; nonzero FAILS).
+    ///    TIMED-OUT candidates print separately and do NOT gate: nothing
+    ///    failed, the plan was merely too slow to finish measuring (and
+    ///    these applications set no budget, so the count is zero anyway).
     /// 3. device execute and fetch through the disclosed layout.
     pub fn run_cuda(
         name: &str,
@@ -145,23 +152,33 @@ pub mod device {
             rt.bind_dyn_range(*var, *value as u64, *value as u64)
                 .context("cuda dyn pin")?;
         }
-        // Own one copy of the hardware-sized parameter set. Search borrows it;
-        // staging then moves the same buffers into the runtime.
+        // Own one copy of the hardware-sized parameter set. Search BORROWS
+        // it (a device-profiled search stages by reference, never copying
+        // a full-size model's weights); staging then moves the same
+        // buffers into the runtime.
         let mut data: FxHashMap<NodeIndex, HostBuffer> = pairs.into_iter().collect();
+        let options = luminal_cuda_lite::CompileOptions {
+            profile_on_device: true,
+            ..luminal_cuda_lite::harness_search_options()
+        };
         let t = std::time::Instant::now();
-        let outcome = rt
-            .search(&data, &luminal_cuda_lite::harness_search_options())
-            .context("cuda search")?;
+        let outcome = rt.search(&data, &options).context("cuda search")?;
         let search_ms = t.elapsed().as_millis();
         println!(
             "{name}: search {search_ms} ms | plans profiled {} | [{}]",
             outcome.plans_profiled,
             outcome.timings.summary()
         );
+        println!(
+            "{name}: winner {:.3} ms measured on device (heuristic cost {} bytes moved)",
+            outcome.best_nanos as f64 / 1e6,
+            outcome.best_heuristic_cost.saturating_sub(1)
+        );
 
         // 2. Refusal counters — all zero expected (ladder acceptance).
         let b = &outcome.refusal_breakdown;
         println!("{name}: refusals {}", b.summary());
+        println!("{name}: timed out {} (not a gate)", b.timed_out);
         if b.extract_refusals != 0 || b.plan_build_refusals != 0 || b.execute_refusals != 0 {
             bail!(
                 "nonzero search refusals — the ladder expects zero with views admitted: {}",

--- a/crates/luminal_cuda_lite/src/device.rs
+++ b/crates/luminal_cuda_lite/src/device.rs
@@ -186,6 +186,23 @@ impl CudaDevice {
     pub fn slab_bytes(&self) -> usize {
         self.slab.as_ref().map(|slab| slab.len()).unwrap_or(0)
     }
+
+    /// RELEASE THE SLAB — the SEARCH-TIME hygiene (#422 policy, Phase
+    /// 4, reversing #401's retention for this one caller):
+    /// [`crate::search`] calls this after every profiled candidate, so a
+    /// candidate whose arena high-water mark is outsized cannot hold
+    /// that memory for the rest of the search and starve its successors.
+    /// The next [`execute_plan`] re-allocates through `ensure_slab`.
+    ///
+    /// SERVING NEVER CALLS IT. `CudaRuntime::execute` keeps the slab
+    /// exactly as Phase 3 landed it: one grow-only allocation for the
+    /// runtime's life, which is the point of the persistent device.
+    /// Nothing else is released here — the context, the stream and the
+    /// NVRTC module cache all survive, which is what keeps kernel
+    /// compilation a once-per-source cost across a whole search.
+    pub fn release_slab(&mut self) {
+        self.slab = None;
+    }
 }
 
 /// A bound buffer: where its bytes are and how many there are. Derived
@@ -249,10 +266,17 @@ fn buffer_bytes(buffer: &Buffer<luminal::layouts::DecodedLayout>) -> Result<usiz
 /// index, a host copy of the slot's BACKING buffer plus its
 /// [`OutputBinding`] (the elected layout) — the escape-and-disclose
 /// fetch, universal over dense and view elections.
+///
+/// `staged` is a map of BORROWED payloads by BufferLit id (Phase 4). It
+/// used to hold the payloads themselves, which was fine while the only
+/// caller was the serving ladder — the runtime already owns them. The
+/// search now stages too, and it stages the CALLER's map, which for a
+/// full-size model is gigabytes of weights: a map of references costs
+/// one pointer per input and no copy at all.
 pub fn execute_plan(
     device: &mut CudaDevice,
     plan: &BufferIrGraph<luminal::layouts::DecodedLayout>,
-    staged: &FxHashMap<i64, HostBuffer>,
+    staged: &FxHashMap<i64, &HostBuffer>,
 ) -> Result<FxHashMap<usize, (HostBuffer, OutputBinding<luminal::layouts::DecodedLayout>)>> {
     // ESCAPE GUARD (ruling 2026-08-27): an output slot's backing storage
     // must SURVIVE the call — FreedBy::Caller, whatever the owner.

--- a/crates/luminal_cuda_lite/src/heuristic.rs
+++ b/crates/luminal_cuda_lite/src/heuristic.rs
@@ -19,10 +19,19 @@
 //! count, coalescing, tensor-core eligibility, library dispatch — so two
 //! plans this ranks a hair apart may differ by an order of magnitude on
 //! a device, and the winner it returns is "the plan that touches the
-//! least memory", never "the fastest plan". It is a placeholder until
-//! this runtime profiles ON DEVICE, mirroring the reference runtime's
-//! evaluator. Read `SearchOutcome::best_nanos` from a CL search as a
-//! byte count with a unit-shaped name, not as a duration.
+//! least memory", never "the fastest plan". Read
+//! `SearchOutcome::best_nanos` from a HEURISTIC CL search as a byte
+//! count with a unit-shaped name, not as a duration.
+//!
+//! ON DEVICE IT IS NOT CONSULTED AT ALL (Phase 4, 2026-09-03 — D6's
+//! "doesn't bias search too much", taken at full strength). With
+//! `CompileOptions::profile_on_device` set, the search ranks on measured
+//! device time and nothing else: no blend, no tie-break, no prior
+//! seeding the first generation. This function still runs once per
+//! profiled candidate, but only so the winner's byte-move cost can be
+//! REPORTED beside its measurement
+//! (`SearchOutcome::best_heuristic_cost`) — which is how the prior's
+//! bias gets measured instead of argued about.
 //!
 //! THE +1 (inherited from the retired `StaticProfiler`) keeps the metric
 //! strictly positive so a zero-cost plan — a pure-identity graph, every

--- a/crates/luminal_cuda_lite/src/lib.rs
+++ b/crates/luminal_cuda_lite/src/lib.rs
@@ -31,9 +31,12 @@
 //! - CL-3: CUDA-native ops (cuBLASLt first).
 //! - CL-4: in-place ties (the Mutating family), views + resident
 //!   geometry.
-//! - STILL OWED: profiling ON DEVICE, mirroring the reference
-//!   evaluator's design, so this runtime ranks by measured time instead
-//!   of by the heuristic's weak prior.
+//! - CL-5 (#420/#422 rejoin Phase 4, 2026-09-03): PROFILING ON DEVICE,
+//!   mirroring the reference evaluator's design —
+//!   `CompileOptions::profile_on_device` ranks candidates by measured
+//!   device time ([`profile`]) instead of by [`heuristic`]'s weak prior.
+//!   The heuristic remains the default and the device-free hosts' only
+//!   option; the two are never blended.
 //!
 //! Out-of-place by design: kernels read operand buffers and
 //! write fresh destinations, mirroring the reference executor's
@@ -54,13 +57,17 @@ pub mod search;
 
 #[cfg(feature = "device")]
 pub mod device;
+/// ON-DEVICE CANDIDATE PROFILING (Phase 4): the search's device
+/// evaluator. Device builds only — it measures, so it needs a device.
+#[cfg(feature = "device")]
+pub mod profile;
 
 pub use bindings::CudaBindings;
 pub use host_buffer::HostBuffer;
 pub use layouts::CudaPlan;
 pub use ops::{cuda_registry, cuda_registry_filtered, cuda_registry_with_cublaslt, RegisteredOp};
 pub use runtime::CudaRuntime;
-pub use search::{harness_search_options, CompileOptions, SearchOutcome};
+pub use search::{harness_search_options, CompileOptions, Evaluator, SearchOutcome};
 
 /// PLAN-TRANSPARENT (M4 Phase 5): claimable WITHOUT a kernel iff the
 /// op's DECLARED EFFECTS prove the planner folds it — no operand ever

--- a/crates/luminal_cuda_lite/src/profile.rs
+++ b/crates/luminal_cuda_lite/src/profile.rs
@@ -1,0 +1,188 @@
+//! THE DEVICE EVALUATOR — this runtime's price for one candidate plan,
+//! measured on the GPU.
+//!
+//! PHASE 4 OF THE #420/#422 REJOIN (2026-09-03), discharging the debt
+//! `lib.rs` has carried since CL-1 ("STILL OWED: profiling ON DEVICE")
+//! and ruling 4 on #386: CL must profile on device *"just like the
+//! existing profiler actually does. we need to mirror that design"*.
+//! The template is `luminal_reference::search`'s
+//! `profile_on_reference_runtime`: stage, warm up once, time `trials`
+//! executes, take the MEAN, and stop early once the candidate has
+//! provably lost.
+//!
+//! # What is mirrored, and the two places this differs
+//!
+//! MIRRORED. One warmup execution (validity + first-touch costs), then
+//! `trials` timed executions; the metric is the MEAN over trials (ruling
+//! 2, 2026-09-02 — a mean only rises as trials accumulate, which is what
+//! makes the early stop an exact argument rather than a guess); the
+//! early stop applies [`crate::search::early_stop_exceeded`] at factor
+//! 1.0 to a LOWER BOUND on the final mean.
+//!
+//! DIFFERENCE 1 — THE DEVICE IS PERSISTENT, the runtime is not rebuilt.
+//! The reference evaluator builds a FRESH `ReferenceRuntime` per
+//! candidate because its runtime is a cheap host object. Here the
+//! equivalent would throw away the CUDA context and the NVRTC module
+//! cache between candidates and recompile every kernel, which is most of
+//! a CUDA search's wall time. So the caller's [`crate::device::CudaDevice`]
+//! is reused: compilation is paid ONCE PER DISTINCT KERNEL SOURCE across
+//! the whole search. What is NOT carried between candidates is the arena
+//! slab — see the slab note on [`profile_candidate`].
+//!
+//! DIFFERENCE 2 — THE TIMED REGION INCLUDES STAGING AND READBACK.
+//! [`crate::device::execute_plan`] is one call that allocates, H2Ds the
+//! staged inputs, launches, synchronizes and D2Hs the outputs; the
+//! reference's `execute()` runs only the kernels, because its
+//! `set_data_buffer` is a separate ladder step. Splitting CL's execute
+//! into stage-once/run-many is real surgery on the executor and is NOT
+//! done here. The consequence is stated rather than hidden: a candidate's
+//! measured mean carries a per-call H2D/D2H term that is essentially the
+//! same for every candidate (same inputs, same outputs), so the RANKING
+//! is preserved while the absolute numbers are inflated — read a CL
+//! device measurement as "the cost of one whole `execute` call", which
+//! is exactly what the serving ladder pays anyway.
+
+use std::time::{Duration, Instant};
+
+use luminal::bufferize::BufferIrGraph;
+use luminal::layouts::DecodedLayout;
+use luminal::prelude::FxHashMap;
+
+use crate::device::{execute_plan, CudaDevice};
+use crate::host_buffer::HostBuffer;
+use crate::search::early_stop_exceeded;
+
+/// What a timed candidate produced.
+#[derive(Debug, Clone, Copy)]
+pub enum Measurement {
+    /// The candidate's MEAN cost per timed execution. `completed_trials`
+    /// is how many trials that mean is over — fewer than `trials` when
+    /// the early stop fired (the partial mean is still >= the lower
+    /// bound that lost, so it is still a loss when ranked).
+    Timed {
+        mean_nanos: u128,
+        completed_trials: usize,
+    },
+    /// The timed run exceeded the caller's budget. The candidate is NOT
+    /// ranked: a partial mean under a timeout is not a measurement of
+    /// the plan, it is a measurement of the budget.
+    TimedOut {
+        elapsed_nanos: u128,
+        completed_trials: usize,
+    },
+}
+
+/// Why a candidate produced no measurement — classified, because the
+/// search accounts the two differently (D10: *"runtimes can choose how
+/// to handle failures at different points"*).
+#[derive(Debug)]
+pub enum ProfileFailure {
+    /// COMPILE / STAGE / WARM UP failed. An ordinary unfit candidate,
+    /// counted with the bufferize refusals: a plan whose kernels NVRTC
+    /// will not compile, whose staged payload does not match the plan's
+    /// geometry, or which the executor refuses (the escape guard, a
+    /// missing binding) is a plan this backend cannot run — the search
+    /// drops it and tries others. It never fails the ladder.
+    Prepare(anyhow::Error),
+    /// A TIMED TRIAL failed after the warmup had already succeeded. The
+    /// same plan ran once and then did not: that is a genuine execution
+    /// refusal (an OOM at a larger slab, a launch failure), and it is
+    /// counted as one.
+    Execute(anyhow::Error),
+}
+
+impl std::fmt::Display for ProfileFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProfileFailure::Prepare(err) => write!(f, "prepare: {err:#}"),
+            ProfileFailure::Execute(err) => write!(f, "execute: {err:#}"),
+        }
+    }
+}
+
+/// PRICE ONE CANDIDATE ON THE DEVICE.
+///
+/// Phases, in order:
+///
+/// 1. PREPARE — one untimed `execute_plan`. This compiles every kernel
+///    the plan needs through the device's persistent module cache, grows
+///    the slab, stages the inputs and runs once, so it doubles as the
+///    validity check the reference evaluator's warmup is. A failure here
+///    is [`ProfileFailure::Prepare`].
+/// 2. TIMED RUN — `trials.max(1)` executions, each timed host-side
+///    around `execute_plan`, which synchronizes the stream before it
+///    returns. (CUDA events would measure the same interval minus the
+///    host-side launch overhead; host timers are used because the whole
+///    call — allocation, H2D, launches, D2H — is what is being priced,
+///    and the synchronize makes the host clock honest about the device
+///    work. Events are the deferred refinement, not a correction.)
+/// 3. EARLY STOP — after each trial, if even the LOWER BOUND on this
+///    candidate's final mean (sum so far divided by ALL trials) already
+///    exceeds `best_so_far`, the remaining trials cannot change the
+///    outcome and are skipped.
+///
+/// THE TIMEOUT COVERS THE TIMED RUN AND NOTHING ELSE (Austin, ambiguity
+/// 1: *"timeout should just cover run"*). The clock starts at the first
+/// timed trial — after compilation — and is read BETWEEN trials, so a
+/// budget is never charged for NVRTC work that the next candidate gets
+/// for free from the module cache, and a trial in flight is never
+/// interrupted (there is no cancel for a launched kernel; the honest
+/// thing is to finish the trial and then stop).
+///
+/// THE SLAB IS THE CALLER'S TO RELEASE. This function grows it through
+/// `execute_plan` and leaves it; `crate::search` releases it after each
+/// candidate (#422 reversing #401's search-time retention), so one
+/// outsized candidate cannot hold device memory hostage for the rest of
+/// the search. Serving never releases it.
+pub fn profile_candidate(
+    device: &mut CudaDevice,
+    plan: &BufferIrGraph<DecodedLayout>,
+    staged: &FxHashMap<i64, &HostBuffer>,
+    trials: usize,
+    best_so_far: Option<u128>,
+    candidate_timeout: Option<Duration>,
+) -> Result<Measurement, ProfileFailure> {
+    // 1. PREPARE: compile + stage + one untimed run (warmup + validity).
+    execute_plan(device, plan, staged).map_err(ProfileFailure::Prepare)?;
+
+    // 2. THE TIMED RUN. The budget's clock starts HERE.
+    let total = trials.max(1);
+    let run_start = Instant::now();
+    let mut sum = 0u128;
+    for trial in 0..total {
+        let start = Instant::now();
+        execute_plan(device, plan, staged).map_err(ProfileFailure::Execute)?;
+        sum += start.elapsed().as_nanos();
+        let completed = trial + 1;
+        if completed == total {
+            break;
+        }
+        // TIMEOUT, checked between trials.
+        if candidate_timeout.is_some_and(|budget| run_start.elapsed() > budget) {
+            return Ok(Measurement::TimedOut {
+                elapsed_nanos: run_start.elapsed().as_nanos(),
+                completed_trials: completed,
+            });
+        }
+        // 3. EARLY STOP (#386), on the lower bound of the final mean.
+        if best_so_far.is_some_and(|best| early_stop_exceeded(sum / total as u128, best, 1.0)) {
+            return Ok(Measurement::Timed {
+                mean_nanos: sum / completed as u128,
+                completed_trials: completed,
+            });
+        }
+    }
+    // A single trial that ran longer than the whole budget is a timeout
+    // too — the between-trials check cannot see it, and reporting it as
+    // a measurement would rank a plan the caller asked not to wait for.
+    if candidate_timeout.is_some_and(|budget| run_start.elapsed() > budget) {
+        return Ok(Measurement::TimedOut {
+            elapsed_nanos: run_start.elapsed().as_nanos(),
+            completed_trials: total,
+        });
+    }
+    Ok(Measurement::Timed {
+        mean_nanos: sum / total as u128,
+        completed_trials: total,
+    })
+}

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -422,12 +422,13 @@ impl CudaRuntime {
             .as_ref()
             .ok_or_else(|| anyhow!("load before search"))?;
 
-        // The caller's payloads are CHECKED here and go no further: this
-        // backend's search ranks candidates with the device-free
-        // heuristic (D6, 2026-09-03), which never runs anything, so
-        // there is nothing to stage. The check stays because binding a
-        // tensor that is not an input of the loaded program is a caller
-        // bug either way.
+        // The caller's payloads are CHECKED here always, because binding
+        // a tensor that is not an input of the loaded program is a
+        // caller bug under either evaluator. Whether they go FURTHER
+        // depends on how the search prices candidates: the device-free
+        // heuristic (D6, 2026-09-03) never runs anything and so needs
+        // nothing staged, while device profiling (Phase 4) executes each
+        // candidate and needs exactly these bytes.
         for tensor in input_data.keys() {
             assert!(
                 program
@@ -437,10 +438,64 @@ impl CudaRuntime {
                 "tensor {tensor:?} is not a bound input"
             );
         }
+        #[cfg(not(feature = "device"))]
+        anyhow::ensure!(
+            !options.profile_on_device,
+            "device profiling requested but cuda-lite was built without the `device` \
+             feature: this host can search by the heuristic, but a request to MEASURE \
+             must not be answered with a prior"
+        );
+
+        // THE SEARCH-TIME STAGING (Phase 4), by BufferLit id and BY
+        // REFERENCE — the ladder's `set_data` staging is a separate,
+        // later step and is untouched. A full-size model's weights are
+        // gigabytes; the search must borrow them, never copy them.
+        #[cfg(feature = "device")]
+        let staged_for_search: FxHashMap<i64, &HostBuffer> = if options.profile_on_device {
+            program
+                .input_slots
+                .iter()
+                .filter_map(|slot| input_data.get(&slot.tensor).map(|data| (slot.buffer, data)))
+                .collect()
+        } else {
+            FxHashMap::default()
+        };
+        // THE DEVICE IS CREATED LAZILY, here or at the first `execute`
+        // (Phase 3's persistent device, unchanged): a search that ranks
+        // by the heuristic still touches no CUDA API at all.
+        #[cfg(feature = "device")]
+        if options.profile_on_device && self.device.is_none() {
+            self.device = Some(crate::device::CudaDevice::new(0)?);
+        }
 
         // THIS INSTANCE's claim set, derived at load from THIS
         // instance's registry — no crate-level default is consulted.
         let allow = Some(self.allow.clone());
+        // FIELD BORROWS, not `self.matchers()`: the device evaluator
+        // holds `&mut self.device` at the same time, and only disjoint
+        // FIELD borrows can coexist — a `&self` method would borrow the
+        // whole runtime.
+        let matchers = &self.matchers;
+        let evaluator = {
+            #[cfg(feature = "device")]
+            {
+                if options.profile_on_device {
+                    crate::search::Evaluator::Device {
+                        device: self
+                            .device
+                            .as_mut()
+                            .expect("the device was just created if it was missing"),
+                        staged: &staged_for_search,
+                    }
+                } else {
+                    crate::search::Evaluator::Heuristic
+                }
+            }
+            #[cfg(not(feature = "device"))]
+            {
+                crate::search::Evaluator::Heuristic
+            }
+        };
 
         // Own matchers, own allow list, own ranking: nothing in this
         // search touches another runtime.
@@ -450,16 +505,17 @@ impl CudaRuntime {
                 &program,
                 options,
                 allow,
-                self.matchers(),
+                matchers,
+                evaluator,
             )?
         } else {
             // BUCKETED (D7): one search per Cartesian combination, each
             // validated bucket-wide before its representative is
-            // searched. Unlike the reference runtime this needs no
-            // per-bucket caller data — the ranking is device-free — so
-            // the ordinary `search` entry serves both shapes.
+            // searched. The caller's data is staged ONCE and every
+            // bucket's search borrows the same map — a bucket only
+            // changes the dim seeds, never the payloads.
             let assembly = crate::search::BucketAssembly {
-                assembled_program: &luminal::egglog_snippet::assembled_program_for(self.matchers()),
+                assembled_program: &luminal::egglog_snippet::assembled_program_for(matchers),
                 pre_schedule: &native.pre_schedule,
                 binding_seeds: &native.binding_seeds,
                 schedule: crate::bindings::CudaBindings::SCHEDULE,
@@ -473,7 +529,8 @@ impl CudaRuntime {
                 &self.dim_buckets,
                 options,
                 allow,
-                self.matchers(),
+                matchers,
+                evaluator,
             )?;
             let first = plans
                 .first()
@@ -538,11 +595,16 @@ impl CudaRuntime {
                 .plan
                 .as_ref()
                 .ok_or_else(|| anyhow!("search before execute"))?;
+            // SERVING KEEPS THE SLAB (#422 policy, Phase 4): nothing
+            // here releases it — only the search does, between
+            // candidates.
+            let staged: FxHashMap<i64, &HostBuffer> =
+                self.staged.iter().map(|(lit, data)| (*lit, data)).collect();
             let device = self
                 .device
                 .as_mut()
                 .expect("the device was just created if it was missing");
-            let outputs = crate::device::execute_plan(device, plan, &self.staged)?;
+            let outputs = crate::device::execute_plan(device, plan, &staged)?;
             self.outputs_host = outputs;
             Ok(())
         }

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -8,14 +8,29 @@
 //! core defined and two runtimes implemented. Both the loop and the
 //! extractor it drives now live in each runtime, duplicated rather than
 //! generalized ("just put this search in the cuda lite runtime\'s crate.
-//! it\'s fine."), and the profiler trait is GONE: this copy ranks
-//! candidates inline with the DEVICE-FREE HEURISTIC in
-//! [`crate::heuristic`] — a weak static prior, never a measurement.
+//! it\'s fine."), and the profiler trait is GONE: candidates are ranked
+//! INLINE by whichever [`Evaluator`] the caller hands in — there is no
+//! trait, no object, and no third implementation waiting to be written.
+//!
+//! TWO EVALUATORS (Phase 4, 2026-09-03):
+//!
+//! * [`Evaluator::Heuristic`] — the DEVICE-FREE default
+//!   ([`crate::heuristic`]): a weak static prior, never a measurement.
+//!   It is what runs on the hosts most of this crate's suite runs on.
+//! * [`Evaluator::Device`] — ON-DEVICE PROFILING ([`crate::profile`]),
+//!   selected by `CompileOptions::profile_on_device`: each candidate
+//!   plan is compiled, warmed and TIMED on a real CUDA device, mirroring
+//!   the reference runtime's evaluator (ruling 4 on #386: *"we need to
+//!   mirror that design"*).
+//!
+//! The two are never blended: with device profiling on, the heuristic is
+//! not consulted at all (D6's "doesn't bias search too much", taken at
+//! full strength — a device build ranks on measured time only).
 //!
 //! Tests live with the reference copy (`luminal_reference::search`).
 
 use std::collections::BTreeMap;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, ensure, Result};
 use colored::Colorize;
@@ -43,6 +58,30 @@ pub struct CompileOptions {
     /// `CompileOptions::search_log`; overridden by `SEARCH_LOG=0`/`1`
     /// or `LUMINAL_LOG=1`.
     pub search_log: bool,
+    /// RANK CANDIDATES BY MEASURED DEVICE TIME (Phase 4, 2026-09-03)
+    /// instead of by the device-free heuristic. OFF by default, so every
+    /// trajectory that existed before this option is byte-for-byte the
+    /// one it was.
+    ///
+    /// ON requires the `device` feature, a CUDA device, and the caller's
+    /// input payloads (the ladder's `search` stages them); without the
+    /// feature the search REFUSES by name rather than silently falling
+    /// back to the heuristic — a caller that asked for measurement must
+    /// never be handed a prior.
+    pub profile_on_device: bool,
+    /// PER-CANDIDATE BUDGET FOR THE TIMED RUN — and for nothing else
+    /// (ruling, 2026-09-03: *"timeout should just cover run"*). The
+    /// clock starts at the first TIMED trial, after the candidate has
+    /// been compiled and warmed, and is checked BETWEEN trials; a
+    /// candidate that exceeds it is not ranked and is counted under
+    /// [`RefusalBreakdown::timed_out`]. `None` = no budget.
+    ///
+    /// It is deliberately NOT a compile budget: NVRTC time is paid once
+    /// per distinct kernel source across the whole search (the device's
+    /// persistent module cache), so charging it to whichever candidate
+    /// happened to hit a cold cache would time out plans for a cost
+    /// their successors do not pay.
+    pub candidate_timeout: Option<Duration>,
 }
 
 impl Default for CompileOptions {
@@ -54,6 +93,8 @@ impl Default for CompileOptions {
             trials: 3,
             seed: 0,
             search_log: true,
+            profile_on_device: false,
+            candidate_timeout: None,
         }
     }
 }
@@ -213,6 +254,14 @@ pub struct SearchOutcome {
     pub best_plan: BufferIrGraph<luminal::layouts::DecodedLayout>,
     pub best_genome: Genome,
     pub best_nanos: u128,
+    /// THE WINNER'S HEURISTIC COST, always computed, never consulted by
+    /// a device-profiled ranking. With [`Evaluator::Heuristic`] it IS
+    /// `best_nanos`; with [`Evaluator::Device`] the two sit side by side
+    /// so a caller can see how far the byte-move prior was from the
+    /// measurement (which is the only honest way to talk about D6's
+    /// "doesn't bias search too much" — by reporting the gap, not by
+    /// mixing the numbers).
+    pub best_heuristic_cost: u128,
     /// Plans actually profiled (distinct fingerprints).
     pub plans_profiled: usize,
     /// Candidates answered from the fingerprint cache without re-profiling.
@@ -247,8 +296,23 @@ pub struct RefusalBreakdown {
     /// candidate at all).
     pub with_dead_ends: usize,
     /// Genomes that extracted but failed bufferize / execute.
+    ///
+    /// UNDER DEVICE PROFILING (Phase 4) the plan-build count also
+    /// carries candidates whose PREPARE step failed — NVRTC compilation,
+    /// module load, staging, or the warmup execution. That is a
+    /// deliberate classification (D10: *"runtimes can choose how to
+    /// handle failures at different points"*): a plan the device cannot
+    /// compile is an ordinary unfit candidate, indistinguishable in kind
+    /// from one bufferize refused, and it must NOT fail the ladder.
     pub plan_build_refusals: usize,
+    /// Failures in a TIMED trial, after the warmup already succeeded.
     pub execute_refusals: usize,
+    /// Candidates whose TIMED RUN exceeded
+    /// [`CompileOptions::candidate_timeout`]. NOT a refusal in the
+    /// execute sense — nothing failed, the plan is simply too slow to
+    /// finish measuring — so it is counted apart and is not part of the
+    /// zero-refusal ladder acceptance.
+    pub timed_out: usize,
     /// First few classified summaries, verbatim.
     pub exemplars: Vec<String>,
 }
@@ -256,13 +320,119 @@ pub struct RefusalBreakdown {
 impl RefusalBreakdown {
     pub fn summary(&self) -> String {
         format!(
-            "extract refusals {} (choice-cycles {}, dead-ends {}), bufferize {}, execute {}",
+            "extract refusals {} (choice-cycles {}, dead-ends {}), bufferize {}, execute {}, \
+             timed out {}",
             self.extract_refusals,
             self.with_choice_cycles,
             self.with_dead_ends,
             self.plan_build_refusals,
-            self.execute_refusals
+            self.execute_refusals,
+            self.timed_out
         )
+    }
+}
+
+/// HOW ONE CANDIDATE IS PRICED — the whole of what used to be a
+/// `PlanProfiler` trait, as a two-variant enum the caller constructs.
+///
+/// NO TRAIT (ruling, 2026-09-03: keep it simple, no new traits). There
+/// are exactly two ways this crate prices a plan and both live in this
+/// crate, so an enum names them and the match is exhaustive.
+pub enum Evaluator<'a> {
+    /// The DEVICE-FREE prior ([`crate::heuristic`]): bytes moved over
+    /// the extracted graph. Nothing executes.
+    Heuristic,
+    /// ON-DEVICE MEASUREMENT ([`crate::profile::profile_candidate`]) on
+    /// a persistent device — the module cache and the slab are the
+    /// runtime's, so kernel compilation is paid once per distinct source
+    /// across the search rather than once per candidate.
+    ///
+    /// `staged` is BORROWED, by BufferLit id, exactly as
+    /// [`crate::device::execute_plan`] wants it. It is a map of
+    /// references and not of payloads on purpose: a full-size model's
+    /// weights are gigabytes on the host and the search must not hold a
+    /// second copy of them.
+    #[cfg(feature = "device")]
+    Device {
+        device: &'a mut crate::device::CudaDevice,
+        staged: &'a FxHashMap<i64, &'a crate::host_buffer::HostBuffer>,
+    },
+    /// The lifetime placeholder for builds WITHOUT the `device` feature,
+    /// so [`search_implementations`]'s signature is the same in both.
+    /// Unconstructible in practice — [`Evaluator::Heuristic`] is the
+    /// only variant a device-free build has.
+    #[cfg(not(feature = "device"))]
+    #[doc(hidden)]
+    NoDevice(std::marker::PhantomData<&'a ()>),
+}
+
+impl Evaluator<'_> {
+    /// Lend this evaluator to a nested search (the bucketed entry runs
+    /// one search per Cartesian combination and must hand the SAME
+    /// device to each).
+    pub fn reborrow(&mut self) -> Evaluator<'_> {
+        match self {
+            Evaluator::Heuristic => Evaluator::Heuristic,
+            #[cfg(feature = "device")]
+            Evaluator::Device { device, staged } => Evaluator::Device { device, staged },
+            #[cfg(not(feature = "device"))]
+            Evaluator::NoDevice(marker) => Evaluator::NoDevice(*marker),
+        }
+    }
+
+    /// Does this evaluator measure on a device?
+    fn is_device(&self) -> bool {
+        #[cfg(feature = "device")]
+        {
+            matches!(self, Evaluator::Device { .. })
+        }
+        #[cfg(not(feature = "device"))]
+        {
+            false
+        }
+    }
+}
+
+/// Main's `early_stop_exceeded` (its `src/op.rs`), retyped from
+/// `Duration` to this branch's u128 nanos: true once a candidate's mean
+/// trial cost exceeds `best * factor`, i.e. the candidate has already
+/// lost by at least that margin and further trials can only refine a
+/// metric that is out of contention.
+///
+/// THE DEVICE EVALUATOR ([`crate::profile`]) applies it at `factor =
+/// 1.0` to a LOWER BOUND on the candidate's final mean (the trials so
+/// far divided by ALL of them, i.e. assuming every remaining trial costs
+/// zero), which makes the stop exact rather than heuristic: a candidate
+/// whose best conceivable final mean already exceeds the incumbent
+/// cannot win. The factor survives because it is main's semantics and
+/// main's tuning knob (`CompileOptions::early_stop_factor`).
+///
+/// Duplicated from `luminal_reference::search` under the duplication
+/// ruling — the two runtimes share no search code.
+pub fn early_stop_exceeded(mean_nanos: u128, best_nanos: u128, factor: f64) -> bool {
+    mean_nanos as f64 > best_nanos as f64 * factor
+}
+
+#[cfg(test)]
+mod early_stop_tests {
+    use super::early_stop_exceeded;
+
+    /// Main's `test_early_stop_exceeded` (`src/op.rs`), retyped from
+    /// `Duration` to nanos.
+    #[test]
+    fn early_stop_exceeded_keeps_mains_margin_semantics() {
+        const MS: u128 = 1_000_000;
+        let best = 5 * MS;
+        // 2x cutoff: 10ms mean is at the boundary, not over it.
+        assert!(!early_stop_exceeded(10 * MS, best, 2.0));
+        assert!(early_stop_exceeded(11 * MS, best, 2.0));
+        // A candidate faster than best never stops early.
+        assert!(!early_stop_exceeded(4 * MS, best, 2.0));
+        // Factor 1.0 stops anything slower than best.
+        assert!(early_stop_exceeded(6 * MS, best, 1.0));
+        // ...and NOT a tie: the incumbent keeps its seat, but a tied
+        // candidate is still worth finishing (it is not yet losing).
+        assert!(!early_stop_exceeded(5 * MS, best, 1.0));
     }
 }
 
@@ -603,6 +773,33 @@ fn bufferize_cycle_tripwire(
     ))
 }
 
+/// The incumbent: the best-ranked candidate so far, its plan, and the
+/// heuristic cost of the same graph (carried alongside, never mixed into
+/// the ranking — see [`SearchOutcome::best_heuristic_cost`]).
+struct Best {
+    nanos: u128,
+    heuristic: u128,
+    genome: Genome,
+    plan: BufferIrGraph<luminal::layouts::DecodedLayout>,
+}
+
+/// What pricing one candidate produced. A cost is ranked; the other
+/// three are accounted and the candidate is dropped.
+///
+/// Only the device evaluator can produce the last three, so a
+/// device-free build constructs `Cost` alone.
+#[cfg_attr(not(feature = "device"), allow(dead_code))]
+enum Priced {
+    Cost(u128),
+    /// The timed run exceeded [`CompileOptions::candidate_timeout`].
+    TimedOut(String),
+    /// Compile / stage / warmup failed — an ordinary unfit candidate
+    /// (D10), counted with the bufferize refusals.
+    PrepareFailed(String),
+    /// A timed trial failed after the warmup had succeeded.
+    ExecuteFailed(String),
+}
+
 /// THE SELECTION LOOP for this backend: the caller supplies its OWN
 /// matcher vocabulary and its OWN allow list — both are properties of
 /// the runtime INSTANCE, chosen when it was loaded (see
@@ -612,18 +809,36 @@ fn bufferize_cycle_tripwire(
 /// not clonable, so the list lives in the runtime and is lent here.
 /// Deterministic for a fixed seed.
 ///
-/// NO CALLER DATA (D6, 2026-09-03): candidates are ranked by
-/// [`crate::heuristic::heuristic_cost_of`], which never runs anything,
-/// so there is nothing to stage. The ladder's `search` still takes the
-/// caller's payloads and still checks them against the program's bound
-/// inputs — it just does not hand them here.
+/// HOW CANDIDATES ARE PRICED is the caller's too, as the one extra
+/// argument: [`Evaluator::Heuristic`] ranks device-free and needs no
+/// caller data (D6, 2026-09-03), [`Evaluator::Device`] carries the
+/// device and the staged payloads and ranks by measured time (Phase 4).
+/// `options.profile_on_device` and the evaluator must AGREE — a
+/// mismatch is refused up front rather than silently ranking by the
+/// prior when measurement was asked for.
+// The evaluator is mutated (reborrowed per candidate) only by the
+// device arm, which a device-free build compiles out.
+#[cfg_attr(not(feature = "device"), allow(unused_mut))]
 pub fn search_implementations(
     egraph: &egraph_serialize::EGraph,
     program: &LogicalProgram,
     options: &CompileOptions,
     allow_override: Option<Vec<&'static str>>,
     matchers: &[Box<dyn luminal::layout_ir::OpMatcher>],
+    mut evaluator: Evaluator<'_>,
 ) -> Result<SearchOutcome> {
+    ensure!(
+        !options.profile_on_device || evaluator.is_device(),
+        "device profiling requested but {}",
+        if cfg!(feature = "device") {
+            "this search was handed the heuristic evaluator (the ladder's \
+             `CudaRuntime::search` builds the device one)"
+        } else {
+            "the `device` feature is off: this build has no device evaluator, and \
+             ranking by the heuristic instead would answer a request for a \
+             measurement with a prior"
+        }
+    );
     let mut timings = SearchTimings::default();
     let analysis_start = Instant::now();
     // The allow list narrows the caller's matcher set; None = the whole set.
@@ -667,7 +882,7 @@ pub fn search_implementations(
     // causes instead of shrugging.
     let mut refusals: Vec<String> = Vec::new();
     let mut breakdown = RefusalBreakdown::default();
-    let mut best: Option<(u128, Genome, BufferIrGraph<luminal::layouts::DecodedLayout>)> = None;
+    let mut best: Option<Best> = None;
     // Live progress (#391), on stderr (via the capture-aware adapter, so
     // test output stays clean) and never on a caller's stdout.
     // `None` = the option (or `SEARCH_LOG`) says quiet.
@@ -683,8 +898,8 @@ pub fn search_implementations(
                     candidates.push(random_genome(&mut rng));
                 }
             }
-            Some((_, parent, _)) => {
-                let parent = parent.clone();
+            Some(incumbent) => {
+                let parent = incumbent.genome.clone();
                 for _ in 0..options.generation_size {
                     candidates.push(mutate(&parent, &mut rng, options.mutations));
                 }
@@ -786,19 +1001,101 @@ pub fn search_implementations(
                             continue;
                         }
                     };
+                    // The heuristic cost of this graph is ALWAYS computed
+                    // — it is what the outcome reports beside a measured
+                    // winner — but under device profiling it is never
+                    // ranked on.
+                    let heuristic = crate::heuristic::heuristic_cost_of(&graph);
                     let profile_start = Instant::now();
-                    // DEVICE-FREE RANKING (D6): a static prior over the
-                    // extracted graph, never a measurement. See
-                    // [`crate::heuristic`] for what it does and does not
-                    // claim.
-                    let profiled: Result<u128> = Ok(crate::heuristic::heuristic_cost_of(&graph));
+                    let priced = if options.profile_on_device {
+                        // ON-DEVICE MEASUREMENT (Phase 4). Compile +
+                        // warm + time on the persistent device, then
+                        // RELEASE THE SLAB: at search time a candidate's
+                        // arena is not kept between candidates (#422
+                        // reversing #401's retention), so a plan with an
+                        // outsized high-water mark cannot starve the
+                        // next candidate of device memory. Serving keeps
+                        // it — `CudaRuntime::execute` never releases.
+                        #[cfg(feature = "device")]
+                        {
+                            let Evaluator::Device { device, staged } = &mut evaluator else {
+                                unreachable!(
+                                    "profile_on_device without a device evaluator is refused \
+                                     before the loop"
+                                )
+                            };
+                            let measured = crate::profile::profile_candidate(
+                                device,
+                                &plan,
+                                staged,
+                                options.trials,
+                                best.as_ref().map(|incumbent| incumbent.nanos),
+                                options.candidate_timeout,
+                            );
+                            device.release_slab();
+                            match measured {
+                                Ok(crate::profile::Measurement::Timed { mean_nanos, .. }) => {
+                                    Priced::Cost(mean_nanos)
+                                }
+                                Ok(crate::profile::Measurement::TimedOut {
+                                    elapsed_nanos,
+                                    completed_trials,
+                                }) => Priced::TimedOut(format!(
+                                    "candidate exceeded the timed-run budget after \
+                                     {completed_trials} trial(s), {:.3} ms elapsed",
+                                    elapsed_nanos as f64 / 1e6
+                                )),
+                                Err(crate::profile::ProfileFailure::Prepare(err)) => {
+                                    Priced::PrepareFailed(format!("{err:#}"))
+                                }
+                                Err(crate::profile::ProfileFailure::Execute(err)) => {
+                                    Priced::ExecuteFailed(format!("{err:#}"))
+                                }
+                            }
+                        }
+                        #[cfg(not(feature = "device"))]
+                        {
+                            unreachable!(
+                                "profile_on_device without the `device` feature is refused \
+                                 before the loop"
+                            )
+                        }
+                    } else {
+                        // DEVICE-FREE RANKING (D6): a static prior over
+                        // the extracted graph, never a measurement. See
+                        // [`crate::heuristic`] for what it does and does
+                        // not claim.
+                        Priced::Cost(heuristic)
+                    };
                     timings.profile_nanos += profile_start.elapsed().as_nanos();
-                    let nanos = match profiled {
-                        Ok(nanos) => nanos,
-                        Err(err) => {
+                    let nanos = match priced {
+                        Priced::Cost(nanos) => nanos,
+                        Priced::TimedOut(note) => {
+                            // NOT a refusal: nothing failed, the plan is
+                            // just too slow to finish measuring. Counted
+                            // apart so the zero-refusal ladder
+                            // acceptance stays about failures.
+                            breakdown.timed_out += 1;
+                            if refusals.len() < 8 {
+                                refusals.push(format!("timed out: {note}"));
+                            }
+                            continue;
+                        }
+                        Priced::PrepareFailed(note) => {
+                            // D10: a plan the device cannot compile,
+                            // stage or warm up is an ordinary unfit
+                            // candidate — accounted with the other
+                            // plan-build refusals, never fatal.
+                            breakdown.plan_build_refusals += 1;
+                            if refusals.len() < 8 {
+                                refusals.push(format!("device prepare: {note}"));
+                            }
+                            continue;
+                        }
+                        Priced::ExecuteFailed(note) => {
                             breakdown.execute_refusals += 1;
                             if refusals.len() < 8 {
-                                refusals.push(format!("execute: {err:#}"));
+                                refusals.push(format!("execute: {note}"));
                             }
                             continue;
                         }
@@ -807,7 +1104,7 @@ pub fn search_implementations(
                     plans_profiled += 1;
                     let improved = best
                         .as_ref()
-                        .is_none_or(|(best_nanos, _, _)| nanos < *best_nanos);
+                        .is_none_or(|incumbent| nanos < incumbent.nanos);
                     if let Some(progress) = progress.as_mut() {
                         // The FIRST profiled plan IS the baseline, so it
                         // reports as `Start`, never as an improvement on
@@ -819,14 +1116,19 @@ pub fn search_implementations(
                         }
                     }
                     if improved {
-                        best = Some((nanos, genome.clone(), plan));
+                        best = Some(Best {
+                            nanos,
+                            heuristic,
+                            genome: genome.clone(),
+                            plan,
+                        });
                     }
                     continue;
                 }
             };
             if best
                 .as_ref()
-                .is_none_or(|(best_nanos, _, _)| nanos < *best_nanos)
+                .is_none_or(|incumbent| nanos < incumbent.nanos)
             {
                 let build_start = Instant::now();
                 let dps = luminal::dps::dps_rewrite(&graph);
@@ -841,7 +1143,12 @@ pub fn search_implementations(
                         continue;
                     }
                 };
-                best = Some((nanos, genome.clone(), plan));
+                best = Some(Best {
+                    nanos,
+                    heuristic: crate::heuristic::heuristic_cost_of(&graph),
+                    genome: genome.clone(),
+                    plan,
+                });
             }
         }
 
@@ -853,14 +1160,15 @@ pub fn search_implementations(
     if let Some(progress) = progress.as_mut() {
         progress.finish();
     }
-    let (best_nanos, best_genome, best_plan) = best.ok_or_else(|| {
+    let best = best.ok_or_else(|| {
         anyhow!("no candidate genome produced an executable plan; refusals: {refusals:#?}")
     })?;
     let _ = program; // binding tables travel with the caller; kept for future bucket plumbing
     Ok(SearchOutcome {
-        best_plan,
-        best_genome,
-        best_nanos,
+        best_plan: best.plan,
+        best_genome: best.genome,
+        best_nanos: best.nanos,
+        best_heuristic_cost: best.heuristic,
         plans_profiled,
         fingerprint_hits,
         timings,
@@ -927,6 +1235,7 @@ pub fn bucketed_search_implementations(
     options: &CompileOptions,
     allow_override: Option<Vec<&'static str>>,
     matchers: &[Box<dyn luminal::layout_ir::OpMatcher>],
+    mut evaluator: Evaluator<'_>,
 ) -> Result<Vec<BucketPlan>> {
     ensure!(!dim_buckets.is_empty(), "no dim buckets supplied");
     let mut plans = Vec::new();
@@ -945,6 +1254,10 @@ pub fn bucketed_search_implementations(
             options,
             allow_override.clone(),
             matchers,
+            // Every bucket's search prices on the SAME device: the
+            // module cache and the staged payloads are shared across
+            // combinations, so the evaluator is lent, not rebuilt.
+            evaluator.reborrow(),
         )?;
         plans.push(BucketPlan {
             ranges,
@@ -1080,5 +1393,10 @@ pub fn harness_search_options() -> CompileOptions {
         trials: 1,
         seed: 0,
         search_log: false,
+        // UNCHANGED BY PHASE 4: the harness budget is device-free, so
+        // every suite that uses it keeps the trajectory it had. Callers
+        // that want measurement flip the flag on a copy (the examples'
+        // `run_cuda` does, and `tests/device_profile.rs`).
+        ..CompileOptions::default()
     }
 }

--- a/crates/luminal_cuda_lite/tests/composed_read_families.rs
+++ b/crates/luminal_cuda_lite/tests/composed_read_families.rs
@@ -41,6 +41,7 @@ fn view_search_options(seed: u64) -> CompileOptions {
         trials: 1,
         seed,
         search_log: false,
+        ..Default::default()
     }
 }
 

--- a/crates/luminal_cuda_lite/tests/cublaslt_bias_premise.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_bias_premise.rs
@@ -223,6 +223,7 @@ fn search_elects_the_bias_form_and_binds_a_col_d() {
             trials: 1,
             seed,
             search_log: false,
+            ..Default::default()
         };
         let mut rt = CudaRuntime::load_with_cublaslt(&cx).expect("load");
         let outcome = match rt.search(&data, &options) {

--- a/crates/luminal_cuda_lite/tests/cublaslt_contracts.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_contracts.rs
@@ -391,6 +391,7 @@ fn marker_elected_bias_plan_matches_decomposed_route_tolerance_based() {
         trials: 1,
         seed: BIAS_ELECTING_SEED,
         search_log: false,
+        ..Default::default()
     };
 
     let (cx, x, w, b, out) = build();
@@ -463,6 +464,7 @@ fn marker_elected_plan_matches_decomposed_route_tolerance_based() {
         trials: 1,
         seed: 0,
         search_log: false,
+        ..Default::default()
     };
 
     // Marker-elected route.

--- a/crates/luminal_cuda_lite/tests/cublaslt_election.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_election.rs
@@ -196,6 +196,7 @@ fn canonical_2d_matmul_elects_the_marker() {
         trials: 1,
         seed: 0,
         search_log: false,
+        ..Default::default()
     };
     let row = search_and_count_opts("matmul_2d(4x8 . 8x3)", &cx, &pairs, &options);
     let Row::Searched { elected, computes } = row else {

--- a/crates/luminal_cuda_lite/tests/device_profile.rs
+++ b/crates/luminal_cuda_lite/tests/device_profile.rs
@@ -177,6 +177,29 @@ fn device_profiled_search_ranks_by_measurement_and_keeps_the_numbers() {
         outcome.best_nanos
     );
 
+    // THE SAME SEARCH, RANKED BY THE PRIOR — reported, not asserted.
+    // Same seed, same budget, same candidates: the only difference is
+    // what decides the winner. Printing the byte cost of each winner is
+    // the direct measurement of D6's "doesn't bias search too much"
+    // question, and it is the reason `best_heuristic_cost` exists.
+    // No assertion: which plan measures fastest is device- and
+    // noise-dependent, and pinning it would pin the noise.
+    let mut prior_rt = CudaRuntime::load(&cx).expect("cuda load");
+    let prior = prior_rt
+        .search(&data, &luminal_cuda_lite::harness_search_options())
+        .expect("heuristic search finds a plan");
+    println!(
+        "device-profiled mini-llama3: the PRIOR would elect a plan of {} bytes moved; \
+         the MEASUREMENT elected one of {} ({})",
+        prior.best_heuristic_cost.saturating_sub(1),
+        outcome.best_heuristic_cost.saturating_sub(1),
+        if prior.best_heuristic_cost == outcome.best_heuristic_cost {
+            "same byte cost"
+        } else {
+            "DIFFERENT — the measurement did not pick the prior's winner"
+        }
+    );
+
     // The plan the measurement elected still computes the same thing.
     for (id, v) in &floats {
         rt.set_data(*id, v.clone());

--- a/crates/luminal_cuda_lite/tests/device_profile.rs
+++ b/crates/luminal_cuda_lite/tests/device_profile.rs
@@ -1,0 +1,222 @@
+//! THE DEVICE EVALUATOR, on a device (`device` feature only) — Phase 4
+//! of the #420/#422 rejoin.
+//!
+//! `CompileOptions::profile_on_device` makes the CUDA-lite search rank
+//! candidates by MEASURED time instead of by the byte-move heuristic
+//! (`crate::profile`, mirroring `luminal_reference`'s evaluator). This
+//! suite is the probe that the whole path works end to end on real
+//! hardware:
+//!
+//! * a device-profiled search over the mini-llama decode block completes
+//!   at the shared harness budget with candidates actually profiled and
+//!   ZERO plan-build refusals (nothing failed to compile, stage or warm
+//!   up);
+//! * the plan it elects still produces the reference runtime's numbers,
+//!   to the fidelity battery's tolerance — a search that measures must
+//!   not also change the answer;
+//! * the measurement and the heuristic cost of the SAME winner are
+//!   printed side by side, which is the only honest way to talk about
+//!   how much the device-free prior was biasing this backend;
+//! * a zero budget times every candidate out, and the refusal accounting
+//!   says so by name rather than reporting an execution failure.
+#![cfg(feature = "device")]
+
+use luminal::dtype::DType;
+use luminal::graph::Graph;
+use luminal::prelude::{FxHashMap, NodeIndex};
+use luminal::shape::IntExpr;
+use luminal_cuda_lite::{CompileOptions, CudaRuntime, HostBuffer};
+use luminal_reference::TypedBuffer;
+use mini_llama3::MiniLlama3;
+
+/// The examples' seeding discipline, verbatim.
+fn weights(n: usize, seed: usize) -> Vec<f32> {
+    (0..n)
+        .map(|i| (((i * 37 + seed * 101 + 13) % 121) as f32 / 100.0) - 0.6)
+        .collect()
+}
+
+const VOCAB: usize = 5;
+const D: usize = 8;
+
+/// The mini-llama3 decode step: embedding gather, QKV projections, the
+/// KV-cache scatter/gather, attention, the SwiGLU MLP and the output
+/// projection — the smallest graph in this crate's suite that exercises
+/// every kernel family the device executor has.
+fn mini_llama3_fixture() -> (
+    Graph,
+    Vec<(NodeIndex, Vec<f32>)>,
+    Vec<(NodeIndex, Vec<i32>)>,
+    NodeIndex,
+) {
+    let mut cx = Graph::new();
+    let model = MiniLlama3::new(VOCAB, D, 12, 4, 2, 1, &mut cx);
+    let ids = cx.tensor(1, DType::Int);
+    let k_cache = cx.tensor((4, 4), DType::F32);
+    let v_cache = cx.tensor((4, 4), DType::F32);
+    let gather_idx = cx.tensor(2, DType::Int);
+    let scatter_idx = cx.tensor(1, DType::Int);
+    let caches = vec![(k_cache, v_cache)];
+    let (logits, _caches_out) =
+        model.forward(ids, &caches, gather_idx, scatter_idx, IntExpr::from(1usize));
+    let logits = logits.output();
+
+    let block = &model.blocks[0];
+    let floats: Vec<(NodeIndex, Vec<f32>)> = vec![
+        (model.embed.weight.id, weights(VOCAB * D, 1)),
+        (block.wq.weight.id, weights(D * D, 2)),
+        (block.wk.weight.id, weights(D * 4, 3)),
+        (block.wv.weight.id, weights(D * 4, 4)),
+        (block.wo.weight.id, weights(D * D, 5)),
+        (block.gate.weight.id, weights(D * 12, 6)),
+        (block.up.weight.id, weights(D * 12, 7)),
+        (block.down.weight.id, weights(12 * D, 8)),
+        (k_cache.id, weights(16, 9)),
+        (v_cache.id, weights(16, 10)),
+    ];
+    let ints: Vec<(NodeIndex, Vec<i32>)> = vec![
+        (ids.id, vec![3i32]),
+        (gather_idx.id, vec![0i32, 1]),
+        (scatter_idx.id, vec![1i32]),
+    ];
+    (cx, floats, ints, logits.id)
+}
+
+/// Read a device output through its RETURNED LAYOUT (the
+/// escape-and-disclose contract; `device_fidelity.rs`'s `walked_dense`).
+fn walked_dense(rt: &CudaRuntime, out: NodeIndex) -> Vec<f32> {
+    let (data, binding) = rt.fetch(out).expect("escape-and-disclose fetch");
+    let bytes = data
+        .as_f32()
+        .unwrap_or_else(|err| panic!("output is not f32: {err}"));
+    luminal_cuda_lite::layouts::dense_f32(&bytes, &binding.layout)
+        .expect("the returned layout reads dense over its backing buffer")
+}
+
+/// The fidelity battery's tolerance, verbatim.
+fn assert_close(want: &[f32], got: &[f32], what: &str) {
+    assert_eq!(want.len(), got.len(), "{what}: length mismatch");
+    for (i, (w, g)) in want.iter().zip(got).enumerate() {
+        let tol = 1e-5f32.max(w.abs() * 1e-5);
+        assert!(
+            (w - g).abs() <= tol,
+            "{what}: element {i} diverges — reference {w} vs device {g}"
+        );
+    }
+}
+
+#[test]
+fn device_profiled_search_ranks_by_measurement_and_keeps_the_numbers() {
+    let (cx, floats, ints, out) = mini_llama3_fixture();
+
+    // The reference answer, from the host runtime's own search.
+    let staged: Vec<(NodeIndex, TypedBuffer)> = floats
+        .iter()
+        .map(|(id, v)| (*id, TypedBuffer::from(v.clone())))
+        .chain(
+            ints.iter()
+                .map(|(id, v)| (*id, TypedBuffer::from(v.clone()))),
+        )
+        .collect();
+    let reference = luminal_reference::harness::run_reference(&cx, &staged);
+    let want = reference.get_f32(out).expect("reference logits").clone();
+
+    // The device-profiled search: the shared 2x4 harness budget, ranked
+    // by measured device time.
+    let data: FxHashMap<NodeIndex, HostBuffer> = floats
+        .iter()
+        .map(|(id, v)| (*id, HostBuffer::from(v.clone())))
+        .chain(
+            ints.iter()
+                .map(|(id, v)| (*id, HostBuffer::from(v.clone()))),
+        )
+        .collect();
+    let options = CompileOptions {
+        profile_on_device: true,
+        ..luminal_cuda_lite::harness_search_options()
+    };
+    let mut rt = CudaRuntime::load(&cx).expect("cuda load");
+    let start = std::time::Instant::now();
+    let outcome = rt
+        .search(&data, &options)
+        .expect("device-profiled search finds a plan");
+    let search_ms = start.elapsed().as_millis();
+
+    println!(
+        "device-profiled mini-llama3: search {search_ms} ms | plans profiled {} | \
+         fingerprint hits {} | [{}]",
+        outcome.plans_profiled,
+        outcome.fingerprint_hits,
+        outcome.timings.summary()
+    );
+    println!(
+        "device-profiled mini-llama3: winner {:.6} ms measured on device, \
+         heuristic cost {} bytes moved | refusals {}",
+        outcome.best_nanos as f64 / 1e6,
+        outcome.best_heuristic_cost.saturating_sub(1),
+        outcome.refusal_breakdown.summary()
+    );
+
+    assert!(
+        outcome.plans_profiled > 0,
+        "no plan was profiled on the device"
+    );
+    let b = &outcome.refusal_breakdown;
+    assert_eq!(
+        (b.plan_build_refusals, b.execute_refusals, b.timed_out),
+        (0, 0, 0),
+        "a device-profiled search of this fixture expects no compile/execute \
+         failures and no timeouts: {}",
+        b.summary()
+    );
+    // A MEASUREMENT, not a byte count: the two are unrelated numbers and
+    // a whole kernel launch cannot be a handful of nanoseconds.
+    assert!(
+        outcome.best_nanos > 1_000,
+        "winner measured {} ns — that is not a device execution",
+        outcome.best_nanos
+    );
+
+    // The plan the measurement elected still computes the same thing.
+    for (id, v) in &floats {
+        rt.set_data(*id, v.clone());
+    }
+    for (id, v) in &ints {
+        rt.set_data(*id, v.clone());
+    }
+    rt.execute().expect("device execute of the profiled winner");
+    let got = walked_dense(&rt, out);
+    assert_close(&want, &got, "device-profiled mini-llama3 logits");
+}
+
+/// THE TIMEOUT COVERS THE TIMED RUN (ruling: *"timeout should just cover
+/// run"*). A zero budget cannot be met by any candidate, so every one of
+/// them times out, none is ranked, and the search refuses — naming the
+/// timeout rather than reporting an execution failure, which is the
+/// distinction `RefusalBreakdown::timed_out` exists to keep.
+#[test]
+fn a_zero_budget_times_every_candidate_out_and_says_so() {
+    let (cx, floats, ints, _out) = mini_llama3_fixture();
+    let data: FxHashMap<NodeIndex, HostBuffer> = floats
+        .iter()
+        .map(|(id, v)| (*id, HostBuffer::from(v.clone())))
+        .chain(
+            ints.iter()
+                .map(|(id, v)| (*id, HostBuffer::from(v.clone()))),
+        )
+        .collect();
+    let options = CompileOptions {
+        profile_on_device: true,
+        candidate_timeout: Some(std::time::Duration::ZERO),
+        ..luminal_cuda_lite::harness_search_options()
+    };
+    let mut rt = CudaRuntime::load(&cx).expect("cuda load");
+    let err = rt
+        .search(&data, &options)
+        .expect_err("a zero timed-run budget leaves no candidate ranked");
+    let text = format!("{err:#}");
+    assert!(
+        text.contains("timed out"),
+        "the refusal must name the timeout, not something else: {text}"
+    );
+}

--- a/crates/luminal_cuda_lite/tests/device_view_differentials.rs
+++ b/crates/luminal_cuda_lite/tests/device_view_differentials.rs
@@ -56,6 +56,7 @@ fn view_search_options() -> CompileOptions {
         trials: 1,
         seed: 0,
         search_log: false,
+        ..Default::default()
     }
 }
 

--- a/crates/luminal_cuda_lite/tests/ladder_refusals.rs
+++ b/crates/luminal_cuda_lite/tests/ladder_refusals.rs
@@ -138,6 +138,7 @@ fn run_rung(layers: usize, d: usize, default_budget: bool) -> (usize, usize, usi
             trials: 1,
             seed: 0,
             search_log: false,
+            ..Default::default()
         }
     };
     let start = std::time::Instant::now();

--- a/crates/luminal_cuda_lite/tests/view_admission.rs
+++ b/crates/luminal_cuda_lite/tests/view_admission.rs
@@ -47,6 +47,7 @@ fn view_search_options() -> CompileOptions {
         trials: 1,
         seed: 0,
         search_log: false,
+        ..Default::default()
     }
 }
 

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -3028,6 +3028,246 @@ laptop gate, not a box-only one.
 - **Kernel-count printing** in the examples' support module counts
   `Compute` nodes including `BufferAlloc`/`BufferFree`; left as is.
 
+## Program: #420/#422 rejoin — Phase 4 (device evaluator)
+
+**The move.** CUDA-lite now profiles candidate plans ON THE DEVICE. Since
+CL-1 this runtime's search has ranked by `heuristic::heuristic_cost_of` —
+bytes moved over the extracted graph, a weak static prior — and `lib.rs`
+carried the debt in writing ("STILL OWED: profiling ON DEVICE, mirroring
+the reference evaluator's design"). `CompileOptions::profile_on_device`
+discharges it: each candidate plan is compiled, warmed and TIMED on a
+real GPU, and the winner is the fastest plan measured, not the plan that
+touches the least memory.
+
+**Austin's rulings this implements** (2026-09-03). Ruling 4 on #386: CL
+must eventually profile on device *"just like the existing profiler
+actually does. we need to mirror that design"* — the reference runtime's
+evaluator is the template, not a new invention. D2: the GA stays. D6: the
+CL-local device-free evaluator stays, is called `heuristic`, and must
+*"not bias search too much"*. Ambiguity 1: *"timeout should just cover
+run"*. D10: *"CL search lives in the runtime. Runtimes can choose how to
+handle failures at different points."* #422's policy on the slab at
+search time, reversing #401's retention. And throughout: keep it simple,
+no new traits.
+
+### What landed
+
+| Where | What |
+| --- | --- |
+| `crates/luminal_cuda_lite/src/profile.rs` (new, `#[cfg(feature = "device")]`) | The device evaluator: `profile_candidate(&mut CudaDevice, plan, staged, trials, best_so_far, candidate_timeout) -> Result<Measurement, ProfileFailure>`. |
+| `crates/luminal_cuda_lite/src/search.rs` | `CompileOptions::{profile_on_device, candidate_timeout}`; `Evaluator<'_>` (the enum that took over the deleted `PlanProfiler` trait's job); `RefusalBreakdown::timed_out`; `SearchOutcome::best_heuristic_cost`; `early_stop_exceeded` + its test, carried over from the reference copy (Phase 1 had dropped it as dead); the one `profiled` site became a two-arm choice. |
+| `crates/luminal_cuda_lite/src/runtime.rs` | `CudaRuntime::search` BUILDS the evaluator: lazily creates `self.device`, stages the caller's payloads by BufferLit id (by reference), and lends both. The bound-input check Phase 1 added stays. |
+| `crates/luminal_cuda_lite/src/device.rs` | `CudaDevice::release_slab()`; `execute_plan`'s `staged` is now `&FxHashMap<i64, &HostBuffer>`. |
+| `crates/luminal_cuda_lite/src/heuristic.rs` | One paragraph: on device it is not consulted at all. |
+| `crates/luminal_cuda_lite/examples/support/mod.rs` | `run_cuda` profiles on device and prints the winner's measurement beside its heuristic cost. |
+| `crates/luminal_cuda_lite/tests/device_profile.rs` (new, device-gated) | The probe (below). |
+
+`Measurement` is `Timed { mean_nanos, completed_trials }` or `TimedOut {
+elapsed_nanos, completed_trials }`; `ProfileFailure` is `Prepare(err)` or
+`Execute(err)`. The evaluator is
+
+```rust
+pub enum Evaluator<'a> {
+    Heuristic,
+    #[cfg(feature = "device")]
+    Device { device: &'a mut CudaDevice, staged: &'a FxHashMap<i64, &'a HostBuffer> },
+}
+```
+
+with a `reborrow(&mut self)` so the bucketed entry can lend the SAME
+device to every Cartesian combination. NO TRAIT: there are exactly two
+ways this crate prices a plan, both live in this crate, and an enum names
+them with an exhaustive match. `search_implementations` takes it as ONE
+extra argument and refuses UP FRONT if `profile_on_device` and the
+evaluator disagree — a request to measure is never answered with a prior.
+
+### What is mirrored from the reference evaluator, and the two divergences
+
+MIRRORED, from `luminal_reference::search::profile_on_reference_runtime`:
+one warmup execution (validity + first-touch), then `trials` timed
+executions; the metric is the MEAN over trials (ruling 2, 2026-09-02 — a
+mean only rises as trials accumulate, which is what makes the early stop
+an exact argument); the early stop applies `early_stop_exceeded` at
+factor 1.0 to a LOWER BOUND on the final mean (the sum so far divided by
+ALL trials, i.e. assuming every remaining trial is free), so it fires
+exactly when the candidate has provably lost.
+
+DIVERGENCE 1 — THE DEVICE IS PERSISTENT, the runtime is not rebuilt. The
+reference builds a fresh `ReferenceRuntime` per candidate because its
+runtime is a cheap host object. The CL equivalent would throw away the
+CUDA context and the NVRTC module cache between candidates and recompile
+every kernel — most of a CUDA search's wall time. So Phase 3's device is
+REUSED and compilation is paid once per distinct kernel source across the
+whole search. What is not carried between candidates is the slab (below).
+
+DIVERGENCE 2 — THE TIMED REGION INCLUDES STAGING AND READBACK.
+`execute_plan` is one call that allocates, H2Ds the staged inputs,
+launches, synchronizes and D2Hs the outputs; the reference's `execute()`
+runs only the kernels because its `set_data_buffer` is a separate ladder
+step. Splitting CL's execute into stage-once/run-many is real surgery on
+the executor and was NOT done. Stated rather than hidden: the H2D/D2H
+term is essentially the same for every candidate (same inputs, same
+outputs), so the RANKING is preserved while the absolute numbers are
+inflated. Read a CL device measurement as "the cost of one whole
+`execute` call" — which is what the serving ladder pays anyway.
+
+### Timeout semantics: the timed RUN, and nothing else
+
+`candidate_timeout` budgets ONLY the timed run. The clock starts at the
+FIRST TIMED TRIAL — after compile, stage and warmup — and is read BETWEEN
+trials, plus once after the last one (so a single trial longer than the
+whole budget is caught too). A trial in flight is never interrupted:
+there is no cancel for a launched kernel, so the honest thing is to
+finish the trial and then stop.
+
+WHY COMPILE IS OUT. NVRTC time is a once-per-distinct-source cost across
+the whole search, paid by whichever candidate happens to hit a cold
+module cache. Charging it to that candidate would time out plans for a
+cost their successors get for free — the budget would be measuring cache
+luck, not the plan.
+
+A timed-out candidate is NOT RANKED. A partial mean under a timeout is a
+measurement of the budget, not of the plan. It is counted in a NEW
+counter, `RefusalBreakdown::timed_out`, kept apart from
+`execute_refusals`: nothing failed, the plan is merely too slow to finish
+measuring, and the zero-refusal ladder acceptance stays about failures.
+`run_cuda` prints it and does not gate on it.
+
+### Failure handling (D10)
+
+| When | Counted as | Why |
+| --- | --- | --- |
+| NVRTC compile, module load, staging geometry, escape guard, warmup execution | `plan_build_refusals` | An ordinary unfit candidate. A plan this backend cannot compile or stage is indistinguishable in kind from one bufferize refused; the search drops it and tries others. It never fails the ladder. |
+| A TIMED trial, after the warmup already succeeded | `execute_refusals` | The same plan ran once and then did not — an OOM at a larger slab, a launch failure. That is a genuine execution refusal. |
+| The timed run exceeded the budget | `timed_out` | Not a failure at all. |
+
+The `RefusalBreakdown::summary()` string gained a `, timed out {n}`
+field; `run_cuda`'s gate is unchanged (extract / plan-build / execute).
+
+### The slab at search time
+
+`CudaDevice::release_slab()` is called by the search after EVERY profiled
+candidate (#422's policy, reversing #401's retention for this one
+caller). One candidate's arena high-water mark therefore cannot hold
+device memory for the rest of the search and starve its successors; the
+next `execute_plan` re-allocates through `ensure_slab`. SERVING KEEPS IT:
+`CudaRuntime::execute` never releases, so the grow-only slab Phase 3
+landed is exactly what a served runtime still has. Nothing else is
+released — the context, the stream and the module cache all survive,
+which is what makes compilation a once-per-source cost.
+
+### The heuristic's bias, reported instead of argued about
+
+D6 says the device-free evaluator must not bias search too much. Taken at
+full strength: with `profile_on_device` set, the heuristic is NOT
+CONSULTED — no blend, no tie-break, no prior seeding generation 0. It
+still runs once per profiled candidate for one reason only: so the
+winner's byte-move cost can be REPORTED beside its measurement, as
+`SearchOutcome::best_heuristic_cost`. `run_cuda` and the probe print the
+pair. That makes the prior's bias a number someone can look at rather
+than a claim.
+
+### Options: nothing existing moved
+
+`CompileOptions::default()` keeps every value it had (generations 8,
+generation_size 8, mutations 2, trials 3, seed 0, search_log true) and
+gains `profile_on_device: false`, `candidate_timeout: None`.
+`harness_search_options()` is unchanged in behaviour. The eight
+exhaustive struct literals in the suites took `..Default::default()`.
+Every CPU trajectory is byte-for-byte the one it was, which the suites
+pin.
+
+`execute_plan`'s `staged` became a map of REFERENCES. The search stages
+the CALLER's payload map, and for a full-size model that is gigabytes of
+weights on the host; a map of owned payloads would have meant a second
+copy of them for the length of the search. One pointer per input instead.
+
+### A100 (branch `rejoin/p4-device-evaluator`, `8b49752d`)
+
+`cargo test -p luminal_cuda_lite --features device --no-fail-fast`: every
+suite green except one PRE-EXISTING failure (below) — lib 11, codegen 13,
+composed_read_families 5, cublaslt_bias_premise 3, cublaslt_contracts 5
+passed / 1 FAILED, cublaslt_contracts_cpu 19, cublaslt_election 9,
+device_fidelity 6, **device_profile 2**, device_view_differentials 4,
+dim_buckets 4, example_smoke 1, input_producer_cleanup 5,
+ladder_refusals 3 (+3 ignored), plan_smoke 2, registry_selection 4,
+scc_sampler_marker 1, view_admission 4 + 1.
+
+THE PROBE, `tests/device_profile.rs` on the mini-llama3 decode block
+(embedding gather, QKV, KV-cache scatter/gather, attention, SwiGLU,
+output projection) at the 2x4 harness budget with `profile_on_device`:
+
+```
+search 12017 ms | plans profiled 6 | fingerprint hits 2
+  [saturation 0ms, serialize 0ms, analysis 88ms, extract 1207ms,
+   plan-build 5996ms, profile-exec 3411ms]
+winner 3.559355 ms measured on device, heuristic cost 11680847 bytes moved
+refusals extract 0 (choice-cycles 0, dead-ends 0), bufferize 0, execute 0, timed out 0
+```
+
+Six plans profiled on the GPU, ZERO compile/stage/warmup failures, zero
+execute failures, zero timeouts, and the elected plan still matches the
+reference runtime's logits to the fidelity battery's tolerance (1e-5
+relative). PROFILE-EXEC IS NOW 28% OF THE SEARCH (3.4 s of 12.0 s) where
+it used to be ~0 — that is the cost of measuring, and plan-build (6.0 s)
+is still the larger term. The debug-build numbers are what they are: the
+3.56 ms includes the whole `execute` call (divergence 2 above).
+
+The second probe pins the timeout semantics: `candidate_timeout:
+Some(Duration::ZERO)` times EVERY candidate out, so none is ranked and
+the search refuses NAMING THE TIMEOUT rather than reporting an execution
+failure.
+
+TRUNK ATTRIBUTION for the cuBLASLt election pin. Phase 3 found
+`cublaslt_contracts::marker_elected_bias_plan_matches_decomposed_route_tolerance_based`
+failing at the Phase 1 tip. Run at TRUNK (`logical-ssa-project`,
+`acde9ac1`) it fails IDENTICALLY — "the fused route must elect
+CublasLtBias for this comparison (seed 0 measured electing on the CPU
+pin)". So it is a PRE-EXISTING TRUNK FAILURE, not a rejoin regression:
+the election that the seed-0 pin records no longer happens. Attribution
+only; not fixed here. The bias-premise sweep (`cublaslt_bias_premise`, 3
+tests) passes on both, which is the test that exists precisely to say how
+election-dependent that pin is.
+
+### Deferred
+
+- **CUDA-EVENT TIMING.** The trials are timed HOST-SIDE with `Instant`
+  around `execute_plan`, which synchronizes the stream before it returns,
+  so the host clock is honest about the device work. Events would measure
+  the same interval minus host-side launch overhead. A refinement, not a
+  correction — and it would want the stage/run split (next item) to be
+  worth much.
+- **STAGE-ONCE / RUN-MANY.** Divergence 2. Splitting `execute_plan` into
+  a staging phase and a launch phase would let the timed region be the
+  kernels alone, which is what the reference times, and would stop
+  re-H2Ding a full-size model's weights on every trial. It is executor
+  surgery and is the single biggest remaining fidelity gap between the
+  two evaluators.
+- **The full-size examples' search cost.** `run_cuda` now measures on
+  device, which multiplies a full-size search's wall time by roughly
+  (1 warmup + `trials` executes) per distinct plan. At the 2x4 harness
+  budget with `trials: 1` that is ~2 whole model executions per profiled
+  plan. The yolo_v11n baseline (search 94 min under the heuristic,
+  2026-09-01) says a full-size device-profiled search is an hours-scale
+  run.
+- **Finalists / BucketLattice.** Not adopted. A two-tier scheme (rank
+  everything by the heuristic, then re-measure the top k on device) would
+  cut device time, but it puts the prior back on the critical path —
+  exactly what D6 warns about — and it was not asked for.
+- **Two-tier graph re-ranking** (measure at one shape, extrapolate to
+  others) — not adopted, same reason plus the static-plan limitation
+  buckets already carry.
+- **`best_nanos` is a union type in spirit.** Under the heuristic it is a
+  byte count with a unit-shaped name; under device profiling it is
+  nanoseconds. `best_heuristic_cost` now lets a reader tell which, but
+  the field is still called `best_nanos`. Renaming it is a wider API
+  change than this phase wanted.
+- **The fingerprint cache** dedups identical plans across genomes, so a
+  repeated plan is measured ONCE and its first measurement is reused.
+  With device noise that is a deliberate choice (one measurement per
+  distinct plan, not per genome); re-measuring and averaging is the
+  alternative nobody asked for.
+
 ## #406 pad — the select construction REVERTED (2026-09-03)
 
 Ruling 4b's "option i" (`select_by_index`: packed 2N iota + two `scatter1d` +

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -3198,25 +3198,54 @@ THE PROBE, `tests/device_profile.rs` on the mini-llama3 decode block
 output projection) at the 2x4 harness budget with `profile_on_device`:
 
 ```
-search 12017 ms | plans profiled 6 | fingerprint hits 2
-  [saturation 0ms, serialize 0ms, analysis 88ms, extract 1207ms,
-   plan-build 5996ms, profile-exec 3411ms]
-winner 3.559355 ms measured on device, heuristic cost 11680847 bytes moved
+debug:   search 12017 ms | plans profiled 6 | fingerprint hits 2
+  [analysis 88ms, extract 1207ms, plan-build 5996ms, profile-exec 3411ms]
+  winner 3.559355 ms measured on device
+release: search  5504 ms | plans profiled 6 | fingerprint hits 2
+  [analysis 19ms, extract 152ms, plan-build 1090ms, profile-exec 3352ms]
+  winner 0.974485 ms measured on device
 refusals extract 0 (choice-cycles 0, dead-ends 0), bufferize 0, execute 0, timed out 0
 ```
 
 Six plans profiled on the GPU, ZERO compile/stage/warmup failures, zero
 execute failures, zero timeouts, and the elected plan still matches the
 reference runtime's logits to the fidelity battery's tolerance (1e-5
-relative). PROFILE-EXEC IS NOW 28% OF THE SEARCH (3.4 s of 12.0 s) where
-it used to be ~0 — that is the cost of measuring, and plan-build (6.0 s)
-is still the larger term. The debug-build numbers are what they are: the
-3.56 ms includes the whole `execute` call (divergence 2 above).
+relative). PROFILE-EXEC IS THE SEARCH'S LARGEST TERM IN RELEASE — 3.35 s
+of 5.50 s, 61%, where it used to be ~0. Note what is inside it: the
+PREPARE execute compiles this plan's kernels through NVRTC, so
+`SearchTimings::profile_nanos` is measurement PLUS first-compile, not
+measurement alone. Only the trials are timed for RANKING; the timings
+struct is coarser than the metric.
+
+THE PRIOR AND THE MEASUREMENT DISAGREE, which is the point:
+
+```
+the PRIOR would elect a plan of 10465553 bytes moved;
+the MEASUREMENT elected one of 11709143
+  (DIFFERENT — the measurement did not pick the prior's winner)
+```
+
+Same seed, same budget, same six candidates; the only difference is what
+decides. The plan the device timed fastest moves ~12% MORE bytes than the
+one the byte-move heuristic would have crowned. That is D6's worry
+measured on hardware rather than argued: on this backend the prior was
+not merely imprecise, it was electing a different plan. (Reported, never
+asserted — which plan measures fastest is device- and noise-dependent,
+and pinning it would pin the noise.)
 
 The second probe pins the timeout semantics: `candidate_timeout:
 Some(Duration::ZERO)` times EVERY candidate out, so none is ranked and
 the search refuses NAMING THE TIMEOUT rather than reporting an execution
 failure.
+
+NO FULL-SIZE EXAMPLE WAS RUN, for two independent reasons from the
+2026-09-01 sizing work: llama3-8B in f32 is ~32 GB of weights on a 40 GB
+A100 and the sizing verdict was "no fused matmul + pre-alloc-everything
+=> decode weights x2", i.e. it does not fit; and the one example that HAS
+passed full-size (yolo_v11n) took 94 minutes of search under the
+HEURISTIC, which device profiling only lengthens. A full-size
+device-profiled run is an hours-scale exercise and belongs to its own
+sitting.
 
 TRUNK ATTRIBUTION for the cuBLASLt election pin. Phase 3 found
 `cublaslt_contracts::marker_elected_bias_plan_matches_decomposed_route_tolerance_based`


### PR DESCRIPTION
**Program:** #420/#422 rejoin, Phase 4 of the stack — base `rejoin/p3-arena` (PR #483). Plan page: https://claude.ai/code/artifact/6b5d25e3-94cf-4089-8977-8e44f971b8a5. Merge in order; retarget to `logical-ssa-project` before merging.

**Rulings (Austin):** CL profiles on device mirroring the reference evaluator's design (#386 ruling 4); the heuristic stays for CPU and must not bias search too much (D6); "timeout should just cover run"; runtimes choose how to handle failures at each point (D10); at search time the slab is freed per candidate (#422's policy accepted).

## What landed (3 commits, `8b49752d` `74671dd1` `36c25aa9`)
- `CompileOptions` gains `profile_on_device: bool` (default false) and `candidate_timeout: Option<Duration>` (default None); `Default` values unchanged; all eight exhaustive literals took `..Default::default()`.
- `Evaluator<'_> { Heuristic, Device { device, staged } }` — one enum, no trait — threaded through CL's search entries; `CudaRuntime::search` builds it, lazily creating the persistent device and staging the caller's payloads by reference.
- `crates/luminal_cuda_lite/src/profile.rs` (device feature): `profile_candidate(device, plan, staged, trials, best_so_far, candidate_timeout) -> Result<Measurement, ProfileFailure>`: one warmup execute (compiles through the persistent kernel cache, so compile is paid once per distinct source across candidates), then `trials` timed executes, mean nanos, exact lower-bound early stop against the incumbent at factor 1.0 (`early_stop_exceeded` restored to CL with its test).
- **Timeout covers the timed run only**: the clock starts at the first timed trial; a timed-out candidate is not ranked and lands in the new `RefusalBreakdown::timed_out`, never in `execute_refusals`. **Failures:** compile, stage or warmup errors are ordinary unfit candidates (`plan_build_refusals`); a trial failing after a successful warmup is an `execute_refusal`. **Slab:** released after every profiled candidate; serving keeps it.
- The heuristic is not consulted at all under device profiling, no blend and no tie-break; it still runs to report `SearchOutcome::best_heuristic_cost` beside the measurement. `run_cuda` enables device profiling under the feature and prints both.
- `execute_plan` now stages `&FxHashMap<i64, &HostBuffer>` so a full-size model's weights are borrowed, not copied.

## A100
Every device suite `ok` except the one pre-existing pin: lib 11, codegen_identity 13, composed_read_families 5, cublaslt_bias_premise 3, cublaslt_contracts_cpu 19, cublaslt_election 9, device_fidelity 6, **device_profile 2 (new)**, device_view_differentials 4, dim_buckets 4, example_smoke 1, input_producer_cleanup 5, ladder_refusals 3, plan_smoke 2, registry_selection 4, scc_sampler_marker 1, view_admission 4.

**Probe** (mini-llama3, 2×4, device profiling, release): search 5,504 ms with 6 plans profiled, of which 3,352 ms was profiling execution; the winner runs in 0.974 ms; zero refusals and zero timeouts; logits match the reference to 1e-5. **Finding:** the heuristic would have elected a plan moving 10,465,553 bytes; the measurement elected one moving 11,709,143 bytes, about 12% more, and faster. That is D6's concern measured on hardware.

**Attribution:** `cublaslt_contracts::marker_elected_bias_plan_matches_decomposed_route_tolerance_based` **fails at trunk `acde9ac1` identically** (seed 0 no longer elects the bias form). Pre-existing, not a rejoin regression, not fixed (the pin class parked by the 2026-09-02 ruling).

No full-size example run: llama3-8B f32 does not fit 40 GB under the sizing verdict, and the one example that has passed full-size took 94 minutes of heuristic search.

**Divergences from the reference template (documented in code):** the device is persistent, so compilation is once per source rather than once per candidate; the timed region includes staging and readback because `execute_plan` is one call, which inflates absolute numbers by a constant term and preserves ranking. Deferred: CUDA-event timing, two-tier graph re-ranking (not adopted), Finalists and the bucket lattice (Phase 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
