### PR TITLE
rejoin P5: Finalists and the bucket lattice in CL — the installed plans are a SET that fits the device budget

### DIFF
--- a/crates/luminal_cuda_lite/src/arena.rs
+++ b/crates/luminal_cuda_lite/src/arena.rs
@@ -58,12 +58,46 @@
 //! candidate plans a search evaluates) is Phase 4's; this pass sizes
 //! ONE installed plan.
 
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use luminal::bufferize::{Buffer, BufferId, BufferIrGraph, BufferNode, Owner, PlanLayout};
 use luminal::layout_ir::FreedBy;
 use luminal::prelude::{petgraph, FxHashMap, NodeIndex};
 use petgraph::visit::{EdgeRef, NodeIndexable};
 use std::collections::{BTreeMap, BinaryHeap};
+
+/// THE ONE SIZING RULE: the buffer backs one tensor, its carried layout
+/// gives the span in elements and the dtype fact gives the byte width
+/// (ALLOCATION BY ASSIGNMENT LOOKUP, corrected contract 2026-08-31 — no
+/// walk, no voting).
+///
+/// IT LIVES HERE, not in `crate::device`, because it is DEVICE-FREE and
+/// two callers need it: the executor's `execute_plan` (which is behind
+/// the `device` feature) and the search's finalist arena planning
+/// (Phase 5, which runs on any host so a budget can be checked without a
+/// GPU). One rule, one place, so the two can never disagree about a
+/// buffer's size.
+pub fn buffer_bytes(buffer: &Buffer<luminal::layouts::DecodedLayout>) -> Result<usize> {
+    let numel = buffer
+        .layout
+        .mirror
+        .literal_span_elements()
+        .ok_or_else(|| {
+            anyhow!(
+                "buffer {:?} (backing {}) has no literal span — symbolic or \
+                 undisclosed-reach layouts are not executable",
+                buffer.label,
+                buffer.backs
+            )
+        })?;
+    let dtype = buffer.layout.dtype.ok_or_else(|| {
+        anyhow!(
+            "buffer {:?} (backing {}) carries no dtype fact",
+            buffer.label,
+            buffer.backs
+        )
+    })?;
+    Ok(numel * crate::host_buffer::dtype_bytes(dtype)?)
+}
 
 /// Device allocations are 256-byte aligned, so every slab range is too:
 /// a sub-range handed to a kernel must satisfy the same alignment the

--- a/crates/luminal_cuda_lite/src/device.rs
+++ b/crates/luminal_cuda_lite/src/device.rs
@@ -72,15 +72,15 @@
 //! occupant's bytes, and would need the memset this note says we do
 //! not do.
 
-use crate::arena::{plan_arena, ArenaPlan};
-use crate::host_buffer::{dtype_bytes, HostBuffer};
+use crate::arena::{buffer_bytes, plan_arena, ArenaPlan};
+use crate::host_buffer::HostBuffer;
 use anyhow::{anyhow, bail, Context, Result};
 use cudarc::driver::{
     result as cu, CudaContext, CudaFunction, CudaModule, CudaSlice, CudaStream, DevicePtr,
     LaunchConfig, PushKernelArg,
 };
 use cudarc::nvrtc::compile_ptx;
-use luminal::bufferize::{Buffer, BufferId, BufferIrGraph, BufferNode, EdgeKind, OutputBinding};
+use luminal::bufferize::{BufferId, BufferIrGraph, BufferNode, EdgeKind, OutputBinding};
 use luminal::dtype::PlanDtype;
 use luminal::prelude::FxHashMap;
 use std::collections::HashMap;
@@ -232,34 +232,6 @@ fn bound_of(bindings: &FxHashMap<BufferId, Bound>, id: &BufferId, who: &str) -> 
              or its BufferFree already ran"
         )
     })
-}
-
-/// The one sizing rule: the buffer backs one tensor, its carried layout
-/// gives the span in elements and the dtype fact gives the byte width
-/// (ALLOCATION BY ASSIGNMENT LOOKUP, corrected contract 2026-08-31 — no
-/// walk, no voting). Shared by the arena planner and Phase 1 so the two
-/// can never disagree about a buffer's size.
-fn buffer_bytes(buffer: &Buffer<luminal::layouts::DecodedLayout>) -> Result<usize> {
-    let numel = buffer
-        .layout
-        .mirror
-        .literal_span_elements()
-        .ok_or_else(|| {
-            anyhow!(
-                "buffer {:?} (backing {}) has no literal span — symbolic or \
-                 undisclosed-reach layouts are not executable",
-                buffer.label,
-                buffer.backs
-            )
-        })?;
-    let dtype = buffer.layout.dtype.ok_or_else(|| {
-        anyhow!(
-            "buffer {:?} (backing {}) carries no dtype fact",
-            buffer.label,
-            buffer.backs
-        )
-    })?;
-    Ok(numel * dtype_bytes(dtype)?)
 }
 
 /// Execute a bufferized plan on `device`. Returns, per output slot

--- a/crates/luminal_cuda_lite/src/finalists.rs
+++ b/crates/luminal_cuda_lite/src/finalists.rs
@@ -1,0 +1,312 @@
+//! FINALISTS — the ranked genomes of ONE bucket, re-materialized lazily
+//! under a hard filter.
+//!
+//! PHASE 5 OF THE #420/#422 REJOIN (2026-09-03), the "then add" half of
+//! Austin's D8 (*"defer temporarily, but then add"*): Phase 4 landed the
+//! device evaluator and explicitly deferred main's `Finalists` /
+//! `BucketLattice` pair. This is that pair, re-expressed for this
+//! branch.
+//!
+//! # What a finalist is, and why the GA's winner is not simply installed
+//!
+//! The genetic search ([`crate::search::search_implementations`]) ranks
+//! candidates and today hands back exactly one — the fastest. That is
+//! enough while nothing can REFUSE the winner after the fact. The moment
+//! a constraint applies to the INSTALLED plan rather than to a candidate
+//! in isolation — a device budget the serving slab must fit inside, a
+//! warmup that has to survive — the search needs a runner-up to fall
+//! back to, and the one after that.
+//!
+//! So the GA now keeps a RANKED LIST (`CompileOptions::keep_finalists`,
+//! default 4) of `(metric, Genome)` pairs, fastest first, and this type
+//! turns them into deployment plans ONE AT A TIME. Rank k is extracted,
+//! DPS-rewritten, layout-decoded, bufferized and arena-planned only when
+//! the selection actually reaches it (main's own words: "extract a full
+//! graph only when the selection reaches its rank"). A refusal at ANY of
+//! those steps is a rejection with a recorded reason, and the walk moves
+//! to rank k+1.
+//!
+//! # The hard filter
+//!
+//! `ensure(target, validate)` is the door. `validate` is the RUNTIME's
+//! (see [`crate::search::finalist_validate`]): under
+//! `CompileOptions::profile_on_device` with a live device it runs ONE
+//! warmup execution of the candidate plan, which is main's hard filter
+//! (its `validate_finalist` = `compile_and_validate_profile_candidate`);
+//! on the device-free heuristic path a plan that bufferized and
+//! arena-planned IS the whole of what this host can check, so validation
+//! is trivially satisfied and the first finalist IS the GA's winner —
+//! handed over as an object, not re-derived (see `Finalists::new`).
+//!
+//! # What is NOT here (main's version, minus LLIR)
+//!
+//! Main's `Finalists` carries `pre_unroll` graphs, the `LLIR_DUMP_DIR` /
+//! `LLIR_DUMP_PRE_UNROLL` dump machinery, and a `search_time_limit` /
+//! `candidate_timeout` clock over the finalization itself. This branch
+//! has no LLIR and no loop unrolling, so the dumps and the pre-unroll
+//! field have nothing to dump; and its one timeout
+//! (`CompileOptions::candidate_timeout`) is documented to cover a TIMED
+//! DEVICE RUN and nothing else (Phase 4's ruling, *"timeout should just
+//! cover run"*), so it is not re-purposed here as a finalization budget.
+//! Re-extraction on this branch is a host-side graph walk, not a search.
+
+use anyhow::Result;
+
+use crate::arena::{buffer_bytes, plan_arena, ArenaPlan};
+use crate::extractor::{self, Genome};
+use crate::layouts::CudaPlan;
+use luminal::prelude::egraph_serialize;
+
+/// One ranked genome, materialized into everything the runtime needs to
+/// judge and install it: the plan, and the arena plan whose `slab_bytes`
+/// is this candidate's device high-water mark.
+#[derive(Debug)]
+pub struct PendingFinalist {
+    /// 1-BASED rank in the GA's ordering — rank 1 is the search's
+    /// winner. (Main's `PendingFinalist.rank` is 1-based too, and its
+    /// fallback log line reads "loading ranked #{rank}".)
+    pub rank: usize,
+    /// The metric the GA ranked this genome by: measured nanoseconds
+    /// under the device evaluator, bytes-moved under the heuristic.
+    pub metric: u128,
+    pub genome: Genome,
+    pub plan: CudaPlan,
+    /// The arena plan for `plan` — the issue order and the slab layout.
+    /// `slab_bytes` is what the aggregate device-budget check reads.
+    pub arena: ArenaPlan,
+}
+
+/// The ranked finalists of one bucket, materialized lazily.
+pub struct Finalists<'a> {
+    /// How this bucket names itself in a failure message (`"bucket 0
+    /// (a in [2, 4])"`, or `"the search"` when unbucketed).
+    label: String,
+    egraph: &'a egraph_serialize::EGraph,
+    /// The extraction session, built ON FIRST USE. Constructing one runs
+    /// the whole analysis (class maps, op specs, the runtime-viability
+    /// fixpoint), which is the expensive part of an extraction — and the
+    /// common case never needs it, because rank 1 arrives pre-built (see
+    /// `winner_plan`). A search that installs its own winner therefore
+    /// pays NOTHING for this machinery beyond one arena plan.
+    session: Option<extractor::ExtractionSession<'a>>,
+    /// The allow list and matcher set the session is built from, held
+    /// for that lazy construction.
+    allow: Option<Vec<&'static str>>,
+    matchers: &'a [Box<dyn luminal::layout_ir::OpMatcher>],
+    /// RANK 1's PLAN, already built by the genetic search. Re-extracting
+    /// the winning genome would reproduce it exactly — the pipeline is
+    /// deterministic — so re-running it would be pure waste, and taking
+    /// the search's own object also makes "an unconstrained search
+    /// installs what it searched" true by construction rather than by
+    /// an argument about determinism. Taken (and left `None`) the first
+    /// time rank 1 is materialized.
+    winner_plan: Option<CudaPlan>,
+    /// `(metric, genome)`, fastest first — the GA's ranking.
+    ranked: Vec<(u128, Genome)>,
+    /// How far down `ranked` [`Finalists::extract_next`] has walked.
+    next_ranked: usize,
+    /// The VIABLE finalists, in rank order — the lattice indexes into
+    /// this.
+    accepted: Vec<PendingFinalist>,
+    rejections: usize,
+    last_rejection: Option<String>,
+}
+
+impl<'a> Finalists<'a> {
+    /// Build the finalist walk for one bucket.
+    ///
+    /// `winner_plan` is the plan the genetic search already built for
+    /// `ranked[0]` — pass it, and rank 1 costs one arena plan instead of
+    /// a whole re-extraction. `egraph`, `allow` and `matchers` are what a
+    /// DEEPER rank is re-extracted from; the session they make is built
+    /// on first use (main builds another `LlirExtractor` per `Finalists`
+    /// eagerly — this branch does not, because its common case never
+    /// extracts at all).
+    pub fn new(
+        label: impl Into<String>,
+        egraph: &'a egraph_serialize::EGraph,
+        allow: Option<Vec<&'static str>>,
+        matchers: &'a [Box<dyn luminal::layout_ir::OpMatcher>],
+        ranked: Vec<(u128, Genome)>,
+        winner_plan: Option<CudaPlan>,
+    ) -> Self {
+        Self {
+            label: label.into(),
+            egraph,
+            session: None,
+            allow,
+            matchers,
+            winner_plan,
+            ranked,
+            next_ranked: 0,
+            accepted: Vec::new(),
+            rejections: 0,
+            last_rejection: None,
+        }
+    }
+
+    /// This bucket's label, as failure messages spell it.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// How many ranked genomes the GA handed over.
+    pub fn ranked_len(&self) -> usize {
+        self.ranked.len()
+    }
+
+    /// How many finalists have been ACCEPTED so far.
+    pub fn accepted_len(&self) -> usize {
+        self.accepted.len()
+    }
+
+    /// How many candidates were rejected — by a build refusal inside
+    /// [`Finalists::extract_next`] or by the caller's `validate`.
+    pub fn rejections(&self) -> usize {
+        self.rejections
+    }
+
+    /// The accepted finalist at `index`, if it has been materialized.
+    pub fn get(&self, index: usize) -> Option<&PendingFinalist> {
+        self.accepted.get(index)
+    }
+
+    /// MATERIALIZE THE NEXT RANKED GENOME: extract, DPS-rewrite, decode
+    /// the elected layouts, bufferize, arena-plan. A refusal at any of
+    /// those steps counts as a REJECTION (with its reason recorded) and
+    /// the walk moves to the next rank — so this returns `None` only
+    /// when the ranked list is exhausted.
+    ///
+    /// The pipeline is deliberately the same five calls the GA made when
+    /// it priced the genome, in the same order, so a genome the search
+    /// ranked cannot fail here for a reason the search did not already
+    /// see — except the arena plan, which the GA never ran (it prices a
+    /// graph, not a slab).
+    pub fn extract_next(&mut self) -> Option<PendingFinalist> {
+        while self.next_ranked < self.ranked.len() {
+            let index = self.next_ranked;
+            self.next_ranked += 1;
+            let rank = index + 1;
+            let (metric, genome) = self.ranked[index].clone();
+            match self.materialize(rank, metric, &genome) {
+                Ok(pending) => return Some(pending),
+                Err(reason) => self.record_rejection(rank, reason),
+            }
+        }
+        None
+    }
+
+    fn materialize(
+        &mut self,
+        rank: usize,
+        metric: u128,
+        genome: &Genome,
+    ) -> Result<PendingFinalist, String> {
+        let plan = match self.winner_plan.take() {
+            // RANK 1, HANDED OVER: the search built this plan from this
+            // genome; nothing about re-deriving it could differ.
+            Some(plan) if rank == 1 => plan,
+            handed_back => {
+                self.winner_plan = handed_back;
+                self.build_plan(genome)?
+            }
+        };
+        let arena = plan_arena(&plan, buffer_bytes).map_err(|err| format!("arena: {err:#}"))?;
+        Ok(PendingFinalist {
+            rank,
+            metric,
+            genome: genome.clone(),
+            plan,
+            arena,
+        })
+    }
+
+    /// Extract + DPS + decode + bufferize one genome, building the
+    /// extraction session if this is the first genome that needs it.
+    fn build_plan(&mut self, genome: &Genome) -> Result<CudaPlan, String> {
+        let session = self.session.get_or_insert_with(|| {
+            extractor::ExtractionSession::new_with_matcher_set(
+                self.egraph,
+                self.allow.as_deref(),
+                self.matchers,
+            )
+        });
+        let graph = match session.extract_with_genome(genome) {
+            Ok(Some(graph)) => graph,
+            Ok(None) => return Err("extract: no boundary reached".to_string()),
+            Err(err) => return Err(format!("extract: {err:#}")),
+        };
+        let dps = luminal::dps::dps_rewrite(&graph);
+        luminal::layouts::decode_layout_table(self.egraph, &dps, "finalist")
+            .and_then(|table| luminal::bufferize::bufferize(&dps, &table))
+            .map_err(|err| format!("bufferize: {err:#}"))
+    }
+
+    fn record_rejection(&mut self, rank: usize, reason: String) {
+        self.rejections += 1;
+        self.last_rejection = Some(format!("ranked #{rank}: {reason}"));
+    }
+
+    /// The candidate PASSED the hard filter: it joins the accepted list
+    /// at the next index.
+    pub fn accept(&mut self, pending: PendingFinalist) {
+        self.accepted.push(pending);
+    }
+
+    /// The candidate FAILED the hard filter (or a set-level constraint
+    /// the caller checked): count it and remember why.
+    pub fn reject(&mut self, pending: PendingFinalist, reason: impl Into<String>) {
+        self.record_rejection(pending.rank, reason.into());
+    }
+
+    /// MATERIALIZE DOWN TO `target`: keep extracting and validating
+    /// until `accepted[target]` exists. Returns false when the ranked
+    /// list runs out first — which is what makes a lattice coordinate
+    /// "cannot go one step slower".
+    ///
+    /// `validate` is the hard filter; an `Err(reason)` rejects the
+    /// candidate and the walk continues at the next rank.
+    pub fn ensure(
+        &mut self,
+        target: usize,
+        validate: &mut dyn FnMut(&PendingFinalist) -> Result<(), String>,
+    ) -> bool {
+        while self.accepted.len() <= target {
+            let Some(pending) = self.extract_next() else {
+                return false;
+            };
+            match validate(&pending) {
+                Ok(()) => self.accept(pending),
+                Err(reason) => self.reject(pending, reason),
+            }
+        }
+        true
+    }
+
+    /// Why this bucket could supply no further finalist — the text the
+    /// lattice quotes into its own failure message.
+    pub fn failure_message(&self) -> String {
+        match &self.last_rejection {
+            Some(reason) => format!(
+                "{} ranked {} genome(s), rejected {} of them; last rejection: {reason}",
+                self.label,
+                self.ranked.len(),
+                self.rejections
+            ),
+            None => format!(
+                "{} ranked {} genome(s) and none is left to try",
+                self.label,
+                self.ranked.len()
+            ),
+        }
+    }
+
+    /// Consume the walk and take the accepted finalist at `index` — the
+    /// install step.
+    pub fn take(mut self, index: usize) -> Option<PendingFinalist> {
+        if index >= self.accepted.len() {
+            return None;
+        }
+        Some(self.accepted.swap_remove(index))
+    }
+}

--- a/crates/luminal_cuda_lite/src/lattice.rs
+++ b/crates/luminal_cuda_lite/src/lattice.rs
@@ -1,0 +1,301 @@
+//! THE BUCKET LATTICE — a best-first walk over per-bucket finalist
+//! ranks, minimizing a coordinate-monotone aggregate.
+//!
+//! PHASE 5 OF THE #420/#422 REJOIN (2026-09-03), the other half of
+//! Austin's D8 "then add". Re-expressed from main's
+//! `src/search/lattice.rs` for a branch with no LLIR.
+//!
+//! # The problem it solves
+//!
+//! A bucketed search produces ONE ranked list of candidates per bucket
+//! ([`crate::finalists::Finalists`]). Installing each bucket's own
+//! winner is right only while nothing constrains the buckets JOINTLY.
+//! This runtime has exactly one such constraint — the serving slab is
+//! grown once and sized to the largest installed plan, so a caller's
+//! device budget applies to the SET, not to any one bucket — and the
+//! moment such a constraint exists, "each bucket's best" can be
+//! infeasible while a set that is one rank slower in ONE bucket fits.
+//!
+//! The candidate space is the Cartesian product of the buckets' ranks: a
+//! point is a vector of indices, one per bucket, and its cost is
+//! `aggregate` over the buckets' metrics at those ranks. The walk is
+//! best-first over that lattice.
+//!
+//! # Why one-coordinate-slower successors are enough
+//!
+//! `aggregate` must be COORDINATE-MONOTONE: raising any one coordinate
+//! (to a slower finalist) must not lower the aggregate. Σ of
+//! nonnegative metrics is, which is the aggregate this runtime uses.
+//! Under that assumption every point's cost is ≥ the cost of each of its
+//! one-step predecessors, so expanding a point into its `n`
+//! one-coordinate-slower successors and always popping the frontier's
+//! strictly-smallest aggregate enumerates the lattice in nondecreasing
+//! cost order — the ordinary best-first argument. A `visited` set keeps
+//! a point from entering the frontier along two different paths, so no
+//! set is ever proposed twice.
+//!
+//! # Laziness
+//!
+//! `initialize` materializes RANK 0 of every bucket and nothing else.
+//! Rank k+1 of bucket i is extracted and hard-filtered only when a
+//! rejected set's successor actually reaches it, through
+//! [`crate::finalists::Finalists::ensure`]. A search that validates on
+//! the first try therefore pays for exactly one finalist per bucket.
+//!
+//! # The single-bucket case
+//!
+//! An UNBUCKETED search runs the same code path over a one-bucket
+//! lattice — main's "one designed difference" from the pre-#420
+//! behaviour, adopted here for the same reason: the aggregate check is a
+//! property of what gets installed, and an unbucketed install is a set of
+//! one. It costs nothing when no budget is set (rank 0 validates and the
+//! first `next` wins) and it means there is ONE selection path to reason
+//! about rather than two.
+
+use crate::finalists::{Finalists, PendingFinalist};
+use luminal::prelude::FxHashSet;
+
+/// One point of the lattice: a finalist index per bucket, in bucket
+/// order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BucketSet {
+    pub indices: Vec<usize>,
+}
+
+/// The aggregate: a coordinate-monotone function of the per-bucket
+/// metrics. A plain `fn` pointer, not a trait and not a boxed closure —
+/// there is one of these in this crate and it is [`sum_metrics`].
+pub type AggregateFn = fn(&[u128]) -> u128;
+
+/// Σ of the buckets' metrics, saturating. Coordinate-monotone because
+/// the metrics are nonnegative.
+pub fn sum_metrics(metrics: &[u128]) -> u128 {
+    metrics
+        .iter()
+        .fold(0u128, |total, metric| total.saturating_add(*metric))
+}
+
+/// Best-first selection over the buckets' finalist ranks.
+pub struct BucketLattice<'a> {
+    buckets: Vec<Finalists<'a>>,
+    aggregate: AggregateFn,
+    /// `(aggregate, indices)` — the open set. Small by construction (at
+    /// most one entry per rejection per bucket), so a linear scan for
+    /// the minimum beats a heap and keeps first-come tie-breaking
+    /// obvious.
+    frontier: Vec<(u128, Vec<usize>)>,
+    visited: FxHashSet<Vec<usize>>,
+    initialized: bool,
+    /// Sets PROPOSED so far — `next` returning a set counts one.
+    attempts: usize,
+    /// Sets the caller REJECTED (the set-level constraint failed).
+    rejections: usize,
+    /// Why the walk stopped, when it stopped for a nameable reason.
+    stopped_reason: Option<String>,
+    last_rejection: Option<String>,
+}
+
+impl<'a> BucketLattice<'a> {
+    /// At least one bucket; the aggregate must be coordinate-monotone
+    /// (see the module note).
+    pub fn new(buckets: Vec<Finalists<'a>>, aggregate: AggregateFn) -> Self {
+        assert!(
+            !buckets.is_empty(),
+            "a bucket lattice needs at least one bucket"
+        );
+        Self {
+            buckets,
+            aggregate,
+            frontier: Vec::new(),
+            visited: FxHashSet::default(),
+            initialized: false,
+            attempts: 0,
+            rejections: 0,
+            stopped_reason: None,
+            last_rejection: None,
+        }
+    }
+
+    /// How many sets the caller rejected — what
+    /// `SearchOutcome::lattice_rejections` reports.
+    pub fn rejections(&self) -> usize {
+        self.rejections
+    }
+
+    /// The next set to try, cheapest first, or `None` when the walk is
+    /// out of options (see [`BucketLattice::failure_message`] for why).
+    pub fn next(
+        &mut self,
+        validate: &mut dyn FnMut(&PendingFinalist) -> Result<(), String>,
+    ) -> Option<BucketSet> {
+        if !self.initialized && !self.initialize(validate) {
+            return None;
+        }
+        if self.frontier.is_empty() {
+            return None;
+        }
+        // The strictly smallest aggregate; ties go to the entry that
+        // entered the frontier first.
+        let mut best = 0usize;
+        for (position, entry) in self.frontier.iter().enumerate().skip(1) {
+            if entry.0 < self.frontier[best].0 {
+                best = position;
+            }
+        }
+        let (_, indices) = self.frontier.remove(best);
+        self.attempts += 1;
+        Some(BucketSet { indices })
+    }
+
+    /// RANK 0 EVERYWHERE. A bucket that cannot supply even one viable
+    /// finalist stops the whole walk, naming itself.
+    fn initialize(
+        &mut self,
+        validate: &mut dyn FnMut(&PendingFinalist) -> Result<(), String>,
+    ) -> bool {
+        self.initialized = true;
+        for index in 0..self.buckets.len() {
+            if !self.buckets[index].ensure(0, validate) {
+                self.stopped_reason = Some(format!(
+                    "failed to find a viable final plan for {}: {}",
+                    self.buckets[index].label(),
+                    self.buckets[index].failure_message()
+                ));
+                return false;
+            }
+        }
+        let origin = vec![0usize; self.buckets.len()];
+        let cost = self.aggregate_at(&origin);
+        self.visited.insert(origin.clone());
+        self.frontier.push((cost, origin));
+        true
+    }
+
+    /// The aggregate over an already-materialized point.
+    fn aggregate_at(&self, indices: &[usize]) -> u128 {
+        let metrics: Vec<u128> = indices
+            .iter()
+            .enumerate()
+            .map(|(bucket, index)| {
+                self.buckets[bucket]
+                    .get(*index)
+                    .map(|finalist| finalist.metric)
+                    .unwrap_or(u128::MAX)
+            })
+            .collect();
+        (self.aggregate)(&metrics)
+    }
+
+    /// Every bucket's arena high-water mark at `set`, in bucket order —
+    /// the numbers the caller's set-level constraint reads. Returned by
+    /// VALUE so the caller can hold them across a `reject`.
+    pub fn slab_bytes(&self, set: &BucketSet) -> Vec<usize> {
+        set.indices
+            .iter()
+            .enumerate()
+            .map(|(bucket, index)| {
+                self.buckets[bucket]
+                    .get(*index)
+                    .map(|finalist| finalist.arena.slab_bytes)
+                    .unwrap_or(0)
+            })
+            .collect()
+    }
+
+    /// The finalist ranks (1-based) at `set`, for reporting.
+    pub fn ranks(&self, set: &BucketSet) -> Vec<usize> {
+        set.indices
+            .iter()
+            .enumerate()
+            .map(|(bucket, index)| {
+                self.buckets[bucket]
+                    .get(*index)
+                    .map(|finalist| finalist.rank)
+                    .unwrap_or(0)
+            })
+            .collect()
+    }
+
+    /// THE SET FAILED the caller's constraint: open its
+    /// one-coordinate-slower successors, materializing the finalists
+    /// they name.
+    pub fn reject(
+        &mut self,
+        set: &BucketSet,
+        reason: impl Into<String>,
+        validate: &mut dyn FnMut(&PendingFinalist) -> Result<(), String>,
+    ) {
+        self.rejections += 1;
+        self.last_rejection = Some(reason.into());
+        for bucket in 0..self.buckets.len() {
+            let mut successor = set.indices.clone();
+            successor[bucket] += 1;
+            if self.visited.contains(&successor) {
+                continue;
+            }
+            if !self.buckets[bucket].ensure(successor[bucket], validate) {
+                // This coordinate cannot go one step slower. That is not
+                // itself a failure — another coordinate may still open —
+                // but it IS the reason the walk ends if none does, so
+                // the first such exhaustion is remembered.
+                if self.stopped_reason.is_none() {
+                    self.stopped_reason = Some(format!(
+                        "{} ran out of finalists: {}",
+                        self.buckets[bucket].label(),
+                        self.buckets[bucket].failure_message()
+                    ));
+                }
+                continue;
+            }
+            let cost = self.aggregate_at(&successor);
+            self.visited.insert(successor.clone());
+            self.frontier.push((cost, successor));
+        }
+    }
+
+    /// THE INSTALL: consume the lattice and hand back, per bucket, its
+    /// selected `(bucket index, plan, arena plan)`.
+    pub fn select(self, set: &BucketSet) -> Vec<(usize, PendingFinalist)> {
+        let mut selected = Vec::with_capacity(self.buckets.len());
+        for (bucket, finalists) in self.buckets.into_iter().enumerate() {
+            let index = set.indices[bucket];
+            let finalist = finalists
+                .take(index)
+                .expect("a proposed set names only materialized finalists");
+            selected.push((bucket, finalist));
+        }
+        selected
+    }
+
+    /// Why nothing viable was found — the text `search` refuses with.
+    ///
+    /// MAIN'S SPLIT, kept: when NOTHING was ever proposed the failure is
+    /// the bucket's (no viable finalist at all), so its message is the
+    /// whole answer; once a set HAS been proposed and rejected, the
+    /// caller's own rejection reason is what the reader needs — it names
+    /// the constraint that was not met — and the exhaustion is appended
+    /// as the reason no slower set was tried.
+    pub fn failure_message(&self) -> String {
+        if self.attempts == 0 {
+            return format!(
+                "no viable plan set: {}",
+                self.stopped_reason
+                    .clone()
+                    .unwrap_or_else(|| "no reason recorded".to_string())
+            );
+        }
+        let reason = self
+            .last_rejection
+            .clone()
+            .or_else(|| self.stopped_reason.clone())
+            .unwrap_or_else(|| "no reason recorded".to_string());
+        let mut message = format!(
+            "no viable plan set after {} proposal(s) and {} rejection(s): {reason}",
+            self.attempts, self.rejections
+        );
+        if let Some(stopped) = &self.stopped_reason {
+            message.push_str(&format!("; no slower set is available ({stopped})"));
+        }
+        message
+    }
+}

--- a/crates/luminal_cuda_lite/src/lib.rs
+++ b/crates/luminal_cuda_lite/src/lib.rs
@@ -37,6 +37,13 @@
 //!   device time ([`profile`]) instead of by [`heuristic`]'s weak prior.
 //!   The heuristic remains the default and the device-free hosts' only
 //!   option; the two are never blended.
+//! - CL-6 (#420/#422 rejoin Phase 5, 2026-09-03): FINALISTS AND THE
+//!   BUCKET LATTICE ([`finalists`], [`lattice`]). The search keeps a
+//!   ranked list of genomes and the plan that gets INSTALLED is chosen by
+//!   a best-first walk over the buckets' finalist ranks under one
+//!   aggregate constraint — `CompileOptions::device_budget_bytes` bounds
+//!   the arena slab the runtime will hold. Unconstrained (the default)
+//!   the walk installs the search's own winner and costs nothing.
 //!
 //! Out-of-place by design: kernels read operand buffers and
 //! write fresh destinations, mirroring the reference executor's
@@ -47,9 +54,15 @@ pub mod arena;
 pub mod binding_check;
 pub mod bindings;
 pub mod extractor;
+/// FINALISTS (Phase 5 of the #420/#422 rejoin): a bucket's ranked
+/// genomes, re-materialized one at a time under a hard filter.
+pub mod finalists;
 pub mod heuristic;
 pub mod host_buffer;
 pub mod kernels;
+/// THE BUCKET LATTICE (Phase 5): best-first selection of ONE finalist
+/// per bucket under a coordinate-monotone aggregate.
+pub mod lattice;
 pub mod layouts;
 pub mod ops;
 pub mod runtime;

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -280,7 +280,7 @@ impl CudaRuntime {
                 );
             }
         }
-        self.plan = Some(plan.outcome.best_plan.clone());
+        self.plan = Some(plan.plan.clone());
         Ok(())
     }
 
@@ -470,13 +470,13 @@ impl CudaRuntime {
 
         // THIS INSTANCE's claim set, derived at load from THIS
         // instance's registry — no crate-level default is consulted.
-        let allow = Some(self.allow.clone());
+        let allow = self.allow.clone();
         // FIELD BORROWS, not `self.matchers()`: the device evaluator
         // holds `&mut self.device` at the same time, and only disjoint
         // FIELD borrows can coexist — a `&self` method would borrow the
         // whole runtime.
         let matchers = &self.matchers;
-        let evaluator = {
+        let mut evaluator = {
             #[cfg(feature = "device")]
             {
                 if options.profile_on_device {
@@ -499,15 +499,45 @@ impl CudaRuntime {
 
         // Own matchers, own allow list, own ranking: nothing in this
         // search touches another runtime.
-        let outcome = if self.dim_buckets.is_empty() {
-            crate::search::search_implementations(
+        //
+        // WHAT `search` RETURNS is a pair: the outcome to report, and the
+        // plan to install. They are no longer the same thing (Phase 5):
+        // the outcome is the genetic search's report, while the installed
+        // plan is whichever FINALIST the bucket lattice selected under the
+        // aggregate device budget. With no budget set they coincide,
+        // which is why every existing caller sees the trajectory it had.
+        let (outcome, unbucketed_plan, searched_buckets) = if self.dim_buckets.is_empty() {
+            let mut outcome = crate::search::search_implementations(
                 &serialized,
                 &program,
                 options,
-                allow,
+                Some(allow.clone()),
                 matchers,
-                evaluator,
-            )?
+                evaluator.reborrow(),
+            )?;
+            // THE UNBUCKETED LATTICE (Phase 5) — a lattice over ONE
+            // bucket, so unbucketed and bucketed installs run the same
+            // code. Main's "one designed difference" from its pre-#420
+            // behaviour, adopted for the same reason: whether the
+            // installed plan fits the caller's device budget is a
+            // property of what is installed, and an unbucketed install is
+            // a set of one.
+            let finalists = vec![crate::finalists::Finalists::new(
+                "the search",
+                &serialized,
+                Some(allow.clone()),
+                matchers,
+                outcome.ranked.clone(),
+                Some(outcome.best_plan.clone()),
+            )];
+            let (selected, rejections) =
+                crate::search::select_finalist_set(finalists, options, &mut evaluator)?;
+            outcome.lattice_rejections = rejections;
+            let (_, finalist) = selected
+                .into_iter()
+                .next()
+                .expect("a one-bucket lattice selects exactly one finalist");
+            (outcome, Some(finalist.plan), Vec::new())
         } else {
             // BUCKETED (D7): one search per Cartesian combination, each
             // validated bucket-wide before its representative is
@@ -528,7 +558,7 @@ impl CudaRuntime {
                 &assembly,
                 &self.dim_buckets,
                 options,
-                allow,
+                Some(allow),
                 matchers,
                 evaluator,
             )?;
@@ -536,9 +566,11 @@ impl CudaRuntime {
                 .first()
                 .map(|plan| plan.outcome.clone())
                 .ok_or_else(|| anyhow!("bucketed search produced no plans"))?;
-            self.bucket_plans = plans;
-            first
+            (first, None, plans)
         };
+        if !searched_buckets.is_empty() {
+            self.bucket_plans = searched_buckets;
+        }
 
         let native = self
             .native
@@ -555,8 +587,12 @@ impl CudaRuntime {
             .enumerate()
             .map(|(index, slot)| (slot.tensor, index))
             .collect();
-        if self.bucket_plans.is_empty() {
-            self.plan = Some(outcome.best_plan.clone());
+        if let Some(plan) = unbucketed_plan {
+            // THE LATTICE'S CHOICE, not `outcome.best_plan` (Phase 5).
+            // Unconstrained they are the same plan — the rank-0 finalist
+            // re-extracts the winning genome — but the installed one is
+            // the one that passed the aggregate check.
+            self.plan = Some(plan);
         } else {
             // With buckets the plan is chosen at execute time; load
             // eagerly only if the runtime already sits at a covered pin.

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -82,6 +82,26 @@ pub struct CompileOptions {
     /// happened to hit a cold cache would time out plans for a cost
     /// their successors do not pay.
     pub candidate_timeout: Option<Duration>,
+    /// HOW MANY RANKED GENOMES THE SEARCH KEEPS (Phase 5, 2026-09-03),
+    /// fastest first, for [`crate::finalists::Finalists`] to fall back
+    /// through. 1 reproduces the pre-Phase-5 behaviour exactly (only the
+    /// winner is ever installable); the default 4 gives the bucket
+    /// lattice three runners-up per bucket to walk into when a set-level
+    /// constraint refuses the fastest.
+    ///
+    /// It costs NOTHING when nothing refuses: finalists past rank 0 are
+    /// extracted only if the walk reaches them.
+    pub keep_finalists: usize,
+    /// THE AGGREGATE DEVICE BUDGET (Phase 5): an upper bound, in bytes,
+    /// on the arena slab the installed plan set will need. `None` (the
+    /// default) is unconstrained and is what every existing caller gets.
+    ///
+    /// It is a SET constraint, which is why it is checked by the bucket
+    /// lattice and not by the per-candidate evaluator: the serving slab
+    /// is grown once and sized to the LARGEST installed plan, so what
+    /// has to fit is `max` over the buckets, and no single bucket's
+    /// search can see that number.
+    pub device_budget_bytes: Option<usize>,
 }
 
 impl Default for CompileOptions {
@@ -95,6 +115,8 @@ impl Default for CompileOptions {
             search_log: true,
             profile_on_device: false,
             candidate_timeout: None,
+            keep_finalists: 4,
+            device_budget_bytes: None,
         }
     }
 }
@@ -273,6 +295,21 @@ pub struct SearchOutcome {
     /// What rejected genomes were rejected FOR (diagnosis ruling
     /// 2026-08-07: understand the breakdown, no auto-repair).
     pub refusal_breakdown: RefusalBreakdown,
+    /// THE RANKED MEASURED GENOMES (Phase 5), fastest first, at most
+    /// `CompileOptions::keep_finalists` of them. `ranked[0]` is the
+    /// winner — the same genome as `best_genome`, by construction.
+    ///
+    /// This is the raw material for [`crate::finalists::Finalists`]: the
+    /// runner-ups a set-level constraint can fall back to. Genomes, not
+    /// plans, because a plan is the expensive half and the walk may
+    /// never need it.
+    pub ranked: Vec<(u128, Genome)>,
+    /// HOW MANY PLAN SETS THE BUCKET LATTICE REJECTED before installing
+    /// one (Phase 5). 0 means the search's own winner (per bucket) was
+    /// installed unchanged — which is what every unconstrained search
+    /// reports. Stamped by the runtime after the lattice runs; the
+    /// genetic search itself always leaves it 0.
+    pub lattice_rejections: usize,
 }
 
 /// Aggregated classification of rejected genomes across one search.
@@ -773,6 +810,27 @@ fn bufferize_cycle_tripwire(
     ))
 }
 
+/// INSERT ONE MEASURED CANDIDATE INTO THE RANKING (Phase 5), keeping
+/// `ranked` sorted fastest-first and no longer than `keep`.
+///
+/// TIES GO AFTER (main's `report_evolving` rule, `genetic.rs:469-479`):
+/// the insertion point is the FIRST position whose metric the newcomer
+/// strictly beats, so an equal-cost incumbent keeps the better rank.
+/// That is what makes `ranked[0]` the same genome the incumbent logic
+/// crowns — the incumbent is only replaced on a strict improvement too.
+fn rank_insert(ranked: &mut Vec<(u128, Genome)>, nanos: u128, genome: &Genome, keep: usize) {
+    let keep = keep.max(1);
+    if ranked.len() >= keep && ranked.last().is_some_and(|(worst, _)| nanos >= *worst) {
+        return; // cannot displace anyone
+    }
+    let position = ranked
+        .iter()
+        .position(|(metric, _)| nanos < *metric)
+        .unwrap_or(ranked.len());
+    ranked.insert(position, (nanos, genome.clone()));
+    ranked.truncate(keep);
+}
+
 /// The incumbent: the best-ranked candidate so far, its plan, and the
 /// heuristic cost of the same graph (carried alongside, never mixed into
 /// the ranking — see [`SearchOutcome::best_heuristic_cost`]).
@@ -882,6 +940,12 @@ pub fn search_implementations(
     // causes instead of shrugging.
     let mut refusals: Vec<String> = Vec::new();
     let mut breakdown = RefusalBreakdown::default();
+    // THE RANKED MEASURED GENOMES (Phase 5): the finalist fallback list.
+    // Only NEWLY PROFILED candidates enter it — a fingerprint cache hit
+    // is the same plan under a different genome, and two identical
+    // finalists at two ranks would waste the lattice's depth on one
+    // choice.
+    let mut ranked: Vec<(u128, Genome)> = Vec::new();
     let mut best: Option<Best> = None;
     // Live progress (#391), on stderr (via the capture-aware adapter, so
     // test output stays clean) and never on a caller's stdout.
@@ -1102,6 +1166,7 @@ pub fn search_implementations(
                     };
                     cache.insert(fingerprint, nanos);
                     plans_profiled += 1;
+                    rank_insert(&mut ranked, nanos, &genome, options.keep_finalists);
                     let improved = best
                         .as_ref()
                         .is_none_or(|incumbent| nanos < incumbent.nanos);
@@ -1143,6 +1208,7 @@ pub fn search_implementations(
                         continue;
                     }
                 };
+                rank_insert(&mut ranked, nanos, &genome, options.keep_finalists);
                 best = Some(Best {
                     nanos,
                     heuristic: crate::heuristic::heuristic_cost_of(&graph),
@@ -1173,17 +1239,166 @@ pub fn search_implementations(
         fingerprint_hits,
         timings,
         refusal_breakdown: breakdown,
+        ranked,
+        // The lattice has not run yet; the runtime stamps this once it
+        // has (see [`select_finalist_set`]).
+        lattice_rejections: 0,
     })
 }
 
+// ===========================================================================
+// PHASE 5: FINALISTS AND THE BUCKET LATTICE — how a searched winner becomes
+// an INSTALLED plan.
+// ===========================================================================
+
+/// THE FINALIST HARD FILTER — the per-plan half of the Phase 5 gate.
+///
+/// MAIN'S SHAPE (`validate_finalist` = `clear_intermediate_buffers` +
+/// `compile_and_validate_profile_candidate`): a finalist is viable only
+/// if the runtime can actually stand it up. Here that means:
+///
+/// * DEVICE-FREE (the heuristic evaluator, which is what most of this
+///   crate's suite runs under): a candidate that reached this function
+///   already extracted, bufferized and arena-planned, and there is
+///   nothing further a host with no GPU can check. The filter passes.
+/// * ON DEVICE (`profile_on_device` with a live evaluator): ONE warmup
+///   `execute_plan` — NVRTC compile, stage, launch, synchronize — which
+///   is exactly the viability check the profiler's prepare phase is. The
+///   slab is released afterwards, matching the search's own per-candidate
+///   hygiene (#422): finalist validation must not leave an outsized
+///   allocation behind for the next bucket.
+///
+/// The candidate timeout is NOT applied here. It is documented to cover
+/// a TIMED RUN (Phase 4's ruling) and a warmup is not one.
+pub fn finalist_validate(
+    pending: &crate::finalists::PendingFinalist,
+    options: &CompileOptions,
+    evaluator: &mut Evaluator<'_>,
+) -> Result<(), String> {
+    let _ = (pending, options);
+    #[cfg(feature = "device")]
+    {
+        if options.profile_on_device {
+            if let Evaluator::Device { device, staged } = evaluator {
+                let ran = crate::device::execute_plan(device, &pending.plan, staged);
+                device.release_slab();
+                ran.map_err(|err| format!("device warmup of ranked #{}: {err:#}", pending.rank))?;
+            }
+        }
+    }
+    #[cfg(not(feature = "device"))]
+    {
+        let _ = evaluator;
+    }
+    Ok(())
+}
+
+/// THE SET CONSTRAINT — the aggregate half of the Phase 5 gate, and the
+/// whole reason a lattice exists on this runtime.
+///
+/// WHAT IS AGGREGATE HERE. This runtime's one resource that spans bucket
+/// plans is the ARENA SLAB: [`crate::device::CudaDevice`] keeps a single
+/// grow-only slab for its whole life and `ensure_slab` grows it to
+/// whatever the plan being executed needs, so a runtime serving several
+/// bucket plans ends up holding `max` over their `slab_bytes`. That
+/// maximum is what a device budget has to bound, and no single bucket's
+/// search can see it — which is precisely a set-level constraint.
+///
+/// WHY `max` AND NOT A SUM. The alternative reading — add each plan's
+/// standalone (boundary + escaping) allocations to the slab — was
+/// considered and rejected: those buffers are allocated inside one
+/// `execute_plan` call and dropped at its end, so they are never
+/// resident across buckets and adding them would charge a budget for
+/// memory that is never simultaneously held. The slab IS the retained
+/// footprint; everything else is per-execution.
+///
+/// `None` budget = unconstrained, which is every pre-Phase-5 caller.
+fn validate_set(slab_bytes: &[usize], options: &CompileOptions) -> Result<(), String> {
+    let Some(budget) = options.device_budget_bytes else {
+        return Ok(());
+    };
+    let peak = slab_bytes.iter().copied().max().unwrap_or(0);
+    if peak > budget {
+        return Err(format!(
+            "the set's plans need an arena slab of {peak} bytes (per-bucket \
+             {slab_bytes:?}), over the {budget}-byte device budget"
+        ));
+    }
+    Ok(())
+}
+
+/// RUN THE BUCKET LATTICE and return the installed finalist per bucket,
+/// plus how many sets were rejected on the way.
+///
+/// The driver loop is main's (`§2.7`), minus the LLIR compile step this
+/// branch does not have: propose the cheapest untried set, check the
+/// aggregate constraint over it, install it or reject it and let the
+/// lattice open the one-coordinate-slower successors.
+///
+/// UNBUCKETED CALLERS PASS ONE BUCKET. That is main's "one designed
+/// difference" and it is deliberate here too: there is one selection
+/// path, and an unbucketed install is a set of one.
+pub fn select_finalist_set(
+    buckets: Vec<crate::finalists::Finalists<'_>>,
+    options: &CompileOptions,
+    evaluator: &mut Evaluator<'_>,
+) -> Result<(Vec<(usize, crate::finalists::PendingFinalist)>, usize)> {
+    let mut lattice = crate::lattice::BucketLattice::new(buckets, crate::lattice::sum_metrics);
+    let mut validate = |pending: &crate::finalists::PendingFinalist| -> Result<(), String> {
+        finalist_validate(pending, options, evaluator)
+    };
+    loop {
+        let Some(set) = lattice.next(&mut validate) else {
+            return Err(anyhow!("{}", lattice.failure_message()));
+        };
+        // Owned numbers, so the immutable borrow of the lattice ends
+        // before a rejection takes it mutably.
+        let slabs = lattice.slab_bytes(&set);
+        match validate_set(&slabs, options) {
+            Ok(()) => {
+                let rejections = lattice.rejections();
+                if rejections > 0 && options.search_log_enabled() {
+                    // MAIN'S FALLBACK LINE ("aggregate fallback: selected
+                    // per-bucket finalist ranks …"): the one moment the
+                    // installed plan is NOT the search's winner is worth
+                    // saying out loud.
+                    eprintln!(
+                        "   {} finalist ranks {:?} after {rejections} rejection(s)",
+                        "Fallback".yellow().bold(),
+                        lattice.ranks(&set)
+                    );
+                }
+                return Ok((lattice.select(&set), rejections));
+            }
+            Err(reason) => lattice.reject(&set, reason, &mut validate),
+        }
+    }
+}
+
 /// One bucket combination's finished search: the dim ranges it covers, the
-/// representative pins it was searched at, and the winning plan.
+/// representative pins it was searched at, and the plan the bucket
+/// lattice INSTALLED for it.
 #[derive(Debug)]
 pub struct BucketPlan {
     pub ranges: BTreeMap<luminal::shape::Symbol, (usize, usize)>,
     pub representative: luminal::shape::DynMap,
     pub program: LogicalProgram,
+    /// This bucket's own genetic search — its winner, its accounting,
+    /// its ranked finalists. It is the SEARCH's report and is left
+    /// exactly as the search wrote it.
     pub outcome: SearchOutcome,
+    /// THE INSTALLED PLAN (Phase 5): the finalist the bucket lattice
+    /// selected. It is `outcome.best_plan` whenever nothing refused the
+    /// search's winner — which is every unconstrained search — and a
+    /// runner-up when the aggregate device budget refused the faster
+    /// set. `execute` loads THIS.
+    pub plan: crate::layouts::CudaPlan,
+    /// The installed finalist's 1-BASED rank in `outcome.ranked`. 1 =
+    /// the search's own winner.
+    pub finalist_rank: usize,
+    /// The installed plan's arena high-water mark, in bytes — what the
+    /// budget was checked against.
+    pub slab_bytes: usize,
 }
 
 /// The pre-search program parts a bucketed search re-renders from — the
@@ -1238,7 +1453,14 @@ pub fn bucketed_search_implementations(
     mut evaluator: Evaluator<'_>,
 ) -> Result<Vec<BucketPlan>> {
     ensure!(!dim_buckets.is_empty(), "no dim buckets supplied");
-    let mut plans = Vec::new();
+    // The per-combination e-graphs are kept ALIVE across the whole
+    // routine, not dropped at the end of each search: Phase 5's
+    // finalists re-extract from them once every bucket has been
+    // searched. They are locals rather than fields of [`BucketPlan`] so
+    // they go away when this function returns — a serialized e-graph for
+    // a real model is large, and nothing after selection reads it.
+    let mut egraphs: Vec<egraph_serialize::EGraph> = Vec::new();
+    let mut searched: Vec<SearchedBucket> = Vec::new();
     for (ranges, representative, program) in bucket_renders(assembly, dim_buckets)? {
         let text = format!("{}\n\n{}", assembly.assembled_program, program.text);
         let mut egraph = luminal::egglog_snippet::new_egraph();
@@ -1259,14 +1481,74 @@ pub fn bucketed_search_implementations(
             // combinations, so the evaluator is lent, not rebuilt.
             evaluator.reborrow(),
         )?;
+        egraphs.push(serialized);
+        searched.push((ranges, representative, program, outcome));
+    }
+
+    // PHASE 5: the buckets' ranked genomes become finalists, and the
+    // lattice picks one SET of them under the aggregate budget.
+    let (selected, rejections) = {
+        let buckets: Vec<crate::finalists::Finalists<'_>> = searched
+            .iter()
+            .zip(&egraphs)
+            .enumerate()
+            .map(|(index, ((ranges, _, _, outcome), egraph))| {
+                crate::finalists::Finalists::new(
+                    bucket_label(index, ranges),
+                    egraph,
+                    allow_override.clone(),
+                    matchers,
+                    outcome.ranked.clone(),
+                    Some(outcome.best_plan.clone()),
+                )
+            })
+            .collect();
+        select_finalist_set(buckets, options, &mut evaluator)?
+    };
+
+    let mut installed: BTreeMap<usize, crate::finalists::PendingFinalist> =
+        selected.into_iter().collect();
+    let mut plans = Vec::new();
+    for (index, (ranges, representative, program, mut outcome)) in searched.into_iter().enumerate()
+    {
+        let finalist = installed
+            .remove(&index)
+            .ok_or_else(|| anyhow!("the lattice selected no plan for bucket {index}"))?;
+        outcome.lattice_rejections = rejections;
         plans.push(BucketPlan {
             ranges,
             representative,
             program,
             outcome,
+            slab_bytes: finalist.arena.slab_bytes,
+            finalist_rank: finalist.rank,
+            plan: finalist.plan,
         });
     }
     Ok(plans)
+}
+
+/// One combination after its genetic search, before the lattice has
+/// chosen which of its finalists to install: `(ranges, representative,
+/// pinned render, the search's report)`.
+type SearchedBucket = (
+    BTreeMap<luminal::shape::Symbol, (usize, usize)>,
+    luminal::shape::DynMap,
+    LogicalProgram,
+    SearchOutcome,
+);
+
+/// How a bucket names itself in a lattice failure message —
+/// `"bucket 0 (a in [2, 4])"`.
+pub(crate) fn bucket_label(
+    index: usize,
+    ranges: &BTreeMap<luminal::shape::Symbol, (usize, usize)>,
+) -> String {
+    let dims: Vec<String> = ranges
+        .iter()
+        .map(|(dim, (min, max))| format!("{dim} in [{min}, {max}]"))
+        .collect();
+    format!("bucket {index} ({})", dims.join(", "))
 }
 
 /// One bucket combination's `(ranges, representative pins, pinned

--- a/crates/luminal_cuda_lite/tests/device_profile.rs
+++ b/crates/luminal_cuda_lite/tests/device_profile.rs
@@ -243,3 +243,81 @@ fn a_zero_budget_times_every_candidate_out_and_says_so() {
         "the refusal must name the timeout, not something else: {text}"
     );
 }
+
+/// PHASE 5 ON DEVICE: the finalist hard filter is a real warmup, and the
+/// aggregate device budget is enforced against real arena slabs.
+///
+/// The two halves the CPU suite (`finalists_lattice.rs`) cannot reach:
+///
+///  * `CompileOptions::device_budget_bytes: Some(0)` cannot hold any plan
+///    of this fixture, so every set in the lattice is rejected and the
+///    search refuses NAMING THE BUDGET. That the message is about the
+///    budget and NOT about a warmup is the pin that the hard filter
+///    passed on every finalist it materialized — under
+///    `profile_on_device` each of them was compiled, staged and RUN once
+///    on the device before the budget ever looked at it.
+///  * With the budget lifted, the same search installs its own winner
+///    (rank 1, zero rejections) and the installed plan executes.
+#[test]
+fn the_finalist_filter_warms_up_on_device_and_the_budget_is_enforced() {
+    let (cx, floats, ints, _out) = mini_llama3_fixture();
+    let data: FxHashMap<NodeIndex, HostBuffer> = floats
+        .iter()
+        .map(|(id, v)| (*id, HostBuffer::from(v.clone())))
+        .chain(
+            ints.iter()
+                .map(|(id, v)| (*id, HostBuffer::from(v.clone()))),
+        )
+        .collect();
+
+    // A budget nothing meets: every finalist is warmed up on the device,
+    // every set is refused for its slab, and the walk runs out.
+    let mut rt = CudaRuntime::load(&cx).expect("cuda load");
+    let err = rt
+        .search(
+            &data,
+            &CompileOptions {
+                profile_on_device: true,
+                keep_finalists: 3,
+                device_budget_bytes: Some(0),
+                ..luminal_cuda_lite::harness_search_options()
+            },
+        )
+        .expect_err("a zero device budget leaves no viable plan set");
+    let text = format!("{err:#}");
+    assert!(
+        text.contains("0-byte device budget"),
+        "the refusal must name the budget: {text}"
+    );
+    assert!(
+        !text.contains("device warmup"),
+        "every finalist should have warmed up successfully; the refusal is the \
+         budget's, not the device's: {text}"
+    );
+
+    // Budget lifted: the search installs its own winner and it runs.
+    let mut rt = CudaRuntime::load(&cx).expect("cuda load");
+    let outcome = rt
+        .search(
+            &data,
+            &CompileOptions {
+                profile_on_device: true,
+                keep_finalists: 3,
+                device_budget_bytes: Some(usize::MAX),
+                ..luminal_cuda_lite::harness_search_options()
+            },
+        )
+        .expect("a budget nothing exceeds installs the winner");
+    assert_eq!(
+        outcome.lattice_rejections, 0,
+        "an unreachable budget must reject nothing"
+    );
+    for (id, v) in &floats {
+        rt.set_data(*id, v.clone());
+    }
+    for (id, v) in &ints {
+        rt.set_data(*id, v.clone());
+    }
+    rt.execute()
+        .expect("the plan the lattice installed executes on the device");
+}

--- a/crates/luminal_cuda_lite/tests/finalists_lattice.rs
+++ b/crates/luminal_cuda_lite/tests/finalists_lattice.rs
@@ -1,0 +1,294 @@
+//! FINALISTS AND THE BUCKET LATTICE (Phase 5 of the #420/#422 rejoin),
+//! CPU-side.
+//!
+//! The genetic search now keeps a RANKED list of genomes
+//! (`CompileOptions::keep_finalists`), and what gets INSTALLED is chosen
+//! by a best-first walk over the buckets' finalist ranks under one
+//! aggregate constraint: `CompileOptions::device_budget_bytes` bounds the
+//! arena slab the runtime will hold — `max` over the installed plans,
+//! because the serving slab is grown once and sized to the largest of
+//! them.
+//!
+//! The three things worth pinning:
+//!
+//!  * UNCONSTRAINED, NOTHING MOVES. With no budget the rank-1 finalist of
+//!    every bucket validates trivially, the lattice reports zero
+//!    rejections, and the installed plan is the search's own winner —
+//!    which is why every pre-Phase-5 suite sees the trajectory it had.
+//!  * A BUDGET THAT REFUSES THE WINNER FALLS BACK. Set just under the
+//!    rank-1 set's slab, the walk rejects it and installs a
+//!    one-coordinate-slower set that fits.
+//!  * A BUDGET NOTHING MEETS REFUSES BY NAME. The error carries the
+//!    budget and the bytes that failed it, rather than a shrug.
+//!
+//! Everything here is device-free: the plans are bufferized and
+//! arena-planned on the host, which is where `slab_bytes` comes from.
+
+use luminal::bufferize::{BufferIrGraph, BufferNode};
+use luminal::dtype::DType;
+use luminal::graph::{DimBucket, Graph};
+use luminal::layouts::DecodedLayout;
+use luminal::prelude::FxHashMap;
+use luminal_cuda_lite::{harness_search_options, CompileOptions, CudaRuntime, HostBuffer};
+
+/// A plan's structural signature — node/edge/buffer counts plus the
+/// multiset of elected compute labels. Two plans with the same signature
+/// are the same election; comparing signatures says "the lattice
+/// installed the plan the search chose" without pinning node ids, which
+/// are not stable across runs.
+fn signature(plan: &BufferIrGraph<DecodedLayout>) -> (usize, usize, usize, Vec<String>) {
+    let mut labels: Vec<String> = plan
+        .dag
+        .node_weights()
+        .filter_map(|node| match node {
+            BufferNode::Compute { op, .. } => Some(op.label().to_string()),
+            _ => None,
+        })
+        .collect();
+    labels.sort();
+    (
+        plan.dag.node_count(),
+        plan.dag.edge_count(),
+        plan.buffers.len(),
+        labels,
+    )
+}
+
+/// The plan_smoke fixture, verbatim.
+fn elementwise_fixture() -> (Graph, FxHashMap<luminal::prelude::NodeIndex, HostBuffer>) {
+    let mut cx = Graph::new();
+    let a = cx.tensor((2usize, 3usize), DType::F32);
+    let b = cx.tensor((2usize, 3usize), DType::F32);
+    let _out = ((a + b) * a).output();
+    let data: FxHashMap<_, _> = [
+        (a.id, vec![1.0f32, 2., 3., 4., 5., 6.].into()),
+        (b.id, vec![10.0f32, 20., 30., 40., 50., 60.].into()),
+    ]
+    .into_iter()
+    .collect();
+    (cx, data)
+}
+
+/// (t1) AN UNCONSTRAINED SEARCH INSTALLS ITS OWN WINNER.
+///
+/// The lattice runs even here — an unbucketed search is a lattice over
+/// one bucket, main's "one designed difference" — and this is the pin
+/// that it costs nothing: zero rejections, rank 1, and the installed
+/// plan is the searched `best_plan` rather than something re-derived
+/// into a different election.
+#[test]
+fn an_unconstrained_search_installs_the_searched_winner() {
+    let (cx, data) = elementwise_fixture();
+    let mut rt = CudaRuntime::load(&cx).expect("cuda load");
+    let outcome = rt
+        .search(&data, &harness_search_options())
+        .expect("search under the CUDA allow list");
+
+    assert!(outcome.plans_profiled > 0, "no plans profiled");
+    assert_eq!(
+        outcome.lattice_rejections, 0,
+        "nothing constrains this search, so no set may be rejected"
+    );
+    assert!(
+        !outcome.ranked.is_empty(),
+        "a search that profiled a plan must rank at least one genome"
+    );
+    assert!(
+        outcome.ranked.len() <= harness_search_options().keep_finalists,
+        "the ranked list must respect keep_finalists: {} > {}",
+        outcome.ranked.len(),
+        harness_search_options().keep_finalists
+    );
+    // `ranked[0]` IS the winner — the finalist walk starts from the same
+    // genome the incumbent logic crowned.
+    assert_eq!(
+        outcome.ranked[0].0, outcome.best_nanos,
+        "the fastest ranked metric must be the winner's"
+    );
+    assert!(
+        outcome.ranked[0].1.choices == outcome.best_genome.choices,
+        "the fastest ranked genome must be the winning genome"
+    );
+    // ...and the plan the runtime holds is that winner's plan.
+    let installed = rt.plan().expect("a plan is installed");
+    assert_eq!(
+        signature(installed),
+        signature(&outcome.best_plan),
+        "the installed plan must be the search's own winner"
+    );
+}
+
+/// A bucketed fixture with real intermediates, so different elections
+/// need different amounts of slab: a projection, a score product, an
+/// exp, a second product and two elementwise combines over a dynamic
+/// context length.
+fn bucketed_fixture() -> Graph {
+    let mut cx = Graph::new();
+    cx.set_dim('a', 3);
+    let d = 8usize;
+    let x = cx.tensor((1usize, d), DType::F32);
+    let wq = cx.tensor((d, d), DType::F32);
+    let k = cx.tensor(('a', d), DType::F32);
+    let q = x.matmul(wq);
+    let scores = q.matmul(k.permute((1, 0)));
+    let e = scores.exp();
+    let p = e * scores;
+    let o = p.matmul(k);
+    let o2 = (o * x) + q;
+    let _out = (o2 * o).output();
+    cx
+}
+
+/// The bucketed search's options: enough sampling that each bucket ranks
+/// several distinct genomes, seeded (seed 2) for a deterministic walk.
+fn bucketed_options(budget: Option<usize>) -> CompileOptions {
+    CompileOptions {
+        generations: 4,
+        generation_size: 8,
+        mutations: 3,
+        trials: 1,
+        seed: 2,
+        search_log: false,
+        keep_finalists: 8,
+        device_budget_bytes: budget,
+        ..Default::default()
+    }
+}
+
+/// (t2) A BUDGET THAT REFUSES THE WINNING SET FALLS BACK TO A SLOWER ONE
+/// THAT FITS.
+///
+/// Two passes over the same fixture. The first is unconstrained and
+/// reports what the winning set actually needs; the second sets the
+/// budget ONE BYTE under that, which by construction refuses the winning
+/// set. The walk then opens one-coordinate-slower successors until one
+/// fits, and what it installs must respect the budget.
+///
+/// SELF-CALIBRATING ON PURPOSE: the budget is derived from the first
+/// pass rather than written as a constant, so the test says "one byte
+/// too little" no matter what the planner's numbers become.
+///
+/// The rejection COUNT is asserted as a lower bound, not pinned: which
+/// successor is proposed first is decided by the metric aggregate, not
+/// by the slabs, so more than one proposal may be over budget before a
+/// fitting one comes up. (Measured at this fixture and seed: 2 — the
+/// rank-1 set and then the successor that raised the cheap bucket's
+/// coordinate.)
+#[test]
+fn a_device_budget_forces_the_lattice_to_a_slower_set() {
+    let cx = bucketed_fixture();
+
+    // Pass 1: what does the winning set need?
+    let mut baseline = CudaRuntime::load(&cx).expect("cuda load");
+    baseline
+        .bind_dim_buckets('a', vec![DimBucket::new(2, 4), DimBucket::new(9, 11)])
+        .expect("disjoint sorted buckets bind");
+    let unconstrained = baseline
+        .search(&Default::default(), &bucketed_options(None))
+        .expect("the unconstrained bucketed search completes");
+    assert_eq!(unconstrained.lattice_rejections, 0);
+    let winning: Vec<usize> = baseline
+        .bucket_plans()
+        .iter()
+        .map(|plan| plan.slab_bytes)
+        .collect();
+    assert_eq!(winning.len(), 2, "one plan per bucket");
+    for plan in baseline.bucket_plans() {
+        assert_eq!(
+            plan.finalist_rank, 1,
+            "unconstrained, every bucket installs its own winner"
+        );
+    }
+    let peak = *winning.iter().max().expect("two buckets");
+    assert!(peak > 0, "this fixture must need a slab: {winning:?}");
+
+    // Pass 2: one byte too little for the winning set.
+    let budget = peak - 1;
+    let mut rt = CudaRuntime::load(&cx).expect("cuda load");
+    rt.bind_dim_buckets('a', vec![DimBucket::new(2, 4), DimBucket::new(9, 11)])
+        .expect("disjoint sorted buckets bind");
+    let outcome = rt
+        .search(&Default::default(), &bucketed_options(Some(budget)))
+        .expect("a slower set fits the budget");
+
+    assert!(
+        outcome.lattice_rejections >= 1,
+        "a budget under the winning set's slab must reject at least that set"
+    );
+    let installed: Vec<usize> = rt
+        .bucket_plans()
+        .iter()
+        .map(|plan| plan.slab_bytes)
+        .collect();
+    let installed_peak = *installed.iter().max().expect("two buckets");
+    assert!(
+        installed_peak <= budget,
+        "the installed set needs {installed_peak} bytes over a {budget}-byte budget \
+         (per bucket {installed:?})"
+    );
+    let ranks: Vec<usize> = rt
+        .bucket_plans()
+        .iter()
+        .map(|plan| plan.finalist_rank)
+        .collect();
+    assert!(
+        ranks.iter().any(|rank| *rank > 1),
+        "the fallback must install a runner-up somewhere, got ranks {ranks:?}"
+    );
+    println!(
+        "budget {budget}: winning set {winning:?} -> installed {installed:?} at ranks \
+         {ranks:?} after {} rejection(s)",
+        outcome.lattice_rejections
+    );
+}
+
+/// (t3) A BUDGET NO CANDIDATE MEETS REFUSES BY NAME.
+///
+/// Zero bytes cannot hold any plan of this fixture, so every set in the
+/// lattice is rejected and the walk runs out. The error must name the
+/// budget and the bytes that failed it — the runtime's choice (D10) is
+/// to refuse rather than install something over budget.
+#[test]
+fn a_budget_nothing_meets_refuses_and_names_it() {
+    let cx = bucketed_fixture();
+    let mut rt = CudaRuntime::load(&cx).expect("cuda load");
+    rt.bind_dim_buckets('a', vec![DimBucket::new(2, 4), DimBucket::new(9, 11)])
+        .expect("disjoint sorted buckets bind");
+    let err = rt
+        .search(&Default::default(), &bucketed_options(Some(0)))
+        .expect_err("a zero budget leaves no viable set");
+    let text = format!("{err:#}");
+    assert!(
+        text.contains("0-byte device budget"),
+        "the refusal must name the budget: {text}"
+    );
+    assert!(
+        text.contains("no viable plan set"),
+        "the refusal must say the LATTICE failed, not the search: {text}"
+    );
+    assert!(
+        text.contains("ran out of finalists"),
+        "the refusal must say why no slower set was tried: {text}"
+    );
+}
+
+/// `keep_finalists: 1` reproduces the pre-Phase-5 world exactly: one
+/// ranked genome, so the lattice has a single point and any constraint
+/// it fails is fatal. The pin is that the OPTION is honoured — a search
+/// that keeps one finalist must not silently keep four.
+#[test]
+fn keep_finalists_bounds_the_ranked_list() {
+    let (cx, data) = elementwise_fixture();
+    let mut rt = CudaRuntime::load(&cx).expect("cuda load");
+    let outcome = rt
+        .search(
+            &data,
+            &CompileOptions {
+                keep_finalists: 1,
+                ..harness_search_options()
+            },
+        )
+        .expect("search completes");
+    assert_eq!(outcome.ranked.len(), 1, "keep_finalists: 1 keeps one");
+    assert_eq!(outcome.lattice_rejections, 0);
+}

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -3283,6 +3283,11 @@ election-dependent that pin is.
   everything by the heuristic, then re-measure the top k on device) would
   cut device time, but it puts the prior back on the critical path —
   exactly what D6 warns about — and it was not asked for.
+  *(SUPERSEDED by Phase 5, below — Austin's D8 on this deferral was
+  "defer temporarily, but then add". What landed there is the finalist
+  fallback and the aggregate set constraint, NOT the two-tier
+  heuristic-then-measure scheme this bullet argues against; the prior
+  never returns to the critical path.)*
 - **Two-tier graph re-ranking** (measure at one shape, extrapolate to
   others) — not adopted, same reason plus the static-plan limitation
   buckets already carry.
@@ -3296,6 +3301,168 @@ election-dependent that pin is.
   With device noise that is a deliberate choice (one measurement per
   distinct plan, not per genome); re-measuring and averaging is the
   alternative nobody asked for.
+
+## Program: #420/#422 rejoin — Phase 5 (finalists + bucket lattice)
+
+**The move.** Phase 4 landed the device evaluator and deferred main's
+`Finalists` / `BucketLattice` pair in writing ("**Finalists /
+BucketLattice.** Not adopted."). Austin's D8 on that deferral was *"defer
+temporarily, but then add"*. This is the "then add". CUDA-lite's search
+now keeps a RANKED list of genomes rather than only the winner, and what
+gets INSTALLED is chosen by a best-first walk over the buckets' finalist
+ranks under one aggregate constraint.
+
+**Why a runtime with buckets needs one.** Until now each bucket installed
+its own GA winner. That is right exactly while nothing constrains the
+buckets JOINTLY. This runtime has one such resource: `CudaDevice` keeps a
+single grow-only arena slab for its whole life and `ensure_slab` grows it
+to whatever the plan being executed needs, so a runtime serving several
+bucket plans ends up holding `max` over their `slab_bytes`. A caller's
+device budget therefore applies to the SET, and no single bucket's search
+can see the number it must meet.
+
+### What landed
+
+| Where | What |
+| --- | --- |
+| `crates/luminal_cuda_lite/src/finalists.rs` (new) | `Finalists<'a>` + `PendingFinalist`: one bucket's ranked genomes, re-materialized ONE AT A TIME (`extract_next` / `accept` / `reject` / `ensure(target, validate)` / `take` / `failure_message`). |
+| `crates/luminal_cuda_lite/src/lattice.rs` (new) | `BucketLattice<'a>` + `BucketSet` + `sum_metrics`: `new(buckets, aggregate)`, `next(validate)`, `reject(set, reason, validate)`, `slab_bytes(set)`, `ranks(set)`, `select(set)`, `failure_message()`. |
+| `crates/luminal_cuda_lite/src/search.rs` | `CompileOptions::{keep_finalists (default 4), device_budget_bytes (default None)}`; `SearchOutcome::{ranked, lattice_rejections}`; `rank_insert`; `finalist_validate`, `validate_set`, `select_finalist_set` (the driver loop); `BucketPlan::{plan, finalist_rank, slab_bytes}`; `bucket_label`. |
+| `crates/luminal_cuda_lite/src/runtime.rs` | `CudaRuntime::search` runs the lattice on BOTH paths and installs its choice; `select_bucket_plan` loads `BucketPlan::plan` (the installed finalist), not `outcome.best_plan`. |
+| `crates/luminal_cuda_lite/src/arena.rs` | `buffer_bytes` MOVED here from `device.rs` (it was `fn`-private and device-gated). It is device-free and now has two callers: the executor and the finalists' arena planning, which must run on a laptop for a budget to be checkable without a GPU. One rule, one place. |
+| `crates/luminal_cuda_lite/tests/finalists_lattice.rs` (new, CPU) | The four pins (below). |
+| `crates/luminal_cuda_lite/tests/device_profile.rs` | One device-gated case: the hard filter warms up on device, and the budget is enforced against real slabs. |
+
+### The aggregate and the constraint
+
+The aggregate is `sum_metrics` — Σ of the per-bucket metrics, saturating.
+It must be COORDINATE-MONOTONE (raising one coordinate to a slower
+finalist must not lower the aggregate), which Σ over nonnegative metrics
+is; that is what makes "expand into one-coordinate-slower successors,
+always pop the strictly-smallest aggregate" enumerate the lattice in
+nondecreasing cost order. A `visited` set stops a point entering the
+frontier along two paths, so no set is proposed twice.
+
+The constraint is `max_i(arena_i.slab_bytes) <= device_budget_bytes`.
+THE ALTERNATIVE READING WAS CONSIDERED AND REJECTED: adding each plan's
+standalone (boundary + escaping) allocations to its slab. Those buffers
+are allocated inside one `execute_plan` call and dropped at its end, so
+they are never resident across buckets; charging a budget for memory that
+is never simultaneously held would be a lie about the resource. The slab
+IS the retained footprint. `None` (the default) is unconstrained, which
+is every pre-Phase-5 caller.
+
+The FINALIST-level filter (`finalist_validate`) is main's hard filter,
+re-expressed: device-free it is trivially satisfied (a candidate that got
+this far extracted, bufferized and arena-planned, and there is nothing
+further a host with no GPU can check); under `profile_on_device` with a
+live device it is ONE warmup `execute_plan` — compile, stage, launch,
+synchronize — after which the slab is released, matching the search's own
+per-candidate hygiene. `candidate_timeout` is NOT applied here: Phase 4
+ruled it covers a TIMED RUN, and a warmup is not one.
+
+### Two deliberate departures from a literal port
+
+RANK 1 IS HANDED OVER, NOT RE-EXTRACTED. Main's `Finalists` builds
+another extractor per bucket and re-extracts even the winner. Here the
+genetic search already built the winner's plan, and `Finalists::new`
+takes it: rank 1 costs one arena plan instead of a whole extraction, and
+the extraction session is built LAZILY, on the first genome that actually
+needs it. Measured on this crate's CPU suite: the eager version cost
++27 s over a 61 s baseline (`cublaslt_election` alone 36 s -> 49 s); with
+the hand-over it is +10 s, and the residue is the arena plan and the plan
+clone. It also makes "an unconstrained search installs what it searched"
+true by construction rather than by an argument about determinism.
+
+THE UNBUCKETED PATH RUNS THE LATTICE TOO, over one bucket — main's "one
+designed difference" from its pre-#420 behaviour, adopted for the same
+reason: whether the installed plan fits the caller's budget is a property
+of what is installed, and an unbucketed install is a set of one. There is
+one selection path to reason about instead of two.
+
+### Dropped from main's version
+
+Everything LLIR-shaped, because this branch has no LLIR: `pre_unroll`
+graphs, the `LLIR_DUMP_DIR` / `LLIR_DUMP_PRE_UNROLL` dump machinery in
+`Finalists::take` and `BucketLattice::select`, and `unroll` on the
+re-extraction path. The ANSI progress bars stay dropped (Phase 4's
+`SearchProgress` is kept and unchanged; the lattice adds ONE line, main's
+"aggregate fallback" report, printed only when a fallback actually
+happened). Main's `search_time_limit` clock over finalization is not
+carried — this branch has no such option, and its one timeout is
+documented to cover a timed device run only, so it was not re-purposed.
+
+### The reference runtime is deliberately untouched
+
+`luminal_reference` gets none of this. It has NO aggregate resource
+across buckets: its executor allocates per call on the host and keeps no
+shared arena, so `validate_set` there would be `Ok(())` unconditionally
+and the lattice would degenerate to "install each bucket's winner" — the
+code it already has, wrapped in machinery that could never reject
+anything. Adding it there is a later phase's job, and it should wait
+until that runtime has a set-level constraint worth checking.
+
+### Tests
+
+CPU (`tests/finalists_lattice.rs`, 4 tests):
+
+- `an_unconstrained_search_installs_the_searched_winner` — zero
+  rejections, `ranked[0]` IS `best_genome`/`best_nanos`, and the
+  installed plan's structural signature (node/edge/buffer counts + sorted
+  compute labels) equals `best_plan`'s. This is the pin that Phase 5
+  costs the existing suites nothing.
+- `a_device_budget_forces_the_lattice_to_a_slower_set` — two passes over
+  a two-bucket attention-shaped fixture. Pass 1 is unconstrained and
+  REPORTS what the winning set needs; pass 2 sets the budget one byte
+  under that, so the winning set is refused by construction. The
+  installed set must fit, and some bucket must install a rank > 1. The
+  budget is self-calibrating rather than a constant, so the test says
+  "one byte too little" whatever the planner's numbers become. Measured
+  at this fixture and seed: winning slabs `[1280, 2560]`, installed
+  `[1280, 1792]` at ranks `[1, 2]` after 2 rejections.
+- `a_budget_nothing_meets_refuses_and_names_it` — a zero budget: every
+  set rejected, and the error names the budget, says the LATTICE failed
+  (not the search), and says why no slower set was tried.
+- `keep_finalists_bounds_the_ranked_list` — `keep_finalists: 1` keeps
+  one, which is the pre-Phase-5 world exactly.
+
+THE REJECTION COUNT IS A LOWER BOUND, NOT A PIN. Which successor is
+proposed after a rejection is decided by the METRIC aggregate, not by the
+slabs, so more than one proposal may be over budget before a fitting one
+comes up (this fixture: 2). Pinning the exact count would pin the
+sampler's ordering, which is the kind of pin the permutation-invariance
+ruling (2026-09-02) says not to write.
+
+Device (`tests/device_profile.rs`,
+`the_finalist_filter_warms_up_on_device_and_the_budget_is_enforced`): a
+zero budget over the mini-llama3 fixture must refuse NAMING THE BUDGET
+and NOT naming a warmup — which is the pin that the hard filter passed on
+every finalist it materialized, i.e. that each was compiled, staged and
+run once on the device before the budget looked at it. Then the same
+search with the budget lifted installs rank 1 with zero rejections and
+executes.
+
+### Deferred
+
+- **THE REFERENCE RUNTIME**, above.
+- **A SET-LEVEL METRIC OTHER THAN Σ.** `AggregateFn` is a plain `fn`
+  pointer and the lattice is generic in it, but there is exactly one
+  aggregate in this crate. A weighted sum (buckets are not equally
+  likely) is the obvious next one and wants a bucket-frequency model
+  nobody has asked for.
+- **STANDALONE BYTES IN THE BUDGET.** Rejected above as a lie about the
+  resource, but the honest version — a per-execution peak that includes
+  the boundary and escaping rows — is a different (and also useful)
+  budget, and would want its own option rather than overloading this one.
+- **A FALLBACK REASON IN `SearchOutcome`.** The outcome reports HOW MANY
+  sets the lattice rejected, not WHY each was rejected; the reasons are
+  in the failure message only when the walk fails outright. A structured
+  per-rejection record is more accounting than anyone has asked for.
+- **`Finalists` HAS NO SYNTHETIC CONSTRUCTOR.** Every finalist comes from
+  a real genome, so the lattice's walk order is only exercised through
+  real searches. A unit test over hand-built finalists would pin the
+  best-first ordering directly; it would also need a public way to inject
+  them, which is test scaffolding in the library.
 
 ## #406 pad — the select construction REVERTED (2026-09-03)
 

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -3442,6 +3442,25 @@ run once on the device before the budget looked at it. Then the same
 search with the budget lifted installs rank 1 with zero rejections and
 executes.
 
+### Verified on the A100 (2026-09-03)
+
+`93dd7cb1` checked out on the box, `cargo test -p luminal_cuda_lite
+--features device --test device_profile --test finalists_lattice`:
+
+```
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 70.34s
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 14.42s
+```
+
+The Phase 4 probe is unchanged by Phase 5 — mini-llama3, 6 plans
+profiled, 2 fingerprint hits, winner 3.617 ms measured, zero refusals —
+and the new device case passes, so the finalist hard filter's warmup arm
+compiles, stages and runs every finalist it materializes before the
+budget is consulted. The CPU lattice case runs identically on the box:
+winning slabs `[1280, 2560]` -> installed `[1280, 1792]` at ranks
+`[1, 2]` after 2 rejections, which is the same walk the mac produced.
+Box returned to `logical-ssa-project`.
+
 ### Deferred
 
 - **THE REFERENCE RUNTIME**, above.


### PR DESCRIPTION
**Program:** #420/#422 rejoin, Phase 5 of the stack — base `rejoin/p4-device-evaluator` (PR #484). Plan page: https://claude.ai/code/artifact/6b5d25e3-94cf-4089-8977-8e44f971b8a5. Merge in order; retarget to `logical-ssa-project` before merging.

**Ruling (Austin, D8):** Finalists and the bucket lattice — "defer temporarily, but then add." This is the add, CL only.

## What landed (`93dd7cb1`, `8f12607b`)
- `CompileOptions.keep_finalists` (default 4) and `CompileOptions.device_budget_bytes` (default None = unconstrained). `SearchOutcome.ranked` (fastest first, at most `keep_finalists`) and `SearchOutcome.lattice_rejections`.
- `finalists.rs`: per-bucket lazy re-extraction of ranked genomes under a validate hook (`extract_next`, `accept`, `reject`, `ensure`, `take`, `failure_message`). Rank 1 is handed over from the search rather than re-extracted, which keeps "an unconstrained search installs what it searched" true by construction and saved 27 s on the CPU election suite.
- `lattice.rs`: best-first walk over per-bucket finalist ranks minimizing the summed metric; a rejected set opens its one-coordinate-slower successors, materializing deeper finalists lazily.
- **Constraint:** the selected set's maximum arena `slab_bytes` must fit `device_budget_bytes`; the serving slab is grow-only and sized to the largest installed plan, so the max is the retained footprint. Standalone bytes are excluded on purpose (they live inside one execute). **Finalist filter:** device-free, the plan builds and arena-plans; under device profiling with a live device, one warmup execute with the slab released after.
- `CudaRuntime::search` runs the lattice on both paths (unbucketed is a one-bucket lattice, main's "one designed difference"); the selected plan per bucket is what `select_bucket_plan` installs; nothing viable → `Err(lattice.failure_message())`.
- `arena::buffer_bytes` moved out of the device-gated executor so finalists can plan on a laptop.

## Gate
Every CPU suite ok including new `finalists_lattice` 4; `cublaslt_election` and `dim_buckets` unchanged; clippy (device feature) and fmt clean. **A100:** `device_profile` 3 passed (Phase 4's probe unchanged: 6 plans, winner 3.6 ms, zero refusals) and `finalists_lattice` 4 passed including the new device warmup-and-budget case; box returned to trunk.

## Judgment calls
Rank 1 handed over, not re-extracted; `select` returns the pending finalist (rank and metric included); the rejection count is asserted `>= 1` because which successor is proposed follows the metric, not the slabs, and the fixture measured 2 (pinning the exact count would pin sampler order, which the permutation-invariance ruling forbids); arena-planning failure rejects the finalist; the reference runtime is untouched (no aggregate resource across buckets); dropped from main's version: LLIR dumps, unroll on re-extraction, ANSI bars, the finalization time-limit clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
