### PR TITLE
Integral scalar powers are exact: odd powers keep their sign

### DIFF
--- a/src/frontend/binary.rs
+++ b/src/frontend/binary.rs
@@ -391,13 +391,21 @@ impl GraphTensor {
         (-not_equal + 1.0).cast(DType::Bool)
     }
 
-    /// Raise the tensor to a power
-    pub fn pow<T>(self, e: T) -> GraphTensor
-    where
-        Self: Mul<T, Output = Self>,
-    {
-        // Approximate, see full impl here: https://github.com/tinygrad/tinygrad/blob/a32c67760140dd26b60d7932268f2e62e96a66e0/tinygrad/tensor.py#L568
-        self.abs().log().mul(e).exp()
+    /// Raise the tensor to a power.
+    ///
+    /// The general case is the real-valued approximation `exp(e * log|self|)`
+    /// (see tinygrad's full impl), which reads the base through `abs` and so
+    /// drops the sign of a negative base at every exponent. A compile-time
+    /// scalar exponent that is finite and a whole number has exact
+    /// multiplication semantics instead, so it is lowered structurally by
+    /// exponentiation by squaring: odd powers keep the sign of a negative
+    /// base, `x^0` is ones, `x^1` is `x`, and a negative exponent is the
+    /// reciprocal of the positive power. That structural path is capped at
+    /// `|e| <= 64`, beyond which the chain of multiplies is not worth its
+    /// graph size and the approximation is used again; tensor exponents always
+    /// take the approximation.
+    pub fn pow<T: PowExponent>(self, e: T) -> GraphTensor {
+        e.raise(self)
     }
 
     // Clipping ops (minimum, maximum, clip)
@@ -444,6 +452,69 @@ impl GraphTensor {
             "self and other need to be the same dtype!"
         );
         (cond.cast(self.dtype) * self) + ((1.0 - cond.cast(DType::F32)).cast(other.dtype) * other)
+    }
+}
+
+/// The largest `|exponent|` [`GraphTensor::pow`] lowers structurally. Past it
+/// the multiply chain costs more graph than the approximation is worth.
+const MAX_STRUCTURAL_POW: i64 = 64;
+
+/// The exponent side of [`GraphTensor::pow`]: how a given exponent type raises
+/// a base. Implemented for `f32` (structural when the scalar is integral) and
+/// for `GraphTensor` (always the approximation).
+pub trait PowExponent {
+    /// Raise `base` to `self`.
+    fn raise(self, base: GraphTensor) -> GraphTensor;
+}
+
+impl PowExponent for GraphTensor {
+    fn raise(self, base: GraphTensor) -> GraphTensor {
+        // Approximate, see full impl here: https://github.com/tinygrad/tinygrad/blob/a32c67760140dd26b60d7932268f2e62e96a66e0/tinygrad/tensor.py#L568
+        base.abs().log().mul(self).exp()
+    }
+}
+
+impl PowExponent for f32 {
+    fn raise(self, base: GraphTensor) -> GraphTensor {
+        if self.is_finite() && self.fract() == 0.0 && self.abs() <= MAX_STRUCTURAL_POW as f32 {
+            return integral_pow(base, self as i64);
+        }
+        // Approximate, see full impl here: https://github.com/tinygrad/tinygrad/blob/a32c67760140dd26b60d7932268f2e62e96a66e0/tinygrad/tensor.py#L568
+        base.abs().log().mul(self).exp()
+    }
+}
+
+/// `base ^ exponent` by exponentiation by squaring, which is exact and keeps
+/// the sign of a negative base at odd exponents. The graph it builds is
+/// logarithmic in `|exponent|`.
+fn integral_pow(base: GraphTensor, exponent: i64) -> GraphTensor {
+    if exponent == 0 {
+        return base
+            .graph()
+            .constant_float(1.0)
+            .cast(base.dtype)
+            .expand_rhs(base.dims());
+    }
+    let mut remaining = exponent.unsigned_abs();
+    let mut factor = base;
+    let mut result = None;
+    while remaining > 0 {
+        if remaining & 1 == 1 {
+            result = Some(match result {
+                Some(value) => value * factor,
+                None => factor,
+            });
+        }
+        remaining >>= 1;
+        if remaining > 0 {
+            factor = factor * factor;
+        }
+    }
+    let result = result.expect("a nonzero exponent sets at least one bit");
+    if exponent < 0 {
+        result.reciprocal()
+    } else {
+        result
     }
 }
 
@@ -775,6 +846,43 @@ pub(super) mod tests {
             shift_from_zero,
             identity,
         );
+    }
+
+    /// Run `func` over one fixed input vector, the way `test_binary_transforms`
+    /// does, but against an expected vector rather than a candle tensor —
+    /// candle's `powf` is IEEE `pow`, which answers NaN exactly where the
+    /// sign-preserving cases below need a number.
+    fn run_pow(values: Vec<f32>, func: impl Fn(GraphTensor) -> GraphTensor) -> Vec<f32> {
+        let mut cx = Graph::new();
+        let a = cx.tensor(vec![values.len()], luminal::dtype::DType::F32);
+        let b = func(a).output();
+        let rt = luminal_reference::harness::run_reference(&cx, &[(a.id, values.into())]);
+        rt.get_f32(b.id).unwrap().to_vec()
+    }
+
+    #[test]
+    fn test_pow_integral_scalar_exponent_keeps_sign() {
+        let input = vec![-2.0f32, -1.0, -0.5, 0.5, 1.0, 2.0];
+        // (-2)^3 = -8, (-2)^2 = 4, (-2)^0 = 1, x^1 = x, (-2)^-1 = -0.5.
+        let cases: Vec<(f32, Vec<f32>)> = vec![
+            (3.0, input.iter().map(|x| x * x * x).collect()),
+            (2.0, input.iter().map(|x| x * x).collect()),
+            (0.0, vec![1.0; input.len()]),
+            (1.0, input.clone()),
+            (-1.0, input.iter().map(|x| 1.0 / x).collect()),
+        ];
+        for (exponent, expected) in cases {
+            assert_close(&run_pow(input.clone(), |a| a.pow(exponent)), &expected);
+        }
+    }
+
+    #[test]
+    fn test_pow_non_integral_scalar_exponent_keeps_the_approximation() {
+        let input = vec![-2.0f32, -1.5, 0.5, 1.5];
+        // The abs-based approximation, sign dropped, is still what non-whole
+        // exponents get.
+        let expected = input.iter().map(|x| x.abs().powf(2.5)).collect::<Vec<_>>();
+        assert_close(&run_pow(input, |a| a.pow(2.5f32)), &expected);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub mod tests;
 
 pub mod prelude {
     pub use crate::dtype::DType;
-    pub use crate::frontend::binary::F32Pow;
+    pub use crate::frontend::binary::{F32Pow, PowExponent};
     pub use crate::frontend::*;
     pub use crate::graph::*;
     pub use crate::shape::*;


### PR DESCRIPTION
`GraphTensor::pow` was one expression for every exponent:

```rust
pub fn pow<T>(self, e: T) -> GraphTensor where Self: Mul<T, Output = Self> {
    self.abs().log().mul(e).exp()
}
```

It reads the base through `abs`, so it answers `|x|^e`: a negative base loses
its sign at *every* exponent. `(-2)^3` came back `+8`, and GPT-2's approximate
GELU — whose cubic term is `x.pow(3)` — was corrupted for every negative input.

Main hit exactly this and fixed it inside the PyTorch translator
(`a3c5df9f`, #437). Austin ruled 2026-09-04 **"fix the front end"**, so the fix
lands here, where every frontend and every caller gets it.

## What changes

A compile-time scalar exponent that is finite and a whole number has exact
multiplication semantics, so it now lowers structurally by exponentiation by
squaring:

- odd powers keep the sign of a negative base — `(-2)^3 = -8`
- `x^0` is a ones constant expanded to the base's dims
- `x^1` is `x`
- a negative exponent is `reciprocal()` of the positive power — `(-2)^-1 = -0.5`

The chain is logarithmic in `|e|` and **capped at `|e| <= 64`**; past the cap
the multiplies cost more graph than the approximation is worth and the
approximation is used again. Tensor exponents and non-whole scalars keep the
approximation unchanged.

## Shape

A `PowExponent` trait with impls for `f32` (structural when integral) and
`GraphTensor` (approximation), which `pow<T: PowExponent>` delegates to. It
replaces the old `where Self: Mul<T, Output = Self>` bound; public call syntax
does not move, because the two exponent types that bound admitted are exactly
the two impls.

## Callers audited

Every `GraphTensor::pow` in the tree passes an `f32`:
`src/frontend/unary.rs:201` (`normalize`'s `abs().pow(p)` and `.pow(1.0 / p)`)
and, in the parked translator, the vector-norm and polygamma sites. The
`1024usize.pow(3)` and `500_000_f32.pow(freqs)` hits are `usize::pow` and the
separate `F32Pow` trait, neither touched.

One numerics note, flagged deliberately: `normalize`'s `abs().pow(p)` at
integral `p` moves from `exp(p*log|x|)` to a multiply chain. The base there is
already non-negative, so no sign is at stake, and the multiply chain is
strictly the more accurate answer.

## Tests

Two tests beside `test_pow`, in the same module: the integral-exponent case
(`3, 2, 0, 1, -1` over an input containing `-2`) and a non-integral case that
still matches the abs-based approximation. They assert against an expected
vector rather than a candle tensor because candle's `powf` is IEEE `pow` and
answers `NaN` precisely where the sign cases need a number — which is also why
the existing `test_pow` passes vacuously on its own negative inputs.

## Gate

```
cargo build -p luminal --lib      Finished `dev` profile [unoptimized + debuginfo] target(s) in 25.44s
cargo test -p luminal --lib pow   test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 247 filtered out; finished in 0.30s
cargo test -p luminal_nn          test result: ok. 31 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.39s
cargo clippy -p luminal --lib     Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.52s
cargo fmt --all -- --check        clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)