### PR TITLE
rejoin P6: review fix-ups — bucket/range exclusivity, single saturation in CL bucketed search, cross-candidate decode cache, cuBLASLt Base-row guard, doc truth

### DIFF
--- a/crates/luminal_cuda_lite/BRINGUP.md
+++ b/crates/luminal_cuda_lite/BRINGUP.md
@@ -20,11 +20,13 @@ the self-contained repo-side summary.
 - `CudaRuntime::allow_list()` derives from the table — search can
   only elect what codegen covers. Pinned as a strict subset of the
   reference inventory (`tests/plan_smoke.rs`).
-- Candidate profiling during search runs on the reference HOST
-  executor — a documented CL-1 cost proxy (the profiler seam
-  parameterization is CL-3; the loop now lives in
-  `crates/luminal_cuda_lite/src/search.rs`, ranking through
-  `crates/luminal_cuda_lite/src/heuristic.rs`).
+- Candidate ranking during search is DEVICE-FREE BY DEFAULT: the loop
+  is this crate's own copy (`crates/luminal_cuda_lite/src/search.rs`)
+  and ranks by `src/heuristic.rs::heuristic_cost_of` — a bytes-moved
+  prior, never a measurement. There is no profiler trait in core or
+  here any more. On-device candidate profiling arrived in Phase 4 of
+  the #420/#422 rejoin, behind `CompileOptions::profile_on_device`
+  (`src/profile.rs`), and needs the `device` feature and a device.
 - `execute` is behind the `device` feature and refuses loudly
   without it. Plan-layer tests are green on macOS.
 - The predecessor crate targeting the deleted HLIR pipeline is parked
@@ -51,7 +53,9 @@ egglog-experimental #60.)
 ## CL-2: device bring-up (the work on the CUDA machine)
 
 1. Write `src/device.rs` (`#[cfg(feature = "device")]`,
-   `execute_plan(plan, staged) -> Result<FxHashMap<i64, TypedBuffer>>`):
+   `execute_plan(plan, staged: &FxHashMap<i64, HostBuffer>) ->
+   Result<FxHashMap<usize, (HostBuffer, OutputBinding<DecodedLayout>)>>`,
+   keyed by output slot):
    - Phase 1 — materialize: for every plan `Buffer`, require
      `dims`+`dtype` (loud on `None`), device-alloc `numel × bytes`;
      H2D staged `lit` buffers (length/dtype-checked, no conversion);
@@ -66,7 +70,9 @@ egglog-experimental #60.)
      operand device pointers in slot order then dest pointers then
      `n`. OUT-OF-PLACE: allocate fresh dests (mirrors the reference
      alias-safety convention; `ties` honored only as ordering).
-   - Phase 4 — D2H every output-role buffer into `TypedBuffer`s.
+   - Phase 4 — D2H every output-role buffer into `HostBuffer`s
+     (`src/host_buffer.rs`; CL does not use the reference runtime's
+     `TypedBuffer`, ruling D4).
    - Salvage: NVRTC compile-to-CUBIN with header-version probing is
      `../luminal_cuda_lite_hlir/src/lib.rs`
      (`compile_module_image_for_current_device`); kernel-cache and
@@ -85,9 +91,11 @@ egglog-experimental #60.)
 
 - CL-3: CUDA-native ops (cuBLASLt matmul first) — needs the
   matcher-injectable search (`ExtractionSession::new_with_matchers`,
-  `search_implementations_with_matchers`) and the profiler
-  parameterization; the parked crate's `host/cublaslt/` carries the
-  kernels and ten `.egg` rewrite files as raw material.
+  `search_implementations_with_matchers`); the parked crate's
+  `host/cublaslt/` carries the kernels and ten `.egg` rewrite files as
+  raw material. (No profiler seam is needed or exists: ranking is
+  either the device-free heuristic or Phase 4's direct device
+  measurement.)
 - CL-4: in-place ties (the Mutating family — deferred per Austin
   2026-08-17: "don't worry about retiring mutation… cleaning later"),
   view admission + resident-geometry join

--- a/crates/luminal_cuda_lite/src/device.rs
+++ b/crates/luminal_cuda_lite/src/device.rs
@@ -59,8 +59,10 @@
 //!   scatters into it. Same stream, so the phases are ordered.
 //! * CUBLASLT D: `beta = 0` on the non-fold forms, which is the BLAS
 //!   skip — C (aliased to D) is not read, D is fully written. The
-//!   C-fold forms read a separate C OPERAND buffer with `beta = 1`,
-//!   never the destination's prior bytes.
+//!   C-fold forms read their C operand at `beta = 1`; C is a DEFINED
+//!   resident — a distinct buffer, or D's own range when the bufferizer
+//!   seeded D onto C's ReadWrite caller buffer through the May permit —
+//!   never an undefined recycled range.
 //!
 //! So no memset is emitted anywhere. The one standing assumption is
 //! that a destination's `numel(dest_dims)` covers its buffer's SPAN:
@@ -139,9 +141,13 @@ impl KernelCache {
 ///
 /// The slab is GROW-ONLY and never parked (#401 as amended by #422):
 /// one runtime-owned allocation, resized upward when an installed plan
-/// needs more than it holds, never released between calls. Nothing has
-/// to be invalidated on a grow — CL captures no CUDA graphs and holds
-/// no device pointers across calls.
+/// needs more than it holds. SERVING never releases it between
+/// [`CudaRuntime::execute`](crate::CudaRuntime::execute) calls; the
+/// SEARCH is the one exception — it releases the slab after every
+/// profiled candidate through [`Self::release_slab`] (#422's search-time
+/// policy), and the next [`execute_plan`] re-allocates through
+/// `ensure_slab`. Nothing has to be invalidated on a grow — CL captures
+/// no CUDA graphs and holds no device pointers across calls.
 pub struct CudaDevice {
     #[allow(dead_code)]
     ctx: Arc<CudaContext>,
@@ -464,9 +470,16 @@ pub fn execute_plan(
                 // NVRTC kernel. The destination is the arena range the
                 // planner assigned (it was a fresh zeroed slice before
                 // Phase 3 of the rejoin); the C-fold forms read their C
-                // operand buffer and write D (C != D pointers, beta =
-                // 1.0f — legal, identical layouts by the marker's rule
-                // guard), and the non-fold forms run beta = 0, which is
+                // operand buffer and write D at beta = 1.0f. C is USUALLY
+                // a distinct live range, but when the program binds D's
+                // output slot onto the same ReadWrite caller buffer that
+                // holds C, the seed is admitted through CublasLtDps's May
+                // permit on operand 2 and C == D — legal, because
+                // `bind_destination` emits identical C and D descriptors,
+                // which is the API's C == D precondition. (Recorder-
+                // produced programs never bind an output onto an input
+                // buffer, so this arises only for hand-authored
+                // boundaries.) The non-fold forms run beta = 0, which is
                 // the BLAS skip, so D's prior bytes are never read.
                 if let Some(dps) = op
                     .as_any()

--- a/crates/luminal_cuda_lite/src/finalists.rs
+++ b/crates/luminal_cuda_lite/src/finalists.rs
@@ -110,6 +110,10 @@ pub struct Finalists<'a> {
     accepted: Vec<PendingFinalist>,
     rejections: usize,
     last_rejection: Option<String>,
+    /// This walk's decoded-layout cache — one per `Finalists`, because
+    /// every rank it re-extracts decodes over the SAME `egraph` and
+    /// decoding is a pure function of `(layout class, dtype)`.
+    layout_cache: luminal::layouts::LayoutDecodeCache,
 }
 
 impl<'a> Finalists<'a> {
@@ -142,6 +146,7 @@ impl<'a> Finalists<'a> {
             accepted: Vec::new(),
             rejections: 0,
             last_rejection: None,
+            layout_cache: luminal::layouts::LayoutDecodeCache::new(),
         }
     }
 
@@ -237,7 +242,7 @@ impl<'a> Finalists<'a> {
             Err(err) => return Err(format!("extract: {err:#}")),
         };
         let dps = luminal::dps::dps_rewrite(&graph);
-        luminal::layouts::decode_layout_table(self.egraph, &dps, "finalist")
+        luminal::layouts::decode_layout_table(self.egraph, &dps, "finalist", &mut self.layout_cache)
             .and_then(|table| luminal::bufferize::bufferize(&dps, &table))
             .map_err(|err| format!("bufferize: {err:#}"))
     }

--- a/crates/luminal_cuda_lite/src/lib.rs
+++ b/crates/luminal_cuda_lite/src/lib.rs
@@ -17,8 +17,9 @@
 //! Phase 1): [`extractor`] and [`search`] are this runtime's own copies
 //! — core keeps the shared machinery (program, assembly, `dps_rewrite`,
 //! `decode_layout_table`, `bufferize`) and nothing that decides which
-//! implementation wins. Candidates rank through [`heuristic`], a
-//! device-free byte-move prior; there is no profiler trait anywhere any
+//! implementation wins. Candidates rank, by default, through
+//! [`heuristic`], a device-free byte-move prior (CL-5 below is the
+//! opt-in device measurement); there is no profiler trait anywhere any
 //! more, in core or here. Host payloads are [`host_buffer::HostBuffer`],
 //! not the reference runtime's `TypedBuffer`.
 //!
@@ -45,10 +46,16 @@
 //!   the arena slab the runtime will hold. Unconstrained (the default)
 //!   the walk installs the search's own winner and costs nothing.
 //!
-//! Out-of-place by design: kernels read operand buffers and
-//! write fresh destinations, mirroring the reference executor's
-//! alias-safety convention; `ties` and `Anti` edges are honored in the
-//! toposort order but no in-place claim is made.
+//! Out-of-place by design: kernels read operand buffers and write a
+//! destination that shares no byte with any simultaneously bound buffer
+//! — the same alias-safety PROPERTY as the reference executor, by a
+//! different mechanism. Since Phase 3 (#420/#422 rejoin) the destination
+//! is a recycled slab range assigned by [`arena`] (its CONTRACT-1
+//! live-range check; [`binding_check`] covers the standalone rows), NOT
+//! a fresh zeroed slice: nothing is zeroed, so every kernel must write
+//! every element it owns and never read its destination — the KERNEL
+//! INVARIANT recorded at the top of `device.rs`. `ties` and `Anti` edges
+//! are honored in the toposort order but no in-place claim is made.
 
 pub mod arena;
 pub mod binding_check;

--- a/crates/luminal_cuda_lite/src/ops/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/mod.rs
@@ -232,6 +232,14 @@ pub fn cuda_registry_with_cublaslt() -> Vec<RegisteredOp> {
 /// that exists. The two presets remain available whole
 /// ([`cuda_registry`], [`cuda_registry_with_cublaslt`]).
 ///
+/// THE FOUR cuBLASLt MARKER ROWS ARE ONE ESTATE, not four independent
+/// ones: the Base row's snippets declare all four constructors and mint
+/// all four forms, so a predicate that drops Base must drop all four.
+/// [`crate::CudaRuntime::load_with_registry`] refuses the other
+/// combination; `active_allow_list` alone cannot tell you, because a
+/// claim is derived from the prototype and says nothing about whether
+/// the assembled program declares the constructor.
+///
 /// A PREDICATE THAT MATCHES NOTHING IS SILENT — it returns the full
 /// registry, and the search then simply has the op available. Assert on
 /// the resulting length (or on

--- a/crates/luminal_cuda_lite/src/ops/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/mod.rs
@@ -28,11 +28,18 @@
 //! trait answers on the prototype and travel with a `RegisteredOp`, but
 //! a row that must actually be EXECUTED needs a codegen row in
 //! [`crate::kernels`], which is keyed by `TypeId` inside this crate.
-//! An outside row without one is simply not claimable: search never
-//! elects it (it is absent from the derived allow list), so the failure
-//! is a refusal, never a wrong plan. Composing an external kernel
-//! superset onto Lite's codegen ("cuda heavy") is PUNTED — no execution
-//! face on `RegisteredOp`, no change to the kernel table's keying.
+//! The kernel-bearing class is matched by LABEL (the constructor minus
+//! `LayoutTensorOp`, `Generic` suffix tolerated) against the kernel
+//! table, while codegen is looked up by `TypeId` at execute. An outside
+//! row whose label matches no kernel-table label never reaches the allow
+//! list, so search refuses. An outside row that REUSES a kernel-table
+//! label IS claimed and can be elected; if the op it extracts is not the
+//! CL type behind that label, the plan is refused at
+//! [`crate::CudaRuntime::execute`] (`no cuda codegen for <label>`) —
+//! loud, never a wrong plan, but not at search. Composing an external
+//! kernel superset onto Lite's codegen ("cuda heavy") is PUNTED — no
+//! execution face on `RegisteredOp`, no change to the kernel table's
+//! keying.
 
 pub mod add;
 pub mod cast;

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -3,13 +3,18 @@
 //! search claiming only this backend's codegen inventory and execution
 //! delegated to the `device` module.
 //!
-//! Everything up to `execute` is device-free and runs anywhere: load
-//! accumulates the native program parts, bind_* appends bounds seeds,
-//! search assembles + saturates + runs THIS crate's genetic search
-//! ([`crate::search`]) with OUR allow list, ranking candidates by the
-//! device-free heuristic ([`crate::heuristic`] — a weak static prior,
-//! not a measurement). Only `execute` requires the `device` feature and
-//! a CUDA device.
+//! Everything up to `execute` is device-free BY DEFAULT and runs
+//! anywhere: load accumulates the native program parts, bind_* appends
+//! bounds seeds, search assembles + saturates + runs THIS crate's
+//! genetic search ([`crate::search`]) with OUR allow list, ranking
+//! candidates by the device-free heuristic ([`crate::heuristic`] — a
+//! weak static prior, not a measurement). Two things need the `device`
+//! feature and a CUDA device: `execute`, and a `search` with
+//! [`crate::search::CompileOptions::profile_on_device`] set (Phase 4),
+//! which creates the device lazily, stages the caller's payloads, and
+//! ranks by measured time (the `profile` module, `device` only) — on a
+//! device-free build it refuses by name rather than falling back to the
+//! prior.
 
 use crate::host_buffer::HostBuffer;
 use anyhow::{anyhow, bail, Context, Result};
@@ -86,11 +91,12 @@ pub struct CudaRuntime {
     /// refuse.
     range_bound: std::collections::BTreeMap<shape::Symbol, (u64, u64)>,
     /// THE PERSISTENT DEVICE (#422, rejoin Phase 3): context, stream,
-    /// NVRTC module cache and the arena slab, created on the first
-    /// [`Self::execute`] and kept for the runtime's life — "each runtime
-    /// remembers its own buffer hygiene". `None` until then, so
-    /// `Default` still gives a device-free runtime that plans and
-    /// searches on any host.
+    /// NVRTC module cache and the arena slab, created lazily — by the
+    /// first device-profiled [`Self::search`] (Phase 4) or by the first
+    /// [`Self::execute`], whichever comes first — and kept for the
+    /// runtime's life, "each runtime remembers its own buffer hygiene".
+    /// `None` until then, so `Default` still gives a device-free runtime
+    /// that plans and searches by the heuristic on any host.
     #[cfg(feature = "device")]
     device: Option<crate::device::CudaDevice>,
 }
@@ -131,11 +137,14 @@ impl CudaRuntime {
     ///
     /// Build the argument with [`crate::ops::cuda_registry_filtered`]
     /// (narrow either preset by label or constructor) or by pushing
-    /// [`crate::ops::RegisteredOp::new`] rows onto one. A row whose op
-    /// is neither kernel-bearing, plan-transparent, nor host-dispatchable
-    /// is simply not claimable — it never reaches the allow list, so the
-    /// search refuses loudly instead of electing something the device
-    /// cannot run.
+    /// [`crate::ops::RegisteredOp::new`] rows onto one. A row whose op is
+    /// neither plan-transparent, host-dispatchable, nor spelled with a
+    /// LABEL the kernel table carries is simply not claimable — it never
+    /// reaches the allow list, so the search refuses loudly instead of
+    /// electing something the device cannot run. A row that REUSES a
+    /// kernel-table label is claimed; if its extracted op is not the CL
+    /// type behind that label, the `TypeId` lookup misses and the plan is
+    /// refused at [`Self::execute`], not at search.
     ///
     /// ONE EXCEPTION TO ROW-BY-ROW SELECTION: the four cuBLASLt marker
     /// rows are ONE vocabulary, declared and minted by the Base row's
@@ -465,6 +474,10 @@ impl CudaRuntime {
     /// Assemble, saturate, and search — with THIS backend's allow list.
     /// On saturation failure the labeled post-checks are re-run in
     /// isolation to name the door, mirroring the reference runtime.
+    ///
+    /// With `options.profile_on_device` this needs the `device` feature
+    /// and a CUDA device: it creates the device lazily and ranks by
+    /// measured time (see the `profile` module, `device` only).
     pub fn search(
         &mut self,
         input_data: &FxHashMap<NodeIndex, HostBuffer>,

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -434,7 +434,6 @@ impl CudaRuntime {
         input_data: &FxHashMap<NodeIndex, HostBuffer>,
         options: &CompileOptions,
     ) -> Result<SearchOutcome> {
-        let (serialized, program) = self.assemble_and_saturate()?;
         let native = self
             .native
             .as_ref()
@@ -447,12 +446,14 @@ impl CudaRuntime {
         // heuristic (D6, 2026-09-03) never runs anything and so needs
         // nothing staged, while device profiling (Phase 4) executes each
         // candidate and needs exactly these bytes.
+        //
+        // The slot list is the LOAD-TIME one, `native.input_slots` — the
+        // same list a rendered program's `input_slots` is cloned from, and
+        // the one the bucketed ladder has, which renders no base program
+        // at all.
         for tensor in input_data.keys() {
             assert!(
-                program
-                    .input_slots
-                    .iter()
-                    .any(|slot| slot.tensor == *tensor),
+                native.input_slots.iter().any(|slot| slot.tensor == *tensor),
                 "tensor {tensor:?} is not a bound input"
             );
         }
@@ -470,7 +471,7 @@ impl CudaRuntime {
         // gigabytes; the search must borrow them, never copy them.
         #[cfg(feature = "device")]
         let staged_for_search: FxHashMap<i64, &HostBuffer> = if options.profile_on_device {
-            program
+            native
                 .input_slots
                 .iter()
                 .filter_map(|slot| input_data.get(&slot.tensor).map(|data| (slot.buffer, data)))
@@ -485,6 +486,26 @@ impl CudaRuntime {
         if options.profile_on_device && self.device.is_none() {
             self.device = Some(crate::device::CudaDevice::new(0)?);
         }
+
+        // THE BASE PROGRAM IS RENDERED AND SATURATED ONLY FOR THE
+        // SINGLE-PIN LADDER. A bucketed dim carries no seeds in this
+        // render — `bind_dyn_range` is refused on it, and the intervals
+        // are seeded per bucket inside `bucketed_search_implementations`
+        // — so an unbucketed render validates nothing the bucketed
+        // search will use, and an authoring check that NEEDS bounds
+        // (`reduce_max`'s `require_extent_at_least`, an iota's value
+        // bounds) would refuse the whole bucketed search over a program
+        // every per-bucket render accepts. It is also a full fixpoint
+        // whose result the bucketed arm discards. The reference ladder's
+        // `search_buckets` never rendered one.
+        //
+        // Computed HERE, before the evaluator borrows `self.device`
+        // mutably: `assemble_and_saturate` takes `&self`.
+        let base = if self.dim_buckets.is_empty() {
+            Some(self.assemble_and_saturate()?)
+        } else {
+            None
+        };
 
         // THIS INSTANCE's claim set, derived at load from THIS
         // instance's registry — no crate-level default is consulted.
@@ -524,7 +545,8 @@ impl CudaRuntime {
         // plan is whichever FINALIST the bucket lattice selected under the
         // aggregate device budget. With no budget set they coincide,
         // which is why every existing caller sees the trajectory it had.
-        let (outcome, unbucketed_plan, searched_buckets) = if self.dim_buckets.is_empty() {
+        let (outcome, unbucketed_plan, searched_buckets) = if let Some((serialized, program)) = base
+        {
             let mut outcome = crate::search::search_implementations(
                 &serialized,
                 &program,

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -136,6 +136,12 @@ impl CudaRuntime {
     /// is simply not claimable — it never reaches the allow list, so the
     /// search refuses loudly instead of electing something the device
     /// cannot run.
+    ///
+    /// ONE EXCEPTION TO ROW-BY-ROW SELECTION: the four cuBLASLt marker
+    /// rows are ONE vocabulary, declared and minted by the Base row's
+    /// snippets. A registry holding a non-Base marker row without Base is
+    /// REFUSED here — such a row would be claimed but never declared, an
+    /// op that cannot be elected under a claim set that says it can.
     pub fn load_with_registry(
         graph: &graph::Graph,
         registry: Vec<crate::ops::RegisteredOp>,
@@ -144,6 +150,36 @@ impl CudaRuntime {
             .logical
             .bound_parts(&crate::bindings::CudaBindings)
             .map_err(|e| anyhow!(e))?;
+        // THE FOUR cuBLASLt MARKER ROWS ARE ONE VOCABULARY. Only the
+        // Base row emits snippets, and that one snippet set declares all
+        // four constructors and every minting rule. A registry holding a
+        // non-Base marker WITHOUT Base would derive a claim for an op the
+        // assembled program never declares and never mints: claimed,
+        // un-electable, and `active_allow_list()` — the check this
+        // module's doc recommends — would say it is available. Refuse the
+        // configuration at load instead, keyed on constructor names.
+        {
+            use crate::ops::cublaslt::CublasLtForm;
+            let has = |ctor: &str| {
+                registry
+                    .iter()
+                    .any(|entry| entry.matcher.egglog_constructor() == ctor)
+            };
+            if let Some(orphan) = CublasLtForm::ALL
+                .into_iter()
+                .filter(|form| *form != CublasLtForm::Base)
+                .find(|form| has(form.constructor_name()))
+            {
+                anyhow::ensure!(
+                    has(CublasLtForm::Base.constructor_name()),
+                    "registry holds the cuBLASLt `{}` row without the Base row `{}`: \
+                     the Base row declares and mints the whole marker vocabulary, so \
+                     the four marker rows must be kept or dropped together",
+                    orphan.constructor_name(),
+                    CublasLtForm::Base.constructor_name()
+                );
+            }
+        }
         // Derive the claim set BEFORE the rows are consumed: the allow
         // list reads the prototypes, the search reads the matchers.
         let allow = Self::allow_list_over(&registry);

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -77,6 +77,14 @@ pub struct CudaRuntime {
     /// `bind_dyn_range` pin plus whatever [`Self::set_dim`] sets. With
     /// buckets bound this is what picks the plan at execute time.
     dims: shape::DynMap,
+    /// EVERY dim [`Self::bind_dyn_range`] has bound, tight or not, with
+    /// the interval it was given. `dims` records only the `[n, n]` pins,
+    /// so it cannot answer the exclusivity question: buckets and range
+    /// bindings must refuse each other in BOTH orders, and a non-tight
+    /// range under a later bucket would otherwise seed the same `IntVar`
+    /// twice and INTERSECT under the bounds lattice's merge rather than
+    /// refuse.
+    range_bound: std::collections::BTreeMap<shape::Symbol, (u64, u64)>,
     /// THE PERSISTENT DEVICE (#422, rejoin Phase 3): context, stream,
     /// NVRTC module cache and the arena slab, created on the first
     /// [`Self::execute`] and kept for the runtime's life — "each runtime
@@ -192,7 +200,10 @@ impl CudaRuntime {
             "(set (lower-bound-of (IntVar \"{name}\")) (bigint {lower}))\n\
              (set (upper-bound-of (IntVar \"{name}\")) (bigint {upper}))\n"
         ));
-        // A tight [n, n] binding IS a pin: remember it, so a bucketed
+        // EVERY range binding is remembered, so `bind_dim_buckets` can
+        // refuse this dim whatever the interval was.
+        self.range_bound.insert(name, (lower, upper));
+        // A tight [n, n] binding IS a pin: remember it too, so a bucketed
         // plan's representative records the whole assignment.
         if lower == upper {
             self.dims.insert(name, lower as usize);
@@ -217,10 +228,17 @@ impl CudaRuntime {
     ) -> Result<()> {
         let dim = dim.into();
         anyhow::ensure!(!buckets.is_empty(), "dim `{dim}` was given no buckets");
+        if let Some((lo, hi)) = self.range_bound.get(&dim) {
+            anyhow::bail!(
+                "dim `{dim}` already carries a range binding [{lo}, {hi}] from \
+                 bind_dyn_range; a bucketed dim is seeded per bucket and must not \
+                 carry a second range binding"
+            );
+        }
         anyhow::ensure!(
             !self.dims.contains_key(&dim),
-            "dim `{dim}` is already pinned by bind_dyn_range; a bucketed dim is \
-             seeded per bucket and must not carry a second range binding"
+            "dim `{dim}` already has a value from set_dim; bind buckets before \
+             setting the execution dim"
         );
         for pair in buckets.windows(2) {
             anyhow::ensure!(

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -27,7 +27,9 @@
 //! not consulted at all (D6's "doesn't bias search too much", taken at
 //! full strength — a device build ranks on measured time only).
 //!
-//! Tests live with the reference copy (`luminal_reference::search`).
+//! The search-loop tests live with the reference copy
+//! (`luminal_reference::search`); this file carries only
+//! `early_stop_tests`, for its own copy of `early_stop_exceeded`.
 
 use std::collections::BTreeMap;
 use std::time::{Duration, Instant};
@@ -325,7 +327,7 @@ pub struct RefusalBreakdown {
     /// can only be nonzero through the sampler's documented full-list
     /// fallback — a component position with no acyclic option at all.
     /// A choice cycle on an acyclic chosen-edge graph is a sampler bug
-    /// and stops the search (see `search_implementations_with_runtime`).
+    /// and stops the search (see `search_implementations`).
     /// Genomes assembled by hand (the election boards) are of course
     /// still free to name cycles, and are still counted here.
     pub with_choice_cycles: usize,

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -933,6 +933,14 @@ pub fn search_implementations(
 
     // fingerprint → measured nanos (the dedup cache).
     let mut cache: FxHashMap<u64, u128> = FxHashMap::default();
+    // THE DECODED-LAYOUT CACHE, one per search and CALLER-OWNED
+    // (`decode_layout_table` takes it by `&mut`). Decoding is a pure
+    // function of `(layout class, dtype)`, and every decode builds a
+    // fresh `Reader` over the whole serialized e-graph — so a cache that
+    // did not span candidates would pay that index once per distinct
+    // layout class per candidate. `egraph` is fixed for this loop, which
+    // is what makes the `ClassId` keys comparable across candidates.
+    let mut layout_cache = luminal::layouts::LayoutDecodeCache::new();
     let mut plans_profiled = 0usize;
     let mut fingerprint_hits = 0usize;
     // Refusal accounting, minimal form (Step 5 down-payment): keep the
@@ -1048,6 +1056,7 @@ pub fn search_implementations(
                         egraph,
                         &dps,
                         "implementation search",
+                        &mut layout_cache,
                     )
                     .and_then(|table| luminal::bufferize::bufferize(&dps, &table));
                     timings.plan_build_nanos += build_start.elapsed().as_nanos();
@@ -1197,9 +1206,13 @@ pub fn search_implementations(
             {
                 let build_start = Instant::now();
                 let dps = luminal::dps::dps_rewrite(&graph);
-                let built =
-                    luminal::layouts::decode_layout_table(egraph, &dps, "implementation search")
-                        .and_then(|table| luminal::bufferize::bufferize(&dps, &table));
+                let built = luminal::layouts::decode_layout_table(
+                    egraph,
+                    &dps,
+                    "implementation search",
+                    &mut layout_cache,
+                )
+                .and_then(|table| luminal::bufferize::bufferize(&dps, &table));
                 timings.plan_build_nanos += build_start.elapsed().as_nanos();
                 let plan = match built {
                     Ok(plan) => plan,

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -1411,8 +1411,10 @@ pub struct BucketAssembly<'a> {
     /// The recorded model, before the schedule.
     pub pre_schedule: &'a str,
     /// The caller's own `bind_*` seeds — for the dims that are NOT
-    /// bucketed. A bucketed dim is refused a range binding, so these
-    /// never collide with the per-bucket seeds appended after them.
+    /// bucketed. Buckets and range bindings refuse each other in BOTH
+    /// orders (a range-bound dim is refused buckets, a bucketed dim is
+    /// refused a range binding), so these never collide with the
+    /// per-bucket seeds appended after them.
     pub binding_seeds: &'a str,
     /// The runtime's schedule text.
     pub schedule: &'a str,

--- a/crates/luminal_cuda_lite/tests/dim_buckets.rs
+++ b/crates/luminal_cuda_lite/tests/dim_buckets.rs
@@ -149,7 +149,25 @@ fn a_dim_cannot_be_both_pinned_and_bucketed() {
     let err = rt
         .bind_dim_buckets('a', vec![DimBucket::new(2, 4)])
         .expect_err("a pinned dim must not take buckets");
-    assert!(format!("{err:#}").contains("already pinned"), "{err:#}");
+    assert!(
+        format!("{err:#}").contains("already carries a range binding [3, 3]"),
+        "{err:#}"
+    );
+
+    // A NON-TIGHT range is just as exclusive: it seeds the same IntVar's
+    // bounds, and `lower-bound-of`/`upper-bound-of` MERGE (max/min) rather
+    // than error, so a second seed set would silently intersect with the
+    // per-bucket one instead of refusing.
+    let (cx, _out) = elementwise_graph();
+    let mut rt = CudaRuntime::load(&cx).expect("cuda load");
+    rt.bind_dyn_range('a', 2, 8).expect("range binds");
+    let err = rt
+        .bind_dim_buckets('a', vec![DimBucket::new(5, 9)])
+        .expect_err("a range-bound dim must not take buckets");
+    assert!(
+        format!("{err:#}").contains("already carries a range binding [2, 8]"),
+        "{err:#}"
+    );
 
     let (cx, _out) = elementwise_graph();
     let mut rt = CudaRuntime::load(&cx).expect("cuda load");

--- a/crates/luminal_cuda_lite/tests/dim_buckets.rs
+++ b/crates/luminal_cuda_lite/tests/dim_buckets.rs
@@ -178,3 +178,25 @@ fn a_dim_cannot_be_both_pinned_and_bucketed() {
         .expect_err("a bucketed dim must not take a range binding");
     assert!(format!("{err:#}").contains("has buckets bound"), "{err:#}");
 }
+
+/// A BOUNDS-DEPENDENT AUTHORING CHECK UNDER BUCKETS (review C3/C10).
+/// `reduce_max` emits `require_extent_at_least` on its axis, which needs
+/// `lower-bound-of` for that dim. A bucketed dim is seeded PER BUCKET,
+/// never in a base render — so a base render of this graph carries no
+/// bounds for 'a' at all and the check refuses. The bucketed ladder must
+/// never render one: every per-bucket render seeds the interval and
+/// passes.
+#[test]
+fn a_bucketed_dim_may_carry_a_bounds_dependent_check() {
+    let mut cx = Graph::new();
+    cx.set_dim('a', 3);
+    let x = cx.tensor(('a', 2), DType::F32);
+    let _out = x.max(0).output();
+
+    let mut rt = CudaRuntime::load(&cx).expect("cuda load");
+    rt.bind_dim_buckets('a', vec![DimBucket::new(2, 4), DimBucket::new(5, 9)])
+        .expect("disjoint sorted buckets bind");
+    rt.search(&Default::default(), &harness_search_options())
+        .expect("a bucketed search never renders the unseeded base program");
+    assert_eq!(rt.bucket_plans().len(), 2, "one plan per bucket");
+}

--- a/crates/luminal_cuda_lite/tests/registry_selection.rs
+++ b/crates/luminal_cuda_lite/tests/registry_selection.rs
@@ -217,3 +217,63 @@ fn registry_labels_agree_with_the_prototypes() {
         );
     }
 }
+
+/// THE ONE ESTATE THAT IS NOT ROW-BY-ROW: only the Base cuBLASLt matcher
+/// emits egglog snippets, and that one snippet set declares all four
+/// marker constructors and every minting rule. A registry holding a
+/// non-Base marker WITHOUT Base would claim an op the assembled program
+/// never declares and never mints — un-electable, while
+/// `active_allow_list()` says it is available. `load_with_registry`
+/// refuses that configuration by name.
+#[test]
+fn a_non_base_cublaslt_row_without_base_is_refused_at_load() {
+    let (cx, _a, _b) = add_graph();
+
+    let mut registry = cuda_registry();
+    registry.push(RegisteredOp::new(
+        Box::new(CublasLtMarkerMatcher {
+            form: CublasLtForm::Bias,
+        }),
+        Box::new(CublasLt {
+            form: CublasLtForm::Bias,
+            spec: None,
+        }),
+    ));
+    let err = match CudaRuntime::load_with_registry(&cx, registry) {
+        Ok(_) => panic!("a Bias row without Base must be refused"),
+        Err(err) => err,
+    };
+    let msg = format!("{err:#}");
+    assert!(msg.contains("LayoutTensorOpCublasLtBias"), "{msg}");
+    assert!(msg.contains("without the Base row"), "{msg}");
+
+    // Dropping Base out of the WHOLE preset is the same configuration,
+    // however the caller arrives at it.
+    let err = match CudaRuntime::load_with_registry(
+        &cx,
+        cuda_registry_filtered(|op| op.constructor() != CublasLtForm::Base.constructor_name()),
+    ) {
+        Ok(_) => panic!("the preset minus Base must be refused"),
+        Err(err) => err,
+    };
+    assert!(
+        format!("{err:#}").contains("without the Base row"),
+        "{err:#}"
+    );
+
+    // Base alone, and all four together, both load.
+    let (cx, _a, _b) = add_graph();
+    CudaRuntime::load_with_registry(&cx, cuda_registry_with_cublaslt())
+        .expect("the whole marker estate loads");
+    let mut base_only = cuda_registry();
+    base_only.push(RegisteredOp::new(
+        Box::new(CublasLtMarkerMatcher {
+            form: CublasLtForm::Base,
+        }),
+        Box::new(CublasLt {
+            form: CublasLtForm::Base,
+            spec: None,
+        }),
+    ));
+    CudaRuntime::load_with_registry(&cx, base_only).expect("Base alone loads");
+}

--- a/crates/luminal_reference/src/harness.rs
+++ b/crates/luminal_reference/src/harness.rs
@@ -206,7 +206,12 @@ pub fn plain_plan_exists(cx: &luminal::graph::Graph) -> anyhow::Result<()> {
     let start = std::time::Instant::now();
     // VALUE-keyed table: decode over the POST-DPS graph bufferize sees.
     let dps = luminal::dps::dps_rewrite(&extracted);
-    let layouts = luminal::layouts::decode_layout_table(&serialized, &dps, "plain plan")?;
+    let layouts = luminal::layouts::decode_layout_table(
+        &serialized,
+        &dps,
+        "plain plan",
+        &mut luminal::layouts::LayoutDecodeCache::new(),
+    )?;
     luminal::bufferize::bufferize(&dps, &layouts)?;
     eprintln!("[plain-plan] dps+bufferize {:?}", start.elapsed());
     Ok(())

--- a/crates/luminal_reference/src/runtime.rs
+++ b/crates/luminal_reference/src/runtime.rs
@@ -90,6 +90,14 @@ pub struct ReferenceRuntime {
     /// `bind_dyn_range` pin, plus whatever [`Self::set_dim`] sets. With
     /// buckets bound this is what picks the plan at execute time.
     dims: luminal::shape::DynMap,
+    /// EVERY dim [`Self::bind_dyn_range`] has bound, tight or not, with
+    /// the interval it was given. `dims` records only the `[n, n]` pins,
+    /// so it cannot answer the exclusivity question: buckets and range
+    /// bindings must refuse each other in BOTH orders, and a non-tight
+    /// range under a later bucket would otherwise seed the same `IntVar`
+    /// twice and INTERSECT under the bounds lattice's merge rather than
+    /// refuse.
+    range_bound: std::collections::BTreeMap<luminal::shape::Symbol, (u64, u64)>,
 }
 
 impl ReferenceRuntime {
@@ -177,7 +185,10 @@ impl ReferenceRuntime {
             "(set (lower-bound-of (IntVar \"{var}\")) (bigint {lower}))\n\
              (set (upper-bound-of (IntVar \"{var}\")) (bigint {upper}))\n"
         ));
-        // A tight [n, n] binding IS a pin: remember it, so a bucketed
+        // EVERY range binding is remembered, so `bind_dim_buckets` can
+        // refuse this dim whatever the interval was.
+        self.range_bound.insert(var, (lower, upper));
+        // A tight [n, n] binding IS a pin: remember it too, so a bucketed
         // plan's representative map records the whole assignment and
         // `select_bucket` sees every dim.
         if lower == upper {
@@ -203,10 +214,17 @@ impl ReferenceRuntime {
     ) -> Result<()> {
         let dim = dim.into();
         ensure!(!buckets.is_empty(), "dim `{dim}` was given no buckets");
+        if let Some((lo, hi)) = self.range_bound.get(&dim) {
+            anyhow::bail!(
+                "dim `{dim}` already carries a range binding [{lo}, {hi}] from \
+                 bind_dyn_range; a bucketed dim is seeded per bucket and must not \
+                 carry a second range binding"
+            );
+        }
         ensure!(
             !self.dims.contains_key(&dim),
-            "dim `{dim}` is already pinned by bind_dyn_range; a bucketed dim is \
-             seeded per bucket and must not carry a second range binding"
+            "dim `{dim}` already has a value from set_dim; bind buckets before \
+             setting the execution dim"
         );
         for pair in buckets.windows(2) {
             ensure!(
@@ -2419,5 +2437,55 @@ mod tests {
             .bind_dim_buckets('a', vec![])
             .expect_err("an empty bucket list must refuse");
         assert!(format!("{err:#}").contains("no buckets"), "{err:#}");
+    }
+
+    /// BUCKETS AND RANGE BINDINGS ARE EXCLUSIVE PER DIM, BOTH ORDERS,
+    /// LOUDLY — and the range need not be tight. Both seed the same
+    /// `IntVar`'s `lower-bound-of` / `upper-bound-of`, which MERGE
+    /// (`max` / `min`) rather than error, so two seed sets on one dim
+    /// would silently INTERSECT: a bucket [5, 9] under a prior range
+    /// [2, 8] would be validated over [5, 8] while the plan claims 9.
+    #[test]
+    fn a_dim_cannot_be_both_range_bound_and_bucketed() {
+        use luminal::graph::DimBucket;
+
+        let graph = || {
+            let mut cx = Graph::new();
+            cx.set_dim('a', 3);
+            let x = cx.tensor(('a', 2), DType::F32);
+            let _out = (x * x).output();
+            cx
+        };
+
+        // A NON-TIGHT range, then buckets: the case `dims` could not see.
+        let mut rt = ReferenceRuntime::load(&graph()).expect("records + loads");
+        rt.bind_dyn_range('a', 2, 8).expect("range binds");
+        let err = rt
+            .bind_dim_buckets('a', vec![DimBucket::new(5, 9)])
+            .expect_err("a range-bound dim must not take buckets");
+        assert!(
+            format!("{err:#}").contains("already carries a range binding [2, 8]"),
+            "{err:#}"
+        );
+
+        // A tight [n, n] pin is a range binding too.
+        let mut rt = ReferenceRuntime::load(&graph()).expect("records + loads");
+        rt.bind_dyn_range('a', 3, 3).expect("pin binds");
+        let err = rt
+            .bind_dim_buckets('a', vec![DimBucket::new(2, 4)])
+            .expect_err("a pinned dim must not take buckets");
+        assert!(
+            format!("{err:#}").contains("already carries a range binding [3, 3]"),
+            "{err:#}"
+        );
+
+        // And the other order.
+        let mut rt = ReferenceRuntime::load(&graph()).expect("records + loads");
+        rt.bind_dim_buckets('a', vec![DimBucket::new(2, 4)])
+            .expect("buckets bind");
+        let err = rt
+            .bind_dyn_range('a', 2, 8)
+            .expect_err("a bucketed dim must not take a range binding");
+        assert!(format!("{err:#}").contains("has buckets bound"), "{err:#}");
     }
 }

--- a/crates/luminal_reference/src/runtime.rs
+++ b/crates/luminal_reference/src/runtime.rs
@@ -1681,8 +1681,13 @@ mod tests {
         .expect("extracts")
         .expect("plan");
         let dps = luminal::dps::dps_rewrite(&extracted);
-        let layouts = luminal::layouts::decode_layout_table(&serialized, &dps, "test")
-            .expect("layouts decode");
+        let layouts = luminal::layouts::decode_layout_table(
+            &serialized,
+            &dps,
+            "test",
+            &mut luminal::layouts::LayoutDecodeCache::new(),
+        )
+        .expect("layouts decode");
         let plan = luminal::bufferize::bufferize(&dps, &layouts).expect("bufferizes");
         let mut rt = crate::ReferenceRuntime::default();
         rt.stage_slots(&program.input_slots, &program.output_slots);

--- a/crates/luminal_reference/src/search.rs
+++ b/crates/luminal_reference/src/search.rs
@@ -22,7 +22,10 @@
 //! duplicates reuse the cached measurement instead of burning profile
 //! time (the plan-hash dedup ruling, 2026-07-27).
 //!
-//! THE TESTS FOR ALL THREE SEARCH COPIES LIVE HERE. The CUDA-lite copy
+//! THE SEARCH-LOOP TESTS FOR ALL THREE COPIES LIVE HERE (`progress_tests`,
+//! `sampler_tests`, the dedup search test). The one exception is
+//! `early_stop_tests`: each runtime copy carries its own, beside its
+//! duplicated `early_stop_exceeded` (Phase 4). `test_runtime::sampler`
 //! carries none.
 
 use std::collections::BTreeMap;
@@ -325,7 +328,7 @@ pub struct RefusalBreakdown {
     /// can only be nonzero through the sampler's documented full-list
     /// fallback — a component position with no acyclic option at all.
     /// A choice cycle on an acyclic chosen-edge graph is a sampler bug
-    /// and stops the search (see `search_implementations_with_runtime`).
+    /// and stops the search (see `search_implementations_with_ops`).
     /// Genomes assembled by hand (the election boards) are of course
     /// still free to name cycles, and are still counted here.
     pub with_choice_cycles: usize,

--- a/crates/luminal_reference/src/search.rs
+++ b/crates/luminal_reference/src/search.rs
@@ -1084,8 +1084,10 @@ pub struct BucketAssembly<'a> {
     /// The recorded model, before the schedule.
     pub pre_schedule: &'a str,
     /// The caller's own `bind_*` seeds — for the dims that are NOT
-    /// bucketed. A bucketed dim is refused a range binding, so these
-    /// never collide with the per-bucket seeds appended after them.
+    /// bucketed. Buckets and range bindings refuse each other in BOTH
+    /// orders (a range-bound dim is refused buckets, a bucketed dim is
+    /// refused a range binding), so these never collide with the
+    /// per-bucket seeds appended after them.
     pub binding_seeds: &'a str,
     /// The runtime's schedule text.
     pub schedule: &'a str,

--- a/crates/luminal_reference/src/search.rs
+++ b/crates/luminal_reference/src/search.rs
@@ -851,6 +851,14 @@ pub fn search_implementations_with_ops(
 
     // fingerprint → measured nanos (the dedup cache).
     let mut cache: FxHashMap<u64, u128> = FxHashMap::default();
+    // THE DECODED-LAYOUT CACHE, one per search and CALLER-OWNED
+    // (`decode_layout_table` takes it by `&mut`). Decoding is a pure
+    // function of `(layout class, dtype)`, and every decode builds a
+    // fresh `Reader` over the whole serialized e-graph — so a cache that
+    // did not span candidates would pay that index once per distinct
+    // layout class per candidate. `egraph` is fixed for this loop, which
+    // is what makes the `ClassId` keys comparable across candidates.
+    let mut layout_cache = luminal::layouts::LayoutDecodeCache::new();
     let mut plans_profiled = 0usize;
     let mut fingerprint_hits = 0usize;
     // Refusal accounting, minimal form (Step 5 down-payment): keep the
@@ -960,6 +968,7 @@ pub fn search_implementations_with_ops(
                         egraph,
                         &dps,
                         "implementation search",
+                        &mut layout_cache,
                     )
                     .and_then(|table| luminal::bufferize::bufferize(&dps, &table));
                     timings.plan_build_nanos += build_start.elapsed().as_nanos();
@@ -1026,9 +1035,13 @@ pub fn search_implementations_with_ops(
             {
                 let build_start = Instant::now();
                 let dps = luminal::dps::dps_rewrite(&graph);
-                let built =
-                    luminal::layouts::decode_layout_table(egraph, &dps, "implementation search")
-                        .and_then(|table| luminal::bufferize::bufferize(&dps, &table));
+                let built = luminal::layouts::decode_layout_table(
+                    egraph,
+                    &dps,
+                    "implementation search",
+                    &mut layout_cache,
+                )
+                .and_then(|table| luminal::bufferize::bufferize(&dps, &table));
                 timings.plan_build_nanos += build_start.elapsed().as_nanos();
                 let plan = match built {
                     Ok(plan) => plan,

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -30,7 +30,7 @@ Dispositions:
 | `7423ca37` | #391 | compile search progress UI | RE-EXPRESSED (`search_log` + Start/Faster/Slower) | branch `merge/main-391-search-ui` (2nd commit) | see **#391 progress UI** below |
 | `7d2817fa` | — | luminal_python: search_iterations pass through more places | FILE-LEVEL | branch `merge/main-7d2817fa-search-iterations` | parked crate: re-point `search_iterations` at `ImplementationSearchOptions` when luminal_python is re-attached to the recorder |
 | `bea18ecf` | #389 | Sdpa gqa fixes | FILE-LEVEL | branch `merge/main-389-sdpa-gqa` | parked crate + non-gating `ci/`: RULED 2026-09-02 (ruling 1) — `ci/example_output.py` SYNCS main's numbers for now, by decision; the loosened gemma / gemma4_moe TPOT figures are main's HLIR cuda_lite draws and still have to be re-baselined against CL A100 draws before they gate anything here |
-| `499d0779` | #386 | Search: early-stop candidate profiling against the best-so-far metric | MIXED — RE-EXPRESSED (core: running mean + fifth positional cutoff + predicate) / FILE-LEVEL (parks, with a stubbed predicate) | branch `merge/main-386-early-stop` (two commits) | REQUIREMENT FOR CL (ruling 4): a device `PlanProfiler` that times candidates on device, mirroring `ReferenceProfiler`'s design, and then honours the cutoff — until then `StaticProfiler` accepts and ignores it; see **#386 early-stop profiling** below |
+| `499d0779` | #386 | Search: early-stop candidate profiling against the best-so-far metric | MIXED — RE-EXPRESSED (core: running mean + fifth positional cutoff + predicate) / FILE-LEVEL (parks, with a stubbed predicate) | branch `merge/main-386-early-stop` (two commits) | REQUIREMENT FOR CL (ruling 4): a device `PlanProfiler` that times candidates on device, mirroring `ReferenceProfiler`'s design, and then honours the cutoff — until then `StaticProfiler` accepts and ignores it; see **#386 early-stop profiling** below — DELIVERED Phase 4 (2026-09-03): `crates/luminal_cuda_lite/src/profile.rs` + `Evaluator::Device` behind `CompileOptions::profile_on_device`, same lower-bound cutoff at factor 1.0; the `PlanProfiler` trait, `StaticProfiler`, `ReferenceProfiler` and `src/implementation_search.rs` named here were deleted in Phase 1 (search is runtime-owned), see **Program: #420/#422 rejoin — Phase 4 (device evaluator)** |
 | `6a5313f2` | #398 | Support for PyTorch OpInfo tests | MIXED — FILE-LEVEL (python + workflow) / RE-EXPRESSED (`TypedBuffer::F64` + typed unary kernels) / DROPPED (`ConstantF64`, the empty-Vec fix) | branch `merge/main-398-opinfo` (two commits) | OpInfo harness, the arange-metadata and acos/acosh lowerings = M4 translator requirements; typed `LogicalConstant`; F32<->F64 cast policy; F64 on CL — see **#398 OpInfo + F64** below |
 | `db3c80fd` | #399 | Add native narrow integer HLIR dtypes | MIXED — FILE-LEVEL (python) / RE-EXPRESSED (I8/U8/I16 TypedBuffer + kernels, int-safe `abs`) | branch `merge/main-399-narrow-ints` (two commits) | **CARVE-OUT to confirm at review**: I8/U8/I16 wrap, I32/I64 stay checked — see **#399 narrow ints** below |
 | `727918cd` | #394 | Optimize CUDA graph materialization and StaticCache writebacks | FILE-LEVEL (parks) + INTENT-ONLY (core) | branch `merge/main-394-cuda-graph-park` | REQUIREMENT FOR THE CL EXECUTOR: durable external device-pointer registration, exact binding-delta graph patching, cached reverse indexes, resource-signature reuse — see **#394 CL executor persistence** below |
@@ -50,7 +50,7 @@ Dispositions:
 | `477d3626` | #417 | Preserve concrete dtypes through loop rolling | INTENT-ONLY (the law written into the estate beside `dtype-of`) | branch `merge/main-417-dtype-contract` | RULED 2026-09-03: *"This is good, let's merge it."* Nothing is file-mergeable — `src/hlir.rs` and `src/op.rs` are deleted and `src/graph.rs` is a different file (the recorder). The principle main paid for is already this branch's design and is now written down; the `output_dtype` table, `concrete_node_dtypes` and the marker assertions are uncarried — see **#417 dtype contracts** below |
 | `6681720b` | #418 | Add CUDA serving runtime support for vLLM integration | FILE-LEVEL (12 python-park files + 4 into the `cuda_lite_hlir` park + 1 metal-park file) + UNCARRIED (`src/dyn_backend.rs`, deleted on this branch) | branch `merge/main-418-serving-parks` | RULED 2026-09-03: *"we'll record only, we'll eventually have to get to parity."* Five EMBEDDABILITY REQUIREMENTS on the live CL executor, each checked against today's `crates/luminal_cuda_lite/src/device.rs`: device selection, a caller-owned borrowed stream with a synchronize-or-not policy, fixed-capacity caller-owned output buffers, functionalized mutation writebacks, and a versioned FFI seam — see **#418 vLLM serving** below |
 | `f285d229` | #420 | Move post-saturation search into the runtime | FILE-LEVEL (3 files into the `cuda_lite_hlir` park + 1 metal-park file) + INTENT-ONLY (15 core/doc files, nothing applied) + DROPPED (all loop unroll / roll / packed machinery, main's `Runtime` trait shape) | branch `rejoin/p0-record-and-park` | RULED 2026-09-03: *"we're going to ignore all the loop unrolling, loop rolling stuff, but we're going to follow all the other aspects and move all of that functionality out of core and into the runtimes."* The boundary move is the program's thesis and lands in later phases; THIS row is record-and-park — see **#420 search into the runtime** below |
-| `598e5ca7` | #422 | Share reusable CUDA runtime through Lite | FILE-LEVEL (41 files into the `cuda_lite_hlir` park, incl. 5 deletions + 1 non-gating `ci/` file) + INTENT-ONLY (arena, runtime-configurable op/matcher selection) + PUNTED-TO-PARK (fusion, attention, cuda-heavy composition) + DROPPED (the `subsume` fusion rule and the four `delete` rules, `CudaRuntimeImpl<O>`) | branch `rejoin/p0-record-and-park` | RULED 2026-09-03: *"put these fusion changes in hlir and punt on them temporarily"*, *"we're going to copy it into the hlir folder and then actually implement it once we're caught up"* (attention/FA3), *"Update the hlir_folder so we have a record of what the target code looks like"* (full-CUDA downstream), *"no code for now"* (zero-copy rebinding) — see **#422 reusable CUDA runtime** below |
+| `598e5ca7` | #422 | Share reusable CUDA runtime through Lite | FILE-LEVEL (41 files into the `cuda_lite_hlir` park, incl. 5 deletions + 1 non-gating `ci/` file) + INTENT-ONLY at walk — DELIVERED by Phase 3 (arena) and PARTIALLY by Phase 2 (runtime-configurable op/matcher selection: the registry half; the execution face still PUNTED) + PUNTED-TO-PARK (fusion, attention, cuda-heavy composition) + DROPPED (the `subsume` fusion rule and the four `delete` rules, `CudaRuntimeImpl<O>`) | branch `rejoin/p0-record-and-park` | RULED 2026-09-03: *"put these fusion changes in hlir and punt on them temporarily"*, *"we're going to copy it into the hlir folder and then actually implement it once we're caught up"* (attention/FA3), *"Update the hlir_folder so we have a record of what the target code looks like"* (full-CUDA downstream), *"no code for now"* (zero-copy rebinding) — see **#422 reusable CUDA runtime** below |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -262,6 +262,19 @@ profiler's design** — warmup, timed trials, a mean metric, and the same
 lower-bound cutoff — at which point `StaticProfiler`'s ignored argument becomes
 a real one. That is a larger question than the cutoff itself, and it is not in
 this batch.
+
+**UPDATE (Phase 4, 2026-09-03).** The precondition above is discharged: CL
+profiles candidates on device when `CompileOptions::profile_on_device` is set
+(`crates/luminal_cuda_lite/src/profile.rs::profile_candidate`; `runtime.rs`'s
+`search` builds `Evaluator::Device`), applying `early_stop_exceeded` at factor
+1.0 to the same lower bound. The names in this section are HISTORICAL:
+`PlanProfiler` / `StaticProfiler` / `ReferenceProfiler`,
+`ImplementationSearchOptions::early_stop_factor` and
+`src/implementation_search.rs` were all deleted in Phase 1, and
+`search_passes_the_incumbent_metric_to_every_later_profile_call` was deleted
+rather than moved (see the Phase 1 section, and finding C6 there for what that
+leaves unpinned); the predicate stays pinned by `early_stop_tests` in each
+runtime's own `search.rs` copy.
 
 ## #398 OpInfo + F64 — what landed, and what is owed
 
@@ -547,11 +560,13 @@ branch. Its two additions, `DynBackend::clear_output_device_ptr` and a
 default `copy_outputs_to_device_ptrs`, are the core seam of a capability CL
 does not have at all, so they are recorded here as intent rather than code.
 
-**THE REQUIREMENT, for whenever CL grows a persistent executor.** CL today is
-single-shot: `crates/luminal_cuda_lite/src/device.rs` `execute_plan`
-allocates every buffer, uploads, launches, synchronizes, downloads, and drops
-the storage — strictly worse per invocation than main's runtime even BEFORE
-this commit. What #394 is worth, in the order it would have to be rebuilt:
+**THE REQUIREMENT, for the persistent executor CL now has (Phase 3, below).**
+CL at this walk (before Phase 3, 2026-09-03) was single-shot:
+`crates/luminal_cuda_lite/src/device.rs` `execute_plan` allocated every buffer,
+uploaded, launched, synchronized, downloaded, and dropped the storage —
+strictly worse per invocation than main's runtime even BEFORE this commit.
+Phase 3 has since made the context, stream, NVRTC module cache and
+interior-buffer slab persistent; items 1-5 below remain unbuilt. What #394 is worth, in the order it would have to be rebuilt:
 
 1. **Durable external pointer registration.** A caller-owned device pointer
    (a torch allocation) binds once; an identical re-registration is a NO-OP,
@@ -758,18 +773,23 @@ is removed by #422 (`598e5ca7`): `PersistentArena` / `park_*` / `attach_*` /
 `intermediate_buffer_bytes` = shared arena len; `clear_intermediate_buffers`
 is a true free again.
 
-**INTENT for CL.** The branch has NO analogue and, importantly, has not yet
-reached the problem: `crates/luminal_cuda_lite/src/device.rs` materializes one
-fresh `alloc_zeros` per `BufferId` per execute and treats the plan's
-`BufferAlloc`/`BufferFree` nodes as explicit no-ops, and CL's search profiles
-candidates on the reference HOST executor (a documented cost proxy), so it
-never churns device arenas. When CL grows on-device candidate profiling or
+**INTENT for CL.** AT ITS WALK the branch had NO analogue and, importantly,
+had not yet reached the problem: `crates/luminal_cuda_lite/src/device.rs`
+materialized one fresh `alloc_zeros` per `BufferId` per execute and treated the
+plan's `BufferAlloc`/`BufferFree` nodes as explicit no-ops, and CL's search
+ranked candidates by a device-free static prior, so it never churned device
+arenas. When CL grows on-device candidate profiling or
 bucketed re-execution, the re-expression is a persistent-allocation field on
 `CudaRuntime` plus honouring `BufferAlloc`/`BufferFree` against ONE
 runtime-owned high-water slab in `device.rs`, kept across `execute` calls
 rather than dropped with the `storage` map (= #422's `SharedArena` form; if CL
 ever profiles candidates on-device, decide explicitly whether to follow #422's
 per-candidate free or #401's retention — they conflict).
+
+DELIVERED 2026-09-03 — Phase 3 (`arena.rs` honours `BufferAlloc`/`BufferFree`
+against one grow-only runtime-owned slab on the persistent `CudaDevice`) and
+Phase 4 (on-device candidate profiling, which is exactly the trigger this
+paragraph names; #422's per-candidate `release_slab()` is the policy chosen).
 
 The transferable design, after #422:
 
@@ -823,11 +843,15 @@ Profiling -> unrolled LLIR -> Runtime`. On this branch:
 - **There is no loop-rolling stage.** Structure reaches egglog through the
   logical ops' own `.egg` estates (`src/logical_op/*`), not through a rolled
   HLIR graph.
-- **Extraction is not genetic-only, and does not produce LLIR.**
-  `src/extractor.rs` walks the e-graph to LayoutTensor ops,
+- **Extraction is not genetic-only, and does not produce LLIR.** AT
+  2026-09-02: `src/extractor.rs` walks the e-graph to LayoutTensor ops,
   `src/implementation_search.rs` runs the search over them, and
   `src/bufferize.rs` lowers the winner to a `BufferIrGraph` of buffers and
-  plan nodes. "LLIR" names nothing here.
+  plan nodes. Since Phase 1 of the #420/#422 rejoin the extractor and the
+  search are RUNTIME-OWNED — `luminal_reference::{extractor, search}`,
+  `luminal_cuda_lite::{extractor, search}` — and only `bufferize` remains in
+  core; see **Program: #420/#422 rejoin — Phase 1**. "LLIR" names nothing
+  here.
 - **What IS still true**, and is the part worth keeping when the document is
   rewritten: semantic equivalence must hold across the whole search space; the
   reference runtime is CPU ground truth; and the program as authored is an
@@ -835,9 +859,11 @@ Profiling -> unrolled LLIR -> Runtime`. On this branch:
   never redefine.
 
 **Owed:** a spec rewritten against the recorder / `egglog_core` /
-`extractor` + `implementation_search` / `bufferize` / CL flow. Adapting this
-text line by line would be worse than starting from the pipeline as it is;
-what should survive the rewrite is the contracts section, not the diagram.
+runtime-owned `extractor` + `search` (per runtime crate, Phase 1) /
+`bufferize` / CL flow — the shape already stated in the note at the top of
+`spec.md`. Adapting this text line by line would be worse than starting from
+the pipeline as it is; what should survive the rewrite is the contracts
+section, not the diagram.
 
 ## #402 translate_module — the seam banked, the scatter fix superseded
 
@@ -2215,6 +2241,17 @@ Each is stated as a requirement on the live CL executor — `execute_plan` in
 `CudaRuntime::execute` (`crates/luminal_cuda_lite/src/runtime.rs:299-307`) —
 with today's state verified in the tree, not assumed.
 
+**STATE AS OF `acde9ac1` (2026-09-03, BEFORE Phase 3 of the #420/#422
+rejoin).** Phases 3 and 4 below changed the executor's shape, so read every
+*Today* item and every `device.rs:NNN` cite in this section as pre-Phase-3:
+`CudaDevice` now persists the context, the one stream, the NVRTC module cache
+and the arena slab across calls, created once and owned by `CudaRuntime`;
+INTERIOR buffers are sub-ranges of that slab rather than fresh allocations; and
+payloads are `HostBuffer`, not `TypedBuffer`. Still true as written: device 0
+is hardcoded, standalone and escaping (output-backing) allocations are fresh
+per call, outputs are D2H'd into fresh host vectors, and the terminal
+synchronize is unconditional. EVERY REQUIREMENT BELOW STILL STANDS.
+
 **(1) Explicit CUDA device selection.** *Today: device 0 is hardcoded, and the
 context is created per call.* `crates/luminal_cuda_lite/src/device.rs:156`:
 
@@ -2268,16 +2305,21 @@ capture demands a stable address, so a per-shape allocation is not an option);
 and the planner/allocator must be forbidden from handing that buffer's range to
 anything else (main's fix is literally a filter — `external_output_nodes`
 excluded from `logical_buffer_offsets` before arena assignment).
-**The seam already exists and already says so.** `device.rs:215-222`, the
-CONTRACT-1 bind-time check, is written for exactly this future:
+**The seam already exists and already says so.** `device.rs:215-222` at
+`acde9ac1` (re-scoped by Phase 3 — see **CONTRACT-1: re-scoped, not dropped,
+not duplicated**), the CONTRACT-1 bind-time check, was written for exactly this
+future:
 
 > distinct BufferIds must be backed by disjoint device ranges … Fresh
 > `alloc_zeros` per buffer makes this hold by construction today; the assert is
 > the contract's enforcement face for when raw caller pointers arrive at this
 > binding surface. Loud refusal, never mistranslation.
 
-That is where a caller pointer table would be bound, and the disjointness
-assert is what would catch a host handing in two overlapping ranges.
+The "fresh `alloc_zeros`" clause is gone since Phase 3: the executor's assert
+now covers only the standalone and donated rows it allocates itself, and the
+slab's half is decided at planning time in `arena.rs`. That is still where a
+caller pointer table would be bound, and the disjointness assert is what would
+catch a host handing in two overlapping ranges.
 #422's zero-copy fix implies: a registration carries `(ptr, capacity)`; a grown
 dynamic output must be re-registered before the plan is bound, never patched in
 the executor — RECORDED ONLY, no runtime checks by ruling (2026-09-03).
@@ -2378,8 +2420,17 @@ failures.
   `search_passes_the_incumbent_metric_to_every_later_profile_call`. It
   drove a hand-written `PlanProfiler` to observe the `best_so_far`
   cutoff crossing the trait boundary — and that boundary no longer
-  exists. #386's semantics stay pinned by `early_stop_exceeded`'s own
-  board, which is where the predicate lives.
+  exists. The PREDICATE's semantics stay pinned by
+  `early_stop_exceeded`'s own board
+  (`luminal_reference::search::early_stop_tests`, and since Phase 4 a
+  copy in `luminal_cuda_lite::search` too). AMENDED 2026-09-03 (review
+  finding C6): the loop's PLUMBING that the deleted test also pinned —
+  `None` for the baseline candidate, the incumbent's mean for every
+  later one, one evaluation per profiled plan (the `best_so_far`
+  binding handed to `profile_on_reference_runtime`) — is currently
+  UNPINNED. With the profiler seam gone there is no hook to observe it
+  short of adding one, and the stop is exact, so no selection outcome
+  can witness it. Recorded, not solved.
 - *The per-candidate input clone stays.* Each candidate gets a fresh
   `ReferenceRuntime` and `set_data_buffer` takes ownership. Removing it
   is a runtime-surface change (a borrowing stage API), not a Phase 1
@@ -2399,11 +2450,19 @@ value inside that bucket, naming the representative and pointing at the
 open item — symbolic plans (spans as expressions) and the capacity
 contract that goes with them. Pinned on both sides.
 
-**Still owed.** Device profiling for CUDA-lite (the heuristic is a weak
-prior — bytes moved is uncorrelated with occupancy, launch count,
-coalescing, library dispatch); the arena allocator behind the runtimes'
-`bufferize` call; whatever consolidation the three copies eventually
-earn, which is a question to ask after the runtimes diverge, not before.
+**Still owed** (as written at Phase 1; AMENDED at Phase 5, 2026-09-03).
+Device profiling for CUDA-lite (the heuristic is a weak prior — bytes
+moved is uncorrelated with occupancy, launch count, coalescing, library
+dispatch) — DELIVERED in Phase 4: `CompileOptions::profile_on_device`,
+`crates/luminal_cuda_lite/src/profile.rs`, see **Program: #420/#422
+rejoin — Phase 4 (device evaluator)** below. The arena allocator behind
+the runtimes' `bufferize` call — DELIVERED for CUDA-lite in Phase 3:
+`crates/luminal_cuda_lite/src/arena.rs`, see **Phase 3 (the arena and
+the persistent device)** below; the reference runtime has none, by
+ruling. Still open: the spec re-authoring against this shape (see
+**#404 spec.md**), and whatever consolidation the three copies
+eventually earn — a question to ask after the runtimes diverge, not
+before.
 
 ## Program: #420/#422 rejoin — Phase 2 (configurable registry)
 
@@ -2459,8 +2518,19 @@ minus the `LayoutTensorOp` prefix and nothing else, so it keeps its
   the allow list through the two DERIVED matcher-only classes
   (plan-transparent, host-dispatchable); a row that must actually be
   executed needs a codegen entry in `kernels`, keyed by `TypeId` inside
-  this crate. A row without one is simply never claimed, so the failure
-  is a refusal at search, never a wrong plan.
+  this crate. AMENDED 2026-09-03 (review finding C12): the kernel-bearing
+  test is by LABEL, codegen by `TypeId`. A row whose label is not in the
+  kernel table is never claimed (refusal at search); a row that REUSES a
+  kernel-table label with a different op type IS claimed and refuses at
+  `execute` (`no cuda codegen for <label>`) — never a wrong plan, but
+  not at search.
+- *One estate that is NOT row-by-row* (added 2026-09-03, review finding
+  C11): the four cuBLASLt marker rows share one egglog vocabulary,
+  declared and minted by the Base row's snippets. A registry holding a
+  non-Base marker row without Base would derive a claim for an op the
+  assembled program never declares — `load_with_registry` refuses that
+  configuration by name (`registry_selection.rs`
+  `a_non_base_cublaslt_row_without_base_is_refused_at_load`).
 
 **The punt, recorded.** Composing an external kernel superset onto
 Lite's codegen ("cuda heavy") is NOT started: no execution face on
@@ -2682,7 +2752,7 @@ graphs and synchronizes. Search is the exception and deliberately reverses
 `discard_search_bucket_compilation_state` at every bucket boundary, because
 *"a slow copying alternative can require several GiB more than the eventual
 winner, and retaining that losing arena starves later candidate
-compilation."* Today CL is nowhere near this: `execute_plan`
+compilation."* At row time (p0, `5b0e3c25`) CL was nowhere near this: `execute_plan`
 (`crates/luminal_cuda_lite/src/device.rs`) materializes one fresh
 `alloc_zeros` per `BufferId` per execute and treats the plan's `BufferAlloc` /
 `BufferFree` nodes as explicit no-ops. The re-expression is a runtime-owned
@@ -2693,18 +2763,31 @@ Two things the spec must get right: exclusion from the slab keys on
 `FreedBy::Caller`, not `Owner::Caller`, and the issue order must be
 liveness-aware or the slab is a sum-of-buffers peak with extra steps.
 
+DELIVERED 2026-09-03 — Phase 3 (`crates/luminal_cuda_lite/src/arena.rs`'s
+`plan_arena` plus the `BufferAlloc` / `BufferFree` arms in `device.rs`, a
+grow-only slab on the persistent `CudaDevice`; both spec points honoured — the
+exclusion keys on `FreedBy::Caller` and the order is liveness-aware), and the
+per-candidate `release_slab()` of Phase 4. See **Program: #420/#422 rejoin —
+Phase 3 (the arena and the persistent device)** and **Phase 4**.
+
 **(2) Configurable op / matcher selection at runtime init.** Main's answer is
 a type tuple (`CudaRuntimeImpl<O: IntoEgglogOp>`, `DefaultCudaOps =
 (kernel::Ops, host::Ops)`, `CudaDynBackend<O>`, `cuda_factory_for`). The
 intent — a downstream backend picks its op set and inherits the compiler,
 resource planner, arena, graph capture and search — is carried; the TYPE
-tuple is not (see DROPPED). The branch form is a value-level registry with the
-execution face injected at load: the estate already composes that way
-(`assembled_program_for` over any matcher list), branch ops carry their rules
-as `.egg` files rather than Rust methods, and the refactor deletes the two
-closed seams that exist today (the `host_dispatchable` name list and the
-executor's downcast arm). Do that BEFORE flipping cuBLASLt always-on, or
-always-on lands as a third registry function the refactor immediately deletes.
+tuple is not (see DROPPED). The branch form is a value-level registry —
+DELIVERED as `load_with_registry` / `cuda_registry_filtered` /
+`RegisteredOp::new`, see **Program: #420/#422 rejoin — Phase 2 (configurable
+registry)**. The estate already composes that way (`assembled_program_for` over
+any matcher list) and branch ops carry their rules as `.egg` files rather than
+Rust methods. The SECOND half — an execution face injected at load, which is
+what would let the refactor delete the two closed seams that exist today (the
+`host_dispatchable` prototype DOWNCAST in `ops/cublaslt/mod.rs`, never a name
+list, and the executor's `CublasLtDps` downcast arm in `device.rs`) — is
+PUNTED; see Phase 2, *The punt, recorded*. Both seams are live at the tip
+(`runtime.rs`'s `allow_list_over`, `device.rs`'s host-call arm). Land the
+execution face BEFORE flipping cuBLASLt always-on, or always-on lands as a
+third registry function the refactor immediately deletes.
 
 **(3) Fusion — PUNTED to the park, by ruling.** #422 turns on the first
 multi-op fusion Lite has ever had: a singleton region per eligible elementwise
@@ -2920,8 +3003,15 @@ lives at the top of `device.rs`):
   destination is completely written before the second launch scatters
   into it; same stream, so the phases are ordered;
 - **cuBLASLt D** — `beta = 0` on the non-fold forms, which is the BLAS
-  skip (C, aliased to D, is not read); the C-fold forms read a separate C
-  OPERAND buffer at `beta = 1`, never the destination's prior bytes.
+  skip (C, aliased to D, is not read); the C-fold forms read their C
+  operand at `beta = 1`. AMENDED 2026-09-03 (review finding C13): C is a
+  DEFINED resident — usually a distinct live range, but D's own range
+  when the program binds an output slot onto the ReadWrite caller buffer
+  that holds C, admitted through `CublasLtDps`'s May permit on operand 2
+  and legal because `bind_destination` emits identical C and D
+  descriptors (the API's C == D precondition). Never an undefined
+  recycled range, which is the property this bullet is for; the earlier
+  "C != D pointers" wording was the pre-arena fresh-slice justification.
 
 Standing assumption, recorded rather than checked: a destination's
 `numel(dest_dims)` covers its buffer's SPAN. True for every codegen'd
@@ -3482,6 +3572,128 @@ Box returned to `logical-ssa-project`.
   real searches. A unit test over hand-built finalists would pin the
   best-first ordering directly; it would also need a public way to inject
   them, which is test scaffolding in the library.
+
+## Program: #420/#422 rejoin — review fix-ups
+
+An adversarial review of the six-branch stack (`rejoin/p0` … `rejoin/p5`)
+confirmed 26 findings. They land on `rejoin/p6-review-fixups`, one commit per
+code finding plus two doc commits, except C1/C8 which had to move DOWN the
+stack — the branch whose commit broke the build is the branch that must repair
+it. Four findings are behaviour; the rest are statements in the tree that the
+stack's own phases falsified. Listed by number, with where each was fixed.
+
+**Behaviour (code).**
+
+- **C1 / C8 — Step B breaks the CUDA-lite `device` feature build in three
+  places (hidden from the CPU gate).** `HostBuffer` became a struct and three
+  `cfg(feature = "device")` sites still matched `HostBuffer::F32(values)` /
+  compared `Vec<f32>` to `&Vec<f32>`, so no A100 example and no device test
+  built from Step B onward. Phase 3 carried the repairs two branches too late,
+  and its carry-fix commit named three sites while fixing two. Fixed by a
+  fix-up commit at the Phase 1 tip ("Step B fix-up: the HostBuffer swap
+  reaches the device-gated files") carrying all three repairs; the stack was
+  rebased onto it and Phase 3's carry-fix commit disappeared as empty.
+  `cargo build -p luminal_cuda_lite --all-targets --features device` now
+  passes at every branch tip.
+- **C2 / C9 — `bind_dim_buckets` accepted a dim that already carried a
+  non-tight RANGE binding, so the two seed sets intersected under the bounds
+  lattice's merge instead of refusing.** Both runtimes now keep `range_bound`
+  (every `bind_dyn_range` call with its interval) and refuse buckets on it,
+  naming the interval; the leftover `dims` check now says what it actually
+  covers (`set_dim`). Commit "Buckets and range bindings are exclusive,
+  whatever the interval"; tests in the reference battery (all three arms) and
+  `crates/luminal_cuda_lite/tests/dim_buckets.rs`.
+- **C3 / C10 — the CUDA-lite bucketed `search` ran a full, discarded
+  saturation of the UNBUCKETED program first**, whose bucketed dims carry no
+  seeds — so a bounds-dependent authoring check (`reduce_max`'s
+  `require_extent_at_least`, an iota's value bounds) refused a bucketed search
+  every per-bucket render accepts. The base program is now rendered only on
+  the single-pin path and the bound-input check reads `native.input_slots`.
+  Commit "The bucketed CUDA search renders no base program"; the new
+  `a_bucketed_dim_may_carry_a_bounds_dependent_check` is the witness.
+- **C4 — the decoded-layout cache shrank from per-search to per-candidate.**
+  `decode_layout_table` allocated its cache per call, and every decode builds
+  a fresh `Reader` over the whole serialized e-graph, so each candidate paid
+  one index per distinct layout class. `decode_layout_table` takes
+  `&mut LayoutDecodeCache` again; each search copy owns one, `Finalists` owns
+  one, one-shot callers pass a fresh map. Commit "The decoded-layout cache is
+  the caller's again, and spans candidates".
+- **C11 — a non-Base cuBLASLt marker row without the Base row was CLAIMED but
+  never declared or minted**, because only the Base matcher emits snippets —
+  a silent no-op that `active_allow_list()` reports as available.
+  `load_with_registry` refuses that configuration by name. Commit "A non-Base
+  cuBLASLt marker row without Base is refused at load"; pinned in
+  `tests/registry_selection.rs`.
+
+**Doc truth, in the source tree** (commit "Doc truth: the comments the
+rejoin's five phases made false").
+
+- **C5 — BRINGUP.md still said CL profiles candidates on the reference HOST
+  executor and described a profiler seam that exists nowhere**; two later
+  bullets still named `TypedBuffer` for `execute_plan`.
+- **C7 / C25 — doc comments referencing symbols the move deleted:**
+  `src/bufferize.rs` linked `crate::extractor::decoded_layout_table` twice
+  (now `crate::layouts::decode_layout_table`), and both `RefusalBreakdown`
+  docs named `search_implementations_with_runtime`, a function in neither
+  copy (now each copy's own loop).
+- **C12 — "an outside row without a codegen entry is never claimed; refusal
+  at search" is false:** the kernel-bearing class is LABEL-keyed while codegen
+  is `TypeId`-keyed and consulted at execute. Corrected in
+  `ops/mod.rs`, in `load_with_registry`'s doc, and in the Phase 2 section
+  above.
+- **C13 — the cuBLASLt arm comments claimed C != D pointers and that D's
+  prior bytes are never read**, a justification that rested on the fresh-slice
+  convention Phase 3 deleted. Corrected in `device.rs` (twice) and in the
+  Phase 3 kernel-invariant bullet above.
+- **C14 / C16 — the `runtime.rs` module header said everything before
+  `execute` is device-free and only `execute` needs the feature**; a
+  `profile_on_device` search needs both. Header and `device` field doc
+  amended.
+- **C15 / C21 — the `CudaDevice` struct doc said the slab is never released
+  between calls**; the search releases it after every profiled candidate.
+- **C19 — both search headers said the CUDA-lite copy carries no tests**;
+  Phase 4 gave it `early_stop_tests`.
+- **C20 — CL `lib.rs` still said kernels "write fresh destinations"**; since
+  Phase 3 they write recycled, unzeroed slab ranges, which is why the KERNEL
+  INVARIANT exists.
+
+**Doc truth, in this ledger** (commit "Ledger: the rejoin's own rows,
+amended in place"). Each is an in-place amendment in the ledger's
+"SUPERSEDED / DELIVERED — see **…**" style; no history is deleted.
+
+- **C6 — the Phase 1 deleted-test bullet claimed "#386's semantics stay
+  pinned".** Only the PREDICATE is pinned; the loop's `best_so_far` plumbing
+  is unpinned and now says so. (No test-only evaluator hook: that would
+  reintroduce the seam the rulings deleted.)
+- **C17 — #422 INTENT (1) still said "Today CL is nowhere near" the arena
+  Phase 3 landed**, and row 53 still marked the arena and registry
+  INTENT-ONLY. Amended, with the #401 INTENT-for-CL paragraph as its
+  companion.
+- **C18 — row 33 and the #386 section still owed CL a device `PlanProfiler`
+  with `StaticProfiler` as the stopgap**; both types are deleted and Phase 4
+  delivered the profiler.
+- **C22 — Phase 1 "Still owed" listed device profiling and the arena**, both
+  delivered later in this same stack.
+- **C23 — #422 INTENT (2) promised a refactor deleting `host_dispatchable`
+  and the executor downcast arm**; Phase 2 punted exactly that, and
+  `host_dispatchable` was never a name list.
+- **C24 — the #418 / #394 "today" snapshots of the executor** (fresh alloc
+  per buffer, single-shot, `TypedBuffer` outputs, the quoted CONTRACT-1
+  comment) are pre-Phase-3; they carry a STATE-AS-OF note and the
+  requirements below them still stand.
+- **C26 — the #404 section described the pipeline and the owed spec rewrite
+  in terms of `src/extractor.rs` / `src/implementation_search.rs`**, which
+  Phase 1 removed from core.
+
+**Not taken, and why.** The reviewer's alternative for C6 (a test-only
+evaluator hook to re-pin the `best_so_far` plumbing) is refused: it
+reintroduces the profiler seam the rulings deleted, to observe a stop that is
+exact and therefore cannot change any outcome. C12's "make the statement true"
+option — keying the kernel-bearing test on the prototype's DPS `TypeId` — is
+recorded, not taken: it changes allow-list derivation and would need checking
+against every shipped prototype. C25's optional aside (the pre-existing
+LAYOUT-vs-VALUE e-class contradiction in `bufferize`'s doc paragraph, identical
+at trunk) is left alone as out of this program's scope.
 
 ## #406 pad — the select construction REVERTED (2026-09-03)
 

--- a/src/bufferize.rs
+++ b/src/bufferize.rs
@@ -1535,7 +1535,7 @@ fn validate_input_program(graph: &ExtractedGraph) -> Result<()> {
 /// `layouts` is the decoded-layout table, keyed by LAYOUT e-class (each
 /// value's `LayoutTensorInfo::layout.eclass`): the runtime's decoder
 /// produced one opaque `L` per layout class it elected (see
-/// [`crate::extractor::decoded_layout_table`]). The table must cover
+/// [`crate::layouts::decode_layout_table`]). The table must cover
 /// every value's layout class — a miss is a loud error, never a default
 /// (every LayoutTensor carries a Layout by construction, so a missing
 /// row means the decoder refused and the plan must too). Keying by
@@ -1547,7 +1547,7 @@ pub fn bufferize<L: PlanLayout>(
     layouts: &HashMap<ClassId, L>,
 ) -> Result<BufferIrGraph<L>> {
     // `layouts` is keyed by VALUE e-class (the runtime's decoded table,
-    // [`crate::extractor::decoded_layout_table`]).
+    // [`crate::layouts::decode_layout_table`]).
     let value_layouts = extraction_layouts(graph, layouts)?;
     let mut plan = lower(buffer_tensor_plan(graph, &value_layouts)?, &value_layouts)?;
     annotate_boundary_lits(&mut plan, graph);

--- a/src/layouts.rs
+++ b/src/layouts.rs
@@ -798,15 +798,28 @@ pub struct DecodedLayout {
     pub dtype: Option<crate::dtype::PlanDtype>,
 }
 
+/// The caller-owned decoded-layout cache: `(layout class, dtype-of fact)`
+/// → the decoded layout. Decoding is a PURE function of that key, so one
+/// map serves every candidate a search decodes over ONE serialized
+/// e-graph — and only that one: `ClassId`s are meaningful only inside the
+/// e-graph they came from, so a new render gets a new cache.
+pub type LayoutDecodeCache = HashMap<(ClassId, Option<crate::dtype::PlanDtype>), DecodedLayout>;
+
 /// Build the decoded-layout table for one extracted graph, keyed by
 /// VALUE e-class: enumerate every elected value and decode its layout
 /// class into a [`DecodedLayout`].
 ///
-/// THE CACHE KEY is `(layout class, dtype-of fact)` — all spellings of a
-/// layout class denote one function, and the dtype fact is the one
-/// extraction-side value fact folded into the decoded type — so one
-/// per-call cache serves every value of the graph. A decode error is
-/// LOUD and refuses the graph: there is no default layout.
+/// THE CACHE IS THE CALLER'S, keyed by `(layout class, dtype-of fact)` —
+/// all spellings of a layout class denote one function, and the dtype
+/// fact is the one extraction-side value fact folded into the decoded
+/// type, so decoding is a PURE function of that key and one cache serves
+/// every value of the graph AND every later graph over the same e-graph.
+/// A search loop holds one for its whole run: `decode_layout` builds a
+/// fresh `Reader` that walks and sorts every node of the serialized
+/// e-graph, so a per-call cache would pay that index once per distinct
+/// layout class per CANDIDATE. A one-shot caller passes
+/// `&mut HashMap::new()`. A decode error is LOUD and refuses the graph:
+/// there is no default layout.
 ///
 /// CALL IT ON THE GRAPH BUFFERIZE WILL SEE — the POST-DPS one. The table
 /// is VALUE-keyed, and the DPS rewrite mints fresh poison-destination
@@ -818,12 +831,11 @@ pub fn decode_layout_table(
     egraph: &EGraph,
     graph: &crate::layout_ir::ExtractedGraph,
     who: &str,
+    cache: &mut LayoutDecodeCache,
 ) -> Result<HashMap<ClassId, DecodedLayout>> {
     use crate::layout_ir::ExtractedNode;
 
     let mut table: HashMap<ClassId, DecodedLayout> = HashMap::new();
-    let mut cache: HashMap<(ClassId, Option<crate::dtype::PlanDtype>), DecodedLayout> =
-        HashMap::new();
     let mut decode = |value: &crate::layout_ir::LayoutTensorInfo,
                       table: &mut HashMap<ClassId, DecodedLayout>|
      -> Result<()> {

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1475,8 +1475,13 @@ mod harness_tests {
         let egraph = serialize_fixture("boundary_gather.egg");
         let graph = luminal::dps::dps_rewrite(&extract_fixture("boundary_gather.egg"));
         // The POST-DPS graph: value-keyed tables cover poisons.
-        let table = luminal::layouts::decode_layout_table(&egraph, &graph, "dtype row test")
-            .expect("the decoder covers every elected value");
+        let table = luminal::layouts::decode_layout_table(
+            &egraph,
+            &graph,
+            "dtype row test",
+            &mut luminal::layouts::LayoutDecodeCache::new(),
+        )
+        .expect("the decoder covers every elected value");
         let plan = bufferize::bufferize(&graph, &table).expect("mixed-dtype plan bufferizes");
 
         let mut by_lit: std::collections::HashMap<i64, PlanDtype> = Default::default();


### PR DESCRIPTION
An adversarial review of the six-branch `#420/#422 rejoin` stack confirmed **26 findings**. This branch carries the fix-ups: one commit per code finding, two for the docs. Four findings are behaviour; the rest are statements in the tree that the stack's own phases falsified.

One finding could not be fixed here at all — it had to move DOWN the stack, because the branch whose commit broke the build is the branch that must repair it. **The whole stack was rebased** onto that repair; every branch tip changed, and `cargo build -p luminal_cuda_lite --all-targets --features device` now passes at each of them.

## The blocker, fixed at Phase 1 (C1, C8)

`HostBuffer` became a struct in Step B and three `cfg(feature = "device")` sites still matched `HostBuffer::F32(values)` or compared `Vec<f32>` to `&Vec<f32>`. Since every CL example routes through `support::device`, no A100 example and no device test built from Step B through Phase 3 — invisible to the macOS CPU gate. Phase 3 carried the repairs two branches too late, and its carry-fix commit's message named three sites while its diff fixed two.

The three repairs now sit in one commit at the **Phase 1** tip (`0ee992cc`, *"Step B fix-up: the HostBuffer swap reaches the device-gated files"*). P2–P5 were rebased onto it; Phase 3's carry-fix commit dropped out as empty and the contract-test hunk of the arena commit resolved to identical text. Rebased tips:

| branch | tip |
| --- | --- |
| `rejoin/p0-record-and-park` | `5b0e3c25` (unchanged) |
| `rejoin/p1-runtime-owned-search` | `0ee992cc` |
| `rejoin/p2-configurable-registry` | `0219855b` |
| `rejoin/p3-arena` | `6dc5498c` |
| `rejoin/p4-device-evaluator` | `a1903293` |
| `rejoin/p5-finalists-lattice` | `b12d1d6a` |

Each branch's merge-base with its predecessor is that predecessor's tip, and every rebased tree is byte-identical to the pre-rebase one.

## Behaviour, on this branch

**C2 / C9 — buckets and range bindings are exclusive, whatever the interval.** The "exclusive per dim, both directions, loudly" invariant was enforced only for TIGHT pins: `bind_dyn_range` recorded a dim in `dims` solely when `lower == upper`, so `bind_dyn_range('a', 2, 8)` then `bind_dim_buckets('a', [[5, 9]])` was accepted in both runtimes. The bucket render emits the caller's seeds and then the per-bucket seeds for the same `IntVar`, and `lower-bound-of` / `upper-bound-of` are declared `:merge (max old new)` / `:merge (min old new)` — the second set narrows rather than errors. Bucket [5, 9] under range [2, 8] was validated over [5, 8] while `BucketPlan.ranges` claimed 9. Both runtimes now keep `range_bound` (every call, with its interval) and refuse buckets on it by name; the leftover `dims` check now says what it actually covers (`set_dim`), which its old message got wrong. Tests: all three arms in the reference battery (which had no exclusivity test at all), the non-tight arm added to CUDA-lite's.

**C3 / C10 — the bucketed CUDA search renders no base program.** `CudaRuntime::search` called `assemble_and_saturate()` unconditionally before branching on `dim_buckets`; the bucketed arm used neither result, since `program.input_slots` is a clone of `native.input_slots`. Worse than a discarded fixpoint: the base render leaves bucketed dims UNBOUNDED, so `x.max(0)` over a bucketed `'a'` was refused with *"reduce_max axis at t0: extent lower bound must reach 1 — bind the dim's range"* — advice `bind_dim_buckets` forbids — over a program every per-bucket render accepts. The base program is now rendered only on the single-pin path; the bound-input check and Phase 4's staging read `native.input_slots`. The new `a_bucketed_dim_may_carry_a_bounds_dependent_check` fails on the parent commit with exactly that refusal. The unbucketed path is untouched.

**C4 — the decoded-layout cache is the caller's again.** Step A folded the `(layout class, dtype)` cache inside `decode_layout_table`, believing the cross-genome cache "bought nothing once the generic went". It amortized `decode_layout`, which builds a fresh `Reader` that walks and sorts every node of the serialized e-graph — so a per-call cache pays that index once per distinct layout class per candidate, plus again on improving fingerprint hits. `decode_layout_table` takes `&mut LayoutDecodeCache`; each search copy owns one, `Finalists` owns one, one-shot callers pass a fresh map. The type's doc records why the cache is caller-owned (decoding is pure in its key) and why it may not outlive one serialized e-graph (`ClassId`s are e-graph-local).

**C11 — a non-Base cuBLASLt marker row without Base is refused at load.** Only the Base matcher emits snippets, and that one set declares all four constructors and every minting rule. A registry holding Bias/Accumulate/AccumulateBias without Base derived a CLAIM (off the prototype, via `host_dispatchable`'s downcast) for an op the assembled program never declares or mints: un-electable, while `active_allow_list()` — the check the module doc recommends — reports it available. `load_with_registry` now refuses that configuration by name. Pinned both ways it can be reached: a hand-pushed Bias row, and the preset filtered to drop Base.

## Doc truth

**In the source tree** (C5, C7, C12, C13, C14, C15, C16, C19, C20, C21, C25): BRINGUP.md still told the device-machine reader that candidates are timed on the reference HOST executor and that "the profiler seam parameterization is CL-3" — CL never did, and no such seam exists in core or here; two bullets still named `TypedBuffer` for `execute_plan`. `src/bufferize.rs` linked `crate::extractor::decoded_layout_table` twice, a module Phase 1 deleted; both `RefusalBreakdown` docs named `search_implementations_with_runtime`, a function in neither copy. The ops-module header claimed an outside row without a codegen entry is "never claimed; refusal at search" — true only when its LABEL does not collide with the kernel table's, since codegen is `TypeId`-keyed at execute. The cuBLASLt arm comments claimed C != D pointers, a justification resting on the fresh-slice convention Phase 3 deleted. The runtime header said only `execute` needs a device, which Phase 4 falsified. The `CudaDevice` doc said the slab is never released, while the search releases it after every candidate. Both search headers said the CUDA-lite copy carries no tests, and lib.rs still said kernels "write fresh destinations".

**In the ledger** (C6, C17, C18, C22, C23, C24, C26, plus the ledger halves of C11/C12/C13): the same mistake seven times — a row states the world in the present tense, a later phase of this same stack delivers it, and nobody revisits the paragraph, so the tip ledger shows a thing owed and delivered in adjacent sections. Every edit is an in-place amendment in the ledger's existing `SUPERSEDED / DELIVERED — see **…**` style; no history is deleted. Two are different in kind: #422 INTENT (2) promised a refactor Phase 2 explicitly punted (and `host_dispatchable` was never a name list), and Phase 1's deleted-test bullet claimed "#386's semantics stay pinned" when only the PREDICATE is — the loop's `best_so_far` plumbing is now recorded as unpinned rather than papered over.

A new ledger section, **"Program: #420/#422 rejoin — review fix-ups"**, lists all 26 findings by title with where each was fixed, and the three proposals deliberately declined: a test-only evaluator hook for C6 (it reintroduces the seam the rulings deleted, to observe a stop that is exact), re-keying the kernel-bearing test on the DPS `TypeId` for C12 (changes allow-list derivation; recorded, not taken), and C25's pre-existing LAYOUT-vs-VALUE aside (identical at trunk, out of scope).

## Gate (all green, on this tip)

```
cargo build --workspace --all-targets                                 ok
cargo build -p luminal_cuda_lite --all-targets --features device      ok
cargo test -p luminal --lib          228 passed; 0 failed; 6 ignored   (the pad proptests finish: 1d, 2d, slice_pad)
cargo test -p luminal_reference      58 / 1 / 7 passed, 0 failed
cargo test -p luminal_cuda_lite      all 20 targets ok, 0 failed
cargo test -p test_runtime           42 targets, all ok, 0 failed
cargo test -p luminal_nn             31 passed; 0 failed
cargo clippy -p luminal -p luminal_reference -p luminal_cuda_lite --lib          clean
cargo clippy -p luminal_cuda_lite --lib --features device                        clean
cargo fmt --all -- --check                                                       clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
