### PR TITLE
CUDA constant literals: shortest-exponent finite forms and bit-pattern non-finites

### DIFF
--- a/crates/luminal_cuda_lite/src/kernels.rs
+++ b/crates/luminal_cuda_lite/src/kernels.rs
@@ -654,6 +654,39 @@ pub(crate) fn cuda_type(dtype: PlanDtype) -> Result<&'static str> {
     })
 }
 
+/// An `f64` as a C token NVRTC will actually parse. Rust's `Display`
+/// for `f64` is not a C literal syntax: non-finite values print as
+/// `inf`/`-inf`/`NaN`, which are not C tokens at all, and a
+/// large-magnitude finite value prints as a bare digit string with no
+/// decimal point and no exponent — `f32::MIN as f64` becomes
+/// `-340282346638528860000000000000000000000`, which C reads as an
+/// *integer* literal too large for any integer type, and the kernel
+/// fails to compile. `{:e}` closes the finite case: it is the shortest
+/// round-trip form and always carries an exponent, so it is always a
+/// `double` literal.
+///
+/// The non-finite cases go through bit patterns rather than the
+/// `INFINITY`/`NAN` macros because this runtime compiles kernels with
+/// NVRTC (`cudarc::nvrtc::compile_ptx`, see `device.rs`), which has no
+/// host math headers, so those macros do not exist there — the same
+/// reason, and the same technique, as the `-inf` reduction identity in
+/// [`crate::ops::reduce_max`]. The bit patterns are `float`-typed; the
+/// caller's existing `({to})` cast converts to the destination type
+/// exactly as it does for a finite literal.
+pub(crate) fn cuda_f64_literal(v: f64) -> String {
+    if v.is_nan() {
+        return "__uint_as_float(0x7fc00000u)".to_string();
+    }
+    if v.is_infinite() {
+        return if v.is_sign_positive() {
+            "__uint_as_float(0x7f800000u)".to_string()
+        } else {
+            "__uint_as_float(0xff800000u)".to_string()
+        };
+    }
+    format!("{v:e}")
+}
+
 pub(crate) fn numel(dims: &[usize]) -> usize {
     dims.iter().product()
 }

--- a/crates/luminal_cuda_lite/src/ops/constant/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/constant/mod.rs
@@ -11,7 +11,7 @@ use luminal::layout_ir::{
     AliasInfo, Bufferizable, ExtractionSite, LayoutIrOp, OpMatcher, Sharing, ToDps,
 };
 
-use crate::kernels::{CodegenCtx, KernelSource, cuda_type, numel};
+use crate::kernels::{CodegenCtx, KernelSource, cuda_f64_literal, cuda_type, numel};
 use anyhow::{Result, bail};
 
 /// `ConstantGeneric() -> out` — pure dataflow source form.
@@ -92,7 +92,7 @@ pub(crate) fn codegen(op: &dyn BufferTensorIrOp, ctx: &CodegenCtx) -> Result<Vec
     // write fence — see `kernels::CodegenCtx::from_descriptors`.
     let to = cuda_type(ctx.dest_dtypes[0])?;
     let n = numel(&ctx.dest_dims[0]);
-    let value = constant.value;
+    let value = cuda_f64_literal(constant.value);
     let source = format!(
         r#"extern "C" __global__ void k({to}* out, unsigned long long n) {{
     unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
@@ -134,5 +134,117 @@ impl OpMatcher for ConstantMatcher {
         Box::new(Constant {
             value: site.child_f64(0),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use luminal::dtype::PlanDtype;
+
+    /// The dest-only geometry a constant lowers against: no operands,
+    /// one F32 destination.
+    fn f32_dest_ctx() -> CodegenCtx {
+        CodegenCtx {
+            operand_dims: vec![],
+            operand_dtypes: vec![],
+            dest_dims: vec![vec![4]],
+            dest_dtypes: vec![PlanDtype::F32],
+            operand_layouts: vec![],
+        }
+    }
+
+    fn source_for(value: f64) -> String {
+        let op = ConstantDps { value };
+        let launches = codegen(&op, &f32_dest_ctx()).expect("constant codegen succeeds");
+        assert_eq!(launches.len(), 1, "constant is a single-launch op");
+        launches.into_iter().next().unwrap().source
+    }
+
+    /// The longest run of consecutive ASCII digits — a decimal-point-free,
+    /// exponent-free digit string is exactly the shape C misreads as an
+    /// out-of-range integer literal.
+    fn longest_digit_run(source: &str) -> usize {
+        let (mut best, mut run) = (0usize, 0usize);
+        for c in source.chars() {
+            if c.is_ascii_digit() {
+                run += 1;
+                best = best.max(run);
+            } else {
+                run = 0;
+            }
+        }
+        best
+    }
+
+    #[test]
+    fn cuda_f64_literal_is_a_valid_c_token_for_extreme_and_non_finite_values() {
+        // Finite: `{:e}` is the shortest round-trip form and always
+        // carries an exponent, so it is always a `double` literal.
+        assert_eq!(cuda_f64_literal(3.0), "3e0");
+        assert_eq!(cuda_f64_literal(f32::MIN as f64), "-3.4028234663852886e38");
+        assert_eq!(cuda_f64_literal(1e30), "1e30");
+        assert_eq!(cuda_f64_literal(-0.0), "-0e0");
+        // Non-finite: bit patterns, because NVRTC has no math headers
+        // and so no `INFINITY`/`NAN` macros.
+        assert_eq!(
+            cuda_f64_literal(f64::NEG_INFINITY),
+            "__uint_as_float(0xff800000u)"
+        );
+        assert_eq!(
+            cuda_f64_literal(f64::INFINITY),
+            "__uint_as_float(0x7f800000u)"
+        );
+        assert_eq!(cuda_f64_literal(f64::NAN), "__uint_as_float(0x7fc00000u)");
+    }
+
+    /// The defect this closes: `Display` formatted `f32::MIN as f64` as
+    /// `-340282346638528860000000000000000000000` (an integer literal
+    /// too large for any C type) and `-inf` as the non-token `-inf`.
+    /// The frontend reaches both — `cummax` seeds with `f32::MIN`
+    /// (`src/frontend/unary.rs`), attention masks fill with `-inf`.
+    #[test]
+    fn constant_literal_is_a_valid_c_token_for_extreme_and_non_finite_values() {
+        let extreme = source_for(f32::MIN as f64);
+        assert!(
+            extreme.contains("out[i] = (float)-3.4028234663852886e38;"),
+            "extreme finite constant lost its exponent form:\n{extreme}"
+        );
+
+        let neg_inf = source_for(f64::NEG_INFINITY);
+        assert!(
+            neg_inf.contains("out[i] = (float)__uint_as_float(0xff800000u);"),
+            "-inf constant did not lower to its bit pattern:\n{neg_inf}"
+        );
+
+        for source in [&extreme, &neg_inf] {
+            assert!(
+                !source.contains("inf"),
+                "Rust's `inf` spelling reached the kernel source:\n{source}"
+            );
+            assert!(
+                !source.contains("NaN"),
+                "Rust's `NaN` spelling reached the kernel source:\n{source}"
+            );
+            assert!(
+                longest_digit_run(source) < 20,
+                "a bare {}-digit run reached the kernel source (C reads it as an \
+                 out-of-range integer literal):\n{source}",
+                longest_digit_run(source)
+            );
+        }
+    }
+
+    /// An ordinary value keeps the kernel text it always had, save for
+    /// the literal itself now carrying an exponent.
+    #[test]
+    fn constant_kernel_text_is_otherwise_unchanged() {
+        assert_eq!(
+            source_for(3.0),
+            r#"extern "C" __global__ void k(float* out, unsigned long long n) {
+    unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) out[i] = (float)3e0;
+}"#
+        );
     }
 }

--- a/crates/luminal_cuda_lite/tests/constant_extreme_literals.rs
+++ b/crates/luminal_cuda_lite/tests/constant_extreme_literals.rs
@@ -1,0 +1,223 @@
+//! EXTREME AND NON-FINITE CONSTANT LITERALS UNDER NVRTC (`device`
+//! feature only). The literal-emission fix (`kernels::cuda_f64_literal`)
+//! is argued from the C grammar and pinned by host string tests; this
+//! suite is the other half — the same values compiled by the REAL NVRTC
+//! and executed on the REAL device, so "valid C token" is proven rather
+//! than asserted.
+//!
+//! THE PATH THE LITERAL TAKES, in order:
+//!
+//!  1. `Graph::constant_float(v)` (src/frontend/other.rs) records
+//!     `LogicalOp::Constant(v as f64)`; the term's f64 child is written
+//!     into the egglog program by `Graph`'s renderer as Rust's `{:?}`
+//!     form — `-3.4028234663852886e38`, `-inf`, `NaN` — which the
+//!     vendored egglog parser accepts as f64 literals.
+//!  2. `expand_rhs` records the broadcast view of that rank-0 constant,
+//!     and the sum with a runtime input keeps the value opaque to any
+//!     algebraic simplification: nothing in the graph can fold it away.
+//!  3. Search elects this runtime's `ConstantDps`. Every test below
+//!     ASSERTS the elected plan carries a `ConstantGeneric` compute
+//!     node whose `value` BITS are the ones under test, so a plan that
+//!     folded the constant away, or that reached codegen with some
+//!     other number, fails loudly instead of passing vacuously. Steps
+//!     1-3 were confirmed on a device-free host before this file
+//!     landed: all four graphs plan, every elected op has a codegen
+//!     row, and the plans carry `-3.4028234663852886e38`, `-inf` and
+//!     `NaN` unchanged. Steps 4-5 are what only a device can settle.
+//!  4. `ops::constant::codegen` formats the value through
+//!     `kernels::cuda_f64_literal` into `out[i] = (float)<literal>;`.
+//!  5. `execute()` hands that source to NVRTC. A literal that is not a
+//!     C token fails to compile HERE (the pre-fix `-inf` / `NaN` and the
+//!     39-digit integer-literal forms all did); a literal that compiles
+//!     but denotes the wrong number shows up in the readback bits.
+//!
+//! CUMULATIVE MAX is the frontend-reachable witness: `GraphTensor::cummax`
+//! seeds its window with `f32::MIN` (src/frontend/unary.rs), which `pad`
+//! mints as exactly this constant (src/frontend/movement.rs `pad` ->
+//! `constant_float(elem)`). It runs here as a fourth case with a host
+//! reference, so the motivating caller is covered end to end and not
+//! only the synthetic constant.
+#![cfg(feature = "device")]
+
+use luminal::bufferize::BufferNode;
+use luminal::dtype::DType;
+use luminal::graph::Graph;
+use luminal::prelude::{FxHashMap, NodeIndex};
+use luminal_cuda_lite::CudaRuntime;
+use luminal_cuda_lite::HostBuffer;
+use luminal_cuda_lite::ops::constant::ConstantDps;
+
+/// Read the device output DENSELY through its RETURNED LAYOUT
+/// (escape-and-disclose, 2026-08-31) — the same universal readback
+/// `tests/device_fidelity.rs` and `tests/device_view_differentials.rs`
+/// use. A dense election evaluates the identity; a broadcast election
+/// evaluates to the same backing element at every coordinate. Either
+/// way the caller sees the value at each output coordinate, which is
+/// what these assertions are about.
+fn walked_dense(rt: &CudaRuntime, out: NodeIndex) -> Vec<f32> {
+    let (data, binding) = rt.fetch(out).expect("escape-and-disclose fetch");
+    let bytes = data
+        .as_f32()
+        .unwrap_or_else(|err| panic!("output is not f32: {err}"));
+    luminal_cuda_lite::layouts::dense_f32(&bytes, &binding.layout)
+        .expect("the returned layout reads dense over its backing buffer")
+}
+
+/// The plan must carry THIS EXACT VALUE as a device kernel. Without
+/// the check the suite could pass on a plan that never reached
+/// `ops::constant::codegen`, which would make every assertion below
+/// vacuous with respect to the literal; the value comparison is on
+/// BITS, so it is meaningful for NaN and the infinities too, and it
+/// doubles as the proof that the f64 survived the egglog round trip
+/// (`Graph`'s renderer writes `{:?}`; the vendored parser reads back
+/// `NaN` / `-inf` / the exponent form).
+fn assert_constant_reaches_the_device(rt: &CudaRuntime, expected: f64, what: &str) {
+    let plan = rt.plan().expect("plan loaded");
+    let elected: Vec<f64> = plan
+        .dag
+        .node_weights()
+        .filter_map(|node| match node {
+            BufferNode::Compute { op, .. } => op
+                .as_any()
+                .downcast_ref::<ConstantDps>()
+                .map(|constant| constant.value),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        elected.iter().any(|v| v.to_bits() == expected.to_bits()),
+        "{what}: no ConstantGeneric compute node carries {expected:?} \
+         (the plan's constants are {elected:?}) — the literal never \
+         reached NVRTC, so this test would prove nothing"
+    );
+}
+
+/// Search under the CUDA allow list, assert the constant is really in
+/// the plan, then NVRTC-compile and run it. Harness copied from
+/// `tests/device_fidelity.rs::run_both`, minus the reference side:
+/// non-finite outputs cannot go through its tolerance comparison
+/// (`NaN != NaN`, and `inf - inf` is `NaN`), so each test states the
+/// exact bits it expects instead.
+fn run_on_device(
+    cx: &Graph,
+    inputs: &[(NodeIndex, Vec<f32>)],
+    out: NodeIndex,
+    expected_constant: f64,
+    what: &str,
+) -> Vec<f32> {
+    let mut rt = CudaRuntime::load(cx).expect("cuda load");
+    // THE TWO RUNTIMES TAKE DIFFERENT HOST PAYLOADS (ruling D4,
+    // 2026-09-03): the CL side stages `HostBuffer` — bytes plus a dtype
+    // tag, ready for an H2D copy.
+    let data: FxHashMap<NodeIndex, HostBuffer> = inputs
+        .iter()
+        .map(|(id, v)| (*id, v.clone().into()))
+        .collect();
+    rt.search(&data, &luminal_cuda_lite::harness_search_options())
+        .expect("cuda search");
+    assert_constant_reaches_the_device(&rt, expected_constant, what);
+    for (id, v) in inputs {
+        rt.set_data(*id, v.clone());
+    }
+    rt.execute()
+        .expect("device execute (NVRTC compiles the constant kernel here)");
+    walked_dense(&rt, out)
+}
+
+/// `zeros + broadcast(constant(value))` over 8 elements. Adding a
+/// runtime input is what forces the constant to be a real device value
+/// rather than something the graph could rewrite away, and `0.0 + x`
+/// is bit-exact for every finite `x` and for the infinities.
+fn constant_plus_zero(value: f32) -> Vec<f32> {
+    const N: usize = 8;
+    let mut cx = Graph::new();
+    let a = cx.tensor(N, DType::F32);
+    let c = cx.constant_float(value).expand_rhs(a.dims());
+    let out = (a + c).output();
+    let got = run_on_device(
+        &cx,
+        &[(a.id, vec![0.0f32; N])],
+        out.id,
+        value as f64,
+        &format!("constant {value:?}"),
+    );
+    assert_eq!(got.len(), N, "constant {value:?}: wrong output length");
+    got
+}
+
+/// `f32::MIN` — the value `cummax` seeds with. Its `Display` form is a
+/// 39-digit run with no decimal point and no exponent, which C reads as
+/// an integer literal too large for any integer type: pre-fix this did
+/// not compile. Bitwise equality is the bar, since `{:e}` must
+/// round-trip the value exactly through the `double` literal and the
+/// `(float)` cast.
+#[test]
+fn extreme_finite_constant_survives_nvrtc_bit_for_bit() {
+    for (i, g) in constant_plus_zero(f32::MIN).iter().enumerate() {
+        assert_eq!(
+            g.to_bits(),
+            f32::MIN.to_bits(),
+            "element {i}: expected f32::MIN ({:e}), got {g:e}",
+            f32::MIN
+        );
+    }
+}
+
+/// `-inf` — what attention masks fill with. Pre-fix the kernel carried
+/// the bare token `-inf`, which is not C at all. `__uint_as_float`
+/// takes its place, and NVRTC has the intrinsic without any header.
+#[test]
+fn negative_infinity_constant_survives_nvrtc() {
+    for (i, g) in constant_plus_zero(f32::NEG_INFINITY).iter().enumerate() {
+        assert!(
+            g.is_infinite() && g.is_sign_negative(),
+            "element {i}: expected -inf, got {g}"
+        );
+    }
+}
+
+/// `NaN` — pre-fix the kernel carried the bare token `NaN`. Only
+/// NaN-ness is asserted: the payload is not contractual, and an add can
+/// legally quiet or re-tag it.
+#[test]
+fn nan_constant_survives_nvrtc() {
+    for (i, g) in constant_plus_zero(f32::NAN).iter().enumerate() {
+        assert!(g.is_nan(), "element {i}: expected NaN, got {g}");
+    }
+}
+
+/// THE FRONTEND-REACHABLE CASE. `cummax` pads its window with
+/// `f32::MIN` (src/frontend/unary.rs), `pad` mints that as
+/// `constant_float(f32::MIN)` (src/frontend/movement.rs), and the
+/// windowed max then selects over it. The seed is the reduction
+/// identity: it must be smaller than every real element, so a literal
+/// that compiled to the wrong magnitude would show up as a wrong
+/// running maximum rather than as a compile error.
+///
+/// The reference is the running maximum computed on the host. `max` is
+/// exact selection — no arithmetic — so equality is exact, not
+/// tolerant.
+#[test]
+fn cummax_seed_constant_survives_nvrtc() {
+    let input = vec![-5.0f32, -3., -9., -1., -7., -2., -8., -4.];
+    let mut cx = Graph::new();
+    let a = cx.tensor(input.len(), DType::F32);
+    let out = a.cummax(0).output();
+    let got = run_on_device(
+        &cx,
+        &[(a.id, input.clone())],
+        out.id,
+        f32::MIN as f64,
+        "cummax seed",
+    );
+
+    let mut running = f32::NEG_INFINITY;
+    let want: Vec<f32> = input
+        .iter()
+        .map(|v| {
+            running = running.max(*v);
+            running
+        })
+        .collect();
+    assert_eq!(got, want, "cummax over {input:?}");
+}

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -1892,6 +1892,8 @@ DESTINATION width, not at f32 unconditionally), and it wants a
 reference-vs-CUDA bit-equality test of the shape main added on the Metal side.
 Recorded here as an open pin.
 
+AMENDED 2026-09-04: fixed in PR #490 (fix/cuda-float-literal-emission).
+
 ## #416 vLLM regions — banked; the zero-extent slice question answered
 
 RULED 2026-09-03: *"this is great and we should merge it. I don't think we


### PR DESCRIPTION
## What

`crates/luminal_cuda_lite/src/ops/constant/mod.rs` interpolated the egglog term's raw `f64` into the CUDA kernel string with Rust's `Display`. `Display` for `f64` is not a C literal syntax, and two of its forms are tokens NVRTC cannot parse:

| value | old emitted token | what C does with it |
|---|---|---|
| `f64::NEG_INFINITY` | `(float)-inf` | `inf` is not a C token — compile error |
| `f64::NAN` | `(float)NaN` | `NaN` is not a C token — compile error |
| `f32::MIN as f64` | `(float)-340282346638528860000000000000000000000` | a bare digit string with no `.` and no exponent is an *integer* literal, too large for any integer type — compile error |

This is a live defect, not a latent one. Both shapes are reachable straight from the frontend: `GraphTensor::cummax` seeds its reduction with `f32::MIN` (`src/frontend/unary.rs:519`), and attention masks fill with `-inf` or a very large negative value. Found by main's #413 review.

## How

One new formatting seam next to `cuda_type`:

```rust
pub(crate) fn cuda_f64_literal(v: f64) -> String
```

in `crates/luminal_cuda_lite/src/kernels.rs`.

- **Finite** → `format!("{v:e}")`. Rust's `LowerExp` is the shortest round-trip form and always carries an exponent, so the result is always a `double` literal: `3e0`, `1e30`, `-3.4028234663852886e38`, `-0e0`. The existing `({to})` cast then converts to the destination type exactly as it did before, so no dtype behaviour changes.
- **Non-finite** → `__uint_as_float(0x7f800000u)` / `__uint_as_float(0xff800000u)` / `__uint_as_float(0x7fc00000u)`. Bit patterns rather than the `INFINITY`/`NAN` macros because this runtime compiles kernels through NVRTC (`cudarc::nvrtc::compile_ptx`, `device.rs:128`), which has no host math headers, so those macros do not exist there. This is the same reason and the same technique as the `-inf` reduction identity already in `ops::reduce_max`.

The kernel text is otherwise byte-identical — only the literal changed.

**`ops::iota` is deliberately untouched.** The brief flagged `iota/mod.rs:111` (`out[i] = ({to})({value});`) as possibly the same pattern. It is not: that `value` is `lower_expr(expr, rank)`, an integer C expression over `long long` (`IotaExpr::Lit(v)` → `{v}LL`), never an `f64` formatted with `Display`.

## How verified

Host-side only, no device. Three tests in a new `#[cfg(test)]` module in `constant/mod.rs` (the helper is `pub(crate)`, so its direct test has to live in-crate):

- `cuda_f64_literal_is_a_valid_c_token_for_extreme_and_non_finite_values` — the exact-token table over `3.0`, `f32::MIN as f64`, `1e30`, `-0.0`, `±inf`, `NaN`. Every finite expectation was confirmed against a real `rustc` run before being pinned.
- `constant_literal_is_a_valid_c_token_for_extreme_and_non_finite_values` — lowers `f32::MIN` and `-inf` constants to an F32 destination through the real `codegen` and asserts the source carries the expected literal and contains **no** `inf`, **no** `NaN`, and **no** run of 20+ consecutive digits. That digit-run assertion is what actually pins the defect closed: the pre-fix output was a 39-digit run.
- `constant_kernel_text_is_otherwise_unchanged` — the full expected kernel string for an ordinary `3.0`, so a future change to the surrounding text has to be deliberate.

Gate, warm target, all green:

```
cargo build -p luminal_cuda_lite --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.73s
cargo check -p luminal_cuda_lite --features device --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.54s
cargo test -p luminal_cuda_lite
    20 result lines, all `ok`, 0 failed (lib unittests 13 passed, incl. the 3 new)
cargo clippy -p luminal_cuda_lite --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.78s
cargo clippy -p luminal_cuda_lite --all-targets --features device
    warning: `luminal_cuda_lite` (test "device_profile") generated 1 warning
    (pre-existing `type_complexity` on device_profile.rs:46, not from this change)
cargo fmt --all -- --check
    exit 0
```

### Device test (`device` feature) — A100 result: 4 passed, 0 failed at a2daa626 (2026-09-04)

`crates/luminal_cuda_lite/tests/constant_extreme_literals.rs` is the other half: the same values compiled by the **real NVRTC** and executed on a **real device**, so "valid C token" stops being an argument from the C grammar. Harness copied from `tests/device_fidelity.rs` (`CudaRuntime::load` → `search` → `execute` → `layouts::dense_f32` readback), minus the reference side — the reference differential's tolerance comparison cannot express these outputs (`NaN != NaN`, and `inf - inf` is `NaN`), so each test states the exact bits it expects.

| test | graph | assertion |
|---|---|---|
| `extreme_finite_constant_survives_nvrtc_bit_for_bit` | `zeros + broadcast(constant(f32::MIN))`, 8 elements | every element **bitwise** `== f32::MIN` — so `{:e}` must round-trip exactly through the `double` literal and the `(float)` cast, not merely compile |
| `negative_infinity_constant_survives_nvrtc` | same, `f32::NEG_INFINITY` | `is_infinite() && is_sign_negative()` |
| `nan_constant_survives_nvrtc` | same, `f32::NAN` | `is_nan()` (the payload is not contractual) |
| `cummax_seed_constant_survives_nvrtc` | `a.cummax(0)` over 8 negative values | equals the host running maximum, **exactly** — `max` selects, it does not compute |

The fourth is the frontend-reachable case this PR was written for: `cummax` pads its window with `f32::MIN`, `pad` mints that as `constant_float(f32::MIN)`, and the seed is the reduction identity — a literal that compiled to the wrong magnitude shows up as a wrong running maximum rather than as a compile error.

Every test asserts the **elected plan** carries a `ConstantGeneric` compute node whose `value` bits are the ones under test, before executing. A plan that folded the constant away, or that reached codegen with some other number, fails loudly instead of passing vacuously.

Everything up to the device boundary was confirmed on a device-free host before this landed: all four graphs plan under the CUDA allow list, every elected op has a codegen row, and the plans carry `-3.4028234663852886e38`, `-inf` and `NaN` unchanged — so the egglog round trip preserves them (`Graph`'s renderer writes Rust's `{:?}`; the vendored parser at `vendor/egglog-checkout/src/ast/parse.rs:1268-1273` has literal arms for exactly `NaN` / `inf` / `-inf`). Mac gate on the new file:

```
cargo check -p luminal_cuda_lite --features device --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.69s
cargo clippy -p luminal_cuda_lite --all-targets --features device
    warning: `luminal_cuda_lite` (test "device_profile") generated 1 warning
    (pre-existing `type_complexity` on device_profile.rs:46, not from this change)
cargo fmt --all -- --check
    exit 0
```

**The A100 run of `constant_extreme_literals.rs` is done: 4/4 passed on the A100 at a2daa626** — NVRTC compilation, execution and readback are the three steps only a device can settle. Until it runs, the claim that these tokens compile rests on the C grammar plus the existing `reduce_max` precedent.

## One thing worth a reviewer's ruling

`ops::reduce_max` already emits a non-finite by bit pattern, and spells it **`__int_as_float(0xff800000)`** — signed intrinsic, no `u` suffix. This PR spells the same value **`__uint_as_float(0xff800000u)`**, which is the exactly-typed form (`0xff800000` has type `unsigned int` in C, so the existing spelling relies on an implementation-defined unsigned→signed conversion). Both work on every real target. I did not unify them, because changing `reduce_max`'s emitted text is beyond this fix's blast radius and that kernel is device-verified as it stands. Say the word and I will follow up with a pass that routes `reduce_max` through the same helper so there is one spelling in the crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


