### PR TITLE
CUDA dyn dims on graph rebuild (#430): parked, and the line's premise stated

### DIFF
--- a/crates/luminal_cuda_lite_hlir/src/kernel/to_host.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/to_host.rs
@@ -2600,6 +2600,21 @@ impl CudaGraphOp {
                 );
             }
             Self::reset_materialization_state(&mut state);
+            // Reset releases the graph-owned dynamic-dimension buffer. The
+            // replacement graph must receive a valid ABI pointer before it is
+            // built; otherwise its first binding update tries to parameterize
+            // dynamic kernels with a null dyn-dims pointer. Bucket-shared
+            // buffers survive the reset and do not need this local fallback.
+            if !self.dyn_dims_order.is_empty() && state.shared_dyn_dims_ptr.is_none() {
+                let mut buffer = stream.alloc_zeros::<i32>(self.dyn_dims_order.len())?;
+                let values = self
+                    .dyn_dims_order
+                    .iter()
+                    .map(|dim| dyn_map.get(dim).copied().unwrap_or(0) as i32)
+                    .collect_vec();
+                stream.memcpy_htod(&values, &mut buffer)?;
+                state.dyn_dims_buffer = Some(buffer);
+            }
             self.build_graph(&mut state, stream, buffers, dyn_map)?;
             current_buffer_ptrs = self
                 .buffer_nodes

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -51,6 +51,7 @@ Dispositions:
 | `6681720b` | #418 | Add CUDA serving runtime support for vLLM integration | FILE-LEVEL (12 python-park files + 4 into the `cuda_lite_hlir` park + 1 metal-park file) + UNCARRIED (`src/dyn_backend.rs`, deleted on this branch) | branch `merge/main-418-serving-parks` | RULED 2026-09-03: *"we'll record only, we'll eventually have to get to parity."* Five EMBEDDABILITY REQUIREMENTS on the live CL executor, each checked against today's `crates/luminal_cuda_lite/src/device.rs`: device selection, a caller-owned borrowed stream with a synchronize-or-not policy, fixed-capacity caller-owned output buffers, functionalized mutation writebacks, and a versioned FFI seam — see **#418 vLLM serving** below |
 | `f285d229` | #420 | Move post-saturation search into the runtime | FILE-LEVEL (3 files into the `cuda_lite_hlir` park + 1 metal-park file) + INTENT-ONLY (15 core/doc files, nothing applied) + DROPPED (all loop unroll / roll / packed machinery, main's `Runtime` trait shape) | branch `rejoin/p0-record-and-park` | RULED 2026-09-03: *"we're going to ignore all the loop unrolling, loop rolling stuff, but we're going to follow all the other aspects and move all of that functionality out of core and into the runtimes."* The boundary move is the program's thesis and lands in later phases; THIS row is record-and-park — see **#420 search into the runtime** below |
 | `598e5ca7` | #422 | Share reusable CUDA runtime through Lite | FILE-LEVEL (41 files into the `cuda_lite_hlir` park, incl. 5 deletions + 1 non-gating `ci/` file) + INTENT-ONLY at walk — DELIVERED by Phase 3 (arena) and PARTIALLY by Phase 2 (runtime-configurable op/matcher selection: the registry half; the execution face still PUNTED) + PUNTED-TO-PARK (fusion, attention, cuda-heavy composition) + DROPPED (the `subsume` fusion rule and the four `delete` rules, `CudaRuntimeImpl<O>`) | branch `rejoin/p0-record-and-park` | RULED 2026-09-03: *"put these fusion changes in hlir and punt on them temporarily"*, *"we're going to copy it into the hlir folder and then actually implement it once we're caught up"* (attention/FA3), *"Update the hlir_folder so we have a record of what the target code looks like"* (full-CUDA downstream), *"no code for now"* (zero-copy rebinding) — see **#422 reusable CUDA runtime** below |
+| `e7f9127a` | #430 | Restore CUDA dyn dims buffer on graph rebuild | FILE-LEVEL (1 file into the `cuda_lite_hlir` park) | branch `merge/main-430-487-cuda-graph-parks` (1st commit) | — nothing live corresponds: this branch's `crates/luminal_cuda_lite` captures no CUDA graphs at all, so there is no rebuild path to fix — see **#430 dyn-dims on rebuild** below, which says that once for the whole eight-commit line |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -3989,6 +3990,45 @@ here, because it made the move a zero-diff change for 12 external files, but a
 rename sweep is owed eventually. And the GA loop is still two copies of ~290
 lines; if it is ever consolidated it needs the evaluator seam, which needs
 Austin.
+
+## #430 dyn-dims on rebuild — parked, and why the whole CUDA-graph line is park-only
+
+Main's `e7f9127a` (+15, one file) closes a null-pointer window in
+`CudaGraphOp`'s rebuild path. When a binding change forces the op to throw away
+its materialized CUDA graph and build a new one,
+`Self::reset_materialization_state(&mut state)` releases the graph-owned
+dynamic-dimension buffer along with everything else; the replacement graph is
+then built while `state.dyn_dims_buffer` is `None`, so its first binding update
+tries to parameterize every dynamic kernel against a null dyn-dims pointer.
+Main's fix re-allocates that buffer from `self.dyn_dims_order` and fills it from
+the live `dyn_map` (missing dims read as `0`) immediately after the reset and
+before `build_graph`, and it is careful to do so only when the buckets supply no
+shared buffer — `state.shared_dyn_dims_ptr.is_none()` — because a bucket-shared
+pointer survives the reset and must not be shadowed by a local allocation.
+
+**Disposition: FILE-LEVEL park, path-rewritten only.** Main's diff applied
+verbatim to `crates/luminal_cuda_lite_hlir/src/kernel/to_host.rs` under
+`crates/luminal_cuda_lite/` -> `crates/luminal_cuda_lite_hlir/`; no re-spelling
+was needed, and the diff-of-diffs against main's hunk set (normalized for line
+offsets) is identical.
+
+**Why nothing live corresponds — stated once for all eight commits of this line
+(#430, #440, #442, #450, #466, #467, #472, #487).** This branch's
+`crates/luminal_cuda_lite` is not main's crate under a shared name; it is a
+rewrite — the CL backend (`search.rs`, `lattice.rs`, `finalists.rs`, `arena.rs`,
+`device.rs`, ~6.0k lines in all) — and it carries NO CUDA-graph machinery
+whatsoever. `grep -rni 'cuda_graph\|CudaGraph\|graph_exec\|stream_capture'
+crates/luminal_cuda_lite/src/` returns zero hits. `execute_plan`
+(`crates/luminal_cuda_lite/src/device.rs:254`) walks the plan's steps and
+launches each kernel individually through `stream.launch_builder(&func)`
+(`device.rs:596`). There is no capture, no graph exec, no replay, no cached
+child graph and no bucket residency set — hence no rebuild path, no capture
+cache and no eviction policy for any of these eight commits to fix. Each of
+them patches machinery that exists only in main's HLIR CUDA crate, which the
+park TRACKS so the target CL must eventually reach keeps moving. When CL grows
+graph capture, this section and the seven below it are the list of hazards main
+has already paid for; until then they are records only, and nothing here is
+compiled — `crates/luminal_cuda_lite_hlir` is not a workspace member.
 
 ## #406 pad — the select construction REVERTED (2026-09-03)
 


### PR DESCRIPTION
reset_materialization_state releases the graph-owned dynamic-dimension buffer
along with the rest of the materialization, so the replacement graph was built
with state.dyn_dims_buffer at None and its first binding update parameterized
every dynamic kernel against a null dyn-dims pointer. Main re-allocates and
fills the buffer from dyn_dims_order and the live dyn_map between the reset and
build_graph, skipping the fallback when the buckets supply a shared pointer,
which survives the reset and must not be shadowed.

One file, applied verbatim into the hlir park under the path rewrite; the
diff-of-diffs against main's hunk set is identical.

This is the first of eight CUDA-graph-line commits, and the ledger section says
once, for all eight, why none of them has a live counterpart: this branch's
crates/luminal_cuda_lite is a rewrite (the CL backend), not main's crate under a
shared name, and it has no CUDA-graph machinery at all -- grep for
cuda_graph/CudaGraph/graph_exec/stream_capture across its src returns zero, and
execute_plan launches each kernel individually through stream.launch_builder.
No capture, no replay, no capture cache, no residency set, so no rebuild path to
fix. The park TRACKS main's crate so the target keeps moving; it is not a
workspace member and nothing here is compiled.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
(cherry picked from commit 39894fd36057066e72e68bd9b6aa23b77bdf1511)

Stacked on \`logical-ssa-project\`. One main commit, parked/recorded per the ledger row and section in this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)