### PR TITLE
Persistent compiled artifacts (#435): parks banked, core parked, parity owed

### DIFF
--- a/crates/luminal_cuda_lite_hlir/Cargo.toml
+++ b/crates/luminal_cuda_lite_hlir/Cargo.toml
@@ -27,6 +27,10 @@ rustc-hash = "2.1.1"
 libc = "0.2"
 libloading = "0.8"
 colorize = "*"
+base64 = "0.22"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
 
 [dev-dependencies]
 candle-core = { version = "0.9.2", features = ["cuda"] }

--- a/crates/luminal_cuda_lite_hlir/README.md
+++ b/crates/luminal_cuda_lite_hlir/README.md
@@ -62,3 +62,12 @@ Choice-set validation detects correlated e-class cycles before LLIR loading.
 Random initial genomes repair only those reachable cycles; later mutations may
 still produce them, in which case candidate filtering discards them without
 profiling and continues searching the remaining legal alternatives.
+
+### `main_core/` — a record of main's core, not code
+
+`main_core/` holds full copies of files from main's own `src/` (core), mirrored
+at main's relative paths, for commits whose core half cannot be diffed onto this
+branch because the file was deleted or replaced here — it starts with the eleven
+core files of main's #435 (`188e92e8`, persistent compiled artifact reuse). It is
+a RECORD ONLY: nothing under it is a module of this crate, this crate is not a
+workspace member, and none of it is compiled, referenced or kept in sync.

--- a/crates/luminal_cuda_lite_hlir/main_core/dtype.rs
+++ b/crates/luminal_cuda_lite_hlir/main_core/dtype.rs
@@ -1,0 +1,124 @@
+use std::fmt::{Debug, Display};
+
+/// Supported dtypes
+/// This is undergoing development. Our goal is to be as explicit as possible about dtype behavior.
+#[derive(Clone, Copy, PartialEq, Default, serde::Deserialize, serde::Serialize)]
+pub enum DType {
+    /// 32-bit float (8e23m)
+    #[default]
+    F32,
+    /// 64-bit float (11e52m)
+    F64,
+
+    /// 16-bit float (5e10m)
+    F16,
+    /// 16-bit float (8e7m)
+    Bf16,
+
+    /// 19-bit float (8e,10m)
+    TF32,
+
+    /// 32-bit signed integer
+    Int,
+    /// 64-bit signed integer.
+    ///
+    /// Debug-formats as `"Int64"` (not `"I64"`) because the egglog optimizer
+    /// uses `{:?}` to serialize `DType` into rule strings and has a built-in
+    /// primitive sort named `I64` for integer literals in shape expressions;
+    /// emitting `"I64"` would shadow that primitive and panic the egraph
+    /// loader with `UnboundFunction("I64", ...)`.
+    I64,
+    /// 4-bit signed integer
+    I4,
+    /// 4-bit unsigned integer
+    U4,
+    /// 8-bit signed integer
+    I8,
+    /// 8-bit unsigned integer
+    U8,
+    /// 16-bit signed integer
+    I16,
+    /// 16-bit unsigned integer
+    U16,
+
+    /// UNSTABLE WARNING
+    /// Boolean (stored as u8, 0 or 1)
+    /// Storage as a byte is subject to change
+    Bool,
+
+    /// 8-bit unsigned float (e8m0)
+    F8UE8M0,
+    /// 8-bit float (e4m3)
+    F8E4M3,
+    /// 8-bit float (e5m2)
+    F8E5M2,
+
+    /// 6-bit float (e2m3)
+    F6E2M3,
+    /// 6-bit float (e3m2)
+    F6E3M2,
+
+    /// 4-bit float (e2m1)
+    F4E2M1,
+}
+
+impl Debug for DType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Mostly identical to the derived Debug, except `I64 -> "Int64"` to
+        // avoid clashing with egglog's primitive `I64` sort (see the variant
+        // docstring above).
+        let name = match self {
+            DType::F32 => "F32",
+            DType::F64 => "F64",
+            DType::F16 => "F16",
+            DType::Bf16 => "Bf16",
+            DType::TF32 => "TF32",
+            DType::Int => "Int",
+            DType::I64 => "Int64",
+            DType::I4 => "I4",
+            DType::U4 => "U4",
+            DType::I8 => "I8",
+            DType::U8 => "U8",
+            DType::I16 => "I16",
+            DType::U16 => "U16",
+            DType::Bool => "Bool",
+            DType::F8UE8M0 => "F8UE8M0",
+            DType::F8E4M3 => "F8E4M3",
+            DType::F8E5M2 => "F8E5M2",
+            DType::F6E2M3 => "F6E2M3",
+            DType::F6E3M2 => "F6E3M2",
+            DType::F4E2M1 => "F4E2M1",
+        };
+        write!(f, "{}", name)
+    }
+}
+
+impl Display for DType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl DType {
+    /// Returns the number of bits per element for this dtype.
+    ///
+    /// This operates in bits (not bytes) so that sub-byte types like F4E2M1, I4, U4
+    /// and 6-bit types like F6E2M3, F6E3M2 can be represented cleanly.
+    /// Use `ShapeTracker::required_total_bytes()` to compute byte sizes for a tensor.
+    pub fn bits(&self) -> usize {
+        match self {
+            DType::F64 | DType::I64 => 64,
+            DType::F32 | DType::Int => 32,
+            DType::TF32 => 19,
+            DType::F16 | DType::Bf16 | DType::I16 | DType::U16 => 16,
+            DType::Bool
+            | DType::I8
+            | DType::U8
+            | DType::F8UE8M0
+            | DType::F8E4M3
+            | DType::F8E5M2 => 8,
+            DType::F6E2M3 | DType::F6E3M2 => 6,
+            DType::F4E2M1 | DType::I4 | DType::U4 => 4,
+        }
+    }
+}

--- a/crates/luminal_cuda_lite_hlir/main_core/dyn_backend.rs
+++ b/crates/luminal_cuda_lite_hlir/main_core/dyn_backend.rs
@@ -1,0 +1,586 @@
+//! Dynamic backend trait and factory-based compilation.
+//!
+//! This module provides:
+//! - [`DynBackend`]: an object-safe trait for dynamic backend dispatch
+//! - [`compile_backend`]: generic helper that handles the full compilation pipeline
+//! - [`BackendFactory`]: function pointer type for backend factories
+//! - [`ReferenceDynBackend`]: the reference implementation for CPU
+
+use std::collections::HashMap;
+
+use half::{bf16, f16};
+use petgraph::stable_graph::NodeIndex;
+
+use crate::dtype::DType;
+use crate::graph::{CompileOptions, Graph};
+use crate::hlir::{Output, ReferenceData, ReferenceRuntime};
+use crate::op::Runtime;
+use crate::shape::DynMap;
+
+// ---------------------------------------------------------------------------
+// DynBackend trait
+// ---------------------------------------------------------------------------
+
+/// Object-safe backend trait for dynamic dispatch.
+///
+/// Wraps a concrete [`Runtime`] implementor, providing a uniform interface
+/// for `luminal_python` (and other dynamic consumers) without requiring
+/// generic type parameters.
+pub trait DynBackend {
+    fn name(&self) -> &str;
+
+    fn artifact_data(&self) -> Option<String> {
+        None
+    }
+
+    /// The device type this backend operates on (e.g. "cpu", "cuda").
+    /// Used by the Python frontend to decide input tensor placement.
+    fn device_type(&self) -> &str {
+        "cpu"
+    }
+
+    fn device_index(&self) -> Option<usize> {
+        None
+    }
+
+    fn set_data_bytes(&mut self, node: NodeIndex, bytes: Vec<u8>, dtype: DType);
+    fn set_data_f32(&mut self, node: NodeIndex, data: Vec<f32>);
+    fn get_output_f32(&self, node: NodeIndex) -> Vec<f32>;
+    fn get_output_f16(&self, _node: NodeIndex) -> Vec<half::f16> {
+        panic!("get_output_f16 not supported by '{}'", self.name());
+    }
+    fn get_output_bf16(&self, _node: NodeIndex) -> Vec<half::bf16> {
+        panic!("get_output_bf16 not supported by '{}'", self.name());
+    }
+    fn get_output_i32(&self, _node: NodeIndex) -> Vec<i32> {
+        panic!("get_output_i32 not supported by '{}'", self.name());
+    }
+    fn get_output_i64(&self, _node: NodeIndex) -> Vec<i64> {
+        panic!("get_output_i64 not supported by '{}'", self.name());
+    }
+    fn get_output_i8(&self, _node: NodeIndex) -> Vec<i8> {
+        panic!("get_output_i8 not supported by '{}'", self.name());
+    }
+    fn get_output_u8(&self, _node: NodeIndex) -> Vec<u8> {
+        panic!("get_output_u8 not supported by '{}'", self.name());
+    }
+    fn get_output_i16(&self, _node: NodeIndex) -> Vec<i16> {
+        panic!("get_output_i16 not supported by '{}'", self.name());
+    }
+    fn get_output_f64(&self, _node: NodeIndex) -> Vec<f64> {
+        panic!("get_output_f64 not supported by '{}'", self.name());
+    }
+    fn get_output_bool(&self, _node: NodeIndex) -> Vec<bool> {
+        panic!("get_output_bool not supported by '{}'", self.name());
+    }
+    /// Execute on the backend's owned stream, or on a borrowed raw CUDA
+    /// stream supplied by the caller.
+    fn execute(&mut self, dyn_map: &DynMap, stream: Option<u64>);
+
+    // --- Optional device pointer support (GPU backends) --------------------
+
+    fn supports_device_ptrs(&self) -> bool {
+        false
+    }
+    /// # Safety
+    /// Device pointer must be valid and point to at least `n_bytes` bytes.
+    unsafe fn set_device_ptr(&mut self, _node: NodeIndex, _ptr: u64, _n_bytes: usize) {
+        panic!("set_device_ptr not supported by '{}'", self.name());
+    }
+    /// # Safety
+    /// Device pointer must remain valid through the next `execute()` call.
+    unsafe fn set_output_device_ptr(&mut self, _node: NodeIndex, _ptr: u64, _n_bytes: usize) {
+        panic!("set_output_device_ptr not supported by '{}'", self.name());
+    }
+    fn clear_output_device_ptr(&mut self, _node: NodeIndex) {
+        panic!("clear_output_device_ptr not supported by '{}'", self.name());
+    }
+    fn output_is_zero_copy(&self, _node: NodeIndex) -> bool {
+        false
+    }
+    /// # Safety
+    /// `dest_ptr` must be a valid device allocation with at least `n_bytes`.
+    unsafe fn copy_output_to_device_ptr(&self, _node: NodeIndex, _dest_ptr: u64, _n_bytes: usize) {
+        panic!(
+            "copy_output_to_device_ptr not supported by '{}'",
+            self.name()
+        );
+    }
+    /// Copy multiple outputs to device pointers. Backends may override this to
+    /// enqueue the full batch and synchronize once.
+    ///
+    /// # Safety
+    /// Every destination pointer must be a valid device allocation with at
+    /// least the corresponding byte count available.
+    unsafe fn copy_outputs_to_device_ptrs(&self, copies: &[(NodeIndex, u64, usize)]) {
+        for &(node, dest_ptr, n_bytes) in copies {
+            unsafe { self.copy_output_to_device_ptr(node, dest_ptr, n_bytes) };
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BackendCompileArgs + BackendFactory + Registry
+// ---------------------------------------------------------------------------
+
+/// Arguments passed to a backend factory during compilation.
+pub struct BackendCompileArgs {
+    pub search_iters: usize,
+    pub device_index: Option<usize>,
+    pub external_cuda_graph: bool,
+    pub weights: Vec<(String, Vec<u8>, DType)>,
+    pub tensor_sizes: HashMap<String, usize>,
+    pub device_ptrs: HashMap<String, (u64, usize)>,
+    pub backend_artifact: Option<String>,
+}
+
+/// Canonical PyCapsule name for [`BackendFactory`] function-pointer capsules.
+///
+/// The version is part of the ABI: `BackendCompileArgs` crosses this boundary
+/// by value, so an older plugin must be rejected rather than reading a changed
+/// struct layout.
+pub const BACKEND_FACTORY_CAPSULE_NAME: &std::ffi::CStr = c"luminal.backend_factory.v2";
+
+/// A factory function that compiles a [`Graph`] into a ready-to-execute [`DynBackend`].
+pub type BackendFactory = fn(&mut Graph, BackendCompileArgs) -> Result<Box<dyn DynBackend>, String>;
+
+/// Compile a graph using a factory function directly.
+pub fn compile_backend_from_factory(
+    factory: BackendFactory,
+    graph: &mut Graph,
+    args: BackendCompileArgs,
+) -> Result<Box<dyn DynBackend>, String> {
+    factory(graph, args)
+}
+
+// ---------------------------------------------------------------------------
+// compile_backend — generic compilation helper
+// ---------------------------------------------------------------------------
+
+/// Optional callback for uploading a device pointer + byte count to a node.
+pub type SetDevicePtrFn<'a, Rt> = &'a dyn Fn(&mut Rt, NodeIndex, u64, usize);
+
+/// Generic compilation pipeline shared by all backends.
+///
+/// Handles: build search space → init runtime → set device ptrs → set dummy
+/// data → search → load weights → wrap as `Box<dyn DynBackend>`.
+///
+/// Backend-specific behavior is injected via callbacks:
+/// - `init`: create the concrete runtime
+/// - `set_raw`: upload raw bytes + dtype to a node
+/// - `set_device_ptr`: optional zero-copy device pointer setter
+/// - `finalize`: perform backend-specific finalization after schedule selection
+/// - `wrap`: wrap the final runtime in a `Box<dyn DynBackend>`
+pub fn compile_backend<Rt: Runtime + 'static>(
+    graph: &mut Graph,
+    args: BackendCompileArgs,
+    init: impl FnOnce() -> Result<Rt, String>,
+    set_raw: impl Fn(&mut Rt, NodeIndex, Vec<u8>, DType),
+    set_device_ptr: Option<SetDevicePtrFn<'_, Rt>>,
+    finalize: impl FnOnce(&mut Graph, &mut Rt) -> Result<(), String>,
+    wrap: impl FnOnce(Rt) -> Box<dyn DynBackend>,
+) -> Result<Box<dyn DynBackend>, String> {
+    // Build label map from input_meta (plain data — no downcast needed,
+    // survives cross-binary type identity mismatches with external plugins).
+    let label_map = build_label_map(graph);
+
+    let has_selected_schedule = graph.selected_schedule().is_some();
+    if !has_selected_schedule {
+        graph.build_search_space::<Rt>(CompileOptions::default());
+    }
+
+    let mut rt = init()?;
+
+    // Set device pointers for zero-copy weights (GPU backends)
+    let mut device_ptr_nodes = rustc_hash::FxHashSet::default();
+    if let Some(set_ptr) = set_device_ptr {
+        for (label, &(ptr, n_bytes)) in &args.device_ptrs {
+            if let Some(&node_id) = label_map.get(label) {
+                set_ptr(&mut rt, node_id, ptr, n_bytes);
+                device_ptr_nodes.insert(node_id);
+            }
+        }
+    }
+
+    // Set dummy ones for Input nodes (required for search profiling).
+    // Must use 1, NOT 0 — zero inputs cause NaN in many ops.
+    for (&node_id, (label, dtype)) in &graph.input_meta {
+        if device_ptr_nodes.contains(&node_id) {
+            continue;
+        }
+        if let Some(&n) = args.tensor_sizes.get(label) {
+            if n > 0 {
+                set_raw(&mut rt, node_id, make_ones_bytes(n, *dtype), *dtype);
+            }
+        }
+    }
+
+    let mut rt = rt;
+    if has_selected_schedule {
+        graph.load_selected_schedule(&mut rt)?;
+    } else {
+        // Search
+        rt = graph.search(
+            rt,
+            CompileOptions::default().search_graph_limit(args.search_iters),
+        );
+    }
+
+    finalize(graph, &mut rt)?;
+
+    // Rebuild label map after search (graph may have changed)
+    let label_map = build_label_map(graph);
+
+    // Load real weights post-search (skip device-ptr weights)
+    for (label, bytes, dtype) in &args.weights {
+        if !args.device_ptrs.contains_key(label) {
+            if let Some(&node_id) = label_map.get(label) {
+                set_raw(&mut rt, node_id, bytes.clone(), *dtype);
+            }
+        }
+    }
+
+    Ok(wrap(rt))
+}
+
+// ---------------------------------------------------------------------------
+// Shared utilities
+// ---------------------------------------------------------------------------
+
+/// Build a `label → NodeIndex` map for all Input nodes in the graph.
+///
+/// Uses `graph.input_meta` (plain data) rather than downcasting, so it works
+/// correctly when the graph was built by a different compilation unit (e.g.
+/// an external backend plugin compiled as a separate wheel).
+pub fn build_label_map(graph: &Graph) -> HashMap<String, NodeIndex> {
+    graph
+        .input_meta
+        .iter()
+        .map(|(&node_id, (label, _))| (label.clone(), node_id))
+        .collect()
+}
+
+/// Create a byte buffer of `n_elements` ones for the given dtype.
+///
+/// IMPORTANT: Must use 1, NOT 0 — zero inputs cause NaN in many ops
+/// (fmod, recip, log, etc.) during search profiling.
+pub fn make_ones_bytes(n_elements: usize, dtype: DType) -> Vec<u8> {
+    // Safety: all source types have defined bit representations; we just
+    // reinterpret the backing Vec<u8> without changing the allocation.
+    unsafe fn as_bytes<T>(v: Vec<T>) -> Vec<u8> {
+        let mut v = std::mem::ManuallyDrop::new(v);
+        let ptr = v.as_mut_ptr() as *mut u8;
+        let len = v.len() * std::mem::size_of::<T>();
+        unsafe { Vec::from_raw_parts(ptr, len, len) }
+    }
+    match dtype {
+        DType::F32 | DType::TF32 => unsafe { as_bytes(vec![1.0f32; n_elements]) },
+        DType::F64 => unsafe { as_bytes(vec![1.0f64; n_elements]) },
+        DType::F16 => unsafe { as_bytes(vec![f16::from_f32(1.0); n_elements]) },
+        DType::Bf16 => unsafe { as_bytes(vec![bf16::from_f32(1.0); n_elements]) },
+        DType::Int => unsafe { as_bytes(vec![1i32; n_elements]) },
+        DType::I64 => unsafe { as_bytes(vec![1i64; n_elements]) },
+        DType::I16 => unsafe { as_bytes(vec![1i16; n_elements]) },
+        DType::U16 => unsafe { as_bytes(vec![1u16; n_elements]) },
+        _ => vec![1u8; n_elements], // I8, U8, Bool, sub-byte types
+    }
+}
+
+/// Convert raw bytes + [`DType`] to [`ReferenceData`].
+pub fn bytes_to_reference_data(bytes: Vec<u8>, dtype: DType) -> ReferenceData {
+    // An empty `Vec<u8>` has no typed allocation to reinterpret. Construct the
+    // correctly typed empty buffer directly so zero-element inputs preserve
+    // their dtype without passing a dangling empty-Vec pointer to
+    // `Vec::from_raw_parts`.
+    if bytes.is_empty() {
+        return match dtype {
+            DType::F32 | DType::TF32 => ReferenceData::F32(Vec::new()),
+            DType::F64 => ReferenceData::F64(Vec::new()),
+            DType::F16 => ReferenceData::F16(Vec::new()),
+            DType::Bf16 => ReferenceData::Bf16(Vec::new()),
+            DType::Int => ReferenceData::Int(Vec::new()),
+            DType::I64 => ReferenceData::I64(Vec::new()),
+            DType::I8 => ReferenceData::I8(Vec::new()),
+            DType::U8 => ReferenceData::U8(Vec::new()),
+            DType::I16 => ReferenceData::I16(Vec::new()),
+            DType::U16 => ReferenceData::Int(Vec::new()),
+            DType::Bool => ReferenceData::Bool(Vec::new()),
+            _ => ReferenceData::F32(Vec::new()),
+        };
+    }
+
+    // Safety: source bytes are from a valid typed buffer; we reinterpret.
+    unsafe fn from_bytes<T: Copy>(bytes: Vec<u8>) -> Vec<T> {
+        let n = bytes.len() / std::mem::size_of::<T>();
+        let cap = bytes.capacity() / std::mem::size_of::<T>();
+        let mut bytes = std::mem::ManuallyDrop::new(bytes);
+        unsafe { Vec::from_raw_parts(bytes.as_mut_ptr() as *mut T, n, cap) }
+    }
+    match dtype {
+        DType::F32 | DType::TF32 => ReferenceData::F32(unsafe { from_bytes(bytes) }),
+        DType::F64 => ReferenceData::F64(unsafe { from_bytes(bytes) }),
+        DType::F16 => ReferenceData::F16(unsafe { from_bytes(bytes) }),
+        DType::Bf16 => ReferenceData::Bf16(unsafe { from_bytes(bytes) }),
+        DType::Int => ReferenceData::Int(unsafe { from_bytes(bytes) }),
+        DType::I64 => ReferenceData::I64(unsafe { from_bytes(bytes) }),
+        DType::Bool => ReferenceData::Bool(bytes.into_iter().map(|b| b != 0).collect()),
+        DType::I8 => ReferenceData::I8(bytes.into_iter().map(|b| b as i8).collect()),
+        DType::U8 => ReferenceData::U8(bytes),
+        DType::I16 => ReferenceData::I16(unsafe { from_bytes(bytes) }),
+        DType::U16 => {
+            let u16s: Vec<u16> = unsafe { from_bytes(bytes) };
+            ReferenceData::Int(u16s.into_iter().map(|v| v as i32).collect())
+        }
+        _ => ReferenceData::F32(vec![]),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ReferenceDynBackend
+// ---------------------------------------------------------------------------
+
+/// [`DynBackend`] wrapper for the reference CPU runtime.
+pub struct ReferenceDynBackend {
+    pub runtime: ReferenceRuntime,
+}
+
+impl DynBackend for ReferenceDynBackend {
+    fn name(&self) -> &str {
+        "reference"
+    }
+
+    fn set_data_bytes(&mut self, node: NodeIndex, bytes: Vec<u8>, dtype: DType) {
+        self.runtime
+            .set_data(node, bytes_to_reference_data(bytes, dtype));
+    }
+
+    fn set_data_f32(&mut self, node: NodeIndex, data: Vec<f32>) {
+        self.runtime.set_data(node, data);
+    }
+
+    fn get_output_f32(&self, node: NodeIndex) -> Vec<f32> {
+        match self.output_buffer(node) {
+            ReferenceData::F32(v) => v.clone(),
+            other => panic!(
+                "get_output_f32: buffer dtype is {:?}, expected F32. \
+                 Add a `Cast(DType::F32)` before the Output.",
+                std::mem::discriminant(other)
+            ),
+        }
+    }
+
+    fn get_output_f16(&self, node: NodeIndex) -> Vec<half::f16> {
+        match self.output_buffer(node) {
+            ReferenceData::F16(v) => v.clone(),
+            other => panic!(
+                "get_output_f16: buffer dtype is {:?}, expected F16. \
+                 Add a `Cast(DType::F16)` before the Output.",
+                std::mem::discriminant(other)
+            ),
+        }
+    }
+
+    fn get_output_bf16(&self, node: NodeIndex) -> Vec<half::bf16> {
+        match self.output_buffer(node) {
+            ReferenceData::Bf16(v) => v.clone(),
+            other => panic!(
+                "get_output_bf16: buffer dtype is {:?}, expected Bf16. \
+                 Add a `Cast(DType::Bf16)` before the Output.",
+                std::mem::discriminant(other)
+            ),
+        }
+    }
+
+    fn get_output_i32(&self, node: NodeIndex) -> Vec<i32> {
+        match self.output_buffer(node) {
+            ReferenceData::Int(v) => v.clone(),
+            other => panic!(
+                "get_output_i32: buffer dtype is {:?}, expected Int (i32). \
+                 Add a `Cast(DType::Int)` before the Output.",
+                std::mem::discriminant(other)
+            ),
+        }
+    }
+
+    fn get_output_i64(&self, node: NodeIndex) -> Vec<i64> {
+        match self.output_buffer(node) {
+            ReferenceData::I64(v) => v.clone(),
+            other => panic!(
+                "get_output_i64: buffer dtype is {:?}, expected I64. \
+                 Add a `Cast(DType::I64)` before the Output.",
+                std::mem::discriminant(other)
+            ),
+        }
+    }
+
+    fn get_output_i8(&self, node: NodeIndex) -> Vec<i8> {
+        match self.output_buffer(node) {
+            ReferenceData::I8(v) => v.clone(),
+            other => panic!(
+                "get_output_i8: buffer dtype is {:?}, expected I8. \
+                 Add a `Cast(DType::I8)` before the Output.",
+                std::mem::discriminant(other)
+            ),
+        }
+    }
+
+    fn get_output_u8(&self, node: NodeIndex) -> Vec<u8> {
+        match self.output_buffer(node) {
+            ReferenceData::U8(v) => v.clone(),
+            other => panic!(
+                "get_output_u8: buffer dtype is {:?}, expected U8. \
+                 Add a `Cast(DType::U8)` before the Output.",
+                std::mem::discriminant(other)
+            ),
+        }
+    }
+
+    fn get_output_i16(&self, node: NodeIndex) -> Vec<i16> {
+        match self.output_buffer(node) {
+            ReferenceData::I16(v) => v.clone(),
+            other => panic!(
+                "get_output_i16: buffer dtype is {:?}, expected I16. \
+                 Add a `Cast(DType::I16)` before the Output.",
+                std::mem::discriminant(other)
+            ),
+        }
+    }
+
+    fn get_output_f64(&self, node: NodeIndex) -> Vec<f64> {
+        match self.output_buffer(node) {
+            ReferenceData::F64(v) => v.clone(),
+            other => panic!(
+                "get_output_f64: buffer dtype is {:?}, expected F64. \
+                 Add a `Cast(DType::F64)` before the Output.",
+                std::mem::discriminant(other)
+            ),
+        }
+    }
+
+    fn get_output_bool(&self, node: NodeIndex) -> Vec<bool> {
+        match self.output_buffer(node) {
+            ReferenceData::Bool(v) => v.clone(),
+            other => panic!(
+                "get_output_bool: buffer dtype is {:?}, expected Bool. \
+                 Add a `Cast(DType::Bool)` before the Output.",
+                std::mem::discriminant(other)
+            ),
+        }
+    }
+
+    fn execute(&mut self, dyn_map: &DynMap, stream: Option<u64>) {
+        assert!(
+            stream.is_none(),
+            "reference backend does not support CUDA streams"
+        );
+        self.runtime.execute(dyn_map);
+    }
+}
+
+impl ReferenceDynBackend {
+    fn output_buffer(&self, node: NodeIndex) -> &ReferenceData {
+        let output_id = self
+            .runtime
+            .graph
+            .node_indices()
+            .find(|n| {
+                (**self.runtime.graph[*n])
+                    .as_any()
+                    .downcast_ref::<Output>()
+                    .is_some_and(|out| out.node == node.index())
+            })
+            .unwrap_or_else(|| panic!("No output node found for {:?}", node));
+        self.runtime
+            .buffers
+            .get(&output_id)
+            .unwrap_or_else(|| panic!("No buffer data for output {:?}", node))
+    }
+}
+
+pub fn reference_factory(
+    graph: &mut Graph,
+    args: BackendCompileArgs,
+) -> Result<Box<dyn DynBackend>, String> {
+    compile_backend::<ReferenceRuntime>(
+        graph,
+        args,
+        || Ok(ReferenceRuntime::default()),
+        // ReferenceRuntime::set_data requires the LLIR graph to be loaded (it searches
+        // for Input nodes in the LLIR). Before search, the LLIR is empty. We guard
+        // against that: if rt.graph is empty, skip (dummy data isn't needed for
+        // reference since its profile is a no-op).
+        |rt, node, bytes, dtype| {
+            if rt.graph.node_count() > 0 {
+                rt.set_data(node, bytes_to_reference_data(bytes, dtype));
+            }
+        },
+        None,
+        |_, _| Ok(()),
+        |rt| Box::new(ReferenceDynBackend { runtime: rt }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_bytes_preserve_reference_dtype() {
+        assert!(matches!(
+            bytes_to_reference_data(Vec::new(), DType::F32),
+            ReferenceData::F32(values) if values.is_empty()
+        ));
+        assert!(matches!(
+            bytes_to_reference_data(Vec::new(), DType::F64),
+            ReferenceData::F64(values) if values.is_empty()
+        ));
+        assert!(matches!(
+            bytes_to_reference_data(Vec::new(), DType::F16),
+            ReferenceData::F16(values) if values.is_empty()
+        ));
+        assert!(matches!(
+            bytes_to_reference_data(Vec::new(), DType::Bf16),
+            ReferenceData::Bf16(values) if values.is_empty()
+        ));
+        assert!(matches!(
+            bytes_to_reference_data(Vec::new(), DType::Int),
+            ReferenceData::Int(values) if values.is_empty()
+        ));
+        assert!(matches!(
+            bytes_to_reference_data(Vec::new(), DType::I64),
+            ReferenceData::I64(values) if values.is_empty()
+        ));
+        assert!(matches!(
+            bytes_to_reference_data(Vec::new(), DType::I8),
+            ReferenceData::I8(values) if values.is_empty()
+        ));
+        assert!(matches!(
+            bytes_to_reference_data(Vec::new(), DType::U8),
+            ReferenceData::U8(values) if values.is_empty()
+        ));
+        assert!(matches!(
+            bytes_to_reference_data(Vec::new(), DType::I16),
+            ReferenceData::I16(values) if values.is_empty()
+        ));
+        assert!(matches!(
+            bytes_to_reference_data(Vec::new(), DType::Bool),
+            ReferenceData::Bool(values) if values.is_empty()
+        ));
+    }
+
+    #[test]
+    fn narrow_integer_bytes_preserve_width_and_signedness() {
+        assert!(matches!(
+            bytes_to_reference_data(vec![0x80, 0xff, 0x7f], DType::I8),
+            ReferenceData::I8(values) if values == [-128, -1, 127]
+        ));
+        assert!(matches!(
+            bytes_to_reference_data(vec![0, 128, 255], DType::U8),
+            ReferenceData::U8(values) if values == [0, 128, 255]
+        ));
+        assert!(matches!(
+            bytes_to_reference_data(vec![0x00, 0x80, 0xff, 0x7f], DType::I16),
+            ReferenceData::I16(values) if values == [-32_768, 32_767]
+        ));
+    }
+}

--- a/crates/luminal_cuda_lite_hlir/main_core/egglog_utils/mod.rs
+++ b/crates/luminal_cuda_lite_hlir/main_core/egglog_utils/mod.rs
@@ -1,0 +1,3968 @@
+use colored::Colorize;
+use egglog::{ast::Span, prelude::RustSpan, var};
+use itertools::Itertools;
+use petgraph::{Direction, graph::NodeIndex};
+use rand::Rng;
+use rustc_hash::FxHashSet;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::{
+    str,
+    sync::{Arc, OnceLock},
+    time::Duration,
+};
+use tracing::trace;
+
+use crate::search::packed::PackedLLIRGraph;
+
+pub use egraph_serialize::{ClassId, NodeId};
+
+pub mod api;
+pub mod base;
+
+pub(crate) fn llir_profile_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("LUMINAL_LLIR_PROFILE").is_some())
+}
+
+const MAIN_SCHEDULE_MAX_CYCLES: usize = 256;
+const MAIN_SCHEDULE_MAX_TUPLES: usize = 10_000_000;
+const SLOW_PHASE_TIME: Duration = Duration::from_secs(1);
+const BIG_TUPLE_DELTA: isize = 5_000;
+
+const EGGLOG_RULESETS: &[&str] = &[
+    "matmul_flatten",
+    "kernel_lower",
+    "direct_kernel",
+    "kernel_specialize",
+    "buffer_reuse",
+    "matmul_backend",
+    "glumoe",
+    "fusion_pair",
+    "fusion_grow",
+    "fusion_merge",
+    // One-shot structural fusion rules (large joins), run once in the
+    // dedicated "fuse late" phase instead of inside the saturating main
+    // cycles. The _pre ruleset holds producer stages (e.g. the RoPE angle
+    // relation) consumed by rules in the main late ruleset.
+    "kernel_fuse_late_pre_rms",
+    "kernel_fuse_late_pre_topk",
+    "kernel_fuse_late_pre_rope",
+    "kernel_fuse_late_pre_sink_attention_base",
+    "kernel_fuse_late_pre_sink_attention_request",
+    "kernel_fuse_late_pre_sink_attention_past",
+    "kernel_fuse_late_pre_sink_attention_finish",
+    "kernel_fuse_late_pre_flashinfer",
+    "kernel_fuse_late",
+    // Expensive one-shot rules that consume facts produced by the earlier
+    // fuse-late runs; scheduled exactly once at the end of the phase.
+    "kernel_fuse_late2_rope",
+    "kernel_fuse_late2_sink_attention",
+    "kernel_fuse_late2_flashinfer_value",
+    "kernel_fuse_late2_flashinfer_softmax_denominator",
+    "kernel_fuse_late2_flashinfer_softmax_source",
+    "kernel_fuse_late2_flashinfer_request",
+    "kernel_fuse_late2_flashinfer_qk",
+    "kernel_fuse_late2_flashinfer_final",
+];
+
+fn parse_log_flag(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+pub fn log_channel_enabled(option_enabled: bool, channel_env: &str) -> bool {
+    if std::env::var("LUMINAL_LOG").is_ok_and(|value| parse_log_flag(&value)) {
+        return true;
+    }
+    if let Ok(value) = std::env::var(channel_env) {
+        return parse_log_flag(&value);
+    }
+    option_enabled
+}
+
+#[derive(Debug, Clone)]
+struct EgglogSchedulePhase {
+    name: String,
+    schedule: String,
+}
+
+pub type EGraphPostprocess = Arc<dyn Fn(&mut SerializedEGraph) + Send + Sync + 'static>;
+
+#[derive(Clone, Default)]
+pub struct LateEgglogPass {
+    /// Egglog declarations and rules for a backend-provided late pass.
+    ///
+    /// These fragments are appended after the core/backend rewrite declarations
+    /// and before the graph program itself, so they can refer to the full IR and
+    /// OpKind datatypes.
+    pub program: String,
+    /// Schedule to run after the normal full-egraph rewrite + cleanup schedule.
+    ///
+    /// Backends can use this for analysis-only layers or for analysis followed
+    /// by backend-specific cleanup rules.
+    pub schedule: String,
+    /// Optional Rust post-processing hook that runs on the serialized e-graph
+    /// after egglog has finished and before the final empty-eclass cascade.
+    pub postprocess: Option<EGraphPostprocess>,
+}
+
+impl std::fmt::Debug for LateEgglogPass {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LateEgglogPass")
+            .field("program", &self.program)
+            .field("schedule", &self.schedule)
+            .field("has_postprocess", &self.postprocess.is_some())
+            .finish()
+    }
+}
+
+impl LateEgglogPass {
+    pub fn new(program: impl Into<String>, schedule: impl Into<String>) -> Self {
+        Self {
+            program: program.into(),
+            schedule: schedule.into(),
+            postprocess: None,
+        }
+    }
+
+    pub fn with_postprocess(
+        mut self,
+        postprocess: impl Fn(&mut SerializedEGraph) + Send + Sync + 'static,
+    ) -> Self {
+        self.postprocess = Some(Arc::new(postprocess));
+        self
+    }
+}
+
+fn op_defs_string(ops: &[Arc<Box<dyn EgglogOp>>]) -> String {
+    // Partition ops by sort class: IR-class (Input, Output) vs OpKind-class (everything else)
+    let mut ir_variants = Vec::new();
+    let mut opkind_variants = Vec::new();
+    for o in ops {
+        let s = o.sort();
+        let variant_str = format!(
+            "({} {})",
+            s.name,
+            s.fields.iter().map(|f| &f.sort).join(" ")
+        );
+        if s.class == "IR" {
+            ir_variants.push(variant_str);
+        } else if s.class == "OpKind" {
+            opkind_variants.push(variant_str);
+        } else {
+            panic!("Unknown sort class '{}' for op '{}'", s.class, s.name);
+        }
+    }
+    let ir_str = ir_variants.join("\n");
+    let opkind_str = opkind_variants.join("\n");
+    let extra_ir: FxHashSet<String> = ops.iter().flat_map(|o| o.ir_defs()).collect();
+    let extra_ir_str = extra_ir.into_iter().join("\n");
+    format!(
+        "
+    (datatype*
+        (IR
+            (OutputJoin IR IR)
+            (Op OpKind IList)
+            {extra_ir_str}
+            {ir_str}
+        )
+        (OpKind
+            {opkind_str}
+        )
+        (IList
+            (ICons IR IList)
+            (INil)
+        )
+    )
+    (function dtype (IR) DType :merge new)
+    "
+    )
+}
+
+pub fn full_egglog(program: &str, ops: &[Arc<Box<dyn EgglogOp>>], cleanup: bool) -> String {
+    let parts = OpTextParts::new(ops, cleanup);
+    full_egglog_with(program, &parts)
+}
+
+/// Pre-computed per-op text fragments. Materialising all op-derived strings
+/// once up front means callers that want to drive multiple egglog runs in
+/// parallel only need to share `&str` references and never touch the non-Send
+/// trait objects in `ops`.
+pub struct OpTextParts {
+    op_defs: String,
+    /// Declarations owned by registered ops, deduplicated and emitted before
+    /// every per-op rewrite. Unlike backend extras, these travel with a raw op
+    /// list through direct `run_egglog` callers as well as Runtime compilation.
+    op_declarations: String,
+    /// Backend-provided egglog text (see [`crate::op::Runtime::extra_egglog`]),
+    /// spliced after `op_defs` and `op_declarations`, before the rewrite rules.
+    /// Empty for core / the reference backend.
+    extra_egglog: String,
+    cleanups: String,
+    /// Names of op kinds that are eligible for cleanup (cleanup() == true).
+    /// Used by the Rust post-processing pass to safely strip HLIR ops only
+    /// when an alternative survives in the same eclass.
+    pub(crate) cleanable_op_names: FxHashSet<String>,
+    late_program: String,
+    rewrites: String,
+    late_phases: Vec<EgglogSchedulePhase>,
+    late_postprocesses: Vec<EGraphPostprocess>,
+}
+
+impl OpTextParts {
+    pub fn new(ops: &[Arc<Box<dyn EgglogOp>>], cleanup: bool) -> Self {
+        Self::new_with_late_passes(ops, cleanup, &[])
+    }
+
+    pub fn new_with_late_passes(
+        ops: &[Arc<Box<dyn EgglogOp>>],
+        cleanup: bool,
+        late_passes: &[LateEgglogPass],
+    ) -> Self {
+        let cleanable_op_names: FxHashSet<String> = ops
+            .iter()
+            .filter(|op| op.cleanup())
+            .map(|op| op.sort().name.to_string())
+            .collect();
+        let mut seen_declarations = FxHashSet::default();
+        let op_declarations = ops
+            .iter()
+            .flat_map(|op| op.egglog_declarations())
+            .filter(|declaration| seen_declarations.insert(declaration.clone()))
+            .join("\n");
+        Self {
+            op_defs: op_defs_string(ops),
+            op_declarations,
+            // Default empty; the backend's Runtime::extra_egglog() is spliced in
+            // by the Rt-aware callers (build_search_space) after construction.
+            extra_egglog: String::new(),
+            // The egglog `cleanup` ruleset deletes HLIR ops unconditionally,
+            // even when no kernel rewrite fired in their eclass. On large
+            // graphs (e.g. YOLO v11) that produces empty eclasses and the
+            // post-processing cascade panics with "No valid graphs present".
+            // We always emit an empty cleanup ruleset and instead do
+            // conditional cleanup in Rust after egglog finishes.
+            cleanups: String::new(),
+            rewrites: ops
+                .iter()
+                .flat_map(|o| o.rewrites())
+                .map(|r| r.to_egglog_string())
+                .join("\n"),
+            cleanable_op_names: if cleanup {
+                cleanable_op_names
+            } else {
+                FxHashSet::default()
+            },
+            late_program: late_passes.iter().map(|p| p.program.as_str()).join("\n"),
+            late_phases: late_passes
+                .iter()
+                .enumerate()
+                .filter_map(|(i, pass)| {
+                    let schedule = normalize_late_schedule(&pass.schedule);
+                    (!schedule.is_empty()).then(|| EgglogSchedulePhase {
+                        name: format!("late pass {:02}", i + 1),
+                        schedule,
+                    })
+                })
+                .collect(),
+            late_postprocesses: late_passes
+                .iter()
+                .filter_map(|pass| pass.postprocess.clone())
+                .collect(),
+        }
+    }
+}
+
+fn full_egglog_with(program: &str, parts: &OpTextParts) -> String {
+    let mut chunks = vec![egglog_setup_with(program, parts), egglog_schedule_program()];
+    chunks.extend(
+        parts
+            .late_phases
+            .iter()
+            .map(|phase| format!("(run-schedule {})", phase.schedule)),
+    );
+    chunks.join("\n")
+}
+
+fn normalize_late_schedule(schedule: &str) -> String {
+    let schedule = schedule.trim();
+    schedule
+        .strip_prefix("(run-schedule ")
+        .and_then(|rest| rest.strip_suffix(')'))
+        .unwrap_or(schedule)
+        .trim()
+        .to_string()
+}
+
+fn egglog_ruleset_declarations() -> String {
+    EGGLOG_RULESETS
+        .iter()
+        .map(|ruleset| format!("(ruleset {ruleset})"))
+        .join("\n")
+}
+
+fn expr_schedule(use_interval_analysis: bool) -> &'static str {
+    if use_interval_analysis {
+        "(saturate (seq expr interval_expr))"
+    } else {
+        "(saturate expr)"
+    }
+}
+
+fn egglog_main_cycle_phases(cycle: usize, use_interval_analysis: bool) -> Vec<EgglogSchedulePhase> {
+    vec![EgglogSchedulePhase {
+        name: format!("cycle {cycle:03} main"),
+        schedule: egglog_main_schedule(use_interval_analysis),
+    }]
+}
+
+fn egglog_final_phases(use_interval_analysis: bool) -> Vec<EgglogSchedulePhase> {
+    vec![
+        // One-shot structural fusion rules with large joins. Running them
+        // once here (dtype facts present, raw HLIR rows not yet deleted by
+        // the cleanup phases) instead of inside the saturating main cycles
+        // avoids re-evaluating tens-of-seconds joins on every iteration.
+        // `seq` so each ruleset's join runs exactly once: producer stages
+        // first, then the consumer rules.
+        EgglogSchedulePhase {
+            name: "fuse late".to_string(),
+            // The second `kernel_fuse_late` run consumes relation facts the
+            // first run produced (e.g. rope_rotated); semi-naive evaluation
+            // makes it a cheap delta join.
+            // Depth = the longest relation cascade: invf(pre) → angles →
+            // rotation → concat each consume the previous run's facts.
+            schedule: "(seq
+                kernel_fuse_late_pre_rms
+                kernel_fuse_late_pre_topk
+                kernel_fuse_late_pre_rope
+                kernel_fuse_late_pre_sink_attention_base
+                kernel_fuse_late_pre_sink_attention_request
+                kernel_fuse_late_pre_sink_attention_past
+                kernel_fuse_late_pre_sink_attention_finish
+                kernel_fuse_late_pre_flashinfer
+                kernel_fuse_late
+                kernel_fuse_late
+                kernel_fuse_late
+                kernel_fuse_late2_rope
+                kernel_fuse_late2_sink_attention
+                kernel_fuse_late2_flashinfer_value
+                kernel_fuse_late2_flashinfer_softmax_denominator
+                kernel_fuse_late2_flashinfer_softmax_source
+                kernel_fuse_late2_flashinfer_request
+                kernel_fuse_late2_flashinfer_qk
+                kernel_fuse_late2_flashinfer_final)"
+                .to_string(),
+        },
+        EgglogSchedulePhase {
+            name: "final expr".to_string(),
+            schedule: expr_schedule(use_interval_analysis).to_string(),
+        },
+        EgglogSchedulePhase {
+            name: "cleanup".to_string(),
+            schedule: "(saturate cleanup)".to_string(),
+        },
+        EgglogSchedulePhase {
+            name: "post cleanup".to_string(),
+            schedule: "(saturate post_cleanup)".to_string(),
+        },
+        EgglogSchedulePhase {
+            name: "base cleanup".to_string(),
+            schedule: "(saturate base_cleanup)".to_string(),
+        },
+    ]
+}
+
+fn egglog_main_schedule(use_interval_analysis: bool) -> String {
+    let expr = expr_schedule(use_interval_analysis);
+    // Producer rules create raw alternatives that downstream fusion consumes.
+    // Fusion grow/merge only consumes Kernel*/FusionEnd alternatives, so keeping
+    // producer discovery saturated before fusion reaches the same fixed point
+    // while avoiding repeated expensive pair-discovery scans during growth.
+    format!(
+        "(saturate (seq
+        (saturate (seq
+            {expr}
+            (saturate dtype_prop)
+            (run matmul_flatten)
+            (run kernel_lower)
+            (run direct_kernel)
+            (run kernel_specialize)
+            (run buffer_reuse)
+            (run matmul_backend)
+            (run glumoe)
+            (run fusion_pair)
+        ))
+        (saturate (seq
+            {expr}
+            (saturate dtype_prop)
+            (run fusion_grow)
+            (run fusion_merge)
+        ))
+    ))"
+    )
+}
+
+fn egglog_schedule_program() -> String {
+    let mut schedules = vec![format!("(run-schedule {})", egglog_main_schedule(false))];
+    schedules.extend(
+        egglog_final_phases(false)
+            .into_iter()
+            .map(|phase| format!("(run-schedule {})", phase.schedule)),
+    );
+    schedules.join("\n")
+}
+
+fn egglog_setup_with(program: &str, parts: &OpTextParts) -> String {
+    egglog_setup_with_options(program, parts, false)
+}
+
+fn egglog_setup_with_options(
+    program: &str,
+    parts: &OpTextParts,
+    use_interval_analysis: bool,
+) -> String {
+    let base_program = if use_interval_analysis {
+        base::base_expression_egglog_with_intervals()
+    } else {
+        base::base_expression_egglog()
+    };
+    [
+        egglog_ruleset_declarations(),
+        base_program,
+        parts.op_defs.clone(),
+        parts.op_declarations.clone(),
+        parts.extra_egglog.clone(),
+        parts.cleanups.clone(),
+        base::base_cleanup_egglog(),
+        parts.rewrites.clone(),
+        parts.late_program.clone(),
+        program.to_string(),
+    ]
+    .join("\n")
+}
+
+use crate::{
+    dtype::DType,
+    graph::{Graph, LLIRGraph},
+    op::{CustomOp, EgglogOp},
+    prelude::FxHashMap,
+    shape::Expression,
+};
+use egglog::{ArcSort, CommandOutput, EGraph, Value};
+use egglog_reports::ReportLevel;
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+///  This is snapshot of an EGraph with Rust native hash maps and sets for enabling more native traversal / algorithm writing.
+///  The name comes from the serialize egraph crates, which returns a ETermDAG, which caused issues, so this is a homebrew semi-static egraph
+pub struct SerializedEGraph {
+    pub enodes: FxHashMap<NodeId, (String, Vec<ClassId>)>,
+    pub eclasses: FxHashMap<ClassId, (String, Vec<NodeId>)>,
+    pub node_to_class: FxHashMap<NodeId, ClassId>,
+    pub roots: Vec<ClassId>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct EgglogStageReport {
+    pub num_matches_per_rule: FxHashMap<String, usize>,
+    pub search_and_apply_time_per_rule: FxHashMap<String, Duration>,
+    pub total_time: Duration,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct EgglogRunReport {
+    pub full: EgglogStageReport,
+    pub phases: Vec<EgglogPhaseReport>,
+    pub total_time: Duration,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct EgglogPhaseReport {
+    pub name: String,
+    pub schedule: String,
+    pub updated: bool,
+    pub iterations: usize,
+    pub tuples_before: usize,
+    pub tuples_after: usize,
+    pub total_time: Duration,
+}
+
+impl SerializedEGraph {
+    /// This is an opinionated function which does more than strictly take the state of the egglog object.
+    /// It also filters out "[...]" nodes and then changes the structure from the e-termDAG that egraph-serialize
+    /// produces to a strict egraph, where the children of e-classes are e-nodes.
+    pub fn new(egraph: &EGraph, root_eclasses: Vec<(ArcSort, Value)>) -> Self {
+        let s = egraph.serialize(egglog::SerializeConfig {
+            root_eclasses,
+            max_functions: None,
+            include_temporary_functions: false,
+            max_calls_per_function: None,
+        });
+        // Convert to SerializedEGraph
+        let mut classes = FxHashMap::default();
+        for (node_id, node) in s.egraph.nodes.iter().filter(|(_, node)| !node.subsumed) {
+            classes
+                .entry(node.eclass.clone())
+                .or_insert(vec![])
+                .push(node_id.clone())
+        }
+        let mut s_egraph = SerializedEGraph {
+            roots: s.egraph.root_eclasses,
+            node_to_class: s
+                .egraph
+                .nodes
+                .iter()
+                .filter(|(_, enode)| !enode.subsumed)
+                .map(|(n, enode)| (n.clone(), enode.eclass.clone()))
+                .collect(),
+            enodes: s
+                .egraph
+                .nodes
+                .iter()
+                .filter(|(_, enode)| !enode.subsumed)
+                .map(|(n, enode)| {
+                    (
+                        n.clone(),
+                        (
+                            enode.op.clone(),
+                            enode
+                                .children
+                                .iter()
+                                .map(|n| s.egraph.nodes[n].eclass.clone())
+                                .collect(),
+                        ),
+                    )
+                })
+                .collect(),
+            eclasses: s
+                .egraph
+                .class_data
+                .iter()
+                .filter_map(|(c, eclass)| {
+                    classes
+                        .get(c)
+                        .map(|nodes| (c.clone(), (eclass.typ.clone().unwrap(), nodes.clone())))
+                })
+                .collect(),
+        };
+        // Strip out all [...] enodes
+        s_egraph.enodes.retain(|_, (label, _)| label != "[...]");
+        loop {
+            let mut to_remove = vec![];
+            for (id, (_, children)) in &s_egraph.enodes {
+                if children.iter().any(|c| {
+                    s_egraph.eclasses.get(c).is_none_or(|(_, nodes)| {
+                        !nodes.iter().any(|n| s_egraph.enodes.contains_key(n))
+                    })
+                }) {
+                    to_remove.push(id.clone());
+                }
+            }
+            for n in &to_remove {
+                s_egraph.enodes.remove(n);
+            }
+            if to_remove.is_empty() {
+                break;
+            }
+        }
+        // Correct the eclass mapping
+        for (_, enodes) in s_egraph.eclasses.values_mut() {
+            enodes.retain(|n| s_egraph.enodes.contains_key(n));
+        }
+        s_egraph.eclasses.retain(|_, (_, c)| !c.is_empty());
+        s_egraph
+            .node_to_class
+            .retain(|n, _| s_egraph.enodes.contains_key(n));
+        s_egraph
+    }
+}
+
+/// Hash a SerializedEGraph by its structural content for dedup comparison.
+/// Only considers IR/IList eclasses and enodes (not primitives like i64, String, DType
+/// which contain per-chunk-specific values like node indices and weight labels).
+pub fn hash_serialized_egraph(egraph: &SerializedEGraph) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    // Only count IR/IList eclasses (computation nodes, not primitives)
+    let ir_eclasses: Vec<_> = egraph
+        .eclasses
+        .values()
+        .filter(|(label, _)| label.contains("IR") || label.contains("IList"))
+        .collect();
+    ir_eclasses.len().hash(&mut hasher);
+    let mut eclass_info: Vec<_> = ir_eclasses
+        .iter()
+        .map(|(label, enodes)| (label.clone(), enodes.len()))
+        .collect();
+    eclass_info.sort();
+    eclass_info.hash(&mut hasher);
+    // Only hash IR/IList enodes by op name and child count
+    let mut enode_info: Vec<_> = egraph
+        .enodes
+        .iter()
+        .filter(|(node_id, _)| {
+            let eclass = &egraph.node_to_class[*node_id];
+            if let Some((label, _)) = egraph.eclasses.get(eclass) {
+                label.contains("IR") || label.contains("IList")
+            } else {
+                false
+            }
+        })
+        .map(|(_, (op, children))| (op.clone(), children.len()))
+        .collect();
+    enode_info.sort();
+    enode_info.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Hash egglog text with normalization for structural dedup.
+///
+/// Structurally identical chunks (e.g. transformer layers) produce identical
+/// egglog text except for:
+/// - Input node indices and labels (differ per layer)
+/// - Output node indices (differ per layer)
+/// - CustomOpKind integer IDs (global custom_ops index, differs per layer)
+///
+/// This function hashes the text while normalizing those chunk-specific values:
+/// - Input lines: only the dtype is hashed (not node index or label)
+/// - Output lines: the marker and persist-only semantics are hashed (not the node index)
+/// - CustomOpKind lines: the integer ID is replaced with a constant
+/// - All other lines (ops, shapes, strides): hashed verbatim
+pub fn hash_egglog_normalized(text: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    for line in text.lines() {
+        if line.contains("(Input ") {
+            // Format: (let tN (Input NODE "LABEL" (DTYPE)))
+            // Strip the node index and label identity, but preserve whether this
+            // is a synthetic boundary input or a real graph input.
+            // The dtype is the last parenthesized token, e.g. "(F32)".
+            if let Some(dtype_start) = line.rfind(" (") {
+                let dtype = &line[dtype_start + 1..];
+                let kind = if line.contains("\"boundary\"") {
+                    "BOUNDARY_INPUT"
+                } else {
+                    "REAL_INPUT"
+                };
+                (kind, dtype).hash(&mut hasher);
+            } else {
+                line.hash(&mut hasher);
+            }
+        } else if line.contains("(Output ") && !line.contains("(OutputJoin ") {
+            // Format: (let tN (Output tM NODE PERSIST_ONLY))
+            // The node id varies between structurally identical chunks, but a
+            // persistence marker is not interchangeable with an observed
+            // output for in-place alias legality.
+            let persist_only = line
+                .split_once("(Output ")
+                .and_then(|(_, tail)| tail.split_whitespace().nth(2))
+                .map(|token| token.trim_end_matches(')'));
+            ("OUTPUT", persist_only).hash(&mut hasher);
+        } else if line.contains("(CustomOpKind ") {
+            // Format: (let tN (Op (CustomOpKind ID (DTYPE)) (ICons ...)))
+            // The integer ID varies per layer. Replace it with a constant.
+            normalize_custom_op_id(line).hash(&mut hasher);
+        } else {
+            line.hash(&mut hasher);
+        }
+    }
+    hasher.finish()
+}
+
+/// Replace the integer ID in a CustomOpKind egglog line with a constant "0".
+fn normalize_custom_op_id(line: &str) -> String {
+    if let Some(custom_start) = line.find("(CustomOpKind ") {
+        let after = &line[custom_start + "(CustomOpKind ".len()..];
+        // The ID is the first token (integer) after "CustomOpKind "
+        if let Some(space_after_id) = after.find(' ') {
+            let id_str = &after[..space_after_id];
+            if id_str.chars().all(|c| c.is_ascii_digit()) {
+                return format!(
+                    "{}0{}",
+                    &line[..custom_start + "(CustomOpKind ".len()],
+                    &line[custom_start + "(CustomOpKind ".len() + space_after_id..]
+                );
+            }
+        }
+    }
+    line.to_string()
+}
+
+pub fn hlir_to_egglog(graph: &Graph) -> (String, String) {
+    use std::cmp::Reverse;
+    use std::collections::{BinaryHeap, HashMap};
+
+    // 1. Topo-order with tie-break: lower NodeIndex first
+    let mut indeg: HashMap<NodeIndex, usize> = graph
+        .node_indices()
+        .map(|n| (n, graph.neighbors_directed(n, Direction::Incoming).count()))
+        .collect();
+
+    let mut ready: BinaryHeap<(Reverse<usize>, NodeIndex)> = BinaryHeap::new();
+    for (n, &d) in &indeg {
+        if d == 0 {
+            ready.push((Reverse(n.index()), *n));
+        }
+    }
+
+    let mut topo_order: Vec<NodeIndex> = Vec::with_capacity(indeg.len());
+    while let Some((_, n)) = ready.pop() {
+        topo_order.push(n);
+        for succ in graph.neighbors_directed(n, Direction::Outgoing) {
+            let e = indeg.get_mut(&succ).unwrap();
+            *e -= 1;
+            if *e == 0 {
+                ready.push((Reverse(succ.index()), succ));
+            }
+        }
+    }
+
+    // 2. Map <node-id> → <egglog var name>
+    let mut names: HashMap<NodeIndex, String> = HashMap::new();
+    // Pre-size output to avoid growth reallocations; ops emit ~100-200 chars each.
+    let mut out = String::with_capacity(topo_order.len() * 160);
+
+    use std::fmt::Write;
+    let mut curr_id = 0;
+    for n in topo_order {
+        let sources: Vec<(NodeIndex, String)> = graph
+            .get_sources(n)
+            .into_iter()
+            .map(|src| (src, names[&src].clone()))
+            .collect_vec();
+        let code = graph[n].to_egglog(&sources);
+        // write!() into the existing buffer skips the intermediate String
+        // that format! would otherwise allocate for each node.
+        let _ = writeln!(out, "(let t{curr_id} {code})");
+        names.insert(n, format!("t{curr_id}"));
+        curr_id += 1;
+    }
+
+    // Join outputs using dummy op
+    let names = graph
+        .externals(Direction::Outgoing)
+        .map(|n| names.remove(&n).unwrap())
+        .collect_vec();
+    let mut root = names[0].clone();
+    for node in names.into_iter().skip(1) {
+        curr_id += 1;
+        let _ = writeln!(out, "(let t{curr_id} (OutputJoin {root} {node}))");
+        root = format!("t{curr_id}");
+    }
+    (out.replace("(MVar \"z\")", "(MIter)"), root)
+}
+
+pub fn elist_to_egglog(shape: &[Expression]) -> String {
+    list_to_egglog(
+        &shape.iter().map(|e| e.to_egglog()).collect_vec(),
+        "ECons",
+        "ENil",
+    )
+}
+
+pub fn list_to_egglog(list: &[impl ToString], cons: &str, nil: &str) -> String {
+    if list.is_empty() {
+        format!("({nil})")
+    } else {
+        format!(
+            "({cons} {} {})",
+            list[0].to_string(),
+            list_to_egglog(&list[1..], cons, nil)
+        )
+    }
+}
+
+fn stage_report(egraph: &egglog::EGraph, total_time: Duration) -> EgglogStageReport {
+    let run_report = egraph.get_overall_run_report();
+    EgglogStageReport {
+        num_matches_per_rule: run_report
+            .num_matches_per_rule
+            .iter()
+            .map(|(name, matches)| (name.to_string(), *matches))
+            .collect(),
+        search_and_apply_time_per_rule: run_report
+            .search_and_apply_time_per_rule
+            .iter()
+            .map(|(name, elapsed)| (name.to_string(), *elapsed))
+            .collect(),
+        total_time,
+    }
+}
+
+fn trace_stage_report(header: &str, report: &EgglogStageReport) {
+    trace!("{}", header.green());
+    trace!(
+        "{}",
+        report
+            .num_matches_per_rule
+            .iter()
+            .filter(|(k, _)| !k.contains("("))
+            .map(|(k, v)| format!(
+                "{k}: {v} ({})",
+                pretty_duration::pretty_duration(&report.search_and_apply_time_per_rule[k], None)
+            ))
+            .join("\n")
+            .green()
+    );
+    trace!(
+        "{}",
+        format!(
+            "---- {} Took {} ----",
+            header,
+            pretty_duration::pretty_duration(&report.total_time, None).bold()
+        )
+        .green()
+    );
+}
+
+fn metric_duration(duration: Duration) -> String {
+    pretty_duration::pretty_duration(&duration, None)
+}
+
+/// Extra per-rule / per-ruleset printing. Requires the normal egglog log
+/// channel plus `EGGLOG_DEBUG=1`.
+fn egglog_debug() -> bool {
+    std::env::var("EGGLOG_DEBUG").is_ok_and(|v| !v.is_empty() && v != "0")
+}
+
+fn metric_name(name: &str) -> String {
+    let mut name = name.split_whitespace().join(" ");
+    if name.len() > 96 {
+        name.truncate(93);
+        name.push_str("...");
+    }
+    name
+}
+
+fn sorted_rule_metrics(report: &egglog_reports::RunReport) -> Vec<(String, Duration, usize)> {
+    let mut rules = report
+        .search_and_apply_time_per_rule
+        .iter()
+        .map(|(rule, elapsed)| {
+            (
+                rule.to_string(),
+                *elapsed,
+                report
+                    .num_matches_per_rule
+                    .get(rule)
+                    .copied()
+                    .unwrap_or_default(),
+            )
+        })
+        .collect_vec();
+    rules.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| b.2.cmp(&a.2)));
+    rules
+}
+
+fn print_rule_plan_hotspots(
+    report: &egglog_reports::RunReport,
+    rules: &[(String, Duration, usize)],
+) {
+    for (rule, _, _) in rules.iter().take(3) {
+        let mut max_stage = None;
+        let mut max_shape = None;
+        for iteration in &report.iterations {
+            if let Some(rule_reports) = iteration.rule_reports().get(rule.as_str()) {
+                for rule_report in rule_reports {
+                    if let Some(plan) = &rule_report.plan {
+                        let scans = plan
+                            .stages
+                            .iter()
+                            .map(|(stage, _, _)| match stage {
+                                egglog_reports::Stage::Intersect { scans } => scans.len(),
+                                egglog_reports::Stage::FusedIntersect { to_intersect, .. } => {
+                                    to_intersect.len() + 1
+                                }
+                            })
+                            .sum::<usize>();
+                        max_shape = Some(
+                            max_shape
+                                .map(|(stages, shape_scans)| {
+                                    if plan.stages.len() > stages {
+                                        (plan.stages.len(), scans)
+                                    } else {
+                                        (stages, shape_scans)
+                                    }
+                                })
+                                .unwrap_or((plan.stages.len(), scans)),
+                        );
+                        for (_, stats, _) in &plan.stages {
+                            if let Some(stats) = stats {
+                                if max_stage
+                                    .map(|(candidates, _)| stats.num_candidates > candidates)
+                                    .unwrap_or(true)
+                                {
+                                    max_stage = Some((stats.num_candidates, stats.num_succeeded));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if let Some((stages, scans)) = max_shape {
+            eprintln!(
+                "      plan    {:<96} stages {:>2} scans {:>2} | max candidates {}",
+                metric_name(rule),
+                stages,
+                scans,
+                max_stage
+                    .map(|(candidates, succeeded)| format!("{candidates} -> {succeeded}"))
+                    .unwrap_or_else(|| "n/a".to_string())
+            );
+        }
+    }
+}
+
+fn print_slow_phase_detail(
+    phase: &EgglogSchedulePhase,
+    report: &egglog_reports::RunReport,
+    tuple_delta: isize,
+    elapsed: Duration,
+    rules: &[(String, Duration, usize)],
+) {
+    eprintln!("      detail  schedule {}", metric_name(&phase.schedule));
+    if tuple_delta > 0 && elapsed > Duration::ZERO {
+        eprintln!(
+            "      detail  growth {:.0} tuples/s | {:.3} ms/new tuple",
+            tuple_delta as f64 / elapsed.as_secs_f64(),
+            elapsed.as_secs_f64() * 1_000.0 / tuple_delta as f64
+        );
+    }
+    for (rule, elapsed, _) in rules
+        .iter()
+        .filter(|(_, elapsed, matches)| *elapsed > Duration::ZERO && *matches == 0)
+        .take(5)
+    {
+        eprintln!(
+            "      zero    {:<96} {:>10}",
+            metric_name(rule),
+            metric_duration(*elapsed)
+        );
+    }
+    let mut per_match = rules
+        .iter()
+        .filter(|(_, elapsed, matches)| *elapsed > Duration::ZERO && *matches > 0)
+        .map(|(rule, elapsed, matches)| {
+            (
+                rule,
+                elapsed.as_secs_f64() * 1_000.0 / *matches as f64,
+                *matches,
+            )
+        })
+        .collect_vec();
+    per_match.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    for (rule, ms_per_match, matches) in per_match.into_iter().take(3) {
+        eprintln!(
+            "      cost    {:<96} {:.3} ms/match | matches {}",
+            metric_name(rule),
+            ms_per_match,
+            matches
+        );
+    }
+    print_rule_plan_hotspots(report, rules);
+
+    let iteration_count = report.iterations.len();
+    for (index, iteration) in report.iterations.iter().enumerate() {
+        if iteration_count > 12 && (8..iteration_count.saturating_sub(3)).contains(&index) {
+            if index == 8 {
+                eprintln!("      iter   ...");
+            }
+            continue;
+        }
+        let (rule, elapsed, matches) = iteration
+            .rule_reports()
+            .iter()
+            .map(|(rule, reports)| {
+                (
+                    rule.to_string(),
+                    reports
+                        .iter()
+                        .map(|report| report.search_and_apply_time)
+                        .sum::<Duration>(),
+                    reports
+                        .iter()
+                        .map(|report| report.num_matches)
+                        .sum::<usize>(),
+                )
+            })
+            .max_by(|a, b| a.1.cmp(&b.1).then_with(|| a.2.cmp(&b.2)))
+            .unwrap_or_else(|| ("-".to_string(), Duration::ZERO, 0));
+        eprintln!(
+            "      iter   {:>2} changed={} | search {:>10} | merge {:>10} | rebuild {:>10} | top {:<64} {:>10} matches {}",
+            index + 1,
+            iteration.changed(),
+            metric_duration(iteration.search_and_apply_time()),
+            metric_duration(iteration.rule_set_report.merge_time),
+            metric_duration(iteration.rebuild_time),
+            metric_name(&rule),
+            metric_duration(elapsed),
+            matches
+        );
+    }
+}
+
+fn print_run_summary_with_log(run_report: &EgglogRunReport, log: bool) {
+    if !log {
+        return;
+    }
+    eprintln!(
+        "{}",
+        format!(
+            "   Egglog summary total {} | phases {}",
+            metric_duration(run_report.total_time),
+            run_report.phases.len()
+        )
+        .cyan()
+    );
+    if !egglog_debug() {
+        return;
+    }
+    let mut phases = run_report.phases.iter().collect_vec();
+    phases.sort_by_key(|phase| std::cmp::Reverse(phase.total_time));
+    for phase in phases.into_iter().take(5) {
+        eprintln!(
+            "      phase   {:<28} {:>10} | tuples {:+} | iterations {}",
+            metric_name(&phase.name),
+            metric_duration(phase.total_time),
+            phase.tuples_after as isize - phase.tuples_before as isize,
+            phase.iterations
+        );
+    }
+    let mut growth = run_report
+        .phases
+        .iter()
+        .map(|phase| {
+            (
+                phase,
+                phase.tuples_after as isize - phase.tuples_before as isize,
+            )
+        })
+        .filter(|(_, delta)| *delta > 0)
+        .collect_vec();
+    growth.sort_by_key(|(_, delta)| std::cmp::Reverse(*delta));
+    for (phase, delta) in growth.into_iter().take(3) {
+        eprintln!(
+            "      growth  {:<28} tuples {:+} | {}",
+            metric_name(&phase.name),
+            delta,
+            metric_duration(phase.total_time)
+        );
+    }
+    let mut rules = run_report
+        .full
+        .search_and_apply_time_per_rule
+        .iter()
+        .map(|(rule, elapsed)| {
+            (
+                rule,
+                *elapsed,
+                run_report
+                    .full
+                    .num_matches_per_rule
+                    .get(rule)
+                    .copied()
+                    .unwrap_or_default(),
+            )
+        })
+        .collect_vec();
+    rules.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| b.2.cmp(&a.2)));
+    for (rule, elapsed, matches) in rules
+        .iter()
+        .filter(|(_, elapsed, matches)| *elapsed > Duration::ZERO || *matches > 0)
+        .take(8)
+    {
+        eprintln!(
+            "      slow    {:<96} {:>10} | matches {}",
+            metric_name(rule),
+            metric_duration(*elapsed),
+            matches
+        );
+    }
+    for (rule, elapsed, _) in rules
+        .iter()
+        .filter(|(_, elapsed, matches)| *elapsed > Duration::ZERO && *matches == 0)
+        .take(8)
+    {
+        eprintln!(
+            "      zero    {:<96} {:>10}",
+            metric_name(rule),
+            metric_duration(*elapsed)
+        );
+    }
+}
+
+fn print_serialized_shape_with_log(s: &egglog::SerializeOutput, log: bool) {
+    if !log || !egglog_debug() {
+        return;
+    }
+    let mut classes = FxHashSet::default();
+    let mut labels: FxHashMap<String, usize> = FxHashMap::default();
+    let mut nodes = 0;
+    for node in s.egraph.nodes.values().filter(|node| !node.subsumed) {
+        nodes += 1;
+        classes.insert(node.eclass.clone());
+        *labels.entry(node.op.clone()).or_default() += 1;
+    }
+    let mut labels = labels.into_iter().collect_vec();
+    labels.sort_by_key(|(_, count)| std::cmp::Reverse(*count));
+    eprintln!(
+        "{}",
+        format!(
+            "   Egglog extract root shape nodes={} classes={} roots={} top_ops={}",
+            nodes,
+            classes.len(),
+            s.egraph.root_eclasses.len(),
+            labels
+                .into_iter()
+                .take(8)
+                .map(|(label, count)| format!("{}={}", metric_name(&label), count))
+                .join(", ")
+        )
+        .cyan()
+    );
+}
+
+fn run_schedule_phase(
+    egraph: &mut egglog::EGraph,
+    phases: &mut Vec<EgglogPhaseReport>,
+    phase: &EgglogSchedulePhase,
+    log: bool,
+) -> Result<bool, egglog::Error> {
+    let command = format!("(run-schedule {})", phase.schedule);
+    let tuples_before = egraph.num_tuples();
+    let start = std::time::Instant::now();
+    let outputs = egraph.parse_and_run_program(None, &command)?;
+    let elapsed = start.elapsed();
+    let tuples_after = egraph.num_tuples();
+
+    let report = outputs
+        .into_iter()
+        .find_map(|output| match output {
+            CommandOutput::RunSchedule(report) => Some(report),
+            _ => None,
+        })
+        .expect("run-schedule did not return a report");
+
+    let updated = report.updated;
+    let iterations = report.iterations.len();
+    let tuple_delta = tuples_after as isize - tuples_before as isize;
+    if log {
+        eprintln!(
+            "{}",
+            format!(
+                "   Egglog {:<28} {:>10} | tuples {} -> {} ({:+}) | updated={} | iterations={}",
+                phase.name,
+                metric_duration(elapsed),
+                tuples_before,
+                tuples_after,
+                tuple_delta,
+                updated,
+                iterations,
+            )
+            .cyan()
+        );
+    }
+
+    if log && egglog_debug() {
+        let mut rulesets = report
+            .search_and_apply_time_per_ruleset
+            .keys()
+            .chain(report.merge_time_per_ruleset.keys())
+            .chain(report.rebuild_time_per_ruleset.keys())
+            .map(|ruleset| ruleset.to_string())
+            .unique()
+            .collect_vec();
+        let ruleset_total = |ruleset: &str| {
+            report
+                .search_and_apply_time_per_ruleset
+                .get(ruleset)
+                .copied()
+                .unwrap_or(Duration::ZERO)
+                + report
+                    .merge_time_per_ruleset
+                    .get(ruleset)
+                    .copied()
+                    .unwrap_or(Duration::ZERO)
+                + report
+                    .rebuild_time_per_ruleset
+                    .get(ruleset)
+                    .copied()
+                    .unwrap_or(Duration::ZERO)
+        };
+        rulesets.sort_by_key(|ruleset| std::cmp::Reverse(ruleset_total(ruleset)));
+        for ruleset in rulesets.into_iter().take(4) {
+            let search = report
+                .search_and_apply_time_per_ruleset
+                .get(ruleset.as_str())
+                .copied()
+                .unwrap_or(Duration::ZERO);
+            let merge = report
+                .merge_time_per_ruleset
+                .get(ruleset.as_str())
+                .copied()
+                .unwrap_or(Duration::ZERO);
+            let rebuild = report
+                .rebuild_time_per_ruleset
+                .get(ruleset.as_str())
+                .copied()
+                .unwrap_or(Duration::ZERO);
+            eprintln!(
+                "      ruleset {:<18} search {:>10} | merge {:>10} | rebuild {:>10}",
+                metric_name(&ruleset),
+                metric_duration(search),
+                metric_duration(merge),
+                metric_duration(rebuild)
+            );
+        }
+
+        let rules = sorted_rule_metrics(&report);
+        for (rule, elapsed, matches) in rules
+            .iter()
+            .filter(|(_, elapsed, matches)| *elapsed > Duration::ZERO || *matches > 0)
+            .take(5)
+        {
+            eprintln!(
+                "      rule    {:<96} {:>10} | matches {}",
+                metric_name(rule),
+                metric_duration(*elapsed),
+                matches
+            );
+        }
+        if elapsed >= SLOW_PHASE_TIME || tuple_delta.abs() >= BIG_TUPLE_DELTA {
+            print_slow_phase_detail(phase, &report, tuple_delta, elapsed, &rules);
+        }
+    }
+
+    phases.push(EgglogPhaseReport {
+        name: phase.name.clone(),
+        schedule: phase.schedule.clone(),
+        updated,
+        iterations,
+        tuples_before,
+        tuples_after,
+        total_time: elapsed,
+    });
+
+    Ok(updated)
+}
+
+#[tracing::instrument(skip_all)]
+pub fn run_egglog_with_report(
+    program: &str,
+    root: &str,
+    ops: &[Arc<Box<dyn EgglogOp>>],
+    cleanup: bool,
+) -> Result<(SerializedEGraph, EgglogRunReport), egglog::Error> {
+    let op_parts = OpTextParts::new(ops, cleanup);
+    run_egglog_with_report_parts(program, root, &op_parts)
+}
+
+#[tracing::instrument(skip_all)]
+pub fn run_egglog_with_report_and_late_passes(
+    program: &str,
+    root: &str,
+    ops: &[Arc<Box<dyn EgglogOp>>],
+    cleanup: bool,
+    late_passes: &[LateEgglogPass],
+) -> Result<(SerializedEGraph, EgglogRunReport), egglog::Error> {
+    let op_parts = OpTextParts::new_with_late_passes(ops, cleanup, late_passes);
+    run_egglog_with_report_parts(program, root, &op_parts)
+}
+
+#[tracing::instrument(skip_all)]
+pub fn run_egglog_with_report_late_passes_and_interval_analysis(
+    program: &str,
+    root: &str,
+    ops: &[Arc<Box<dyn EgglogOp>>],
+    cleanup: bool,
+    late_passes: &[LateEgglogPass],
+    use_interval_analysis: bool,
+) -> Result<(SerializedEGraph, EgglogRunReport), egglog::Error> {
+    // This convenience wrapper doesn't expose the backend extra-egglog hook;
+    // the Rt-aware path (Graph::build_search_space) is what threads it.
+    run_egglog_with_report_late_passes_interval_analysis_and_log(
+        program,
+        root,
+        ops,
+        cleanup,
+        late_passes,
+        "",
+        use_interval_analysis,
+        log_channel_enabled(false, "EGGLOG_LOG"),
+    )
+}
+
+#[tracing::instrument(skip_all)]
+#[allow(clippy::too_many_arguments)]
+pub fn run_egglog_with_report_late_passes_interval_analysis_and_log(
+    program: &str,
+    root: &str,
+    ops: &[Arc<Box<dyn EgglogOp>>],
+    cleanup: bool,
+    late_passes: &[LateEgglogPass],
+    extra_egglog: &str,
+    use_interval_analysis: bool,
+    log: bool,
+) -> Result<(SerializedEGraph, EgglogRunReport), egglog::Error> {
+    let mut op_parts = OpTextParts::new_with_late_passes(ops, cleanup, late_passes);
+    op_parts.extra_egglog = extra_egglog.to_string();
+    run_egglog_with_report_parts_impl(program, root, &op_parts, use_interval_analysis, log)
+}
+
+/// Same as [`run_egglog_with_report`], but takes pre-computed [`OpTextParts`].
+/// Useful when a caller runs many egglog invocations with the same op set
+/// and wants to factor the op-derived text work out of a parallel loop.
+/// Takes only `&str` / `&OpTextParts` inputs so the whole function is `Send`.
+#[tracing::instrument(skip_all)]
+pub fn run_egglog_with_report_parts(
+    program: &str,
+    root: &str,
+    op_parts: &OpTextParts,
+) -> Result<(SerializedEGraph, EgglogRunReport), egglog::Error> {
+    run_egglog_with_report_parts_impl(
+        program,
+        root,
+        op_parts,
+        false,
+        log_channel_enabled(false, "EGGLOG_LOG"),
+    )
+}
+
+fn run_egglog_with_report_parts_impl(
+    program: &str,
+    root: &str,
+    op_parts: &OpTextParts,
+    use_interval_analysis: bool,
+    log: bool,
+) -> Result<(SerializedEGraph, EgglogRunReport), egglog::Error> {
+    #[cfg(debug_assertions)]
+    {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        static WARNED_DEBUG_EGGLOG: AtomicBool = AtomicBool::new(false);
+        if log && !WARNED_DEBUG_EGGLOG.swap(true, Ordering::Relaxed) {
+            eprintln!(
+                "{}",
+                "   Egglog warning: running in a debug build; model-sized saturation can be very slow. Use `cargo run --release ...` for CUDA model examples."
+                    .yellow()
+            );
+        }
+    }
+
+    let total_start = std::time::Instant::now();
+
+    let full_start = std::time::Instant::now();
+    let setup_text_start = std::time::Instant::now();
+    let setup_code = egglog_setup_with_options(program, op_parts, use_interval_analysis);
+    let setup_text_elapsed = setup_text_start.elapsed();
+    let setup_lines = setup_code.lines().count();
+    let mut egraph = egglog::EGraph::default();
+    egraph.set_report_level(ReportLevel::WithPlan);
+    let setup_start = std::time::Instant::now();
+    let setup_tuples_before = egraph.num_tuples();
+    let parse_start = std::time::Instant::now();
+    let commands = egraph.parser.get_program_from_string(None, &setup_code)?;
+    let parse_elapsed = parse_start.elapsed();
+    trace!("{}", "Egglog setup running...".green());
+    let setup_run_start = std::time::Instant::now();
+    let _outputs = egraph.run_program(commands)?;
+    let setup_run_elapsed = setup_run_start.elapsed();
+    let setup_tuples_after = egraph.num_tuples();
+
+    if log {
+        eprintln!(
+            "{}",
+            format!(
+                "   Egglog {:<28} {:>10} | text {} parse {} run {} | lines {} bytes {} | tuples {} -> {} ({:+})",
+                "setup",
+                metric_duration(setup_start.elapsed()),
+                metric_duration(setup_text_elapsed),
+                metric_duration(parse_elapsed),
+                metric_duration(setup_run_elapsed),
+                setup_lines,
+                setup_code.len(),
+                setup_tuples_before,
+                setup_tuples_after,
+                setup_tuples_after as isize - setup_tuples_before as isize,
+            )
+            .cyan()
+        );
+    }
+
+    trace!("{}", "Egglog running...".green());
+    let mut phases = Vec::new();
+    let mut reached_fixed_point = false;
+    for cycle in 1..=MAIN_SCHEDULE_MAX_CYCLES {
+        let mut cycle_updated = false;
+        for phase in egglog_main_cycle_phases(cycle, use_interval_analysis) {
+            cycle_updated |= run_schedule_phase(&mut egraph, &mut phases, &phase, log)?;
+        }
+        if egraph.num_tuples() > MAIN_SCHEDULE_MAX_TUPLES {
+            return Err(egglog::Error::BackendError(format!(
+                "egglog saturation exceeded tuple budget: {} > {}",
+                egraph.num_tuples(),
+                MAIN_SCHEDULE_MAX_TUPLES
+            )));
+        }
+        if !cycle_updated {
+            reached_fixed_point = true;
+            break;
+        }
+    }
+    if !reached_fixed_point {
+        return Err(egglog::Error::BackendError(format!(
+            "egglog saturation did not reach a fixed point within {MAIN_SCHEDULE_MAX_CYCLES} cycles"
+        )));
+    }
+    for phase in egglog_final_phases(use_interval_analysis) {
+        run_schedule_phase(&mut egraph, &mut phases, &phase, log)?;
+    }
+    for phase in &op_parts.late_phases {
+        run_schedule_phase(&mut egraph, &mut phases, phase, log)?;
+    }
+    let full_report = stage_report(&egraph, full_start.elapsed());
+    trace_stage_report("---- Egglog Rule Matches ----", &full_report);
+
+    let run_report = EgglogRunReport {
+        full: full_report,
+        phases,
+        total_time: total_start.elapsed(),
+    };
+    print_run_summary_with_log(&run_report, log);
+    trace!(
+        "{}",
+        format!(
+            "---- Egglog Total Took {} ----",
+            pretty_duration::pretty_duration(&run_report.total_time, None).bold()
+        )
+        .green()
+    );
+
+    let (sort, value) = egraph.eval_expr(&var!(root))?;
+    let s = egraph.serialize(egglog::SerializeConfig {
+        root_eclasses: vec![(sort, value)],
+        max_functions: None,
+        include_temporary_functions: false,
+        max_calls_per_function: None,
+    });
+    print_serialized_shape_with_log(&s, log);
+    // Convert to SerializedEGraph
+    let mut classes = FxHashMap::default();
+    for (node_id, node) in s.egraph.nodes.iter().filter(|(_, node)| !node.subsumed) {
+        classes
+            .entry(node.eclass.clone())
+            .or_insert(vec![])
+            .push(node_id.clone())
+    }
+    let mut egraph = SerializedEGraph {
+        roots: s.egraph.root_eclasses,
+        node_to_class: s
+            .egraph
+            .nodes
+            .iter()
+            .filter(|(_, enode)| !enode.subsumed)
+            .map(|(n, enode)| (n.clone(), enode.eclass.clone()))
+            .collect(),
+        enodes: s
+            .egraph
+            .nodes
+            .iter()
+            .filter(|(_, enode)| !enode.subsumed)
+            .map(|(n, enode)| {
+                (
+                    n.clone(),
+                    (
+                        enode.op.clone(),
+                        enode
+                            .children
+                            .iter()
+                            .map(|n| s.egraph.nodes[n].eclass.clone())
+                            .collect(),
+                    ),
+                )
+            })
+            .collect(),
+        eclasses: s
+            .egraph
+            .class_data
+            .iter()
+            .filter_map(|(c, eclass)| {
+                classes
+                    .get(c)
+                    .map(|nodes| (c.clone(), (eclass.typ.clone().unwrap(), nodes.clone())))
+            })
+            .collect(),
+    };
+    // Strip out all [...] enodes
+    egraph.enodes.retain(|_, (label, _)| label != "[...]");
+
+    // Conditional cleanup: an `Op` enode in our IR has the shape
+    // `Op (OpKind ...) (IList ...)`. The first child of `Op` is an OpKind
+    // eclass; the OpKind enode's label tells us whether it's an HLIR op
+    // (e.g. "MulKind") or a backend op (e.g. "FusionEndKind"). The egglog
+    // `cleanup` ruleset can over-delete by removing HLIR variants that have
+    // no kernel alternative (e.g. when dtype propagation didn't reach the
+    // sub-expression). On conv-heavy graphs that drops Op eclasses to empty
+    // and cascades all the way to the root with "No valid graphs present in
+    // the e-graph!".
+    //
+    // We now perform cleanup here in Rust where it's safe: for every Op
+    // eclass we look at the OpKind eclasses each Op points at, and strip
+    // Op enodes whose kind is cleanable only if a non-cleanable kind exists
+    // somewhere in the same Op eclass.
+    let cleanable = &op_parts.cleanable_op_names;
+    if !cleanable.is_empty() {
+        // For each OpKind eclass, find the unique kind label (if any).
+        // OpKind eclasses contain enodes like (MulKind ...) / (FusionEndKind ...).
+        let mut opkind_class_kinds: FxHashMap<egraph_serialize::ClassId, FxHashSet<String>> =
+            FxHashMap::default();
+        for (nid, (label, _)) in &egraph.enodes {
+            let cid = &egraph.node_to_class[nid];
+            // The opkind labels come straight from the serializer's `op` field.
+            opkind_class_kinds
+                .entry(cid.clone())
+                .or_default()
+                .insert(label.clone());
+        }
+
+        let mut to_strip = Vec::new();
+        // Walk Op enodes and decide which to drop.
+        // For each Op eclass, group its Op enodes by (cleanable | survivor)
+        // based on the OpKind in the first child eclass.
+        let mut op_eclass_status: FxHashMap<
+            egraph_serialize::ClassId,
+            (Vec<egraph_serialize::NodeId>, bool),
+        > = FxHashMap::default();
+        for (nid, (label, children)) in &egraph.enodes {
+            if label != "Op" {
+                continue;
+            }
+            // Identify OpKind via first child eclass.
+            let kind_class = match children.first() {
+                Some(c) => c,
+                None => continue,
+            };
+            let kinds = match opkind_class_kinds.get(kind_class) {
+                Some(k) => k,
+                None => continue,
+            };
+            let cleanable_kind = kinds.iter().all(|k| cleanable.contains(k));
+            let op_class = &egraph.node_to_class[nid];
+            let entry = op_eclass_status
+                .entry(op_class.clone())
+                .or_insert_with(|| (Vec::new(), false));
+            if cleanable_kind {
+                entry.0.push(nid.clone());
+            } else {
+                entry.1 = true;
+            }
+        }
+        for (_op_class, (cleanable_nodes, has_survivor)) in op_eclass_status {
+            if has_survivor {
+                to_strip.extend(cleanable_nodes);
+            }
+        }
+        for nid in to_strip {
+            egraph.enodes.remove(&nid);
+        }
+    }
+
+    for postprocess in &op_parts.late_postprocesses {
+        postprocess(&mut egraph);
+    }
+
+    // Cascade: remove enodes whose children reference empty eclasses
+    loop {
+        let mut to_remove = vec![];
+        for (id, (_, children)) in &egraph.enodes {
+            if children.iter().any(|c| {
+                egraph
+                    .eclasses
+                    .get(c)
+                    .is_none_or(|(_, nodes)| !nodes.iter().any(|n| egraph.enodes.contains_key(n)))
+            }) {
+                to_remove.push(id.clone());
+            }
+        }
+        for n in &to_remove {
+            egraph.enodes.remove(n);
+        }
+        if to_remove.is_empty() {
+            break;
+        }
+    }
+    // Correct the eclass mapping
+    for (_, enodes) in egraph.eclasses.values_mut() {
+        enodes.retain(|n| egraph.enodes.contains_key(n));
+    }
+    egraph.eclasses.retain(|_, (_, c)| !c.is_empty());
+    egraph
+        .node_to_class
+        .retain(|n, _| egraph.enodes.contains_key(n));
+    assert!(
+        egraph.roots.iter().all(|c| egraph.eclasses.contains_key(c)),
+        "No valid graphs present in the e-graph!"
+    );
+
+    Ok((egraph, run_report))
+}
+
+#[tracing::instrument(skip_all)]
+pub fn run_egglog(
+    program: &str,
+    root: &str,
+    ops: &[Arc<Box<dyn EgglogOp>>],
+    cleanup: bool,
+) -> Result<SerializedEGraph, egglog::Error> {
+    run_egglog_with_report(program, root, ops, cleanup).map(|(egraph, _)| egraph)
+}
+
+#[tracing::instrument(skip_all)]
+pub fn run_egglog_with_late_passes(
+    program: &str,
+    root: &str,
+    ops: &[Arc<Box<dyn EgglogOp>>],
+    cleanup: bool,
+    late_passes: &[LateEgglogPass],
+) -> Result<SerializedEGraph, egglog::Error> {
+    run_egglog_with_report_and_late_passes(program, root, ops, cleanup, late_passes)
+        .map(|(egraph, _)| egraph)
+}
+
+#[tracing::instrument(skip_all)]
+pub fn run_egglog_with_late_passes_and_interval_analysis(
+    program: &str,
+    root: &str,
+    ops: &[Arc<Box<dyn EgglogOp>>],
+    cleanup: bool,
+    late_passes: &[LateEgglogPass],
+    use_interval_analysis: bool,
+) -> Result<SerializedEGraph, egglog::Error> {
+    run_egglog_with_report_late_passes_and_interval_analysis(
+        program,
+        root,
+        ops,
+        cleanup,
+        late_passes,
+        use_interval_analysis,
+    )
+    .map(|(egraph, _)| egraph)
+}
+
+#[tracing::instrument(skip_all)]
+#[allow(clippy::too_many_arguments)]
+pub fn run_egglog_with_late_passes_interval_analysis_and_log(
+    program: &str,
+    root: &str,
+    ops: &[Arc<Box<dyn EgglogOp>>],
+    cleanup: bool,
+    late_passes: &[LateEgglogPass],
+    extra_egglog: &str,
+    use_interval_analysis: bool,
+    log: bool,
+) -> Result<SerializedEGraph, egglog::Error> {
+    run_egglog_with_report_late_passes_interval_analysis_and_log(
+        program,
+        root,
+        ops,
+        cleanup,
+        late_passes,
+        extra_egglog,
+        use_interval_analysis,
+        log,
+    )
+    .map(|(egraph, _)| egraph)
+}
+
+/// Same as [`run_egglog`] but takes pre-computed [`OpTextParts`], so the
+/// whole function is `Send`. Used by the parallel grouped-egraphs build.
+#[tracing::instrument(skip_all)]
+pub fn run_egglog_with(
+    program: &str,
+    root: &str,
+    op_parts: &OpTextParts,
+) -> Result<SerializedEGraph, egglog::Error> {
+    run_egglog_with_report_parts(program, root, op_parts).map(|(egraph, _)| egraph)
+}
+
+pub fn extract_expr_list<'a>(
+    egraph: &'a SerializedEGraph,
+    node: &'a NodeId,
+    list_cache: &mut FxHashMap<&'a NodeId, Vec<Expression>>,
+    expr_cache: &mut FxHashMap<&'a NodeId, Expression>,
+) -> Option<Vec<Expression>> {
+    if let Some(l) = list_cache.get(node) {
+        return Some(l.clone());
+    }
+    if egraph.enodes[node].0 == "ENil" {
+        return Some(vec![]);
+    }
+    let eclass = &egraph.enodes[node].1[0];
+    let expr = extract_expr(egraph, &egraph.eclasses[eclass].1[0], expr_cache)?;
+    match egraph.enodes[&egraph.eclasses[&egraph.enodes[node].1[1]].1[0]]
+        .0
+        .as_str()
+    {
+        "ENil" => Some(vec![expr]),
+        "ECons" => {
+            let mut rest = extract_expr_list(
+                egraph,
+                &egraph.eclasses[&egraph.enodes[node].1[1]].1[0],
+                list_cache,
+                expr_cache,
+            )?;
+            rest.insert(0, expr);
+            list_cache.insert(node, rest.clone());
+            Some(rest)
+        }
+        _ => unreachable!(),
+    }
+}
+
+pub fn extract_dtype<'a>(egraph: &'a SerializedEGraph, node: &'a NodeId) -> DType {
+    match egraph.enodes[node].0.as_str() {
+        "F32" => DType::F32,
+        "F64" => DType::F64,
+        "F16" => DType::F16,
+        "Bf16" => DType::Bf16,
+        "Int" => DType::Int,
+        // `"Int64"` rather than `"I64"` to avoid colliding with egglog's
+        // built-in I64 primitive (see `DType::I64` docstring).
+        "Int64" => DType::I64,
+        "Bool" => DType::Bool,
+        "F4E2M1" => DType::F4E2M1,
+        "F6E2M3" => DType::F6E2M3,
+        "F6E3M2" => DType::F6E3M2,
+        "F8E4M3" => DType::F8E4M3,
+        "F8E5M2" => DType::F8E5M2,
+        "F8UE8M0" => DType::F8UE8M0,
+        "I4" => DType::I4,
+        "U4" => DType::U4,
+        "I8" => DType::I8,
+        "U8" => DType::U8,
+        "I16" => DType::I16,
+        "U16" => DType::U16,
+        "TF32" => DType::TF32,
+        other => panic!("unknown dtype {other}"),
+    }
+}
+
+/// Decode the op label of an egglog String-primitive e-node into its name.
+///
+/// egglog spells these either `Boxed("name")` or as a bare quoted `"name"`
+/// depending on the sort. Stripped anchored, so a name whose content contains
+/// `")` or `Boxed("` survives intact.
+fn decode_string_literal_op(op: &str) -> Option<String> {
+    let body = op
+        .strip_prefix("Boxed(")
+        .and_then(|s| s.strip_suffix(')'))
+        .unwrap_or(op);
+    let inner = body.strip_prefix('"')?.strip_suffix('"')?;
+    Some(inner.to_string())
+}
+
+pub fn extract_expr<'a>(
+    egraph: &'a SerializedEGraph,
+    node: &'a NodeId,
+    expr_cache: &mut FxHashMap<&'a NodeId, Expression>,
+) -> Option<Expression> {
+    if let Some(e) = expr_cache.get(node) {
+        return Some(*e);
+    }
+
+    fn extract_shortest<'a>(
+        egraph: &'a SerializedEGraph,
+        class: &'a ClassId,
+        seen: &mut FxHashMap<&'a NodeId, usize>,
+        cache: &mut FxHashMap<&'a NodeId, Option<Vec<&'a NodeId>>>,
+    ) -> Option<Vec<&'a NodeId>> {
+        const MAX_CYCLES: usize = 1;
+        egraph.eclasses[class]
+            .1
+            .iter()
+            .filter_map(|en| {
+                if *seen.get(en).unwrap_or(&0) >= MAX_CYCLES || egraph.enodes[en].0 == "[...]" {
+                    return None;
+                }
+                if let Some(c) = cache.get(en) {
+                    return c.clone();
+                }
+                *seen.entry(en).or_insert(0) += 1;
+                let out = if egraph.enodes[en].1.is_empty() {
+                    Some(vec![en])
+                } else {
+                    egraph.enodes[en]
+                        .1
+                        .iter()
+                        .try_fold(vec![en], |mut acc, ch| {
+                            extract_shortest(egraph, ch, seen, cache).map(|p| {
+                                acc.extend(p);
+                                acc
+                            })
+                        })
+                };
+                *seen.get_mut(en).unwrap() -= 1;
+                cache.insert(en, out.clone());
+                out
+            })
+            .min_by_key(|p| p.len())
+    }
+
+    let traj = extract_shortest(
+        egraph,
+        &egraph.node_to_class[node],
+        &mut FxHashMap::default(),
+        &mut FxHashMap::default(),
+    )?;
+    fn build_expression(
+        egraph: &SerializedEGraph,
+        trajectory: &[&NodeId],
+        current: &mut usize,
+    ) -> Expression {
+        let nid = trajectory[*current];
+        let op = egraph.enodes[nid].0.as_str();
+        match op {
+            // unary math
+            "MNeg" | "MRecip" => {
+                *current += 1;
+                let c0 = build_expression(egraph, trajectory, current);
+                match op {
+                    "MNeg" => c0 * -1,
+                    "MRecip" => 1 / c0,
+                    _ => unreachable!(),
+                }
+            }
+            // binary math
+            "MAdd" | "MSub" | "MMul" | "MDiv" | "MMod" | "MMin" | "MMax" | "MAnd" | "MOr"
+            | "MGte" | "MLt" | "MFloorTo" | "MCeilDiv" => {
+                *current += 1;
+                let lhs = build_expression(egraph, trajectory, current);
+                *current += 1;
+                let rhs = build_expression(egraph, trajectory, current);
+                match op {
+                    "MAdd" => lhs + rhs,
+                    "MSub" => lhs - rhs,
+                    "MMul" => lhs * rhs,
+                    "MDiv" => lhs / rhs,
+                    "MMod" => lhs % rhs,
+                    "MMin" => lhs.min(rhs),
+                    "MMax" => lhs.max(rhs),
+                    "MAnd" => lhs & rhs,
+                    "MOr" => lhs | rhs,
+                    "MGte" => lhs.gte(rhs),
+                    "MLt" => lhs.lt(rhs),
+                    "MCeilDiv" => lhs.ceil_div(rhs),
+                    "MFloorTo" => lhs / rhs * rhs, // TODO: real floorto in Expression
+                    _ => unreachable!(),
+                }
+            }
+            // wrappers around a literal/var child
+            "MNum" | "MVar" => {
+                *current += 1;
+                build_expression(egraph, trajectory, current)
+            }
+            "MIter" => Expression::from(crate::shape::Symbol::reserved_index()),
+            op => {
+                if let Some(name) = decode_string_literal_op(op) {
+                    Expression::from(crate::shape::symbol_from_egglog_name(&name))
+                } else if let Ok(n) = op.parse::<i64>() {
+                    Expression::from(n)
+                } else {
+                    panic!(
+                        "unsupported expression op '{op}': expected an integer, or a dim \
+                         name quoted as \"name\" / Boxed(\"name\")"
+                    )
+                }
+            }
+        }
+    }
+    let e = build_expression(egraph, &traj, &mut 0);
+    expr_cache.insert(node, e);
+    Some(e)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct InternedIdKey {
+    data: usize,
+    len: usize,
+}
+
+impl InternedIdKey {
+    fn new(id: &impl AsRef<str>) -> Self {
+        let text = id.as_ref();
+        Self {
+            data: text.as_ptr() as usize,
+            len: text.len(),
+        }
+    }
+}
+
+pub type EGraphChoiceSet<'a> = FxHashMap<&'a ClassId, &'a NodeId>;
+
+type DenseIndex = u32;
+const NO_DENSE_INDEX: DenseIndex = DenseIndex::MAX;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct DenseNode {
+    class: DenseIndex,
+    slot: DenseIndex,
+}
+
+/// Compact search genome used internally by [`LlirExtractor`]. Public
+/// extraction continues to accept [`EGraphChoiceSet`], but the compiler's
+/// hot search loop never has to hash e-graph strings after the initial genome
+/// is converted.
+#[derive(Clone, Debug)]
+pub struct IndexedChoiceSet {
+    choices: Vec<DenseIndex>,
+    hash: u64,
+}
+
+struct IndexedEClass<'a> {
+    id: &'a ClassId,
+    label: &'a str,
+    nodes: &'a [NodeId],
+    searchable: bool,
+}
+
+struct IndexedENode<'a> {
+    id: &'a NodeId,
+    label: &'a str,
+    children: Vec<DenseIndex>,
+}
+
+struct CachedIndexedExtraction {
+    /// Exact selected bindings that can affect this extraction. This lets the
+    /// hot path validate a cached immutable op with direct integer loads,
+    /// without re-walking its OpKind and IList term.
+    dependencies: Box<[(DenseIndex, DenseIndex)]>,
+    op: crate::op::LLIROp,
+    sources: Box<[DenseNode]>,
+}
+
+/// Reusable state for turning many choice sets from the same serialized
+/// e-graph into LLIR graphs.
+///
+/// Search extracts hundreds of candidates from an immutable e-graph.  The
+/// op-name dispatch table and decoded expression metadata are consequently
+/// candidate-independent and should be built once, not rediscovered for
+/// every LLIR node in every candidate.
+pub struct LlirExtractor<'a> {
+    egraph: &'a SerializedEGraph,
+    ops: &'a [Arc<Box<dyn EgglogOp>>],
+    op_by_name: FxHashMap<String, usize>,
+    list_cache: FxHashMap<&'a NodeId, Vec<Expression>>,
+    expr_cache: FxHashMap<&'a NodeId, Expression>,
+    indexed_classes: Vec<IndexedEClass<'a>>,
+    indexed_nodes: Vec<Vec<(DenseIndex, IndexedENode<'a>)>>,
+    indexed_opkind_consistent: Vec<Vec<(DenseIndex, bool)>>,
+    class_to_index: FxHashMap<&'a ClassId, DenseIndex>,
+    root_index: DenseIndex,
+    indexed_extractions: Vec<Vec<(DenseIndex, Vec<CachedIndexedExtraction>)>>,
+    mutation_nodes: Vec<Option<Vec<DenseIndex>>>,
+    visit_epoch: u32,
+    visited: Vec<u32>,
+    reachable: Vec<DenseNode>,
+    reachability_stack: Vec<DenseNode>,
+    graph_nodes: Vec<(u32, usize)>,
+}
+
+#[derive(Clone, Copy)]
+struct CachedENode<'a> {
+    label: &'a str,
+    children: &'a [ClassId],
+    class: &'a ClassId,
+}
+
+#[derive(Clone, Copy)]
+struct CachedEClass<'a> {
+    label: &'a str,
+    nodes: &'a [NodeId],
+}
+
+impl<'a> LlirExtractor<'a> {
+    pub fn new(egraph: &'a SerializedEGraph, ops: &'a [Arc<Box<dyn EgglogOp>>]) -> Self {
+        let started_at = std::time::Instant::now();
+        let op_by_name = ops
+            .iter()
+            .enumerate()
+            .map(|(index, op)| (op.sort().name, index))
+            .collect();
+
+        let mut classes = egraph.eclasses.keys().collect::<Vec<_>>();
+        classes.sort_unstable_by(|left, right| left.as_ref().cmp(right.as_ref()));
+
+        let mut class_to_index = FxHashMap::default();
+        for (index, class) in classes.into_iter().enumerate() {
+            let index = DenseIndex::try_from(index).expect("too many e-classes to index");
+            class_to_index.insert(class, index);
+        }
+        let mut indexed_classes: Vec<Option<IndexedEClass<'a>>> = std::iter::repeat_with(|| None)
+            .take(class_to_index.len())
+            .collect();
+        for (class, (label, nodes)) in &egraph.eclasses {
+            let index = class_to_index[class] as usize;
+            indexed_classes[index] = Some(IndexedEClass {
+                id: class,
+                label,
+                nodes,
+                searchable: is_search_choice_eclass(label),
+            });
+        }
+        let indexed_classes: Vec<IndexedEClass<'a>> = indexed_classes
+            .into_iter()
+            .map(|class| class.expect("indexed e-class slot was not initialized"))
+            .collect();
+        let root_index = class_to_index[&egraph.roots[0]];
+        let serialized_node_count: usize =
+            egraph.eclasses.values().map(|(_, nodes)| nodes.len()).sum();
+        let mutation_nodes = std::iter::repeat_with(|| None)
+            .take(indexed_classes.len())
+            .collect();
+        let indexed_nodes = std::iter::repeat_with(Vec::new)
+            .take(indexed_classes.len())
+            .collect();
+        let indexed_opkind_consistent = std::iter::repeat_with(Vec::new)
+            .take(indexed_classes.len())
+            .collect();
+        let indexed_extractions = std::iter::repeat_with(Vec::new)
+            .take(indexed_classes.len())
+            .collect();
+        let indexed_class_count = indexed_classes.len();
+        let extractor = Self {
+            egraph,
+            ops,
+            op_by_name,
+            list_cache: FxHashMap::default(),
+            expr_cache: FxHashMap::default(),
+            indexed_classes,
+            indexed_nodes,
+            indexed_opkind_consistent,
+            class_to_index,
+            root_index,
+            indexed_extractions,
+            mutation_nodes,
+            visit_epoch: 0,
+            visited: vec![0; indexed_class_count],
+            reachable: Vec::new(),
+            reachability_stack: Vec::new(),
+            graph_nodes: vec![(0, usize::MAX); indexed_class_count],
+        };
+        if llir_profile_enabled() {
+            eprintln!(
+                "LLIR_INDEX_PROFILE total_ms={:.3} classes={} nodes={}",
+                started_at.elapsed().as_secs_f64() * 1e3,
+                extractor.indexed_classes.len(),
+                serialized_node_count,
+            );
+        }
+        extractor
+    }
+
+    fn indexed_selected(&self, choices: &IndexedChoiceSet, class: DenseIndex) -> DenseNode {
+        let class_info = &self.indexed_classes[class as usize];
+        let slot = if class_info.searchable {
+            let selected = choices.choices[class as usize];
+            assert_ne!(
+                selected, NO_DENSE_INDEX,
+                "indexed genome is missing searchable e-class {}",
+                class_info.id
+            );
+            selected
+        } else {
+            0
+        };
+        DenseNode { class, slot }
+    }
+
+    fn indexed_node_id(&self, node: DenseNode) -> &'a NodeId {
+        &self.indexed_classes[node.class as usize].nodes[node.slot as usize]
+    }
+
+    fn dense_node_for_id(&self, id: &NodeId) -> DenseNode {
+        let class_id = &self.egraph.node_to_class[id];
+        let class = self.class_to_index[class_id];
+        let slot = self.indexed_classes[class as usize]
+            .nodes
+            .iter()
+            .position(|candidate| candidate == id)
+            .expect("e-node is missing from its owning e-class");
+        DenseNode {
+            class,
+            slot: DenseIndex::try_from(slot).expect("too many e-nodes in e-class"),
+        }
+    }
+
+    fn indexed_node_parts(&mut self, node: DenseNode) -> (&'a NodeId, &'a str, Vec<DenseIndex>) {
+        let mut position = self.indexed_nodes[node.class as usize]
+            .iter()
+            .position(|(slot, _)| *slot == node.slot);
+        if position.is_none() {
+            let id = self.indexed_node_id(node);
+            let (label, children) = &self.egraph.enodes[id];
+            let indexed = IndexedENode {
+                id,
+                label,
+                children: children
+                    .iter()
+                    .map(|child| self.class_to_index[child])
+                    .collect(),
+            };
+            let class_cache = &mut self.indexed_nodes[node.class as usize];
+            position = Some(class_cache.len());
+            class_cache.push((node.slot, indexed));
+        }
+        let indexed = &self.indexed_nodes[node.class as usize][position.unwrap()].1;
+        (indexed.id, indexed.label, indexed.children.clone())
+    }
+
+    fn indexed_opkind_is_consistent(&mut self, node: DenseNode) -> bool {
+        if let Some((_, consistent)) = self.indexed_opkind_consistent[node.class as usize]
+            .iter()
+            .find(|(slot, _)| *slot == node.slot)
+        {
+            return *consistent;
+        }
+        let consistent = opkind_metadata_consistent(self.egraph, self.indexed_node_id(node));
+        self.indexed_opkind_consistent[node.class as usize].push((node.slot, consistent));
+        consistent
+    }
+
+    fn mutation_pool(&mut self, class: DenseIndex) -> &[DenseIndex] {
+        if self.mutation_nodes[class as usize].is_none() {
+            let class_info = &self.indexed_classes[class as usize];
+            let marker_free: Vec<DenseIndex> = class_info
+                .nodes
+                .iter()
+                .enumerate()
+                .filter(|(_, node)| !enode_is_loop_input_marker(self.egraph, node))
+                .map(|(slot, _)| DenseIndex::try_from(slot).expect("too many e-nodes in e-class"))
+                .collect();
+            let consistent: Vec<DenseIndex> = if class_info.label == "OpKind" {
+                class_info
+                    .nodes
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, node)| opkind_metadata_consistent(self.egraph, node))
+                    .map(|(slot, _)| {
+                        DenseIndex::try_from(slot).expect("too many e-nodes in e-class")
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            let all = || {
+                (0..class_info.nodes.len())
+                    .map(|slot| DenseIndex::try_from(slot).expect("too many e-nodes in e-class"))
+                    .collect()
+            };
+            let pool = if !consistent.is_empty() {
+                let filtered: Vec<DenseIndex> = consistent
+                    .iter()
+                    .copied()
+                    .filter(|node| marker_free.contains(node))
+                    .collect();
+                if filtered.is_empty() {
+                    consistent
+                } else {
+                    filtered
+                }
+            } else if !marker_free.is_empty() {
+                marker_free
+            } else {
+                all()
+            };
+            self.mutation_nodes[class as usize] = Some(pool);
+        }
+        self.mutation_nodes[class as usize].as_deref().unwrap()
+    }
+
+    pub fn index_choice_set(&self, choices: &EGraphChoiceSet<'a>) -> IndexedChoiceSet {
+        let mut indexed = vec![NO_DENSE_INDEX; self.indexed_classes.len()];
+        let mut hash = 0u64;
+        for (&class, &node) in choices {
+            let class_index = self.class_to_index[class];
+            let slot = self.indexed_classes[class_index as usize]
+                .nodes
+                .iter()
+                .position(|candidate| candidate == node)
+                .expect("chosen e-node is not in its e-class");
+            let slot = DenseIndex::try_from(slot).expect("too many e-nodes in e-class");
+            indexed[class_index as usize] = slot;
+            hash ^= hash_choice_entry(class, node);
+        }
+        IndexedChoiceSet {
+            choices: indexed,
+            hash,
+        }
+    }
+
+    pub(crate) fn named_choices(&self, choices: &IndexedChoiceSet) -> Vec<(String, String)> {
+        self.indexed_classes
+            .iter()
+            .enumerate()
+            .filter(|(_, class)| class.searchable)
+            .map(|(index, class)| {
+                let slot = choices.choices[index] as usize;
+                (class.id.to_string(), class.nodes[slot].to_string())
+            })
+            .collect()
+    }
+
+    pub(crate) fn index_named_choices(&self, choices: &[(String, String)]) -> IndexedChoiceSet {
+        let choices = choices
+            .iter()
+            .map(|(class, node)| {
+                let class = self
+                    .egraph
+                    .eclasses
+                    .keys()
+                    .find(|candidate| candidate.as_ref() == class)
+                    .unwrap_or_else(|| panic!("artifact references unknown e-class '{class}'"));
+                let node = self.egraph.eclasses[class]
+                    .1
+                    .iter()
+                    .find(|candidate| candidate.as_ref() == node)
+                    .unwrap_or_else(|| panic!("artifact references unknown e-node '{node}'"));
+                (class, node)
+            })
+            .collect();
+        self.index_choice_set(&choices)
+    }
+
+    pub fn random_indexed_choice(&self, rng: &mut (impl Rng + ?Sized)) -> IndexedChoiceSet {
+        let choices = random_initial_choice(self.egraph, rng);
+        self.index_choice_set(&choices)
+    }
+
+    pub fn random_indexed_generation(
+        &self,
+        generation_size: usize,
+        prev_selected: &mut FxHashSet<u64>,
+        rng: &mut (impl Rng + ?Sized),
+    ) -> Vec<IndexedChoiceSet> {
+        let mut generation = Vec::with_capacity(generation_size);
+        let max_attempts = generation_size.saturating_mul(100);
+        let mut attempts = 0;
+        while generation.len() < generation_size && attempts < max_attempts {
+            attempts += 1;
+            let genome = self.random_indexed_choice(rng);
+            if prev_selected.insert(genome.hash) {
+                generation.push(genome);
+            }
+        }
+        generation
+    }
+
+    pub fn extract_reachable_indexed_generation(
+        &mut self,
+        base: &IndexedChoiceSet,
+        generation_size: usize,
+        mutations_per_generation: usize,
+        prev_selected: &mut FxHashSet<u64>,
+        rng: &mut (impl Rng + ?Sized),
+    ) -> Vec<IndexedChoiceSet> {
+        let mut seen_nodes = FxHashSet::default();
+        let mut seen_classes = FxHashSet::default();
+        let mut mutable_classes = Vec::new();
+        let root = self.root_index;
+        let root_class = &self.indexed_classes[root as usize];
+        if root_class.searchable && root_class.nodes.len() > 1 {
+            seen_classes.insert(root);
+            mutable_classes.push(root);
+        }
+        let mut stack = vec![self.indexed_selected(base, root)];
+        while let Some(node) = stack.pop() {
+            if !seen_nodes.insert(node) {
+                continue;
+            }
+            let (_, _, children) = self.indexed_node_parts(node);
+            for child_class in children {
+                let class = &self.indexed_classes[child_class as usize];
+                if !class.searchable {
+                    continue;
+                }
+                if class.nodes.len() > 1 && seen_classes.insert(child_class) {
+                    mutable_classes.push(child_class);
+                }
+                stack.push(self.indexed_selected(base, child_class));
+            }
+        }
+
+        if mutable_classes.is_empty() {
+            if prev_selected.insert(base.hash) {
+                return vec![base.clone()];
+            }
+            return Vec::new();
+        }
+
+        let mut offspring = Vec::with_capacity(generation_size);
+        let max_attempts = generation_size.saturating_mul(100);
+        let mut attempts = 0;
+        while offspring.len() < generation_size && attempts < max_attempts {
+            attempts += 1;
+            let mut child = base.clone();
+            let mutation_count = rng.random_range(1..=mutations_per_generation.max(1));
+            for _ in 0..mutation_count {
+                let class = mutable_classes[rng.random_range(0..mutable_classes.len())];
+                let new_node = {
+                    let pool = self.mutation_pool(class);
+                    pool[rng.random_range(0..pool.len())]
+                };
+                let old_node = std::mem::replace(&mut child.choices[class as usize], new_node);
+                let class_info = &self.indexed_classes[class as usize];
+                child.hash ^=
+                    hash_choice_entry(class_info.id, &class_info.nodes[old_node as usize]);
+                child.hash ^=
+                    hash_choice_entry(class_info.id, &class_info.nodes[new_node as usize]);
+            }
+            if prev_selected.insert(child.hash) {
+                offspring.push(child);
+            }
+        }
+        offspring
+    }
+
+    /// Extract through integer-indexed e-classes and e-nodes into a dense
+    /// rolled representation. The caller materializes the fully-unrolled
+    /// public `StableGraph` directly from this representation.
+    pub fn extract_indexed_packed(
+        &mut self,
+        choices: &IndexedChoiceSet,
+        custom_ops: &[crate::op::LLIROp],
+    ) -> PackedLLIRGraph {
+        let started_at = std::time::Instant::now();
+        let profile = llir_profile_enabled();
+        let mut cache_hits = 0usize;
+        let mut cache_misses = 0usize;
+        self.visit_epoch = self.visit_epoch.wrapping_add(1);
+        if self.visit_epoch == 0 {
+            self.visited.fill(0);
+            self.visit_epoch = 1;
+        }
+        self.reachable.clear();
+        self.reachability_stack.clear();
+
+        let root = self.indexed_selected(choices, self.root_index);
+        self.visited[root.class as usize] = self.visit_epoch;
+        self.reachable.push(root);
+        self.reachability_stack.push(root);
+        let estimated_nodes = (self.indexed_classes.len() / 4).max(64);
+        let mut ops = Vec::with_capacity(estimated_nodes);
+        let mut incoming_offsets = Vec::with_capacity(estimated_nodes + 1);
+        let mut dense_sources = Vec::with_capacity(estimated_nodes * 6 / 5);
+        let mut input_nodes = Vec::with_capacity(8);
+        let mut kind_children = Vec::with_capacity(8);
+        let mut dependencies = Vec::with_capacity(16);
+        while let Some(node_index) = self.reachability_stack.pop() {
+            self.graph_nodes[node_index.class as usize] = (self.visit_epoch, usize::MAX);
+
+            if self.indexed_classes[node_index.class as usize].label != "IR" {
+                let (_, _, node_children) = self.indexed_node_parts(node_index);
+                for child_class in node_children {
+                    if !self.indexed_classes[child_class as usize].searchable {
+                        continue;
+                    }
+                    let child = self.indexed_selected(choices, child_class);
+                    if self.visited[child.class as usize] != self.visit_epoch {
+                        self.visited[child.class as usize] = self.visit_epoch;
+                        self.reachable.push(child);
+                        self.reachability_stack.push(child);
+                    }
+                }
+                continue;
+            }
+
+            let cached_location = self.indexed_extractions[node_index.class as usize]
+                .iter()
+                .enumerate()
+                .find(|(_, (slot, _))| *slot == node_index.slot)
+                .and_then(|(entry_index, (_, variants))| {
+                    variants
+                        .iter()
+                        .position(|cached| {
+                            cached.dependencies.iter().all(|&(class, selected)| {
+                                self.indexed_selected(choices, class).slot == selected
+                            })
+                        })
+                        .map(|cached_index| (entry_index, cached_index))
+                });
+            if let Some((entry_index, cached_index)) = cached_location {
+                cache_hits += 1;
+                let cached = &self.indexed_extractions[node_index.class as usize][entry_index].1
+                    [cached_index];
+                let graph_node = ops.len();
+                ops.push(cached.op.clone());
+                incoming_offsets.push(dense_sources.len());
+                self.graph_nodes[node_index.class as usize] = (self.visit_epoch, graph_node);
+                dense_sources.extend(cached.sources.iter().copied());
+                for &source in cached.sources.iter() {
+                    if self.visited[source.class as usize] != self.visit_epoch {
+                        self.visited[source.class as usize] = self.visit_epoch;
+                        self.reachable.push(source);
+                        self.reachability_stack.push(source);
+                    }
+                }
+                continue;
+            }
+
+            let (_, node_label, node_children) = self.indexed_node_parts(node_index);
+            if node_label == "OutputJoin" {
+                for child_class in node_children {
+                    if !self.indexed_classes[child_class as usize].searchable {
+                        continue;
+                    }
+                    let child = self.indexed_selected(choices, child_class);
+                    if self.visited[child.class as usize] != self.visit_epoch {
+                        self.visited[child.class as usize] = self.visit_epoch;
+                        self.reachable.push(child);
+                        self.reachability_stack.push(child);
+                    }
+                }
+                continue;
+            }
+
+            input_nodes.clear();
+            kind_children.clear();
+            dependencies.clear();
+            let mut op_index = None;
+            let mut custom_id = None;
+
+            if node_label == "Op" {
+                let kind_class = node_children[0];
+                let ilist_class = node_children[1];
+                let selected_kind_node = self.indexed_selected(choices, kind_class);
+                dependencies.push((kind_class, selected_kind_node.slot));
+                let mut kind_node = selected_kind_node;
+                if !self.indexed_opkind_is_consistent(kind_node) {
+                    let fallback_slot = self.mutation_pool(kind_class).first().copied();
+                    if let Some(slot) = fallback_slot {
+                        kind_node = DenseNode {
+                            class: kind_class,
+                            slot,
+                        };
+                    }
+                }
+                let (_, kind_label, kind_node_children) = self.indexed_node_parts(kind_node);
+                for child_class in kind_node_children {
+                    let selected = self.indexed_selected(choices, child_class);
+                    kind_children.push(selected);
+                    if self.indexed_classes[child_class as usize].searchable {
+                        dependencies.push((child_class, selected.slot));
+                    }
+                }
+
+                let mut current = self.indexed_selected(choices, ilist_class);
+                dependencies.push((ilist_class, current.slot));
+                loop {
+                    let (_, list_label, list_children) = self.indexed_node_parts(current);
+                    if list_label == "INil" {
+                        break;
+                    }
+                    let input_class = list_children[0];
+                    let tail_class = list_children[1];
+                    let input = self.indexed_selected(choices, input_class);
+                    input_nodes.push(input);
+                    dependencies.push((input_class, input.slot));
+                    current = self.indexed_selected(choices, tail_class);
+                    dependencies.push((tail_class, current.slot));
+                }
+
+                if kind_label == "CustomOpKind" {
+                    let id_node = self.indexed_node_id(kind_children[0]);
+                    let id: usize = self.egraph.enodes[id_node].0.parse().unwrap();
+                    custom_id = Some(id);
+                } else {
+                    op_index = Some(
+                        *self
+                            .op_by_name
+                            .get(kind_label)
+                            .unwrap_or_else(|| panic!("{kind_label} extraction not implemented!")),
+                    );
+                }
+            } else {
+                let Some(&index) = self.op_by_name.get(node_label) else {
+                    for child_class in node_children {
+                        if !self.indexed_classes[child_class as usize].searchable {
+                            continue;
+                        }
+                        let child = self.indexed_selected(choices, child_class);
+                        if self.visited[child.class as usize] != self.visit_epoch {
+                            self.visited[child.class as usize] = self.visit_epoch;
+                            self.reachable.push(child);
+                            self.reachability_stack.push(child);
+                        }
+                    }
+                    continue;
+                };
+                op_index = Some(index);
+                for child_class in node_children {
+                    let selected = self.indexed_selected(choices, child_class);
+                    kind_children.push(selected);
+                    if self.indexed_classes[child_class as usize].searchable {
+                        dependencies.push((child_class, selected.slot));
+                    }
+                }
+            }
+
+            cache_misses += 1;
+            let child_refs: Vec<&NodeId> = kind_children
+                .iter()
+                .map(|child| self.indexed_node_id(*child))
+                .collect();
+            let input_refs: Vec<&NodeId> = input_nodes
+                .iter()
+                .map(|input| self.indexed_node_id(*input))
+                .collect();
+            let (op, source_refs) = if let Some(custom_id) = custom_id {
+                (custom_ops[custom_id].clone(), input_refs)
+            } else {
+                self.ops[op_index.unwrap()].extract(
+                    self.egraph,
+                    &child_refs,
+                    input_refs,
+                    &mut self.list_cache,
+                    &mut self.expr_cache,
+                )
+            };
+            let sources: Vec<DenseNode> = source_refs
+                .iter()
+                .map(|source| {
+                    input_nodes
+                        .iter()
+                        .chain(kind_children.iter())
+                        .copied()
+                        .find(|node| self.indexed_node_id(*node) == *source)
+                        .unwrap_or_else(|| self.dense_node_for_id(source))
+                })
+                .collect();
+            let graph_node = ops.len();
+            ops.push(op.clone());
+            incoming_offsets.push(dense_sources.len());
+            self.graph_nodes[node_index.class as usize] = (self.visit_epoch, graph_node);
+            dense_sources.extend(sources.iter().copied());
+            for &source in &sources {
+                if self.visited[source.class as usize] != self.visit_epoch {
+                    self.visited[source.class as usize] = self.visit_epoch;
+                    self.reachable.push(source);
+                    self.reachability_stack.push(source);
+                }
+            }
+            let cached = CachedIndexedExtraction {
+                dependencies: dependencies.clone().into_boxed_slice(),
+                op,
+                sources: sources.into_boxed_slice(),
+            };
+            let class_cache = &mut self.indexed_extractions[node_index.class as usize];
+            if let Some((_, variants)) = class_cache
+                .iter_mut()
+                .find(|(slot, _)| *slot == node_index.slot)
+            {
+                variants.push(cached);
+            } else {
+                class_cache.push((node_index.slot, vec![cached]));
+            }
+        }
+
+        incoming_offsets.push(dense_sources.len());
+        let mut incoming_sources = Vec::with_capacity(dense_sources.len());
+        let mut outgoing_offsets = vec![0usize; ops.len() + 1];
+        for source in dense_sources {
+            let (source_epoch, source) = self.graph_nodes[source.class as usize];
+            assert_eq!(source_epoch, self.visit_epoch, "source e-node is stale");
+            assert_ne!(source, usize::MAX, "source e-node was not materialized");
+            incoming_sources.push(source);
+            outgoing_offsets[source + 1] += 1;
+        }
+        for index in 1..outgoing_offsets.len() {
+            outgoing_offsets[index] += outgoing_offsets[index - 1];
+        }
+        let mut outgoing_cursor = outgoing_offsets[..ops.len()].to_vec();
+        let mut outgoing_targets = vec![usize::MAX; incoming_sources.len()];
+        for destination in 0..ops.len() {
+            for &source in
+                &incoming_sources[incoming_offsets[destination]..incoming_offsets[destination + 1]]
+            {
+                outgoing_targets[outgoing_cursor[source]] = destination;
+                outgoing_cursor[source] += 1;
+            }
+        }
+        if profile {
+            eprintln!(
+                "LLIR_EXTRACT_PROFILE total_ms={:.3} indexed=true cache_hits={} cache_misses={} reachable={} rolled_nodes={} rolled_edges={}",
+                started_at.elapsed().as_secs_f64() * 1e3,
+                cache_hits,
+                cache_misses,
+                self.reachable.len(),
+                ops.len(),
+                incoming_sources.len(),
+            );
+        }
+        PackedLLIRGraph {
+            ops,
+            incoming_offsets,
+            incoming_sources,
+            outgoing_offsets,
+            outgoing_targets,
+        }
+    }
+}
+
+fn is_search_choice_eclass(label: &str) -> bool {
+    label.contains("IR") || label.contains("IList") || label.contains("OpKind")
+}
+
+fn reachable_choice_nodes<'a>(
+    egraph: &'a SerializedEGraph,
+    choices: &EGraphChoiceSet<'a>,
+) -> Result<FxHashSet<&'a NodeId>, String> {
+    let root_class = egraph
+        .roots
+        .first()
+        .ok_or_else(|| "Egraph has no root eclass".to_string())?;
+    let root_choice = *choices
+        .get(root_class)
+        .ok_or_else(|| format!("No choice for root eclass {}", root_class.as_ref()))?;
+    let mut reachable = FxHashSet::default();
+    let mut stack = vec![root_choice];
+    while let Some(node) = stack.pop() {
+        if !reachable.insert(node) {
+            continue;
+        }
+        let (_, children) = egraph
+            .enodes
+            .get(node)
+            .ok_or_else(|| format!("Enode {} not found in egraph", node.as_ref()))?;
+        for child_class in children {
+            let (label, _) = egraph
+                .eclasses
+                .get(child_class)
+                .ok_or_else(|| format!("Eclass {} not found", child_class.as_ref()))?;
+            if is_search_choice_eclass(label) {
+                let child = *choices.get(child_class).ok_or_else(|| {
+                    format!("No choice for reachable eclass {}", child_class.as_ref())
+                })?;
+                stack.push(child);
+            }
+        }
+    }
+    Ok(reachable)
+}
+
+/// Return the selected nodes left after topologically removing every reachable
+/// leaf. An empty set means the selected term is acyclic; a non-empty set
+/// contains at least one correlated choice cycle (and nodes blocked by it).
+fn unresolved_choice_dependencies<'a>(
+    egraph: &'a SerializedEGraph,
+    choices: &EGraphChoiceSet<'a>,
+    reachable: &FxHashSet<&'a NodeId>,
+) -> Result<FxHashSet<&'a NodeId>, String> {
+    let mut remaining_dependencies: FxHashMap<&NodeId, usize> = FxHashMap::default();
+    let mut dependency_users: FxHashMap<&NodeId, Vec<&NodeId>> = FxHashMap::default();
+    for &node in reachable {
+        let mut dependencies = FxHashSet::default();
+        for child_class in &egraph.enodes[node].1 {
+            let (label, _) = egraph
+                .eclasses
+                .get(child_class)
+                .ok_or_else(|| format!("Eclass {} not found", child_class.as_ref()))?;
+            if !is_search_choice_eclass(label) {
+                continue;
+            }
+            let dependency = *choices.get(child_class).ok_or_else(|| {
+                format!("No choice for reachable eclass {}", child_class.as_ref())
+            })?;
+            if dependencies.insert(dependency) {
+                dependency_users.entry(dependency).or_default().push(node);
+            }
+        }
+        remaining_dependencies.insert(node, dependencies.len());
+    }
+
+    let mut ready: Vec<&NodeId> = remaining_dependencies
+        .iter()
+        .filter_map(|(&node, &count)| (count == 0).then_some(node))
+        .collect();
+    while let Some(dependency) = ready.pop() {
+        remaining_dependencies.remove(dependency);
+        if let Some(users) = dependency_users.get(dependency) {
+            for &user in users {
+                let Some(count) = remaining_dependencies.get_mut(user) else {
+                    continue;
+                };
+                *count -= 1;
+                if *count == 0 {
+                    ready.push(user);
+                }
+            }
+        }
+    }
+    Ok(remaining_dependencies.into_keys().collect())
+}
+
+fn cyclic_choice_components<'a>(
+    egraph: &'a SerializedEGraph,
+    choices: &EGraphChoiceSet<'a>,
+    reachable: &FxHashSet<&'a NodeId>,
+) -> Result<Vec<Vec<&'a NodeId>>, String> {
+    let unresolved = unresolved_choice_dependencies(egraph, choices, reachable)?;
+    if unresolved.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut dependencies: FxHashMap<&NodeId, Vec<&NodeId>> = FxHashMap::default();
+    let mut users: FxHashMap<&NodeId, Vec<&NodeId>> = FxHashMap::default();
+    for &node in &unresolved {
+        let mut unique = FxHashSet::default();
+        for child_class in &egraph.enodes[node].1 {
+            let Some((label, _)) = egraph.eclasses.get(child_class) else {
+                continue;
+            };
+            if !is_search_choice_eclass(label) {
+                continue;
+            }
+            let dependency = *choices.get(child_class).ok_or_else(|| {
+                format!("No choice for reachable eclass {}", child_class.as_ref())
+            })?;
+            if unresolved.contains(dependency) && unique.insert(dependency) {
+                dependencies.entry(node).or_default().push(dependency);
+                users.entry(dependency).or_default().push(node);
+            }
+        }
+        dependencies.entry(node).or_default();
+        users.entry(node).or_default();
+    }
+
+    // Iterative Kosaraju keeps this safe for the deep IList chains found in
+    // large transformer e-graphs.
+    let mut visited = FxHashSet::default();
+    let mut finish_order = Vec::with_capacity(unresolved.len());
+    for &start in &unresolved {
+        if visited.contains(start) {
+            continue;
+        }
+        let mut stack = vec![(start, false)];
+        while let Some((node, expanded)) = stack.pop() {
+            if expanded {
+                finish_order.push(node);
+                continue;
+            }
+            if !visited.insert(node) {
+                continue;
+            }
+            stack.push((node, true));
+            for &dependency in &dependencies[node] {
+                if !visited.contains(dependency) {
+                    stack.push((dependency, false));
+                }
+            }
+        }
+    }
+
+    visited.clear();
+    let mut cyclic = Vec::new();
+    for &start in finish_order.iter().rev() {
+        if !visited.insert(start) {
+            continue;
+        }
+        let mut component = Vec::new();
+        let mut stack = vec![start];
+        while let Some(node) = stack.pop() {
+            component.push(node);
+            for &user in &users[node] {
+                if visited.insert(user) {
+                    stack.push(user);
+                }
+            }
+        }
+        let self_cycle = component.len() == 1 && dependencies[component[0]].contains(&component[0]);
+        if component.len() > 1 || self_cycle {
+            cyclic.push(component);
+        }
+    }
+    Ok(cyclic)
+}
+
+fn repair_choice_cycles<'a>(
+    egraph: &'a SerializedEGraph,
+    choices: &mut EGraphChoiceSet<'a>,
+    rng: &mut (impl Rng + ?Sized),
+) {
+    // Repair only the reachable selected term. Unreachable eclasses still need
+    // entries for a complete genome, but cycles among those entries cannot
+    // appear in the extracted LLIR and should not narrow the search space.
+    for _ in 0..128 {
+        let Ok(reachable) = reachable_choice_nodes(egraph, choices) else {
+            return;
+        };
+        let Ok(components) = cyclic_choice_components(egraph, choices, &reachable) else {
+            return;
+        };
+        if components.is_empty() {
+            return;
+        }
+
+        let mut repairs = Vec::new();
+        for component in components {
+            crate::mask_events::CHOICE_CYCLE_REPAIR.record();
+            let component_set: FxHashSet<&NodeId> = component.iter().copied().collect();
+            for selected_node in component {
+                let Some(class) = egraph.node_to_class.get(selected_node) else {
+                    continue;
+                };
+                let Some((label, alternatives)) = egraph.eclasses.get(class) else {
+                    continue;
+                };
+                let dependency_score = |candidate: &NodeId| {
+                    let mut blocked_classes = FxHashSet::default();
+                    for child_class in &egraph.enodes[candidate].1 {
+                        let Some((child_label, _)) = egraph.eclasses.get(child_class) else {
+                            continue;
+                        };
+                        if is_search_choice_eclass(child_label)
+                            && (child_class == class
+                                || choices
+                                    .get(child_class)
+                                    .is_some_and(|node| component_set.contains(*node)))
+                        {
+                            blocked_classes.insert(child_class);
+                        }
+                    }
+                    blocked_classes.len()
+                };
+                let selected_score = dependency_score(selected_node);
+                let mut class_repairs = Vec::new();
+                let mut class_best_reduction = 0usize;
+                for alternative in alternatives {
+                    if alternative == selected_node
+                        || (label == "OpKind" && !opkind_metadata_consistent(egraph, alternative))
+                    {
+                        continue;
+                    }
+                    let alternative_score = dependency_score(alternative);
+                    let reduction = selected_score.saturating_sub(alternative_score);
+                    if reduction == 0 {
+                        continue;
+                    }
+                    if reduction > class_best_reduction {
+                        class_best_reduction = reduction;
+                        class_repairs.clear();
+                    }
+                    if reduction == class_best_reduction {
+                        class_repairs.push((class, alternative));
+                    }
+                }
+                if !class_repairs.is_empty() {
+                    repairs.push(class_repairs[rng.random_range(0..class_repairs.len())]);
+                }
+            }
+        }
+
+        if repairs.is_empty() {
+            return;
+        }
+        // Each selected node belongs to exactly one eclass, and SCCs are
+        // disjoint, so these class-local repairs can be applied together.
+        // This removes a cyclic frontier per round without conflating
+        // downstream nodes blocked by a cycle with the cycle itself.
+        for (class, alternative) in repairs {
+            choices.insert(class, alternative);
+        }
+    }
+}
+
+fn extractor_list_len(egraph: &SerializedEGraph, eclass_id: &ClassId) -> Option<usize> {
+    let mut len = 0usize;
+    let mut cur_eclass: ClassId = eclass_id.clone();
+    let mut visited: FxHashSet<ClassId> = FxHashSet::default();
+    loop {
+        if !visited.insert(cur_eclass.clone()) {
+            return None;
+        }
+        let (label, enodes) = egraph.eclasses.get(&cur_eclass)?;
+        if !label.contains("List") {
+            return Some(len);
+        }
+        let head_enode = enodes.first()?;
+        let head_label = &egraph.enodes[head_enode].0;
+        if head_label == "ENil" || head_label == "INil" {
+            return Some(len);
+        }
+        if head_label != "ECons" && head_label != "ICons" {
+            return Some(len);
+        }
+        len += 1;
+        let children = &egraph.enodes[head_enode].1;
+        if children.len() < 2 {
+            return Some(len);
+        }
+        cur_eclass = children[1].clone();
+    }
+}
+
+fn opkind_metadata_consistent(egraph: &SerializedEGraph, node: &NodeId) -> bool {
+    let lens: Vec<usize> = egraph.enodes[node]
+        .1
+        .iter()
+        .filter_map(|c| {
+            let lbl = &egraph.eclasses[c].0;
+            if lbl.contains("List") {
+                extractor_list_len(egraph, c)
+            } else {
+                None
+            }
+        })
+        .collect();
+    lens.is_empty() || lens.iter().all(|l| *l == lens[0])
+}
+
+/// Count the total number of possible searchable choice sets, capped at `limit`.
+///
+/// Search deduplicates candidates by `EGraphChoiceSet`, so this gives the exact
+/// number of candidates when it is below `limit` without risking overflow on
+/// large search spaces.
+pub fn count_choice_sets_up_to(egraph: &SerializedEGraph, limit: usize) -> usize {
+    if limit == 0 {
+        return 0;
+    }
+
+    let mut count = 1usize;
+    for (label, enodes) in egraph.eclasses.values() {
+        if !is_search_choice_eclass(label) {
+            continue;
+        }
+
+        count = count.saturating_mul(enodes.len());
+        if count >= limit {
+            return limit;
+        }
+    }
+    count
+}
+
+/// Draw a complete random genome, then repair only cycles in its reachable
+/// selected term. Legal choices outside those cycles are left untouched so
+/// specialization remains a measured-search decision.
+/// Indices of enodes that are not loop-input markers. A `LoopInput` /
+/// `LoopInputStatic` spelling in a class that also holds the raw value is an
+/// identity wrapper (egglog unions invariant markers with their source), and
+/// choosing it re-wraps the value — the marker's source child is its own
+/// class, so extraction materializes self-referential marker chains. Restrict
+/// choices to non-marker spellings whenever any exist; classes holding only
+/// the marker (genuine varying streams) are unaffected.
+fn enode_is_loop_input_marker(egraph: &SerializedEGraph, n: &NodeId) -> bool {
+    // IR enodes are all headed `Op`; the marker kind lives in the first
+    // child (the OpKind class).
+    let (head, children) = &egraph.enodes[n];
+    if head != "Op" {
+        return false;
+    }
+    let Some(kind_class) = children.first() else {
+        return false;
+    };
+    egraph
+        .eclasses
+        .get(kind_class)
+        .is_some_and(|(_, kind_enodes)| {
+            kind_enodes.iter().any(|k| {
+                let op = egraph.enodes[k].0.as_str();
+                op == "LoopInput" || op == "LoopInputStatic"
+            })
+        })
+}
+
+fn non_marker_enode_indices(egraph: &SerializedEGraph, enodes: &[NodeId]) -> Vec<usize> {
+    enodes
+        .iter()
+        .enumerate()
+        .filter(|(_, n)| !enode_is_loop_input_marker(egraph, n))
+        .map(|(i, _)| i)
+        .collect()
+}
+
+pub fn random_initial_choice<'a>(
+    egraph: &'a SerializedEGraph,
+    rng: &mut (impl Rng + ?Sized),
+) -> EGraphChoiceSet<'a> {
+    let mut choices = EGraphChoiceSet::default();
+    for (eclass, (label, enodes)) in &egraph.eclasses {
+        if !is_search_choice_eclass(label) {
+            continue;
+        }
+        // Use synth-injected enodes when available — they point at
+        // deterministic single-variant kind eclasses produced by the
+        // deep-clone fallback in `inject_kernel_alternatives`, so the
+        // extractor's first-enode walk is guaranteed length-consistent.
+        // Without this bias, the chooser frequently lands on an egglog-
+        // rewritten KernelOp whose ELIST children inherit a multi-variant
+        // eclass (caused by length-changing rewrites such as merge_dims /
+        // RemoveNthFromEnd), which produces a flatten_strides assertion
+        // mismatch downstream.
+        let synth_indices: Vec<usize> = enodes
+            .iter()
+            .enumerate()
+            .filter_map(|(i, n)| n.as_ref().starts_with("synth_").then_some(i))
+            .collect();
+        let consistent_opkind_indices: Vec<usize> = if label == "OpKind" {
+            enodes
+                .iter()
+                .enumerate()
+                .filter_map(|(i, n)| opkind_metadata_consistent(egraph, n).then_some(i))
+                .collect()
+        } else {
+            Vec::new()
+        };
+        let marker_free = non_marker_enode_indices(egraph, enodes);
+        if !consistent_opkind_indices.is_empty() && consistent_opkind_indices.len() < enodes.len() {
+            crate::mask_events::OPKIND_INCONSISTENT.record();
+        }
+        if !marker_free.is_empty() && marker_free.len() < enodes.len() {
+            crate::mask_events::MARKER_CHOICE_RESTRICTED.record();
+        }
+        let restrict = |pool: Vec<usize>| -> Vec<usize> {
+            if marker_free.is_empty() {
+                return pool;
+            }
+            let filtered: Vec<usize> = pool
+                .iter()
+                .copied()
+                .filter(|i| marker_free.contains(i))
+                .collect();
+            if filtered.is_empty() { pool } else { filtered }
+        };
+        let consistent_opkind_indices = restrict(consistent_opkind_indices);
+        let synth_indices = restrict(synth_indices);
+        let pick_idx = if !consistent_opkind_indices.is_empty() {
+            consistent_opkind_indices[rng.random_range(0..consistent_opkind_indices.len())]
+        } else if !synth_indices.is_empty() {
+            synth_indices[rng.random_range(0..synth_indices.len())]
+        } else if !marker_free.is_empty() {
+            marker_free[rng.random_range(0..marker_free.len())]
+        } else {
+            rng.random_range(0..enodes.len())
+        };
+        choices.insert(eclass, &enodes[pick_idx]);
+    }
+    repair_choice_cycles(egraph, &mut choices, rng);
+    choices
+}
+
+/// Validate that a choice set is complete and consistent.
+/// Returns Ok(()) if valid, Err with description if invalid.
+pub fn validate_choice_set<'a>(
+    egraph: &'a SerializedEGraph,
+    choices: &EGraphChoiceSet<'a>,
+    ops: &[Arc<Box<dyn EgglogOp>>],
+) -> Result<(), String> {
+    // Check all searchable eclasses have a choice.
+    for (eclass, (label, enodes)) in &egraph.eclasses {
+        if !is_search_choice_eclass(label) {
+            continue;
+        }
+        let Some(chosen) = choices.get(eclass) else {
+            return Err(format!("Missing choice for eclass {}", eclass.as_ref()));
+        };
+        // Check chosen enode exists in the eclass
+        if !enodes.contains(chosen) {
+            return Err(format!(
+                "Chosen enode {} not in eclass {}",
+                chosen.as_ref(),
+                eclass.as_ref()
+            ));
+        }
+    }
+
+    // Independently legal e-node choices can still form a correlated cycle:
+    // an IR alternative may consume an e-class whose selected alternative
+    // eventually consumes the original IR again. Extraction terminates its
+    // reachability walk by deduplicating nodes, but the resulting LLIR is
+    // cyclic and therefore cannot be scheduled. Reject that choice set as a
+    // statically invalid candidate before compilation or measurement.
+    //
+    let reachable = reachable_choice_nodes(egraph, choices)?;
+    let unresolved = unresolved_choice_dependencies(egraph, choices, &reachable)?;
+    if let Some(cycle_node) = unresolved.iter().next() {
+        return Err(format!(
+            "Selected choices contain a dependency cycle involving enode {}",
+            cycle_node.as_ref()
+        ));
+    }
+
+    // Check all reachable IR nodes have corresponding ops
+    for node in &reachable {
+        let (op_name, children) = &egraph.enodes[*node];
+        let eclass = &egraph.node_to_class[*node];
+        let (label, _) = &egraph.eclasses[eclass];
+        if label != "IR" {
+            continue; // Skip IList / OpKind nodes
+        }
+        if op_name == "OutputJoin" {
+            continue;
+        }
+        if op_name == "Op" {
+            // Normalized op — check OpKind child
+            if let Some(kind_eclass) = children.first() {
+                if let Some(kn) = choices.get(kind_eclass) {
+                    let kind_name = &egraph.enodes[kn].0;
+                    if kind_name != "CustomOpKind"
+                        && !ops.iter().any(|op| op.sort().name == *kind_name)
+                    {
+                        return Err(format!("No extractor for OpKind {kind_name}"));
+                    }
+                }
+            }
+            continue;
+        }
+        // Direct IR variant (Input, Output)
+        if !ops.iter().any(|op| op.sort().name == *op_name) {
+            return Err(format!("No extractor for op {op_name}"));
+        }
+    }
+
+    Ok(())
+}
+
+/// Hash a single (class_id, node_id) entry. Used both for the full
+/// choice-set hash and for the incremental updates in
+/// `extract_generation`.
+fn hash_choice_entry(class_id: &ClassId, node_id: &NodeId) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    class_id.hash(&mut hasher);
+    node_id.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Hash a choice set for uniqueness checking. Order-independent XOR
+/// of per-entry hashes. The XOR design lets `extract_generation`
+/// update the hash incrementally on each `insert(k, new)` by XORing
+/// out `hash_choice_entry(k, old)` and XORing in
+/// `hash_choice_entry(k, new)`, dropping the per-attempt cost from
+/// O(N log N) over the full choice set to O(M) where M = mutations
+/// applied. On large e-graphs (e.g. Gemma's ~3.5M-entry choice set)
+/// that's the difference between ~135 seconds and a few milliseconds
+/// per generation.
+pub fn hash_choice_set(choices: &EGraphChoiceSet) -> u64 {
+    let mut h = 0u64;
+    for (k, v) in choices.iter() {
+        h ^= hash_choice_entry(k, v);
+    }
+    h
+}
+
+/// Extract a generation of mutated offspring from a base genome.
+///
+/// Takes a base `EGraphChoiceSet` and produces up to `generation_size` mutated offspring,
+/// each with `mutations_per_generation` random mutations. Offspring are deduplicated
+/// against `prev_selected` (which is updated with new hashes).
+///
+/// If the search space is exhausted, returns as many unique offspring as possible.
+pub fn extract_generation<'a>(
+    egraph: &'a SerializedEGraph,
+    base: &EGraphChoiceSet<'a>,
+    generation_size: usize,
+    mutations_per_generation: usize,
+    prev_selected: &mut FxHashSet<u64>,
+    rng: &mut (impl Rng + ?Sized),
+) -> Vec<EGraphChoiceSet<'a>> {
+    let mutable_classes: Vec<&ClassId> = egraph
+        .eclasses
+        .iter()
+        .filter(|(_, (label, enodes))| is_search_choice_eclass(label) && enodes.len() > 1)
+        .map(|(class_id, _)| class_id)
+        .collect();
+    extract_generation_from_classes(
+        egraph,
+        base,
+        &mutable_classes,
+        generation_size,
+        mutations_per_generation,
+        prev_selected,
+        rng,
+    )
+}
+
+pub fn extract_reachable_generation<'a>(
+    egraph: &'a SerializedEGraph,
+    base: &EGraphChoiceSet<'a>,
+    generation_size: usize,
+    mutations_per_generation: usize,
+    prev_selected: &mut FxHashSet<u64>,
+    rng: &mut (impl Rng + ?Sized),
+) -> Vec<EGraphChoiceSet<'a>> {
+    let mutable_classes = reachable_mutable_choice_classes(egraph, base);
+    extract_generation_from_classes(
+        egraph,
+        base,
+        &mutable_classes,
+        generation_size,
+        mutations_per_generation,
+        prev_selected,
+        rng,
+    )
+}
+
+fn reachable_mutable_choice_classes<'a>(
+    egraph: &'a SerializedEGraph,
+    choices: &EGraphChoiceSet<'a>,
+) -> Vec<&'a ClassId> {
+    let mut reachable = FxHashSet::default();
+    let mut class_seen = FxHashSet::default();
+    let mut mutable_classes = Vec::new();
+    let Some(root) = egraph.roots.first() else {
+        return mutable_classes;
+    };
+    let Some(root_choice) = choices.get(root) else {
+        return mutable_classes;
+    };
+    if let Some((label, enodes)) = egraph.eclasses.get(root) {
+        if is_search_choice_eclass(label) && enodes.len() > 1 && class_seen.insert(root) {
+            mutable_classes.push(root);
+        }
+    }
+
+    let mut stack = vec![*root_choice];
+    while let Some(node) = stack.pop() {
+        if !reachable.insert(node) {
+            continue;
+        }
+        let Some((_, children)) = egraph.enodes.get(node) else {
+            continue;
+        };
+        for child_class in children {
+            let Some((label, enodes)) = egraph.eclasses.get(child_class) else {
+                continue;
+            };
+            if is_search_choice_eclass(label) {
+                if enodes.len() > 1 && class_seen.insert(child_class) {
+                    mutable_classes.push(child_class);
+                }
+                if let Some(chosen_node) = choices.get(child_class) {
+                    stack.push(*chosen_node);
+                }
+            }
+        }
+    }
+
+    mutable_classes
+}
+
+fn extract_generation_from_classes<'a>(
+    egraph: &'a SerializedEGraph,
+    base: &EGraphChoiceSet<'a>,
+    mutable_classes: &[&'a ClassId],
+    generation_size: usize,
+    mutations_per_generation: usize,
+    prev_selected: &mut FxHashSet<u64>,
+    rng: &mut (impl Rng + ?Sized),
+) -> Vec<EGraphChoiceSet<'a>> {
+    // If there are no mutable classes, we can only return the base if it's unseen
+    if mutable_classes.is_empty() {
+        let h = hash_choice_set(base);
+        if !prev_selected.contains(&h) {
+            prev_selected.insert(h);
+            return vec![base.clone()];
+        }
+        return vec![];
+    }
+
+    let mut offspring = Vec::with_capacity(generation_size);
+    // Limit attempts to avoid infinite loops when search space is exhausted
+    let max_attempts = generation_size * 100;
+    let mut attempts = 0;
+    // Compute the base's full hash exactly once. Each attempt starts from
+    // this and applies XOR diffs for its mutations — no per-attempt
+    // O(N log N) sort+hash over the full choice set.
+    let base_hash = hash_choice_set(base);
+
+    while offspring.len() < generation_size && attempts < max_attempts {
+        attempts += 1;
+
+        // Create a mutated offspring from base
+        let mut child = base.clone();
+        let mut child_hash = base_hash;
+
+        for _ in 0..rng.random_range(1..=mutations_per_generation) {
+            // Pick a random mutable eclass
+            let class_id = mutable_classes[rng.random_range(0..mutable_classes.len())];
+            let (label, enodes) = &egraph.eclasses[class_id];
+            // Pick a random enode for this class
+            let consistent_opkind_nodes: Vec<&NodeId> = if label == "OpKind" {
+                enodes
+                    .iter()
+                    .filter(|n| opkind_metadata_consistent(egraph, n))
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            let marker_free = non_marker_enode_indices(egraph, enodes);
+            if !marker_free.is_empty() && marker_free.len() < enodes.len() {
+                crate::mask_events::MARKER_CHOICE_RESTRICTED.record();
+            }
+            let new_node = if !consistent_opkind_nodes.is_empty() {
+                let pool: Vec<&NodeId> = if marker_free.is_empty() {
+                    consistent_opkind_nodes
+                } else {
+                    let filtered: Vec<&NodeId> = consistent_opkind_nodes
+                        .iter()
+                        .copied()
+                        .filter(|n| !enode_is_loop_input_marker(egraph, n))
+                        .collect();
+                    if filtered.is_empty() {
+                        consistent_opkind_nodes
+                    } else {
+                        filtered
+                    }
+                };
+                pool[rng.random_range(0..pool.len())]
+            } else if !marker_free.is_empty() {
+                &enodes[marker_free[rng.random_range(0..marker_free.len())]]
+            } else {
+                &enodes[rng.random_range(0..enodes.len())]
+            };
+            // Insert returns the previous binding (if any); fold the diff
+            // into the running hash. If the new pick equals the old one,
+            // the two XORs cancel and `child_hash` is unchanged — exactly
+            // the right behaviour.
+            let old_node = child.insert(class_id, new_node);
+            if let Some(old_node) = old_node {
+                child_hash ^= hash_choice_entry(class_id, old_node);
+            }
+            child_hash ^= hash_choice_entry(class_id, new_node);
+        }
+
+        // Hash and check if seen before
+        if !prev_selected.contains(&child_hash) {
+            prev_selected.insert(child_hash);
+            offspring.push(child);
+        }
+    }
+    offspring
+}
+
+#[tracing::instrument(skip_all)]
+pub fn egglog_to_llir<'a>(
+    egraph: &'a SerializedEGraph,
+    choices: EGraphChoiceSet<'a>,
+    ops: &'a Vec<Arc<Box<dyn EgglogOp>>>,
+    custom_ops: &[Box<dyn CustomOp>],
+    list_cache: &mut FxHashMap<&'a NodeId, Vec<Expression>>,
+    expr_cache: &mut FxHashMap<&'a NodeId, Expression>,
+    custom_op_id_remap: Option<&FxHashMap<usize, usize>>,
+) -> LLIRGraph {
+    egglog_to_llir_from_root(
+        egraph,
+        choices,
+        ops,
+        custom_ops,
+        list_cache,
+        expr_cache,
+        custom_op_id_remap,
+        &egraph.roots[0],
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn egglog_to_llir_from_root<'a>(
+    egraph: &'a SerializedEGraph,
+    choices: EGraphChoiceSet<'a>,
+    ops: &'a Vec<Arc<Box<dyn EgglogOp>>>,
+    custom_ops: &[Box<dyn CustomOp>],
+    list_cache: &mut FxHashMap<&'a NodeId, Vec<Expression>>,
+    expr_cache: &mut FxHashMap<&'a NodeId, Expression>,
+    custom_op_id_remap: Option<&FxHashMap<usize, usize>>,
+    root_class: &ClassId,
+) -> LLIRGraph {
+    let op_by_name: FxHashMap<String, usize> = ops
+        .iter()
+        .enumerate()
+        .map(|(index, op)| (op.sort().name, index))
+        .collect();
+    let mut node_cache = FxHashMap::default();
+    let mut class_cache = FxHashMap::default();
+    let mut opkind_consistency_cache = FxHashMap::default();
+    egglog_to_llir_from_root_cached(
+        egraph,
+        &choices,
+        ops,
+        &op_by_name,
+        custom_ops,
+        list_cache,
+        expr_cache,
+        &mut node_cache,
+        &mut class_cache,
+        &mut opkind_consistency_cache,
+        custom_op_id_remap,
+        root_class,
+    )
+}
+
+fn cached_enode<'a>(
+    egraph: &'a SerializedEGraph,
+    cache: &mut FxHashMap<InternedIdKey, CachedENode<'a>>,
+    node: &NodeId,
+) -> CachedENode<'a> {
+    let key = InternedIdKey::new(node);
+    if let Some(cached) = cache.get(&key) {
+        return *cached;
+    }
+    let (label, children) = &egraph.enodes[node];
+    let cached = CachedENode {
+        label,
+        children,
+        class: &egraph.node_to_class[node],
+    };
+    cache.insert(key, cached);
+    cached
+}
+
+fn cached_eclass<'a>(
+    egraph: &'a SerializedEGraph,
+    cache: &mut FxHashMap<InternedIdKey, CachedEClass<'a>>,
+    class: &ClassId,
+) -> CachedEClass<'a> {
+    let key = InternedIdKey::new(class);
+    if let Some(cached) = cache.get(&key) {
+        return *cached;
+    }
+    let (label, nodes) = &egraph.eclasses[class];
+    let cached = CachedEClass { label, nodes };
+    cache.insert(key, cached);
+    cached
+}
+
+fn cached_opkind_consistency(
+    egraph: &SerializedEGraph,
+    cache: &mut FxHashMap<InternedIdKey, bool>,
+    node: &NodeId,
+) -> bool {
+    let key = InternedIdKey::new(node);
+    if let Some(&consistent) = cache.get(&key) {
+        return consistent;
+    }
+    let consistent = opkind_metadata_consistent(egraph, node);
+    cache.insert(key, consistent);
+    consistent
+}
+
+fn walk_ilist_cached<'a>(
+    egraph: &'a SerializedEGraph,
+    ilist_eclass: &'a ClassId,
+    choices: &EGraphChoiceSet<'a>,
+    node_cache: &mut FxHashMap<InternedIdKey, CachedENode<'a>>,
+) -> Vec<&'a NodeId> {
+    let mut inputs = Vec::with_capacity(4);
+    let mut current = choices[ilist_eclass];
+    loop {
+        let node = cached_enode(egraph, node_cache, current);
+        if node.label == "INil" {
+            break;
+        }
+        let input_eclass = &node.children[0];
+        inputs.push(choices[input_eclass]);
+        current = choices[&node.children[1]];
+    }
+    inputs
+}
+
+#[allow(clippy::too_many_arguments)]
+fn egglog_to_llir_from_root_cached<'a>(
+    egraph: &'a SerializedEGraph,
+    choices: &EGraphChoiceSet<'a>,
+    ops: &'a [Arc<Box<dyn EgglogOp>>],
+    op_by_name: &FxHashMap<String, usize>,
+    custom_ops: &[Box<dyn CustomOp>],
+    list_cache: &mut FxHashMap<&'a NodeId, Vec<Expression>>,
+    expr_cache: &mut FxHashMap<&'a NodeId, Expression>,
+    node_cache: &mut FxHashMap<InternedIdKey, CachedENode<'a>>,
+    class_cache: &mut FxHashMap<InternedIdKey, CachedEClass<'a>>,
+    opkind_consistency_cache: &mut FxHashMap<InternedIdKey, bool>,
+    custom_op_id_remap: Option<&FxHashMap<usize, usize>>,
+    root_class: &ClassId,
+) -> LLIRGraph {
+    // Make reachability set from root
+    let root = choices[root_class];
+    let mut reachable_keys = FxHashSet::default();
+    reachable_keys.insert(root);
+    let mut reachable = vec![root];
+    let mut reachability_stack = vec![root];
+    while let Some(r) = reachability_stack.pop() {
+        let node = cached_enode(egraph, node_cache, r);
+        for ch in node.children {
+            if is_search_choice_eclass(cached_eclass(egraph, class_cache, ch).label) {
+                let n = choices[ch];
+                if reachable_keys.insert(n) {
+                    reachability_stack.push(n);
+                    reachable.push(n);
+                }
+            }
+        }
+    }
+    let mut graph = LLIRGraph::with_capacity(reachable.len() / 2, reachable.len());
+    let mut edges_to_place = Vec::with_capacity(reachable.len());
+    let mut enode_to_node = FxHashMap::default();
+    // Iterate the small reachable set rather than the full choice set.
+    // On large e-graphs (e.g., Gemma's ~3.48M-entry choice set produced
+    // by the binary-fusion grow rules cascading through super-block
+    // chains), `reachable` is ~3K nodes and the choice set is ~1000×
+    // larger. Filtering the choice set against `reachable` was
+    // dominating per-candidate `egglog_to_llir` time.
+    for &node_id in &reachable {
+        let node = cached_enode(egraph, node_cache, node_id);
+        if cached_eclass(egraph, class_cache, node.class).label != "IR" {
+            // Skip IList enodes — `reachable` includes them because the
+            // reachability walk follows IList children, but only IR
+            // enodes become LLIR nodes.
+            continue;
+        }
+        let node_key = node_id;
+        let enode_label = node.label;
+        if enode_label == "Op" {
+            // Normalized op: (Op OpKind IList)
+            // child[0] = OpKind eclass, child[1] = IList eclass
+            let kind_eclass = &node.children[0];
+            let ilist_eclass = &node.children[1];
+
+            // Resolve OpKind enode. The kind eclass may contain multiple
+            // structurally-equivalent kind enodes whose ELIST children
+            // were unioned but resolve (under the extractor's first-enode
+            // walk) to inconsistent lengths — picking such an enode causes
+            // a downstream `flatten_strides` length mismatch. Candidate
+            // generation filters these out where possible; this fallback is
+            // structural only and does not rank backend implementations.
+            let kind_class = cached_eclass(egraph, class_cache, kind_eclass);
+            let kind_enodes = kind_class.nodes;
+            let kind_enode = choices
+                .get(kind_eclass)
+                .copied()
+                .filter(|n| cached_opkind_consistency(egraph, opkind_consistency_cache, n))
+                .or_else(|| {
+                    kind_enodes
+                        .iter()
+                        .find(|n| cached_opkind_consistency(egraph, opkind_consistency_cache, n))
+                })
+                .unwrap_or(&kind_enodes[0]);
+            let kind_node = cached_enode(egraph, node_cache, kind_enode);
+            let kind_label = kind_node.label;
+
+            // Resolve kind's metadata children (shapes, strides, etc.)
+            let kind_children: Vec<&NodeId> = kind_node
+                .children
+                .iter()
+                .map(|c| {
+                    let class = cached_eclass(egraph, class_cache, c);
+                    if is_search_choice_eclass(class.label) {
+                        choices[c]
+                    } else {
+                        &class.nodes[0]
+                    }
+                })
+                .collect_vec();
+
+            // Walk IList to get IR inputs
+            let input_enodes = walk_ilist_cached(egraph, ilist_eclass, choices, node_cache);
+
+            // Check for CustomOpKind first
+            if kind_label == "CustomOpKind" {
+                // kind_children: [id, dtype]
+                let id: usize = egraph.enodes[kind_children[0]].0.parse().unwrap();
+                let remapped_id = custom_op_id_remap
+                    .and_then(|m| m.get(&id).copied())
+                    .unwrap_or(id);
+                let r = graph.add_node(custom_ops[remapped_id].to_llir_op());
+                enode_to_node.insert(node_key, r);
+                for source in input_enodes {
+                    edges_to_place.push((source, node_key));
+                }
+            } else {
+                // Find matching op by OpKind name
+                let Some(&op_index) = op_by_name.get(kind_label) else {
+                    todo!("{kind_label} extraction not implemented!");
+                };
+                let op = &ops[op_index];
+                let (op_instance, sources) =
+                    op.extract(egraph, &kind_children, input_enodes, list_cache, expr_cache);
+                let r = graph.add_node(op_instance);
+                enode_to_node.insert(node_key, r);
+                edges_to_place.extend(sources.iter().map(|source| (*source, node_key)));
+            }
+        } else if enode_label != "OutputJoin" {
+            // Direct IR variant (Input, Output) — skip unknown labels (backend IR wrappers)
+            let Some(&op_index) = op_by_name.get(enode_label) else {
+                continue;
+            };
+            let op = &ops[op_index];
+            let ch = node
+                .children
+                .iter()
+                .map(|c| {
+                    let class = cached_eclass(egraph, class_cache, c);
+                    if is_search_choice_eclass(class.label) {
+                        choices[c]
+                    } else {
+                        &class.nodes[0]
+                    }
+                })
+                .collect_vec();
+            // Direct IR ops pass children as kind_children, empty input_enodes
+            let (op_instance, sources) = op.extract(egraph, &ch, vec![], list_cache, expr_cache);
+            let r = graph.add_node(op_instance);
+            enode_to_node.insert(node_key, r);
+            edges_to_place.extend(sources.iter().map(|source| (*source, node_key)));
+        }
+    }
+    for (src, dest) in edges_to_place {
+        let src_node_id = *enode_to_node.get(&src).unwrap_or_else(|| {
+            panic!("Source enode {src:?} not found in enode_to_node map during edge placement")
+        });
+        let dest_node_id = *enode_to_node.get(&dest).unwrap_or_else(|| {
+            panic!(
+                "Destination enode {dest:?} not found in enode_to_node map during edge placement",
+            )
+        });
+
+        graph.add_edge(src_node_id, dest_node_id, ());
+    }
+
+    // if enabled!(Level::TRACE) {
+    //     fs::write(
+    //         format!("llir_graphs/llir_{}.dot", i),
+    //         graph.clone().to_dot().unwrap(),
+    //     )
+    //     .unwrap();
+    // }
+    // Loop markers (LoopStart/End/Input/InputStatic/Output) are intentionally
+    // preserved here — `crate::graph::collapse_loops_to_first_iter` produces
+    // a single-iteration LLIR for fast per-candidate profiling, and the full
+    // `crate::graph::unroll_loops_in_llir` runs once on the chosen best LLIR
+    // before it is loaded into the runtime.
+    graph
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        EGraphChoiceSet, LateEgglogPass, LlirExtractor, OpTextParts, SerializedEGraph,
+        count_choice_sets_up_to, egglog_setup_with_options, random_initial_choice,
+        run_egglog_with_late_passes, validate_choice_set,
+    };
+    use crate::egglog_utils::api::{Rule, SortDef, sort};
+    use crate::egglog_utils::base::OP_KIND;
+    use crate::prelude::FxHashMap;
+    use crate::{
+        hlir::HLIROps,
+        op::{EgglogOp, IntoEgglogOp},
+    };
+    use egraph_serialize::{ClassId, NodeId};
+    use rand::{SeedableRng, rngs::StdRng};
+
+    const TEST_OP_DECLARATION: &str = "(relation op_owned_test_relation ())";
+
+    #[derive(Debug, Default)]
+    struct OpOwnedDeclarationTest;
+
+    impl EgglogOp for OpOwnedDeclarationTest {
+        fn sort(&self) -> SortDef {
+            sort(OP_KIND, "OpOwnedDeclarationTest", &[])
+        }
+
+        fn egglog_declarations(&self) -> Vec<String> {
+            vec![TEST_OP_DECLARATION.to_string()]
+        }
+
+        fn rewrites(&self) -> Vec<Rule> {
+            vec![Rule::raw(
+                "(rule ((op_owned_test_relation)) ()
+                    :ruleset expr
+                    :name \"consume op-owned declaration\")",
+            )]
+        }
+
+        fn cleanup(&self) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn op_owned_declarations_are_deduplicated_before_rewrites() {
+        let ops = <(OpOwnedDeclarationTest, OpOwnedDeclarationTest)>::into_vec();
+        let parts = OpTextParts::new(&ops, false);
+        let program = egglog_setup_with_options("", &parts, false);
+
+        assert_eq!(program.matches(TEST_OP_DECLARATION).count(), 1);
+        assert!(
+            program.find(TEST_OP_DECLARATION).unwrap()
+                < program
+                    .find(":name \"consume op-owned declaration\"")
+                    .unwrap()
+        );
+    }
+
+    // The backend extra-egglog hook (Runtime::extra_egglog) is carried on
+    // OpTextParts.extra_egglog and must be spliced into the program exactly once,
+    // after op-owned declarations and before the rewrite rules.
+    #[test]
+    fn extra_egglog_is_spliced_between_op_defs_and_rewrites() {
+        let marker = "(function tron_is_attn_softmax (IR IR) bool :merge (or old new))";
+
+        // Default: no extra egglog → marker absent.
+        let parts = OpTextParts::new(&[], false);
+        assert!(parts.extra_egglog.is_empty());
+        let plain = egglog_setup_with_options("", &parts, false);
+        assert!(!plain.contains(marker));
+
+        // With a backend declaration set, it appears in the program exactly once.
+        // (Its position — after op declarations, before rewrite rules — is
+        // fixed by the array-literal order in egglog_setup_with_options.)
+        let mut parts = OpTextParts::new(&[], false);
+        parts.extra_egglog = marker.to_string();
+        let program = egglog_setup_with_options("", &parts, false);
+        assert_eq!(program.matches(marker).count(), 1, "spliced exactly once");
+    }
+
+    fn eclass(id: &str, label: &str, n_nodes: usize) -> (ClassId, (String, Vec<NodeId>)) {
+        (
+            ClassId::from(id),
+            (
+                label.to_string(),
+                (0..n_nodes)
+                    .map(|i| NodeId::from(format!("{id}_{i}")))
+                    .collect(),
+            ),
+        )
+    }
+
+    fn egraph(eclasses: Vec<(ClassId, (String, Vec<NodeId>))>) -> SerializedEGraph {
+        SerializedEGraph {
+            enodes: FxHashMap::default(),
+            eclasses: eclasses.into_iter().collect(),
+            node_to_class: FxHashMap::default(),
+            roots: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn llir_extractor_indexes_eclasses_by_id() {
+        let root = ClassId::from("c");
+        let mut egraph = egraph(vec![
+            eclass("c", "Shape", 1),
+            eclass("a", "Shape", 1),
+            eclass("b", "Shape", 1),
+        ]);
+        egraph.roots.push(root);
+
+        let extractor = LlirExtractor::new(&egraph, &[]);
+        let ids = extractor
+            .indexed_classes
+            .iter()
+            .map(|class| class.id.as_ref())
+            .collect::<Vec<_>>();
+
+        assert_eq!(ids, ["a", "b", "c"]);
+    }
+
+    #[test]
+    fn counts_ir_and_ilist_choice_sets() {
+        let egraph = egraph(vec![
+            eclass("a", "IR", 2),
+            eclass("b", "IList", 3),
+            eclass("op", "OpKind", 5),
+            eclass("c", "Shape", 99),
+        ]);
+
+        assert_eq!(count_choice_sets_up_to(&egraph, 100), 30);
+    }
+
+    #[test]
+    fn caps_count_at_limit() {
+        let egraph = egraph(vec![eclass("a", "IR", 1_000), eclass("b", "IList", 1_000)]);
+
+        assert_eq!(count_choice_sets_up_to(&egraph, 10), 10);
+    }
+
+    fn dependency_egraph(cyclic: bool) -> SerializedEGraph {
+        let a_class = ClassId::from("a");
+        let b_class = ClassId::from("b");
+        let a_node = NodeId::from("a_node");
+        let b_node = NodeId::from("b_node");
+
+        let mut egraph = SerializedEGraph {
+            enodes: FxHashMap::default(),
+            eclasses: FxHashMap::default(),
+            node_to_class: FxHashMap::default(),
+            roots: vec![a_class.clone()],
+        };
+        egraph
+            .eclasses
+            .insert(a_class.clone(), ("IR".into(), vec![a_node.clone()]));
+        egraph
+            .eclasses
+            .insert(b_class.clone(), ("IR".into(), vec![b_node.clone()]));
+        egraph
+            .enodes
+            .insert(a_node.clone(), ("Output".into(), vec![b_class.clone()]));
+        egraph.enodes.insert(
+            b_node.clone(),
+            if cyclic {
+                ("Output".into(), vec![a_class.clone()])
+            } else {
+                ("Input".into(), Vec::new())
+            },
+        );
+        egraph.node_to_class.insert(a_node, a_class);
+        egraph.node_to_class.insert(b_node, b_class);
+        egraph
+    }
+
+    fn sole_choices(egraph: &SerializedEGraph) -> EGraphChoiceSet<'_> {
+        egraph
+            .eclasses
+            .iter()
+            .map(|(class, (_, nodes))| (class, &nodes[0]))
+            .collect()
+    }
+
+    #[test]
+    fn choice_validation_accepts_acyclic_dependencies() {
+        let egraph = dependency_egraph(false);
+        let choices = sole_choices(&egraph);
+        let ops = <HLIROps as IntoEgglogOp>::into_vec();
+
+        assert_eq!(validate_choice_set(&egraph, &choices, &ops), Ok(()));
+    }
+
+    #[test]
+    fn choice_validation_rejects_correlated_dependency_cycles() {
+        let egraph = dependency_egraph(true);
+        let choices = sole_choices(&egraph);
+        let ops = <HLIROps as IntoEgglogOp>::into_vec();
+
+        let error = validate_choice_set(&egraph, &choices, &ops).unwrap_err();
+        assert!(
+            error.contains("dependency cycle"),
+            "unexpected validation error: {error}"
+        );
+    }
+
+    #[test]
+    fn random_initial_choice_repairs_reachable_cycles() {
+        let mut egraph = dependency_egraph(true);
+        let a_class = egraph.roots[0].clone();
+        let leaf = NodeId::from("a_leaf");
+        egraph
+            .enodes
+            .insert(leaf.clone(), ("Input".into(), Vec::new()));
+        egraph
+            .eclasses
+            .get_mut(&a_class)
+            .expect("root class")
+            .1
+            .push(leaf.clone());
+        egraph.node_to_class.insert(leaf, a_class);
+        let ops = <HLIROps as IntoEgglogOp>::into_vec();
+
+        for seed in 0..32 {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let choices = random_initial_choice(&egraph, &mut rng);
+            assert_eq!(
+                validate_choice_set(&egraph, &choices, &ops),
+                Ok(()),
+                "seed {seed} retained a reachable cycle"
+            );
+        }
+    }
+
+    #[test]
+    fn runs_late_pass_after_full_cleanup() {
+        let ops = <HLIROps as IntoEgglogOp>::into_vec();
+        let program = r#"
+            (let t0 (Input 0 "" (F32)))
+            (let t1 (Output t0 0 false))
+        "#;
+        let late_pass = LateEgglogPass::new(
+            r#"
+            (ruleset late_test)
+            (rule ((= ?out (Output ?inp ?id ?persist_only)))
+                  ((union ?out ?inp))
+                  :ruleset late_test
+                  :name "late-output-to-input")
+            "#,
+            "(run-schedule (saturate late_test))",
+        );
+
+        let egraph = run_egglog_with_late_passes(program, "t1", &ops, false, &[late_pass])
+            .expect("late pass should run");
+        let root = egraph.roots.first().expect("root eclass");
+        let root_labels: Vec<_> = egraph.eclasses[root]
+            .1
+            .iter()
+            .map(|node| egraph.enodes[node].0.as_str())
+            .collect();
+
+        assert!(
+            root_labels.contains(&"Input"),
+            "late union should add Input to root eclass, got {root_labels:?}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod string_literal_op_tests {
+    use super::decode_string_literal_op;
+    use crate::shape::symbol_from_egglog_name;
+
+    #[test]
+    fn decodes_both_spellings_whole() {
+        assert_eq!(
+            decode_string_literal_op(r#"Boxed("s")"#).as_deref(),
+            Some("s")
+        );
+        assert_eq!(decode_string_literal_op(r#""s""#).as_deref(), Some("s"));
+        // Whole name, not a prefix.
+        assert_eq!(
+            decode_string_literal_op(r#"Boxed("s77")"#).as_deref(),
+            Some("s77")
+        );
+        assert_eq!(decode_string_literal_op(r#""s77""#).as_deref(), Some("s77"));
+    }
+
+    #[test]
+    fn stripping_is_anchored_not_substring() {
+        // A name whose content embeds the delimiters must survive.
+        assert_eq!(
+            decode_string_literal_op(r#"Boxed("a")b")"#).as_deref(),
+            Some(r#"a")b"#)
+        );
+    }
+
+    #[test]
+    fn non_string_ops_decode_to_none() {
+        assert_eq!(decode_string_literal_op("5"), None);
+        assert_eq!(decode_string_literal_op("MAdd"), None);
+    }
+
+    /// The reserved index round-trips: it appears in serialized strides.
+    #[test]
+    fn reserved_index_survives_the_boundary() {
+        assert_eq!(symbol_from_egglog_name("z").to_string(), "z");
+    }
+
+    /// The bug this whole change exists to remove. Extraction used to take
+    /// `name.chars().next()`, so a dim named `s77` came back as `s` — a
+    /// *different, possibly live* variable, silently. The bad name then missed
+    /// in `dyn_map`, and cuda_lite turned that miss into a dimension of 0.
+    #[test]
+    fn multichar_dim_names_survive_extraction() {
+        assert_eq!(symbol_from_egglog_name("s77").to_string(), "s77");
+        assert_ne!(symbol_from_egglog_name("s77"), symbol_from_egglog_name("s"));
+    }
+
+    /// Names that cannot be a C identifier or an egglog literal are still
+    /// rejected loudly rather than mangled into something that collides.
+    #[test]
+    #[should_panic(expected = "bad dim name out of egglog")]
+    fn malformed_dim_name_from_egglog_is_loud() {
+        symbol_from_egglog_name("s-77");
+    }
+}

--- a/crates/luminal_cuda_lite_hlir/main_core/graph.rs
+++ b/crates/luminal_cuda_lite_hlir/main_core/graph.rs
@@ -1,0 +1,2990 @@
+use crate::egglog_utils::{
+    hlir_to_egglog, log_channel_enabled, run_egglog_with_late_passes_interval_analysis_and_log,
+};
+pub use crate::search::unroll::{collapse_loops_to_first_iter, unroll_loops_in_llir};
+use crate::search::{BucketSearchSpace, SearchSpace, bucket_index_combinations};
+use crate::shape::{DimInterval, DynDimIntervals};
+use crate::{
+    egglog_utils::SerializedEGraph,
+    op::{EgglogOp, IntoEgglogOp, LLIROp},
+};
+use crate::{hlir::CustomOpKind, op::*, prelude::*};
+use colored::Colorize;
+use itertools::Itertools;
+use petgraph::{Direction, stable_graph::StableGraph, visit::EdgeRef};
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
+use tracing;
+
+mod artifact;
+
+pub use artifact::{ScheduleBucket, SelectedSchedule};
+
+pub type LLIRGraph = StableGraph<LLIROp, ()>;
+pub type HLIRGraph = StableGraph<Box<dyn HLIROp>, ()>;
+
+#[derive(Debug, Clone)]
+struct RollingOccurrence {
+    nodes: Vec<NodeIndex>,
+    boundary_inputs: Vec<NodeIndex>,
+    output_nodes: Vec<NodeIndex>,
+}
+
+#[derive(Debug, Clone)]
+struct RollingCandidate {
+    occurrences: Vec<RollingOccurrence>,
+    state_param_indices: Vec<usize>,
+    savings: usize,
+}
+
+#[derive(Debug, Clone)]
+struct RollingRun {
+    occurrences: Vec<RollingOccurrence>,
+    starts: Vec<usize>,
+    window: usize,
+}
+
+#[derive(Debug, Clone, Default)]
+struct RollingSearchDiagnostics {
+    windows_probed: usize,
+    adjacent_hash_matches: usize,
+    repeated_signature_runs: usize,
+    rejected_zero_state_params: usize,
+    best_rejected: Option<RollingRejectedCandidate>,
+    top_runs: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct RollingRejectedCandidate {
+    window: usize,
+    repetitions: usize,
+    boundary_inputs: usize,
+    state_params: usize,
+    savings: usize,
+}
+
+#[derive(Debug, Clone)]
+struct RollingSearchReport {
+    candidate: Option<RollingCandidate>,
+    diagnostics: RollingSearchDiagnostics,
+}
+
+/// A compiled bucket: (bucket_indices, representative_dyn_map, stitched_llir).
+pub type BucketLLIR = (DynMap, DynMap, LLIRGraph);
+
+/// Borrowed view of a compiled bucket used for non-committing aggregate
+/// candidate filtering.
+#[derive(Clone, Copy)]
+pub struct BucketLLIRRef<'a> {
+    pub bucket_indices: &'a DynMap,
+    pub representative_dyn_map: &'a DynMap,
+    pub llir: &'a LLIRGraph,
+}
+
+impl<'a> From<&'a BucketLLIR> for BucketLLIRRef<'a> {
+    fn from((bucket_indices, representative_dyn_map, llir): &'a BucketLLIR) -> Self {
+        Self {
+            bucket_indices,
+            representative_dyn_map,
+            llir,
+        }
+    }
+}
+
+/// A bucket for a dynamic dimension, defining a range of valid values.
+/// For an exact value, use `min == max` (zero-length range).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct DimBucket {
+    pub min: usize,
+    pub max: usize,
+    representative_override: Option<usize>,
+}
+
+impl DimBucket {
+    /// Create a new bucket covering `[min, max]` inclusive.
+    /// For an exact value, pass `min == max`.
+    pub fn new(min: usize, max: usize) -> Self {
+        assert!(min <= max, "DimBucket min ({min}) must be <= max ({max})");
+        DimBucket {
+            min,
+            max,
+            representative_override: None,
+        }
+    }
+
+    /// Override the representative value used during search profiling.
+    /// Must be within `[min, max]`.
+    pub fn representative(mut self, val: usize) -> Self {
+        assert!(
+            val >= self.min && val <= self.max,
+            "Representative {val} must be in [{}, {}]",
+            self.min,
+            self.max
+        );
+        self.representative_override = Some(val);
+        self
+    }
+
+    /// The representative value used during search profiling.
+    /// Defaults to midpoint `(min + max) / 2`.
+    pub fn representative_value(&self) -> usize {
+        self.representative_override
+            .unwrap_or((self.min + self.max) / 2)
+    }
+
+    /// Check if `val` falls within this bucket's range.
+    pub fn contains(&self, val: usize) -> bool {
+        val >= self.min && val <= self.max
+    }
+}
+
+/// Options for building an e-graph search space and searching it.
+///
+/// Use the builder pattern to configure search parameters:
+/// ```
+/// use luminal::prelude::CompileOptions;
+/// let opts = CompileOptions::default()
+///     .search_graph_limit(5)
+///     .search_time_limit(std::time::Duration::from_secs(30))
+///     .generation_size(50)
+///     .mutations(40)
+///     .trials(15);
+/// ```
+#[derive(Debug, Clone)]
+pub struct CompileOptions {
+    /// Maximum number of graphs to evaluate during search.
+    pub limit: usize,
+    /// Maximum wall-clock time to spend searching.
+    pub search_time_limit: std::time::Duration,
+    /// Number of offspring per generation (default: 10)
+    pub generation_size: usize,
+    /// Number of mutations applied to each offspring (default: 10)
+    pub mutations: usize,
+    /// Number of profiling trials per candidate (default: 3)
+    pub trials: usize,
+    /// Number of best genomes to keep as parents per generation (default: 1)
+    pub keep_best: usize,
+    /// Generations without a new best before exploration escalates:
+    /// mutation counts grow per stagnant generation (escaping local minima
+    /// needs multi-gene jumps) and every other stagnant generation samples
+    /// fresh random genomes. 0 disables (default: 0).
+    pub restart_stagnation: usize,
+    /// Per-candidate viability budget covering compile (`load_llir`) + run.
+    /// Candidates exceeding it are discarded (default: 60 seconds).
+    pub candidate_timeout: Option<std::time::Duration>,
+    /// Caps how long profiling runs a single trial; not a rejection criterion.
+    pub execution_timeout: Option<std::time::Duration>,
+    /// Stop profiling a candidate early once its running mean exceeds
+    /// `factor ×` the best candidate's metric. The partial mean is still
+    /// returned and ranked normally, so this never changes which candidates
+    /// are eligible — it only stops spending trials on candidates that have
+    /// already lost by at least this margin. `None` disables (default).
+    pub early_stop_factor: Option<f64>,
+    /// Dynamic dimension values applied after search-space construction and
+    /// before search. These values persist in [`Graph::dyn_map`] and provide
+    /// the base representative values for unbucketed dimensions. Per-bucket
+    /// representatives override them during bucketed search, and
+    /// [`CompileOptions::profile_dims`] override them only while profiling.
+    pub search_dims: DynMap,
+    /// Optional profiling dimension overrides.
+    pub profile_dims: DynMap,
+    /// Bucket definitions per dynamic dimension. Dimensions without buckets use
+    /// a single implicit bucket.
+    pub dim_buckets: FxHashMap<Symbol, Vec<DimBucket>>,
+    /// Enable egglog progress logging. Quiet by default; overridden by
+    /// `EGGLOG_LOG=1` or `LUMINAL_LOG=1`.
+    pub egglog_log: bool,
+    /// Enable automatic loop rolling and its diagnostics. Disabled by default;
+    /// overridden by `ROLLING_LOG=1` or `LUMINAL_LOG=1`.
+    pub rolling_log: bool,
+    /// Enable search progress logging. Enabled by default; overridden by
+    /// `SEARCH_LOG=0`/`1` or `LUMINAL_LOG=1`.
+    pub search_log: bool,
+}
+
+/// Resolve a caller-supplied dimension name, rejecting the reserved loop index.
+///
+/// Covers the methods that give a dimension a value, not every way in:
+/// `Graph::dyn_map` and `CompileOptions::{search_dims, profile_dims,
+/// dim_buckets}` are public fields, and a serialized `ShapeTracker`
+/// deserializes without passing through here.
+fn checked_dim(dimension: impl Into<Symbol>) -> Symbol {
+    let dimension = dimension.into();
+    assert!(
+        !dimension.is_reserved(),
+        "{}",
+        crate::shape::InvalidSymbolName::Reserved
+    );
+    dimension
+}
+
+impl CompileOptions {
+    /// Set the maximum number of graphs to evaluate during search.
+    pub fn search_graph_limit(mut self, limit: usize) -> Self {
+        self.limit = limit;
+        self
+    }
+
+    /// Set the maximum wall-clock time to spend searching.
+    pub fn search_time_limit(mut self, search_time_limit: std::time::Duration) -> Self {
+        self.search_time_limit = search_time_limit;
+        self
+    }
+
+    /// Set the number of offspring per generation.
+    pub fn generation_size(mut self, generation_size: usize) -> Self {
+        self.generation_size = generation_size;
+        self
+    }
+
+    /// Set the number of mutations per offspring.
+    pub fn mutations(mut self, mutations: usize) -> Self {
+        self.mutations = mutations;
+        self
+    }
+
+    /// Set the number of profiling trials per candidate.
+    pub fn trials(mut self, trials: usize) -> Self {
+        self.trials = trials;
+        self
+    }
+
+    /// Set the number of best genomes to keep as parents per generation.
+    pub fn keep_best(mut self, keep_best: usize) -> Self {
+        self.keep_best = keep_best;
+        self
+    }
+
+    pub fn restart_stagnation(mut self, generations: usize) -> Self {
+        self.restart_stagnation = generations;
+        self
+    }
+
+    /// Set the outer per-candidate timeout (compilation + execution).
+    pub fn candidate_timeout(mut self, candidate_timeout: std::time::Duration) -> Self {
+        self.candidate_timeout = Some(candidate_timeout);
+        self
+    }
+
+    /// Set the inner single-execution timeout (execution only, excludes compile).
+    pub fn execution_timeout(mut self, execution_timeout: std::time::Duration) -> Self {
+        self.execution_timeout = Some(execution_timeout);
+        self
+    }
+
+    /// Stop profiling a candidate once its running mean exceeds `factor ×`
+    /// the current best. See [`CompileOptions::early_stop_factor`].
+    pub fn early_stop_factor(mut self, factor: f64) -> Self {
+        assert!(
+            factor >= 1.0,
+            "early_stop_factor below 1.0 would truncate candidates still in contention"
+        );
+        self.early_stop_factor = Some(factor);
+        self
+    }
+
+    /// Set a dynamic dimension after search-space construction and before
+    /// search. This is equivalent to calling [`Graph::set_dim`] between
+    /// [`Graph::build_search_space`] and [`Graph::search`], while still using
+    /// the unified [`Graph::compile`] API.
+    pub fn search_dim(mut self, dim: impl Into<Symbol>, value: usize) -> Self {
+        let dim = checked_dim(dim);
+        self.search_dims.insert(dim, value);
+        self
+    }
+
+    /// Override a dynamic dimension value used during search profiling.
+    pub fn profile_dim(mut self, dim: impl Into<Symbol>, value: usize) -> Self {
+        let dim = checked_dim(dim);
+        self.profile_dims.insert(dim, value);
+        self
+    }
+
+    /// Define buckets for a dynamic dimension.
+    ///
+    /// Bucketed compilation builds a separate search space and selected LLIR for
+    /// each bucket combination. Buckets must not overlap and must cover all
+    /// values that will be used at runtime.
+    pub fn dim_buckets(mut self, dimension: impl Into<Symbol>, buckets: &[DimBucket]) -> Self {
+        let dimension = checked_dim(dimension);
+        validate_dim_buckets(dimension, buckets);
+        self.dim_buckets.insert(dimension, buckets.to_vec());
+        self
+    }
+
+    /// Enable or disable egglog progress logging.
+    pub fn egglog_log(mut self, enabled: bool) -> Self {
+        self.egglog_log = enabled;
+        self
+    }
+
+    /// Enable or disable automatic loop rolling and its diagnostics.
+    pub fn rolling_log(mut self, enabled: bool) -> Self {
+        self.rolling_log = enabled;
+        self
+    }
+
+    /// Enable or disable search progress logging.
+    pub fn search_log(mut self, enabled: bool) -> Self {
+        self.search_log = enabled;
+        self
+    }
+
+    fn egglog_log_enabled(&self) -> bool {
+        log_channel_enabled(self.egglog_log, "EGGLOG_LOG")
+    }
+
+    fn rolling_log_enabled(&self) -> bool {
+        log_channel_enabled(self.rolling_log, "ROLLING_LOG")
+    }
+
+    /// Whether search progress logging is on, honoring `SEARCH_LOG` /
+    /// `LUMINAL_LOG` overrides.
+    pub fn search_log_enabled(&self) -> bool {
+        log_channel_enabled(self.search_log, "SEARCH_LOG")
+    }
+}
+
+impl Default for CompileOptions {
+    fn default() -> Self {
+        Self {
+            limit: 100,
+            search_time_limit: std::time::Duration::MAX,
+            generation_size: 10,
+            mutations: 10,
+            trials: 3,
+            keep_best: 1,
+            restart_stagnation: 0,
+            candidate_timeout: Some(std::time::Duration::from_secs(60)),
+            execution_timeout: Some(std::time::Duration::from_secs(1)),
+            early_stop_factor: None,
+            search_dims: FxHashMap::default(),
+            profile_dims: FxHashMap::default(),
+            dim_buckets: FxHashMap::default(),
+            egglog_log: false,
+            rolling_log: false,
+            search_log: true,
+        }
+    }
+}
+
+fn validate_dim_buckets(dimension: Symbol, buckets: &[DimBucket]) {
+    assert!(
+        !buckets.is_empty(),
+        "Buckets for dim '{dimension}' must not be empty"
+    );
+    for (i, a) in buckets.iter().enumerate() {
+        for b in buckets.iter().skip(i + 1) {
+            assert!(
+                a.max < b.min || b.max < a.min,
+                "Overlapping buckets for dim '{}': [{}, {}] and [{}, {}]",
+                dimension,
+                a.min,
+                a.max,
+                b.min,
+                b.max,
+            );
+        }
+    }
+}
+
+/// A Luminal compute graph.
+///
+/// All computation is represented as a directed acyclic graph.
+#[derive(Debug, Default)]
+pub struct Graph {
+    /// A map of dynamic dimensions to concrete dimension sizes
+    pub dyn_map: DynMap,
+    /// Edge weights: (Input index, Output index, Input shape)
+    pub graph: HLIRGraph,
+    /// The saturated search space built by [`Graph::build_search_space`]:
+    /// one e-graph per bucket combination, handed to the runtime to search.
+    search_space: Option<SearchSpace>,
+    /// Custom ops
+    pub custom_ops: Vec<Box<dyn CustomOp>>,
+    /// Optional graph-wide interval assumptions for dynamic dimensions.
+    pub dim_intervals: DynDimIntervals,
+    /// Metadata for Input nodes: NodeIndex -> (label, dtype).
+    /// Stored as plain data so it survives cross-binary type identity mismatches
+    /// when external backend plugins are compiled separately.
+    pub input_meta: FxHashMap<NodeIndex, (String, DType)>,
+    selected_schedule: Option<SelectedSchedule>,
+}
+
+impl Graph {
+    /// Create a new graph
+    pub fn new() -> Graph {
+        Graph::default()
+    }
+
+    fn run_auto_loop_rolling_prepass(&mut self, options: &CompileOptions) {
+        let log = options.rolling_log_enabled();
+        let before = self.graph.node_count();
+        // Roll to a fixpoint. Each pass rolls the single best repeated
+        // region, and rolling one region can expose the next: a periodic
+        // layer pattern (e.g. 5 local + 1 global attention layer) first
+        // rolls into a multi-layer body, and only then do the identical
+        // layers inside that one surviving body form a rollable run of
+        // their own. Termination: every roll strictly deletes duplicate
+        // body nodes, and marker ops are unique so they never form new
+        // repeats.
+        let mut rolled = 0usize;
+        while self.auto_roll_loops_prepass_with_log(log) > 0 {
+            rolled += 1;
+        }
+        if rolled == 0 {
+            println!(
+                "   {:>6}  no loop regions found (max body={})",
+                "Rolled".cyan().bold(),
+                before / 2,
+            );
+        }
+        if log {
+            self.debug_validate_rolled_regions();
+        }
+    }
+
+    /// ROLLING_LOG diagnostic: walk each rolled region's body in the HLIR and
+    /// report any path that reaches another region's markers without passing
+    /// through this region's own exit markers. Inner regions reaching outer
+    /// markers directly means some cross-region edge was not rewired through
+    /// a marker at insert time.
+    fn debug_validate_rolled_regions(&self) {
+        use crate::hlir::{LoopEnd, LoopInput, LoopOutput, LoopOutputSelect, LoopStart, Output};
+        let mut markers: FxHashMap<NodeIndex, usize> = FxHashMap::default();
+        let mut entries: FxHashMap<usize, Vec<NodeIndex>> = FxHashMap::default();
+        for n in self.graph.node_indices() {
+            if let Some(op) = self.try_get_op::<LoopStart>(n) {
+                markers.insert(n, op.loop_id);
+                entries.entry(op.loop_id).or_default().push(n);
+            } else if let Some(op) = self.try_get_op::<LoopEnd>(n) {
+                markers.insert(n, op.loop_id);
+            } else if let Some(op) = self.try_get_op::<LoopInput>(n) {
+                markers.insert(n, op.loop_id);
+                entries.entry(op.loop_id).or_default().push(n);
+            } else if let Some(op) = self.try_get_op::<LoopOutput>(n) {
+                markers.insert(n, op.loop_id);
+            } else if let Some(op) = self.try_get_op::<LoopOutputSelect>(n) {
+                markers.insert(n, op.loop_id);
+            }
+        }
+        for (&id, seeds) in entries.iter().sorted_by_key(|(id, _)| **id) {
+            let mut seen: FxHashSet<NodeIndex> = FxHashSet::default();
+            let mut bridges = 0usize;
+            let mut worklist: Vec<(NodeIndex, NodeIndex)> = seeds
+                .iter()
+                .flat_map(|m| {
+                    self.graph
+                        .neighbors_directed(*m, Direction::Outgoing)
+                        .map(|s| (s, *m))
+                        .collect::<Vec<_>>()
+                })
+                .collect();
+            while let Some((n, pred)) = worklist.pop() {
+                if seen.contains(&n) {
+                    continue;
+                }
+                if let Some(&owner) = markers.get(&n) {
+                    if owner != id {
+                        bridges += 1;
+                        if bridges <= 3 {
+                            println!(
+                                "   {:>6}  region {id} bridge: {} -> {} (owner {owner})",
+                                "Rolled".red().bold(),
+                                self.graph[pred],
+                                self.graph[n],
+                            );
+                        }
+                    }
+                    continue;
+                }
+                if self.try_get_op::<Output>(n).is_some() {
+                    continue;
+                }
+                seen.insert(n);
+                for succ in self
+                    .graph
+                    .neighbors_directed(n, Direction::Outgoing)
+                    .collect::<Vec<_>>()
+                {
+                    worklist.push((succ, n));
+                }
+            }
+            println!(
+                "   {:>6}  region {id}: body={} foreign-marker bridges={}",
+                "Rolled".cyan().bold(),
+                seen.len(),
+                bridges,
+            );
+        }
+    }
+
+    /// Add edges whose relative edge-id order carries meaning (LoopInput
+    /// per-iteration sources) with freshly allocated, ascending edge ids.
+    /// StableGraph recycles freed edge indices LIFO, so after any removals a
+    /// plain `add_edge` sequence lands on arbitrary ids — and `get_sources`
+    /// / serialization order edges by id. Drain the free list with dummy
+    /// edges first, add the real edges in fresh index territory, then drop
+    /// the dummies.
+    fn add_iteration_ordered_edges(&mut self, pending: Vec<(NodeIndex, Vec<NodeIndex>)>) {
+        use petgraph::visit::EdgeIndexable;
+        let Some(&(anchor, _)) = pending.first() else {
+            return;
+        };
+        let bound = EdgeIndexable::edge_bound(&self.graph);
+        let mut dummies = Vec::new();
+        loop {
+            let e = self.graph.add_edge(anchor, anchor, ());
+            let fresh = e.index() >= bound;
+            dummies.push(e);
+            if fresh {
+                break;
+            }
+        }
+        for (marker, sources) in pending {
+            for src in sources {
+                self.graph.add_edge(src, marker, ());
+            }
+        }
+        for e in dummies {
+            self.graph.remove_edge(e);
+        }
+    }
+
+    /// Mutate the HLIR graph in place to fold N repeated body occurrences into
+    /// a single body plus loop-marker ops. See `auto_roll_loops_prepass`.
+    fn insert_loop_region_ops(&mut self, candidate: RollingCandidate, log: bool) -> usize {
+        use crate::hlir::{LoopEnd, LoopInput, LoopOutput, LoopOutputSelect, LoopStart, Output};
+        use petgraph::visit::EdgeRef;
+
+        let nodes_before = self.graph.node_count();
+        let n_iters = candidate.occurrences.len();
+        // Regions roll one at a time; each gets the next free id so nested
+        // and disjoint regions stay distinguishable through egglog and the
+        // LLIR unroll/collapse passes.
+        let loop_id = self
+            .graph
+            .node_indices()
+            .filter_map(|n| {
+                self.try_get_op::<LoopStart>(n)
+                    .map(|start| start.loop_id + 1)
+            })
+            .max()
+            .unwrap_or(0);
+
+        // Build the body-node sets EXCLUDING `Output` HLIR nodes. An Output
+        // inside a rolled occurrence is a graph-external sink for that
+        // iteration's value, not body computation; we treat it as a cross-
+        // region consumer so each iteration's Output survives all the way
+        // through and gets rewired to its `LoopOutputSelect(i)` below.
+        let body_nodes: FxHashSet<NodeIndex> = candidate.occurrences[0]
+            .nodes
+            .iter()
+            .copied()
+            .filter(|&n| self.try_get_op::<Output>(n).is_none())
+            .collect();
+        let mut duplicate_body_nodes: FxHashSet<NodeIndex> = FxHashSet::default();
+        for occ in &candidate.occurrences[1..] {
+            for &n in &occ.nodes {
+                if self.try_get_op::<Output>(n).is_none() {
+                    duplicate_body_nodes.insert(n);
+                }
+            }
+        }
+
+        let n_boundary = candidate.occurrences[0].boundary_inputs.len();
+        let state_set: FxHashSet<usize> = candidate.state_param_indices.iter().copied().collect();
+
+        let mut state_out_pos_per_slot: Vec<usize> =
+            Vec::with_capacity(candidate.state_param_indices.len());
+        let mut state_output_positions: FxHashSet<usize> = FxHashSet::default();
+        for &p in &candidate.state_param_indices {
+            let next_val = candidate.occurrences[1].boundary_inputs[p];
+            let pos = candidate.occurrences[0]
+                .output_nodes
+                .iter()
+                .position(|&n| n == next_val)
+                .expect("state param must have a producer in output_nodes");
+            state_out_pos_per_slot.push(pos);
+            state_output_positions.insert(pos);
+        }
+
+        let mut created = 0usize;
+        // Loop markers cross the HLIR -> egglog -> LLIR boundary and therefore
+        // carry the same concrete dtype as the tensor they represent. Compute
+        // those dtypes from the still-unmodified graph before inserting any
+        // markers; an unknown or inconsistent dtype is a compile error, never
+        // an F32 default.
+        let dtype_map = self.concrete_node_dtypes();
+        // Track all NodeIndex slots we newly assign for loop-marker ops.
+        // StableGraph reuses freed node indices; removals later in this
+        // function might target slots that happen to coincide with a new
+        // loop-marker's NodeIndex, so we explicitly exclude those.
+        let mut added_loop_ops: FxHashSet<NodeIndex> = FxHashSet::default();
+        // LoopInput per-iteration source edges, added together at the end:
+        // edge-id order IS logical input order across HLIR (`get_sources`
+        // sorts by id), and StableGraph recycles freed edge indices LIFO, so
+        // adding these amid the rewiring below — or after a previous pass's
+        // duplicate-body deletions — would hand them arbitrary recycled ids
+        // and silently permute iteration order at serialization.
+        let mut deferred_source_edges: Vec<(NodeIndex, Vec<NodeIndex>)> = Vec::new();
+
+        for (slot_idx, (&p, &out_pos)) in candidate
+            .state_param_indices
+            .iter()
+            .zip(state_out_pos_per_slot.iter())
+            .enumerate()
+        {
+            let initial = candidate.occurrences[0].boundary_inputs[p];
+            let body_state_out = candidate.occurrences[0].output_nodes[out_pos];
+            let last_state_out = candidate.occurrences[n_iters - 1].output_nodes[out_pos];
+            let dtype = dtype_map[&initial];
+            for (role, node) in [
+                ("loop body state output", body_state_out),
+                ("loop final state output", last_state_out),
+            ] {
+                let actual = dtype_map[&node];
+                assert_eq!(
+                    actual,
+                    dtype,
+                    "loop {loop_id} slot {slot_idx} changes dtype: initial node {} is {dtype:?}, {role} node {} is {actual:?}",
+                    initial.index(),
+                    node.index(),
+                );
+            }
+
+            let loop_start = self.graph.add_node(Box::new(LoopStart {
+                loop_id,
+                slot_idx,
+                iters: Expression::from(n_iters as i32),
+                dtype,
+            }));
+            added_loop_ops.insert(loop_start);
+            self.graph.add_edge(initial, loop_start, ());
+
+            let edges_out_of_initial: Vec<_> = self
+                .graph
+                .edges_directed(initial, Direction::Outgoing)
+                .filter(|e| body_nodes.contains(&e.target()))
+                .map(|e| (e.id(), e.target()))
+                .collect();
+            for (eid, dst) in edges_out_of_initial {
+                self.graph.remove_edge(eid);
+                self.graph.add_edge(loop_start, dst, ());
+            }
+
+            let loop_end = self.graph.add_node(Box::new(LoopEnd {
+                loop_id,
+                slot_idx,
+                dtype,
+            }));
+            added_loop_ops.insert(loop_end);
+            self.graph.add_edge(body_state_out, loop_end, ());
+
+            let external_edges: Vec<_> = self
+                .graph
+                .edges_directed(last_state_out, Direction::Outgoing)
+                .filter(|e| {
+                    let t = e.target();
+                    !body_nodes.contains(&t) && !duplicate_body_nodes.contains(&t)
+                })
+                .map(|e| (e.id(), e.target()))
+                .collect();
+            for (eid, dst) in external_edges {
+                self.graph.remove_edge(eid);
+                self.graph.add_edge(loop_end, dst, ());
+            }
+
+            created += 2;
+        }
+
+        for p in 0..n_boundary {
+            if state_set.contains(&p) {
+                continue;
+            }
+            let per_iter_sources: Vec<NodeIndex> = candidate
+                .occurrences
+                .iter()
+                .map(|occ| occ.boundary_inputs[p])
+                .collect();
+            if per_iter_sources.windows(2).all(|w| w[0] == w[1]) {
+                continue;
+            }
+
+            let body_input = candidate.occurrences[0].boundary_inputs[p];
+            let dtype = self.uniform_node_dtype(
+                &per_iter_sources,
+                &dtype_map,
+                &format!("loop {loop_id} input stream {p}"),
+            );
+            assert_eq!(
+                dtype, dtype_map[&body_input],
+                "loop {loop_id} input stream {p} body input has a different concrete dtype"
+            );
+            if log {
+                println!(
+                    "   {:>6}  loop {loop_id} stream {p}: per-iter sources {:?}",
+                    "Rolled".cyan().bold(),
+                    per_iter_sources
+                        .iter()
+                        .map(|n| n.index())
+                        .collect::<Vec<_>>(),
+                );
+            }
+            let loop_input = self.graph.add_node(Box::new(LoopInput {
+                loop_id,
+                stream_id: p,
+                dtype,
+            }));
+            added_loop_ops.insert(loop_input);
+            // Deferred: added at the end with fresh ascending edge ids —
+            // see `add_iteration_ordered_edges`.
+            deferred_source_edges.push((loop_input, per_iter_sources.clone()));
+
+            let body_edges: Vec<_> = self
+                .graph
+                .edges_directed(body_input, Direction::Outgoing)
+                .filter(|e| body_nodes.contains(&e.target()))
+                .map(|e| (e.id(), e.target()))
+                .collect();
+            for (eid, dst) in body_edges {
+                self.graph.remove_edge(eid);
+                self.graph.add_edge(loop_input, dst, ());
+            }
+
+            created += 1;
+        }
+
+        let n_outputs = candidate.occurrences[0].output_nodes.len();
+        for q in 0..n_outputs {
+            if state_output_positions.contains(&q) {
+                continue;
+            }
+
+            // Per iteration, determine (body_producer, edges_to_rewire):
+            //  * If `output_nodes[q]` is an Output HLIR (graph sink): the
+            //    body producer is that Output's predecessor, and the edge to
+            //    rewire is the predecessor → Output edge itself.
+            //  * Otherwise: body producer is `output_nodes[q]`; the edges to
+            //    rewire are all of its outgoing edges whose target is OUTSIDE
+            //    the rolled region (post-loop consumers — Output HLIR or any
+            //    downstream computation, treated identically).
+            let mut per_iter_plan: Vec<(NodeIndex, Vec<(petgraph::graph::EdgeIndex, NodeIndex)>)> =
+                Vec::with_capacity(n_iters);
+            let mut complete = true;
+            for occ in &candidate.occurrences {
+                let node = occ.output_nodes[q];
+                if self.try_get_op::<Output>(node).is_some() {
+                    // Output HLIR sink. Its predecessor is the body producer;
+                    // the single (pred → Output) edge is what we rewire.
+                    let pred_edge = self
+                        .graph
+                        .edges_directed(node, Direction::Incoming)
+                        .next()
+                        .map(|e| (e.id(), e.source(), node));
+                    match pred_edge {
+                        Some((eid, pred, output)) => {
+                            per_iter_plan.push((pred, vec![(eid, output)]));
+                        }
+                        None => {
+                            complete = false;
+                            break;
+                        }
+                    }
+                } else {
+                    // Internal body producer. Cross-region edges = its
+                    // outgoing edges whose target is not in any iter's body.
+                    let edges: Vec<_> = self
+                        .graph
+                        .edges_directed(node, Direction::Outgoing)
+                        .filter(|e| {
+                            let t = e.target();
+                            !body_nodes.contains(&t) && !duplicate_body_nodes.contains(&t)
+                        })
+                        .map(|e| (e.id(), e.target()))
+                        .collect();
+                    if edges.is_empty() {
+                        // Nothing actually crosses the region for this iter.
+                        // Skip the whole stream — without a consumer the
+                        // Select would dangle.
+                        complete = false;
+                        break;
+                    }
+                    per_iter_plan.push((node, edges));
+                }
+            }
+            if !complete {
+                continue;
+            }
+
+            // Iter-0 body producer feeds the LoopOutput marker.
+            let body_output = per_iter_plan[0].0;
+            let per_iter_outputs: Vec<NodeIndex> = per_iter_plan
+                .iter()
+                .map(|(producer, _)| *producer)
+                .collect();
+            let dtype = self.uniform_node_dtype(
+                &per_iter_outputs,
+                &dtype_map,
+                &format!("loop {loop_id} output stream {q}"),
+            );
+
+            let loop_output = self.graph.add_node(Box::new(LoopOutput {
+                loop_id,
+                stream_id: q,
+                dtype,
+            }));
+            self.graph.add_edge(body_output, loop_output, ());
+            added_loop_ops.insert(loop_output);
+
+            // For each iter, create a LoopOutputSelect(i) and rewire the
+            // cross-region edges to flow through it.
+            for (i, (_, edges)) in per_iter_plan.into_iter().enumerate() {
+                let select = self.graph.add_node(Box::new(LoopOutputSelect {
+                    loop_id,
+                    stream_id: q,
+                    iter: i,
+                    dtype,
+                }));
+                self.graph.add_edge(loop_output, select, ());
+                added_loop_ops.insert(select);
+
+                for (edge_id, consumer) in edges {
+                    self.graph.remove_edge(edge_id);
+                    self.graph.add_edge(select, consumer, ());
+                }
+                created += 1;
+            }
+            created += 1; // for the LoopOutput marker itself
+        }
+
+        // Delete duplicate body nodes. Skip any node we just added as a
+        // loop-marker op (StableGraph may reuse NodeIndex slots, so an
+        // added marker could collide with a previously-freed body node id).
+        for &node in &duplicate_body_nodes {
+            if added_loop_ops.contains(&node) {
+                continue;
+            }
+            self.graph.remove_node(node);
+        }
+
+        self.add_iteration_ordered_edges(deferred_source_edges);
+
+        if log && created > 0 {
+            let nodes_after = self.graph.node_count();
+            // Region partition: body_nodes is the surviving one-iteration body,
+            // `created` is the marker scaffold (LoopStart/End/Input/Output),
+            // and the rest is graph outside the loop region (embedding,
+            // weights, post-loop / lm-head).
+            let inside_body = body_nodes.len();
+            let inside_markers = created;
+            let outside = nodes_after - inside_body - inside_markers;
+            println!(
+                "   {:>6}  rolled HLIR: {} -> {} nodes ({} loop ops inserted, {} duplicate body nodes deleted)",
+                "Rolled".cyan().bold(),
+                nodes_before,
+                nodes_after,
+                created,
+                duplicate_body_nodes.len(),
+            );
+            println!(
+                "   {:>6}  region partition: {} inside ({} body + {} markers) / {} outside",
+                "Rolled".cyan().bold(),
+                inside_body + inside_markers,
+                inside_body,
+                inside_markers,
+                outside,
+            );
+        }
+        created
+    }
+
+    /// Resolve every HLIR node's concrete dtype in topological order.
+    ///
+    /// Each operation owns its dtype contract through
+    /// [`HLIROp::output_dtype`]. There is no graph-level opcode table and no
+    /// fallback dtype: malformed graphs fail before a transform can stamp
+    /// incorrect metadata onto a structural marker.
+    fn concrete_node_dtypes(&self) -> FxHashMap<NodeIndex, DType> {
+        let order = petgraph::algo::toposort(&self.graph, None).unwrap_or_else(|cycle| {
+            panic!("HLIR contains a cycle at node {}", cycle.node_id().index())
+        });
+        let mut dtypes = FxHashMap::default();
+        for node in order {
+            let sources = self.get_sources(node);
+            let input_dtypes: Vec<_> = sources
+                .iter()
+                .map(|source| {
+                    dtypes.get(source).copied().unwrap_or_else(|| {
+                        panic!(
+                            "HLIR node {} ({}) depends on node {} before its concrete dtype is known",
+                            node.index(),
+                            self.graph[node],
+                            source.index(),
+                        )
+                    })
+                })
+                .collect();
+            let dtype = self.graph[node].output_dtype(&input_dtypes);
+            if let Some((_, metadata_dtype)) = self.input_meta.get(&node) {
+                assert_eq!(
+                    dtype,
+                    *metadata_dtype,
+                    "HLIR node {} ({}) has conflicting concrete dtypes: op={dtype:?}, metadata={metadata_dtype:?}",
+                    node.index(),
+                    self.graph[node],
+                );
+            }
+            dtypes.insert(node, dtype);
+        }
+        dtypes
+    }
+
+    fn uniform_node_dtype(
+        &self,
+        nodes: &[NodeIndex],
+        dtypes: &FxHashMap<NodeIndex, DType>,
+        context: &str,
+    ) -> DType {
+        let (&first, rest) = nodes
+            .split_first()
+            .unwrap_or_else(|| panic!("{context} has no tensor sources"));
+        let dtype = dtypes[&first];
+        for &node in rest {
+            let actual = dtypes[&node];
+            assert_eq!(
+                actual,
+                dtype,
+                "{context} mixes concrete dtypes: node {} is {dtype:?}, node {} is {actual:?}",
+                first.index(),
+                node.index(),
+            );
+        }
+        dtype
+    }
+
+    /// Set a runtime dimension
+    pub fn set_dim(&mut self, dimension: impl Into<Symbol>, val: usize) {
+        let dimension = checked_dim(dimension);
+        self.dyn_map.insert(dimension, val);
+    }
+
+    pub fn set_dim_interval(&mut self, dimension: impl Into<Symbol>, min: i64, max: i64) {
+        let dimension = checked_dim(dimension);
+        self.dim_intervals
+            .insert(dimension, DimInterval::new(min, max));
+    }
+
+    /// Attempt to discover repeated HLIR regions and build explicit region
+    /// descriptors for loop-carried state edges.
+    /// Returns the number of detected inter-region boundaries.
+    ///
+    /// This is a conservative prepass:
+    /// - only rolls candidates with at least one loop-carried state parameter
+    /// - only inserts when the carried edge shapes can be inferred
+    pub fn auto_roll_loops_prepass(&mut self) -> usize {
+        let log = log_channel_enabled(false, "ROLLING_LOG");
+        self.auto_roll_loops_prepass_with_log(log)
+    }
+
+    fn auto_roll_loops_prepass_with_log(&mut self, log: bool) -> usize {
+        let max_region_size = self.graph.node_count() / 2;
+        if max_region_size < 1 {
+            return 0;
+        }
+        if log {
+            println!(
+                "   {:>6}  scanning {} HLIR nodes for loop regions (max body={})",
+                "Rolled".cyan().bold(),
+                self.graph.node_count(),
+                max_region_size,
+            );
+        }
+        let report = self.best_rolling_candidate(max_region_size);
+        let Some(candidate) = report.candidate else {
+            if log {
+                self.print_rolling_search_diagnostics(&report.diagnostics);
+            }
+            return 0;
+        };
+        if log {
+            println!(
+                "   {:>6}  candidate: body={} trips={} boundary_inputs={} state_params={:?}",
+                "Rolled".yellow().bold(),
+                candidate.occurrences[0].nodes.len(),
+                candidate.occurrences.len(),
+                candidate.occurrences[0].boundary_inputs.len(),
+                candidate.state_param_indices,
+            );
+            if let Some(rejected) = &report.diagnostics.best_rejected {
+                println!(
+                    "   {:>6}  best rejected: body={} trips={} boundary_inputs={} state_params={} savings={}",
+                    "Rolled".yellow().bold(),
+                    rejected.window,
+                    rejected.repetitions,
+                    rejected.boundary_inputs,
+                    rejected.state_params,
+                    rejected.savings,
+                );
+            }
+            for run in report.diagnostics.top_runs.iter().take(5) {
+                println!("   {:>6}  run: {}", "Rolled".yellow().bold(), run);
+            }
+        }
+        if candidate.occurrences.len() < 2 {
+            return 0;
+        }
+        // Reject rolls that grow the graph: a roll that deletes fewer
+        // duplicate nodes than the markers it creates is pure overhead.
+        // (Termination of the rolling fixpoint doesn't depend on this —
+        // every roll irreversibly consumes a repetition run, since markers
+        // are unique and can never form new repeats — so break-even rolls
+        // are kept for their search-space compression.)
+        let net = rolling_net_savings(&candidate);
+        if net < 0 {
+            if log {
+                println!(
+                    "   {:>6}  best candidate rejected: net savings {} <= 0 (body={} trips={})",
+                    "Rolled".yellow().bold(),
+                    net,
+                    candidate.occurrences[0].nodes.len(),
+                    candidate.occurrences.len(),
+                );
+            }
+            return 0;
+        }
+
+        // Mutate the HLIR in place — insert LoopStart/LoopEnd/LoopInput/
+        // LoopOutput markers, delete N-1 duplicate bodies. The loop structure
+        // is encoded in the HLIR graph itself and the downstream single-root
+        // egglog path picks it up unchanged.
+        self.insert_loop_region_ops(candidate, log)
+    }
+
+    fn print_rolling_search_diagnostics(&self, diagnostics: &RollingSearchDiagnostics) {
+        let best_rejected = diagnostics
+            .best_rejected
+            .as_ref()
+            .map(|candidate| {
+                format!(
+                    "best rejected: body={} trips={} boundary_inputs={} state_params={} savings={}",
+                    candidate.window,
+                    candidate.repetitions,
+                    candidate.boundary_inputs,
+                    candidate.state_params,
+                    candidate.savings
+                )
+            })
+            .unwrap_or_else(|| "best rejected: none".to_string());
+        println!(
+            "   {:>6}  diagnostics: windows={} hash_matches={} repeated_runs={} rejected(zero_state={}); {}",
+            "Rolled".yellow().bold(),
+            diagnostics.windows_probed,
+            diagnostics.adjacent_hash_matches,
+            diagnostics.repeated_signature_runs,
+            diagnostics.rejected_zero_state_params,
+            best_rejected,
+        );
+        for run in diagnostics.top_runs.iter().take(5) {
+            println!("   {:>6}  run: {}", "Rolled".yellow().bold(), run);
+        }
+    }
+
+    /// Innermost enclosing rolled region per HLIR node. Walked outer-to-inner
+    /// (ascending loop_id = creation order), so later (inner) regions
+    /// overwrite nothing: an outer walk stops at the inner region's markers
+    /// and never sees the inner body. Nodes outside every region are absent.
+    fn region_scope_map(&self) -> FxHashMap<NodeIndex, usize> {
+        use crate::hlir::{LoopInput, LoopStart, Output};
+        let mut entries: std::collections::BTreeMap<usize, Vec<NodeIndex>> =
+            std::collections::BTreeMap::new();
+        for n in self.graph.node_indices() {
+            if let Some(op) = self.try_get_op::<LoopStart>(n) {
+                entries.entry(op.loop_id).or_default().push(n);
+            } else if let Some(op) = self.try_get_op::<LoopInput>(n) {
+                entries.entry(op.loop_id).or_default().push(n);
+            }
+        }
+        let mut scope: FxHashMap<NodeIndex, usize> = FxHashMap::default();
+        for (&id, seeds) in &entries {
+            let mut worklist: Vec<NodeIndex> = seeds
+                .iter()
+                .flat_map(|m| {
+                    self.graph
+                        .neighbors_directed(*m, Direction::Outgoing)
+                        .collect::<Vec<_>>()
+                })
+                .collect();
+            let mut seen: FxHashSet<NodeIndex> = FxHashSet::default();
+            while let Some(n) = worklist.pop() {
+                if seen.contains(&n)
+                    || self.is_rolled_loop_marker(n)
+                    || self.try_get_op::<Output>(n).is_some()
+                {
+                    continue;
+                }
+                seen.insert(n);
+                scope.insert(n, id);
+                for succ in self
+                    .graph
+                    .neighbors_directed(n, Direction::Outgoing)
+                    .collect::<Vec<_>>()
+                {
+                    worklist.push(succ);
+                }
+            }
+        }
+        scope
+    }
+
+    fn is_rolled_loop_marker(&self, n: NodeIndex) -> bool {
+        use crate::hlir::{
+            LoopEnd, LoopInput, LoopInputStatic, LoopOutput, LoopOutputSelect, LoopStart,
+        };
+        self.try_get_op::<LoopStart>(n).is_some()
+            || self.try_get_op::<LoopEnd>(n).is_some()
+            || self.try_get_op::<LoopInput>(n).is_some()
+            || self.try_get_op::<LoopInputStatic>(n).is_some()
+            || self.try_get_op::<LoopOutput>(n).is_some()
+            || self.try_get_op::<LoopOutputSelect>(n).is_some()
+    }
+
+    fn best_rolling_candidate(&self, max_region_size: usize) -> RollingSearchReport {
+        // The signature memo is keyed by NodeIndex; clear it so entries from a
+        // prior (now-mutated) graph state can't leak into this read-only search.
+        clear_rolling_sig_cache();
+        let Some(full_topo) = stable_toposort_by_node_index(&self.graph) else {
+            return RollingSearchReport {
+                candidate: None,
+                diagnostics: RollingSearchDiagnostics::default(),
+            };
+        };
+        // Inputs, Outputs, and loop markers are region boundary, not body:
+        // they feed or drain repeated windows without belonging to them.
+        // Markers especially must be excluded — after one roll, per-iteration
+        // values (e.g. layer weights) arrive through LoopInput markers whose
+        // stream ids differ, and letting them into windows breaks the hash
+        // match for otherwise-identical bodies nested inside the roll.
+        let topo: Vec<NodeIndex> = full_topo
+            .into_iter()
+            .filter(|n| {
+                self.try_get_op::<crate::hlir::Input>(*n).is_none()
+                    && self.try_get_op::<crate::hlir::Output>(*n).is_none()
+                    && !self.is_rolled_loop_marker(*n)
+            })
+            .collect();
+        if topo.len() < 2 {
+            return RollingSearchReport {
+                candidate: None,
+                diagnostics: RollingSearchDiagnostics::default(),
+            };
+        }
+        let uses = build_uses(&self.graph);
+        // A roll must not straddle a rolled-region boundary: occurrences in
+        // different scopes would produce overlapping (not nested) regions.
+        // Markers are invisible to scan windows, so this scope check is the
+        // fence that keeps repetition discovery from crossing into or out of
+        // an existing rolled body.
+        let node_scope = self.region_scope_map();
+        let scope_uniform = |occs: &[RollingOccurrence]| {
+            let mut nodes = occs.iter().flat_map(|occ| occ.nodes.iter());
+            let first = nodes.next().map(|n| node_scope.get(n).copied());
+            match first {
+                None => true,
+                Some(s0) => nodes.all(|n| node_scope.get(n).copied() == s0),
+            }
+        };
+        let topo_index: FxHashMap<NodeIndex, usize> =
+            topo.iter().enumerate().map(|(i, &n)| (n, i)).collect();
+        // Cap the largest probed window. A useful rolling candidate is one
+        // repeating unit — a transformer layer (≈3.4k HLIR nodes for a gpt-oss
+        // MoE layer; ≈6.7k for a 2-minibatch dual-branch layer). With two
+        // structurally-similar branches (default + minibatch prefill share
+        // weights) the cheap rolling hash matches MANY large windows spanning
+        // both branches; each triggers an O(window) `canonicalize_occurrence`
+        // that ultimately fails the signature check. Probing windows all the way
+        // to `topo.len()/2` made those dead-end canonicalizes dominate (still
+        // minutes even after the externals-scan fix below). Capping the window
+        // comfortably above one layer skips them without changing the selected
+        // candidate (the per-layer roll has the best savings = window·(reps−1)
+        // and lives at a small window). A real body larger than the cap just
+        // isn't rolled (correctness preserved). Tunable via LUMINAL_MAX_ROLL_BODY.
+        let roll_body_cap = std::env::var("LUMINAL_MAX_ROLL_BODY")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&v| v >= 1)
+            .unwrap_or(8192);
+        let max_window = max_region_size.min(topo.len() / 2).min(roll_body_cap);
+        let probe_windows = rolling_probe_window_sizes(max_window);
+        let node_hashes: Vec<u64> = topo
+            .iter()
+            .map(|&node| cheap_rolling_node_hash(&self.graph, node, &self.custom_ops))
+            .collect();
+        let rolling_hash = RollingHash64::new(&node_hashes);
+        let mut diagnostics = RollingSearchDiagnostics::default();
+        let mut best_overall: Option<RollingCandidate> = None;
+        let mut discovered_runs: Vec<RollingRun> = Vec::new();
+
+        // Search all window sizes down to 1, using cheap rolling hashes only as a
+        // gate for expensive canonicalization. Candidate selection remains purely
+        // based on valid HLIR-op reduction.
+        for window in probe_windows {
+            let mut start = 0usize;
+            while start + window * 2 <= topo.len() {
+                diagnostics.windows_probed += 1;
+                let first_hash = rolling_hash.window_hash(start, window);
+                let second_hash = rolling_hash.window_hash(start + window, window);
+                if first_hash != second_hash {
+                    start += 1;
+                    continue;
+                }
+                diagnostics.adjacent_hash_matches += 1;
+
+                let mut occs = vec![];
+                let mut starts = vec![];
+                let first_nodes = topo[start..start + window].to_vec();
+                let Some((sig, first_boundary, first_outputs)) = canonicalize_occurrence(
+                    &self.graph,
+                    &first_nodes,
+                    &uses,
+                    &topo_index,
+                    &self.custom_ops,
+                ) else {
+                    start += 1;
+                    continue;
+                };
+                starts.push(start);
+                occs.push(RollingOccurrence {
+                    nodes: first_nodes,
+                    boundary_inputs: first_boundary,
+                    output_nodes: first_outputs,
+                });
+
+                let mut pos = start + window;
+                while pos + window <= topo.len() {
+                    if rolling_hash.window_hash(pos, window) != first_hash {
+                        break;
+                    }
+                    let nodes = topo[pos..pos + window].to_vec();
+                    let Some((next_sig, boundary_inputs, output_nodes)) = canonicalize_occurrence(
+                        &self.graph,
+                        &nodes,
+                        &uses,
+                        &topo_index,
+                        &self.custom_ops,
+                    ) else {
+                        break;
+                    };
+                    if next_sig != sig {
+                        break;
+                    }
+                    starts.push(pos);
+                    occs.push(RollingOccurrence {
+                        nodes,
+                        boundary_inputs,
+                        output_nodes,
+                    });
+                    pos += window;
+                }
+                if occs.len() < 2 {
+                    start += 1;
+                    continue;
+                }
+                diagnostics.repeated_signature_runs += 1;
+                discovered_runs.push(RollingRun {
+                    occurrences: occs.clone(),
+                    starts: starts.clone(),
+                    window,
+                });
+                let stride = starts
+                    .windows(2)
+                    .next()
+                    .map(|w| w[1].saturating_sub(w[0]))
+                    .unwrap_or(0);
+                let summary = format!(
+                    "body={} trips={} stride={} boundary_inputs={} state_params={} starts={:?}",
+                    window,
+                    occs.len(),
+                    stride,
+                    occs[0].boundary_inputs.len(),
+                    collect_state_params(&occs, &uses, &self.graph).len(),
+                    starts.iter().copied().take(4).collect::<Vec<_>>()
+                );
+                if occs.len() >= 20 && diagnostics.top_runs.len() < 16 {
+                    diagnostics.top_runs.push(summary);
+                }
+
+                let state_params = collect_state_params(&occs, &uses, &self.graph);
+                if state_params.is_empty()
+                    || !candidate_is_rollable(&occs, &state_params)
+                    || !scope_uniform(&occs)
+                {
+                    let rejected = RollingRejectedCandidate {
+                        window,
+                        repetitions: occs.len(),
+                        boundary_inputs: occs[0].boundary_inputs.len(),
+                        state_params: state_params.len(),
+                        savings: window * (occs.len() - 1),
+                    };
+                    diagnostics.rejected_zero_state_params += 1;
+                    let replace = diagnostics.best_rejected.as_ref().is_none_or(|best| {
+                        (rejected.savings, rejected.repetitions, rejected.window)
+                            > (best.savings, best.repetitions, best.window)
+                    });
+                    if replace {
+                        diagnostics.best_rejected = Some(rejected);
+                    }
+                    start = pos.saturating_sub(window).max(start + 1);
+                    continue;
+                }
+
+                let savings = window * (occs.len() - 1);
+                let _ = sig;
+                let candidate = RollingCandidate {
+                    occurrences: occs,
+                    state_param_indices: state_params,
+                    savings,
+                };
+                let replace = best_overall.as_ref().is_none_or(|b| {
+                    (rolling_net_savings(&candidate), candidate.occurrences.len())
+                        > (rolling_net_savings(b), b.occurrences.len())
+                });
+                if replace {
+                    best_overall = Some(candidate);
+                }
+                start = pos.saturating_sub(window).max(start + 1);
+            }
+        }
+        if crate::egglog_utils::log_channel_enabled(false, "ROLLING_LOG")
+            && let Some(best) = &best_overall
+        {
+            // Probe the windows adjacent to the accepted run: if another
+            // repetition of the body exists but didn't match, the first
+            // divergent node names what broke the periodicity of the linear
+            // order (phase misalignment shows up as an immediate mismatch,
+            // interleaved shared nodes as a mismatch at their topo slot).
+            let window = best.occurrences[0].nodes.len();
+            let first_start = topo_index[&best.occurrences[0].nodes[0]];
+            let last_start = topo_index[&best.occurrences.last().unwrap().nodes[0]];
+            for (label, probe_start) in [
+                ("before", first_start.checked_sub(window)),
+                ("after", Some(last_start + window)),
+            ] {
+                let Some(probe_start) = probe_start else {
+                    continue;
+                };
+                if probe_start + window > topo.len() {
+                    continue;
+                }
+                let mismatches = (0..window)
+                    .filter(|i| node_hashes[probe_start + i] != node_hashes[first_start + i])
+                    .take(4)
+                    .map(|i| {
+                        format!(
+                            "+{i}: {:?} vs body {:?}",
+                            self.graph[topo[probe_start + i]],
+                            self.graph[topo[first_start + i]]
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                let total = (0..window)
+                    .filter(|i| node_hashes[probe_start + i] != node_hashes[first_start + i])
+                    .count();
+                println!(
+                    "   Rolled  probe {label} run (start {probe_start}, window {window}): {total} hash mismatches{}{}",
+                    if mismatches.is_empty() {
+                        ""
+                    } else {
+                        "; first: "
+                    },
+                    mismatches.join(" | ")
+                );
+            }
+        }
+        let mut grown_best = best_overall.take().map(|best| {
+            // `best` is already rollable (gated above). Growing only ever
+            // extends occurrences, which could re-introduce a cross-occurrence
+            // dependency; if it does, keep the validated (smaller) seed.
+            let seed = best.clone();
+            let grown = grow_rolling_candidate(
+                &self.graph,
+                &uses,
+                &topo_index,
+                best,
+                &discovered_runs,
+                &self.custom_ops,
+            );
+            if candidate_is_rollable(&grown.occurrences, &grown.state_param_indices)
+                && scope_uniform(&grown.occurrences)
+            {
+                grown
+            } else {
+                seed
+            }
+        });
+        for run in &discovered_runs {
+            let state_param_indices = collect_state_params(&run.occurrences, &uses, &self.graph);
+            let seed = RollingCandidate {
+                occurrences: run.occurrences.clone(),
+                state_param_indices,
+                savings: 0,
+            };
+            let grown = grow_rolling_candidate(
+                &self.graph,
+                &uses,
+                &topo_index,
+                seed,
+                &discovered_runs,
+                &self.custom_ops,
+            );
+            if grown.state_param_indices.is_empty()
+                || !candidate_is_rollable(&grown.occurrences, &grown.state_param_indices)
+                || !scope_uniform(&grown.occurrences)
+            {
+                continue;
+            }
+            let replace = grown_best.as_ref().is_none_or(|best| {
+                (rolling_net_savings(&grown), grown.occurrences.len())
+                    > (rolling_net_savings(best), best.occurrences.len())
+            });
+            if replace {
+                grown_best = Some(grown);
+            }
+        }
+        RollingSearchReport {
+            candidate: grown_best,
+            diagnostics,
+        }
+    }
+
+    /// Create a new tensor with shape S
+    pub fn tensor(&mut self, shape: impl ToShape) -> GraphTensor {
+        self.named_tensor("", shape)
+    }
+
+    /// Create a new tensor with shape S and a name. This name will show up on the graph when displayed
+    pub fn named_tensor(&mut self, name: impl ToString, shape: impl ToShape) -> GraphTensor {
+        let name = name.to_string();
+        let id = self.graph.add_node(Box::new(crate::hlir::Input {
+            node: 0,
+            label: name.clone(),
+            dtype: DType::default(),
+        }));
+        self.get_op_mut::<crate::hlir::Input>(id).node = id.index();
+        self.input_meta.insert(id, (name.clone(), DType::default()));
+        GraphTensor {
+            id,
+            graph_ref: self,
+            shape: ShapeTracker::new(shape),
+            dtype: DType::default(),
+        }
+    }
+
+    /// Get the sources of a node given it's id
+    pub fn get_sources(&self, node_id: NodeIndex) -> Vec<NodeIndex> {
+        self.graph
+            .edges_directed(node_id, Direction::Incoming)
+            .sorted_by_key(|e| e.id())
+            .map(|e| e.source())
+            .collect()
+    }
+
+    /// Get the dests of a node given it's id
+    #[allow(clippy::borrowed_box)]
+    pub fn get_dests(&self, node_id: NodeIndex) -> Vec<(NodeIndex, &Box<dyn HLIROp>)> {
+        self.graph
+            .edges_directed(node_id, Direction::Outgoing)
+            .sorted_by_key(|e| e.id())
+            .map(|e| (e.target(), &self.graph[e.target()]))
+            .collect()
+    }
+
+    /// Add an op to the graph with the given input edges. Returns the new node's index.
+    ///
+    /// ```rust
+    /// # use luminal::prelude::*;
+    /// # let mut cx = Graph::new();
+    /// let a = cx.tensor(3);
+    /// let b_id = cx.add_op(
+    ///     luminal::hlir::Mul { input_shapes: vec![a.shape, a.shape], ..Default::default() },
+    ///     &[a.id],
+    /// );
+    /// let b = GraphTensor::from_id(b_id, a.shape, a.graph(), a.dtype);
+    /// ```
+    pub fn add_op<O: HLIROp + 'static>(&mut self, op: O, inputs: &[NodeIndex]) -> NodeIndex {
+        let id = self.graph.add_node(Box::new(op));
+        for &src in inputs {
+            self.graph.add_edge(src, id, ());
+        }
+        id
+    }
+
+    pub fn try_get_op<T: HLIROp + 'static>(&self, node: NodeIndex) -> Option<&T> {
+        self.node_weight(node).unwrap().as_any().downcast_ref::<T>()
+    }
+    pub fn get_op<T: HLIROp + 'static>(&self, node: NodeIndex) -> &T {
+        self.try_get_op(node).unwrap()
+    }
+    pub fn try_get_op_mut<T: HLIROp + 'static>(&mut self, node: NodeIndex) -> Option<&mut T> {
+        self.node_weight_mut(node)
+            .unwrap()
+            .as_any_mut()
+            .downcast_mut::<T>()
+    }
+    pub fn get_op_mut<T: HLIROp + 'static>(&mut self, node: NodeIndex) -> &mut T {
+        self.try_get_op_mut(node).unwrap()
+    }
+
+    pub fn custom_op(
+        &mut self,
+        op: impl CustomOp + 'static,
+        inputs: impl ToIds,
+        shape: impl ToShape,
+        dtype: DType,
+    ) -> GraphTensor {
+        self.custom_ops.push(Box::new(op));
+        let input_ids = inputs.to_ids();
+        let id = self.add_op(
+            CustomOpKind {
+                id: self.custom_ops.len() - 1,
+                dtype,
+            },
+            &input_ids,
+        );
+        GraphTensor::from_id(
+            id,
+            ShapeTracker::new_with_element_bits(shape, dtype.bits()),
+            self,
+            dtype,
+        )
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub fn build_search_space<Rt: Runtime>(&mut self, options: CompileOptions) {
+        let mut ops = Rt::Ops::into_vec();
+        ops.extend(<crate::hlir::HLIROps as IntoEgglogOp>::into_vec());
+        self.build_search_space_with_ops::<Rt>(ops, options);
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub fn build_search_space_exclude_ops<Rt: Runtime, Ex: IntoEgglogOp>(
+        &mut self,
+        options: CompileOptions,
+    ) {
+        let exclude_ops = Ex::into_vec()
+            .into_iter()
+            .map(|e| e.sort().name)
+            .collect::<FxHashSet<_>>();
+        let mut ops = Rt::Ops::into_vec();
+        ops.retain(|o| !exclude_ops.contains(&o.sort().name));
+        ops.extend(<crate::hlir::HLIROps as IntoEgglogOp>::into_vec());
+        self.build_search_space_with_ops::<Rt>(ops, options);
+    }
+
+    /// Roll loops, then saturate one e-graph per bucket combination into a
+    /// [`SearchSpace`] the runtime searches in [`Runtime::compile`].
+    fn build_search_space_with_ops<Rt: Runtime>(
+        &mut self,
+        ops: Vec<Arc<Box<dyn EgglogOp>>>,
+        options: CompileOptions,
+    ) {
+        self.run_auto_loop_rolling_prepass(&options);
+        let dim_buckets = options.dim_buckets.clone();
+        let late_pass_dyn_map = self.late_pass_dyn_map(&dim_buckets);
+        let late_passes = Rt::late_egglog_passes(&ops, &options, &late_pass_dyn_map);
+        let extra_egglog = Rt::extra_egglog();
+
+        let (program, root) = hlir_to_egglog(self);
+        let buckets = bucket_index_combinations(&dim_buckets)
+            .into_iter()
+            .map(|bucket_indices| {
+                let intervals = self.bucket_intervals(&dim_buckets, &bucket_indices);
+                let (contextual_program, use_interval_analysis) =
+                    self.egglog_program_with_interval_facts(&program, &intervals);
+                let egraph = run_egglog_with_late_passes_interval_analysis_and_log(
+                    &contextual_program,
+                    &root,
+                    &ops,
+                    Rt::CLEANUP_HLIR,
+                    &late_passes,
+                    &extra_egglog,
+                    use_interval_analysis,
+                    options.egglog_log_enabled(),
+                )
+                .unwrap();
+                BucketSearchSpace {
+                    egraph,
+                    bucket_indices,
+                    intervals,
+                }
+            })
+            .collect();
+        let custom_ops = self.custom_ops.iter().map(|op| op.to_llir_op()).collect();
+        self.search_space = Some(SearchSpace {
+            buckets,
+            ops,
+            custom_ops,
+            dim_buckets,
+        });
+    }
+
+    /// Graph-wide interval assumptions narrowed to one bucket combination.
+    fn bucket_intervals(
+        &self,
+        dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
+        bucket_indices: &DynMap,
+    ) -> DynDimIntervals {
+        let mut intervals = self.dim_intervals.clone();
+        for (&dim, &idx) in bucket_indices {
+            let bucket = &dim_buckets[&dim][idx];
+            let min = i64::try_from(bucket.min)
+                .expect("DimBucket min must fit into i64 for interval analysis");
+            let max = i64::try_from(bucket.max)
+                .expect("DimBucket max must fit into i64 for interval analysis");
+            let bucket_interval = DimInterval::new(min, max);
+            intervals
+                .entry(dim)
+                .and_modify(|existing| {
+                    existing.min = existing.min.max(bucket_interval.min);
+                    existing.max = existing.max.min(bucket_interval.max);
+                    assert!(
+                        existing.min <= existing.max,
+                        "Bucket interval for dim '{dim}' does not overlap graph interval"
+                    );
+                })
+                .or_insert(bucket_interval);
+        }
+        intervals
+    }
+
+    fn egglog_program_with_interval_facts(
+        &self,
+        program: &str,
+        intervals: &DynDimIntervals,
+    ) -> (String, bool) {
+        let facts = crate::egglog_utils::base::interval_facts_egglog(intervals, []);
+        if facts.is_empty() {
+            (program.to_string(), false)
+        } else {
+            (format!("{facts}\n{program}"), true)
+        }
+    }
+
+    /// Dyn map handed to backend late passes: bucket maxima override the
+    /// graph's values so passes plan for the largest shape.
+    fn late_pass_dyn_map(&self, dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>) -> DynMap {
+        let mut dyn_map = self.dyn_map.clone();
+        for (&dim, buckets) in dim_buckets {
+            if let Some(max) = buckets.iter().map(|bucket| bucket.max).max() {
+                dyn_map.insert(dim, max);
+            }
+        }
+        dyn_map
+    }
+    /// The built search space, if [`Graph::build_search_space`] has run.
+    pub fn search_space(&self) -> Option<&SearchSpace> {
+        self.search_space.as_ref()
+    }
+
+    /// Get a reference to the first e-graph search space (if built)
+    pub fn egraph(&self) -> Option<&SerializedEGraph> {
+        self.search_space
+            .as_ref()
+            .and_then(|space| space.buckets.first())
+            .map(|bucket| &bucket.egraph)
+    }
+
+    /// Get a reference to the available ops (if search space is built)
+    pub fn egglog_ops(&self) -> Option<&Vec<Arc<Box<dyn EgglogOp>>>> {
+        self.search_space.as_ref().map(|space| &space.ops)
+    }
+
+    /// Build the search space and search it with one shared set of options.
+    ///
+    /// This is the usual compile entry point when runtime inputs such as
+    /// weights have already been loaded. Use `build_search_space` and `search`
+    /// directly when the two phases need to be separated.
+    #[tracing::instrument(skip_all)]
+    pub fn compile<R: Runtime>(&mut self, runtime: R, options: CompileOptions) -> R {
+        let mut rng = rand::rng();
+        self.compile_with_rng(runtime, options, &mut rng)
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub fn compile_with_rng<R: Runtime, G: rand::Rng>(
+        &mut self,
+        runtime: R,
+        options: CompileOptions,
+        rng: &mut G,
+    ) -> R {
+        self.build_search_space::<R>(options.clone());
+        let runtime = self.search_with_rng(runtime, options, rng);
+        // Legality-by-construction burn-down: any post-extraction mask that
+        // fired during this compile is a contract violation to fix, not a
+        // normal event — always report it.
+        if let Some(report) = crate::mask_events::report() {
+            println!("{report}");
+        }
+        runtime
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub fn search<R: Runtime>(&mut self, runtime: R, options: CompileOptions) -> R {
+        let mut rng = rand::rng();
+        self.search_with_rng(runtime, options, &mut rng)
+    }
+
+    /// Hand the built search space to the runtime, which searches it by
+    /// whatever strategy it implements and loads the programs it selects.
+    #[tracing::instrument(skip_all)]
+    pub fn search_with_rng<R: Runtime, G: rand::Rng>(
+        &mut self,
+        mut runtime: R,
+        options: CompileOptions,
+        rng: &mut G,
+    ) -> R {
+        for (&dim, &value) in &options.search_dims {
+            self.set_dim(dim, value);
+        }
+        let space = self
+            .search_space
+            .as_ref()
+            .expect("build_search_space must run before search");
+        assert!(
+            options.dim_buckets.is_empty() || options.dim_buckets == space.dim_buckets,
+            "dim buckets must be configured in CompileOptions before build_search_space; search cannot change buckets after build",
+        );
+        runtime.compile(space, &self.dyn_map, &options, rng);
+        self.selected_schedule = runtime.selected_schedule();
+        runtime
+    }
+}
+impl Deref for Graph {
+    type Target = HLIRGraph;
+    fn deref(&self) -> &Self::Target {
+        &self.graph
+    }
+}
+
+impl DerefMut for Graph {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.graph
+    }
+}
+
+fn build_uses(graph: &HLIRGraph) -> FxHashMap<NodeIndex, Vec<(NodeIndex, usize)>> {
+    let mut uses: FxHashMap<NodeIndex, Vec<(NodeIndex, usize)>> = FxHashMap::default();
+    for n in graph.node_indices() {
+        uses.entry(n).or_default();
+    }
+    for dst in graph.node_indices() {
+        let sources: Vec<_> = graph
+            .edges_directed(dst, Direction::Incoming)
+            .sorted_by_key(|e| e.id())
+            .map(|e| e.source())
+            .collect();
+        for (port, src) in sources.into_iter().enumerate() {
+            if let Some(v) = uses.get_mut(&src) {
+                v.push((dst, port));
+            }
+        }
+    }
+    uses
+}
+
+fn stable_toposort_by_node_index(graph: &HLIRGraph) -> Option<Vec<NodeIndex>> {
+    let mut indegree: FxHashMap<NodeIndex, usize> = FxHashMap::default();
+    for n in graph.node_indices() {
+        indegree.insert(n, graph.edges_directed(n, Direction::Incoming).count());
+    }
+
+    let mut ready = std::collections::BTreeSet::new();
+    for (&node, &degree) in &indegree {
+        if degree == 0 {
+            ready.insert(node);
+        }
+    }
+
+    let mut ordered = Vec::with_capacity(graph.node_count());
+    while let Some(node) = ready.pop_first() {
+        ordered.push(node);
+        for edge in graph.edges_directed(node, Direction::Outgoing) {
+            let target = edge.target();
+            let degree = indegree
+                .get_mut(&target)
+                .expect("toposort target must exist in indegree map");
+            *degree -= 1;
+            if *degree == 0 {
+                ready.insert(target);
+            }
+        }
+    }
+
+    (ordered.len() == graph.node_count()).then_some(ordered)
+}
+
+struct RollingHash64 {
+    prefix: Vec<u64>,
+    powers: Vec<u64>,
+}
+
+impl RollingHash64 {
+    const BASE: u64 = 1_000_000_007;
+
+    fn new(tokens: &[u64]) -> Self {
+        let mut prefix = Vec::with_capacity(tokens.len() + 1);
+        let mut powers = Vec::with_capacity(tokens.len() + 1);
+        prefix.push(0u64);
+        powers.push(1u64);
+        for &token in tokens {
+            let next_prefix = prefix
+                .last()
+                .copied()
+                .unwrap()
+                .wrapping_mul(Self::BASE)
+                .wrapping_add(token.wrapping_add(1));
+            prefix.push(next_prefix);
+            let next_power = powers.last().copied().unwrap().wrapping_mul(Self::BASE);
+            powers.push(next_power);
+        }
+        Self { prefix, powers }
+    }
+
+    fn window_hash(&self, start: usize, len: usize) -> u64 {
+        self.prefix[start + len].wrapping_sub(self.prefix[start].wrapping_mul(self.powers[len]))
+    }
+}
+
+fn cheap_rolling_node_hash(
+    graph: &HLIRGraph,
+    node: NodeIndex,
+    custom_ops: &[Box<dyn CustomOp>],
+) -> u64 {
+    let op = rolling_op_signature(graph, node, custom_ops);
+    let mut hash: u64 = 1469598103934665603;
+    for byte in op.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(1099511628211);
+    }
+    // Only in-degree (op arity) may enter the hash. Out-degree counts external
+    // consumers, and boundary nodes legitimately differ in fan-out between
+    // occurrences (an interior repetition feeds the next one, the last feeds
+    // the epilogue) — the canonical signature models those consumers as loop
+    // outputs, so a gate stricter than the matcher would reject valid trips.
+    let in_degree = graph.neighbors_directed(node, Direction::Incoming).count() as u64;
+    hash ^= in_degree.wrapping_mul(0x9e3779b185ebca87);
+    hash
+}
+
+thread_local! {
+    // Memoized per-node rolling signatures. `rolling_op_signature_uncached`
+    // Debug-formats the op (allocating + recursing over its shape/stride
+    // metadata), and the rolling search calls it for the SAME node across many
+    // overlapping windows — O(window) per `canonicalize_occurrence`, summed over
+    // every (window, start) hash-match. On a 36-layer dual-branch graph that
+    // re-formatting dominated the prepass (16+ min). The signature is a pure
+    // function of (node, custom_ops) while the graph + custom_ops are read-only
+    // (the search phase never mutates them), so memoize it keyed by node. Cleared
+    // at the start of each `best_rolling_candidate` so stale NodeIndex→signature
+    // entries can never leak across a graph mutation.
+    static ROLLING_SIG_CACHE: std::cell::RefCell<FxHashMap<NodeIndex, String>> =
+        std::cell::RefCell::new(FxHashMap::default());
+}
+
+fn clear_rolling_sig_cache() {
+    ROLLING_SIG_CACHE.with(|c| c.borrow_mut().clear());
+}
+
+fn rolling_op_signature(
+    graph: &HLIRGraph,
+    node: NodeIndex,
+    custom_ops: &[Box<dyn CustomOp>],
+) -> String {
+    ROLLING_SIG_CACHE.with(|c| {
+        if let Some(sig) = c.borrow().get(&node) {
+            return sig.clone();
+        }
+        let sig = rolling_op_signature_uncached(graph, node, custom_ops);
+        c.borrow_mut().insert(node, sig.clone());
+        sig
+    })
+}
+
+fn rolling_op_signature_uncached(
+    graph: &HLIRGraph,
+    node: NodeIndex,
+    custom_ops: &[Box<dyn CustomOp>],
+) -> String {
+    if graph[node].as_any().is::<crate::hlir::Output>() {
+        return "Output".to_string();
+    }
+    if let Some(kind) = graph[node].as_any().downcast_ref::<CustomOpKind>() {
+        // The `id` is a global custom_ops index and differs for every call
+        // (e.g. one rope per layer), which would make structurally identical
+        // layer bodies hash differently and defeat loop rolling. Hash the
+        // referenced op's content instead: identical custom ops (same kernel
+        // parameters) compare equal across layers, distinct ones stay
+        // distinct.
+        return format!("CustomOp({:?}, {:?})", custom_ops[kind.id], kind.dtype);
+    }
+
+    // Use Debug, NOT Display — Display for many HLIR ops drops their
+    // shape/stride metadata (e.g. `Display for Mul` emits just "Mul"), so
+    // two structurally-different ops with the same kind would hash equal
+    // and get falsely grouped as a repeating pattern. Debug captures those
+    // fields. Output is the exception: its `node` field is only the source
+    // slot for runtime storage, so it must not participate in rolling
+    // identity.
+    format!("{:?}", graph[node])
+}
+
+fn rolling_probe_window_sizes(max_window: usize) -> Vec<usize> {
+    if max_window == 0 {
+        return vec![];
+    }
+    (1..=max_window).rev().collect()
+}
+
+fn canonicalize_occurrence(
+    graph: &HLIRGraph,
+    ordered_nodes: &[NodeIndex],
+    uses: &FxHashMap<NodeIndex, Vec<(NodeIndex, usize)>>,
+    topo_index: &FxHashMap<NodeIndex, usize>,
+    custom_ops: &[Box<dyn CustomOp>],
+) -> Option<(String, Vec<NodeIndex>, Vec<NodeIndex>)> {
+    let region: FxHashSet<NodeIndex> = ordered_nodes.iter().copied().collect();
+    if region.is_empty() {
+        return None;
+    }
+    let internal_index: FxHashMap<NodeIndex, usize> = ordered_nodes
+        .iter()
+        .enumerate()
+        .map(|(i, &n)| (n, i))
+        .collect();
+    let mut param_index: FxHashMap<NodeIndex, usize> = FxHashMap::default();
+    let mut boundary_inputs = vec![];
+    let mut node_parts = vec![];
+
+    for &node in ordered_nodes {
+        let op = rolling_op_signature(graph, node, custom_ops);
+        let inputs: Vec<NodeIndex> = graph
+            .edges_directed(node, Direction::Incoming)
+            .sorted_by_key(|e| e.id())
+            .map(|e| e.source())
+            .collect();
+        let mut inp_parts = vec![];
+        for src in inputs {
+            if let Some(&idx) = internal_index.get(&src) {
+                inp_parts.push(format!("n{idx}"));
+            } else {
+                let p = *param_index.entry(src).or_insert_with(|| {
+                    boundary_inputs.push(src);
+                    boundary_inputs.len() - 1
+                });
+                inp_parts.push(format!("p{p}"));
+            }
+        }
+        node_parts.push(format!("{op}({})", inp_parts.join(",")));
+    }
+
+    let mut output_nodes: Vec<NodeIndex> = ordered_nodes
+        .iter()
+        .copied()
+        .filter(|n| {
+            uses.get(n)
+                .is_some_and(|out_uses| out_uses.iter().any(|(user, _)| !region.contains(user)))
+                // A node is an Outgoing-external (graph sink) iff it has no
+                // outgoing edges. The previous `graph.externals(Outgoing).any(..)`
+                // re-scanned EVERY node in the graph for each node in the window,
+                // making this O(window × graph) per canonicalize — the dominant
+                // cost that stalled the dual-branch rolling prepass. Check the
+                // node's own out-edges instead (O(out-degree)).
+                || graph
+                    .edges_directed(*n, Direction::Outgoing)
+                    .next()
+                    .is_none()
+        })
+        .collect();
+    output_nodes.sort_by_key(|n| topo_index[n]);
+    let outputs: Vec<String> = output_nodes
+        .iter()
+        .filter_map(|n| internal_index.get(n).copied())
+        .map(|idx| format!("o{idx}"))
+        .collect();
+
+    let sig = format!("{}|{}", node_parts.join(";"), outputs.join(","));
+    Some((sig, boundary_inputs, output_nodes))
+}
+
+fn collect_state_params(
+    occurrences: &[RollingOccurrence],
+    uses: &FxHashMap<NodeIndex, Vec<(NodeIndex, usize)>>,
+    graph: &HLIRGraph,
+) -> Vec<usize> {
+    if occurrences.len() < 2 {
+        return vec![];
+    }
+    let param_count = occurrences[0].boundary_inputs.len();
+    let mut state_params = vec![];
+
+    for p in 0..param_count {
+        let mut is_state = true;
+        for i in 1..occurrences.len() {
+            let earlier = &occurrences[i - 1];
+            let later = &occurrences[i];
+            let val = later.boundary_inputs.get(p).copied();
+            let Some(val) = val else {
+                is_state = false;
+                break;
+            };
+            if !earlier.output_nodes.contains(&val) {
+                is_state = false;
+                break;
+            }
+            let external_uses: Vec<_> = uses
+                .get(&val)
+                .map(|u| {
+                    u.iter()
+                        .copied()
+                        .filter(|(user, _)| !earlier.nodes.contains(user))
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            if external_uses.is_empty() {
+                is_state = false;
+                break;
+            }
+            if graph.externals(Direction::Outgoing).any(|root| root == val) {
+                is_state = false;
+                break;
+            }
+            if external_uses
+                .iter()
+                .any(|(user, _)| !later.nodes.contains(user))
+            {
+                is_state = false;
+                break;
+            }
+        }
+        if is_state {
+            state_params.push(p);
+        }
+    }
+    state_params
+}
+
+/// A rolling candidate is only valid to collapse into a single loop body if
+/// every boundary-input parameter is either:
+///   - a loop-carried state param (its value is produced by the IMMEDIATELY
+///     preceding occurrence — already enforced by `collect_state_params`), or
+///   - fed from OUTSIDE the candidate's occurrences (an external producer, e.g.
+///     a per-iteration weight tensor — these may legitimately differ across
+///     occurrences; the loop indexes them by iteration).
+///
+/// If a NON-state boundary input is produced by ANOTHER occurrence in the
+/// candidate, that's a cross-occurrence dependency that is not the adjacent
+/// loop-carry (e.g. occurrence `i` consuming occurrence `i-2`'s output, as
+/// happens when minibatch-pipelined prefill is rolled at the per-minibatch
+/// granularity: stream-0 of layer L+1 depends on stream-0 of layer L, skipping
+/// stream-1). Collapsing the duplicate bodies folds that `i ← i-2` edge back
+/// onto the single rolled body, creating a directed cycle that makes the egglog
+/// Kahn toposort drop nodes and panic. Rejecting such candidates lets the search
+/// fall back to a coarser, valid window (e.g. rolling whole layers — both
+/// minibatch streams together — where the only cross-occurrence edges are the
+/// adjacent layer-to-layer state).
+fn candidate_is_rollable(occurrences: &[RollingOccurrence], state_params: &[usize]) -> bool {
+    if occurrences.len() < 2 {
+        return false;
+    }
+    let state_set: FxHashSet<usize> = state_params.iter().copied().collect();
+    let all_occ_nodes: FxHashSet<NodeIndex> = occurrences
+        .iter()
+        .flat_map(|o| o.nodes.iter().copied())
+        .collect();
+    let param_count = occurrences[0].boundary_inputs.len();
+    for p in 0..param_count {
+        if state_set.contains(&p) {
+            continue;
+        }
+        for occ in occurrences {
+            if let Some(&src) = occ.boundary_inputs.get(p) {
+                if all_occ_nodes.contains(&src) {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+/// Net node-count change of rolling a candidate: duplicate body nodes
+/// deleted minus marker ops created (mirroring `insert_loop_region_ops`:
+/// LoopStart + LoopEnd per state slot, one LoopInput per iteration-varying
+/// non-state boundary stream, and one LoopOutput plus a per-iteration Select
+/// for each non-state output stream). Rolling is only worth doing — and the
+/// rolling fixpoint only terminates — when this is positive.
+fn rolling_net_savings(candidate: &RollingCandidate) -> i64 {
+    let occs = &candidate.occurrences;
+    let n_iters = occs.len();
+    let states: FxHashSet<usize> = candidate.state_param_indices.iter().copied().collect();
+    let deleted = occs[0].nodes.len() * (n_iters - 1);
+    let varying_inputs = (0..occs[0].boundary_inputs.len())
+        .filter(|p| !states.contains(p))
+        .filter(|&p| {
+            !occs
+                .windows(2)
+                .all(|w| w[0].boundary_inputs[p] == w[1].boundary_inputs[p])
+        })
+        .count();
+    let output_streams = occs[0].output_nodes.len().saturating_sub(states.len());
+    let markers = 2 * states.len() + varying_inputs + output_streams * (n_iters + 1);
+    deleted as i64 - markers as i64
+}
+
+fn grow_rolling_candidate(
+    graph: &HLIRGraph,
+    uses: &FxHashMap<NodeIndex, Vec<(NodeIndex, usize)>>,
+    topo_index: &FxHashMap<NodeIndex, usize>,
+    mut candidate: RollingCandidate,
+    discovered_runs: &[RollingRun],
+    custom_ops: &[Box<dyn CustomOp>],
+) -> RollingCandidate {
+    loop {
+        let candidate_starts: Vec<usize> = candidate
+            .occurrences
+            .iter()
+            .map(|occ| {
+                occ.nodes
+                    .first()
+                    .map(|n| topo_index[n])
+                    .unwrap_or(usize::MAX)
+            })
+            .collect();
+        let candidate_ends: Vec<usize> = candidate
+            .occurrences
+            .iter()
+            .map(|occ| occ.nodes.last().map(|n| topo_index[n] + 1).unwrap_or(0))
+            .collect();
+
+        let mut best_growth: Option<RollingCandidate> = None;
+        for run in discovered_runs {
+            for shift in 0..=1usize {
+                if run.occurrences.len() < candidate.occurrences.len() + shift {
+                    continue;
+                }
+                let aligned = (0..candidate.occurrences.len()).all(|i| {
+                    run.starts[i + shift] == candidate_ends[i]
+                        || run.starts[i + shift] + run.window == candidate_starts[i]
+                });
+                if !aligned {
+                    continue;
+                }
+
+                let mut merged_occs = Vec::with_capacity(candidate.occurrences.len());
+                // `i` indexes the candidate side while `i + shift` indexes the
+                // run side — explicit range is clearer than zip-with-skip.
+                #[allow(clippy::needless_range_loop)]
+                for i in 0..candidate.occurrences.len() {
+                    let run_occ = &run.occurrences[i + shift];
+                    let mut nodes = if run.starts[i + shift] + run.window == candidate_starts[i] {
+                        let mut n = run_occ.nodes.clone();
+                        n.extend(candidate.occurrences[i].nodes.iter().copied());
+                        n
+                    } else {
+                        let mut n = candidate.occurrences[i].nodes.clone();
+                        n.extend(run_occ.nodes.iter().copied());
+                        n
+                    };
+                    nodes.sort_by_key(|n| topo_index[n]);
+                    let Some((sig, boundary_inputs, output_nodes)) =
+                        canonicalize_occurrence(graph, &nodes, uses, topo_index, custom_ops)
+                    else {
+                        merged_occs.clear();
+                        break;
+                    };
+                    if i == 0 && sig.is_empty() {
+                        merged_occs.clear();
+                        break;
+                    }
+                    merged_occs.push(RollingOccurrence {
+                        nodes,
+                        boundary_inputs,
+                        output_nodes,
+                    });
+                }
+                if merged_occs.len() != candidate.occurrences.len() {
+                    continue;
+                }
+                let first_sig = canonicalize_occurrence(
+                    graph,
+                    &merged_occs[0].nodes,
+                    uses,
+                    topo_index,
+                    custom_ops,
+                )
+                .map(|(sig, _, _)| sig);
+                let Some(first_sig) = first_sig else { continue };
+                if merged_occs.iter().skip(1).any(|occ| {
+                    canonicalize_occurrence(graph, &occ.nodes, uses, topo_index, custom_ops)
+                        .map(|(sig, _, _)| sig != first_sig)
+                        .unwrap_or(true)
+                }) {
+                    continue;
+                }
+                let state_param_indices = collect_state_params(&merged_occs, uses, graph);
+                if state_param_indices.is_empty() {
+                    continue;
+                }
+                let savings = merged_occs[0].nodes.len() * (merged_occs.len() - 1);
+                let _ = first_sig;
+                let grown = RollingCandidate {
+                    occurrences: merged_occs,
+                    state_param_indices,
+                    savings,
+                };
+                let replace = best_growth.as_ref().is_none_or(|best| {
+                    (
+                        grown.savings,
+                        grown.occurrences[0].nodes.len(),
+                        grown.occurrences.len(),
+                    ) > (
+                        best.savings,
+                        best.occurrences[0].nodes.len(),
+                        best.occurrences.len(),
+                    )
+                });
+                if replace {
+                    best_growth = Some(grown);
+                }
+            }
+        }
+
+        match best_growth {
+            Some(grown) if grown.savings > candidate.savings => candidate = grown,
+            _ => return candidate,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::egglog_utils::hash_egglog_normalized;
+    use crate::hlir::{Input, LoopEnd, LoopInput, LoopStart, Output, ReferenceOp, Sin};
+    use crate::search::unroll::materialize_unrolled_llir;
+
+    // A rolling candidate is only collapsible if every non-state boundary input
+    // is fed from OUTSIDE the candidate's occurrences. A non-state input produced
+    // by another occurrence (e.g. occ `i` consuming occ `i-2`'s output) is a
+    // non-adjacent cross-occurrence dependency that, once the bodies are folded
+    // into one, becomes a directed cycle — which makes the egglog Kahn toposort
+    // drop nodes and panic. `candidate_is_rollable` must reject those.
+    #[test]
+    fn candidate_is_rollable_rejects_cross_occurrence_dep() {
+        let n = NodeIndex::new;
+        let occ = |body: usize, input: usize| RollingOccurrence {
+            nodes: vec![n(body)],
+            boundary_inputs: vec![n(input)],
+            output_nodes: vec![n(body)],
+        };
+
+        // Both occurrences' inputs come from outside the candidate (100, 101) →
+        // rollable.
+        let rollable = vec![occ(0, 100), occ(1, 101)];
+        assert!(candidate_is_rollable(&rollable, &[]));
+
+        // Occurrence 1's input is node 0, which lives INSIDE occurrence 0, and
+        // param 0 is not a state param → reject.
+        let cyclic = vec![occ(0, 100), occ(1, 0)];
+        assert!(!candidate_is_rollable(&cyclic, &[]));
+
+        // Same shape, but param 0 is declared a loop-carried state param → the
+        // adjacent loop-carry is allowed.
+        assert!(candidate_is_rollable(&cyclic, &[0]));
+
+        // Fewer than two occurrences is never rollable.
+        assert!(!candidate_is_rollable(&[occ(0, 100)], &[]));
+    }
+    use crate::tests::{assert_close, random_vec};
+
+    #[test]
+    fn materialize_many_disjoint_loops_without_a_global_cartesian_product() {
+        const N_LOOPS: usize = 64;
+        let mut rolled = LLIRGraph::default();
+        for loop_id in 0..N_LOOPS {
+            let input = rolled.add_node(LLIROp::new::<Input>(Box::new(Input {
+                node: loop_id,
+                label: String::new(),
+                dtype: DType::F32,
+            })));
+            let start = rolled.add_node(LLIROp::new::<LoopStart>(Box::new(LoopStart {
+                loop_id,
+                slot_idx: 0,
+                iters: Expression::from(2),
+                dtype: DType::F32,
+            })));
+            let body = rolled.add_node(LLIROp::new::<dyn ReferenceOp>(
+                Box::new(Sin::default()) as Box<dyn ReferenceOp>
+            ));
+            let end = rolled.add_node(LLIROp::new::<LoopEnd>(Box::new(LoopEnd {
+                loop_id,
+                slot_idx: 0,
+                dtype: DType::F32,
+            })));
+            let output = rolled.add_node(LLIROp::new::<Output>(Box::new(Output {
+                node: loop_id,
+                persist_only: false,
+            })));
+            rolled.add_edge(input, start, ());
+            rolled.add_edge(start, body, ());
+            rolled.add_edge(body, end, ());
+            rolled.add_edge(end, output, ());
+        }
+
+        let materialized = materialize_unrolled_llir(&rolled)
+            .expect("independent loop regions must not multiply one another's contexts");
+
+        // Per region: one input + two body instances + one output, connected
+        // as a three-edge chain. A global product would overflow at 2^64.
+        assert_eq!(materialized.node_count(), N_LOOPS * 4);
+        assert_eq!(materialized.edge_count(), N_LOOPS * 3);
+        assert!(
+            materialized
+                .node_weights()
+                .all(|op| { op.to_op::<LoopStart>().is_none() && op.to_op::<LoopEnd>().is_none() })
+        );
+    }
+
+    #[test]
+    fn test_hash_egglog_normalized_same_structure() {
+        // Two egglog texts differing only in Input node indices and labels
+        let text_a = r#"(let t0 (Input 42 "boundary" (F32)))
+(let t1 (Input 100 "layers.0.wq.weight" (F32)))
+(let t2 (Add (ECons 128 (ECons 4096 (ENil))) t1 (ECons 1 (ECons 128 (ENil))) t0 (ECons 1 (ECons 1 (ENil))) (ECons 1 (ECons 128 (ENil)))))
+(let t3 (Output t2 42 false))
+"#;
+        let text_b = r#"(let t0 (Input 84 "boundary" (F32)))
+(let t1 (Input 200 "layers.1.wq.weight" (F32)))
+(let t2 (Add (ECons 128 (ECons 4096 (ENil))) t1 (ECons 1 (ECons 128 (ENil))) t0 (ECons 1 (ECons 1 (ENil))) (ECons 1 (ECons 128 (ENil)))))
+(let t3 (Output t2 84 false))
+"#;
+        assert_eq!(
+            hash_egglog_normalized(text_a),
+            hash_egglog_normalized(text_b),
+            "Structurally identical chunks should hash the same"
+        );
+    }
+
+    #[test]
+    fn test_hash_egglog_normalized_different_structure() {
+        let text_a = r#"(let t0 (Input 42 "boundary" (F32)))
+(let t1 (Add (ECons 128 (ENil)) t0 (ECons 1 (ENil)) t0 (ECons 1 (ENil)) (ECons 1 (ENil))))
+"#;
+        let text_b = r#"(let t0 (Input 42 "boundary" (F32)))
+(let t1 (Mul (ECons 128 (ENil)) t0 (ECons 1 (ENil)) t0 (ECons 1 (ENil)) (ECons 1 (ENil))))
+"#;
+        assert_ne!(
+            hash_egglog_normalized(text_a),
+            hash_egglog_normalized(text_b),
+            "Different op types should produce different hashes"
+        );
+    }
+
+    #[test]
+    fn test_hash_egglog_normalized_different_dtypes() {
+        let text_a = "(let t0 (Input 42 \"boundary\" (F32)))\n";
+        let text_b = "(let t0 (Input 42 \"boundary\" (F16)))\n";
+        assert_ne!(
+            hash_egglog_normalized(text_a),
+            hash_egglog_normalized(text_b),
+            "Different dtypes should produce different hashes"
+        );
+    }
+
+    #[test]
+    fn test_hash_egglog_normalized_output_join_not_normalized() {
+        // OutputJoin lines should be hashed verbatim, not treated as Output
+        let text_a = "(let t0 (OutputJoin t1 t2))\n";
+        let text_b = "(let t0 (OutputJoin t3 t4))\n";
+        assert_ne!(
+            hash_egglog_normalized(text_a),
+            hash_egglog_normalized(text_b),
+            "OutputJoin lines should be hashed verbatim"
+        );
+    }
+
+    #[test]
+    fn test_hash_egglog_normalized_distinguishes_persist_only_output() {
+        let observed = "(let t1 (Output t0 42 false))\n";
+        let persist_only = "(let t1 (Output t0 42 true))\n";
+        assert_ne!(
+            hash_egglog_normalized(observed),
+            hash_egglog_normalized(persist_only),
+            "persistence and observed-output semantics must not share a cached egraph"
+        );
+    }
+
+    #[test]
+    fn test_hash_egglog_normalized_custom_op_id() {
+        // CustomOpKind lines differ only in the integer ID (layer index)
+        let text_a = r#"(let t0 (Input 441 "boundary" (F32)))
+(let t1 (Op (CustomOpKind 1 (F32)) (ICons t74 (ICons t120 (ICons t28 (INil))))))
+(let t2 (Output t1 585 false))
+"#;
+        let text_b = r#"(let t0 (Input 585 "boundary" (F32)))
+(let t1 (Op (CustomOpKind 2 (F32)) (ICons t74 (ICons t120 (ICons t28 (INil))))))
+(let t2 (Output t1 729 false))
+"#;
+        assert_eq!(
+            hash_egglog_normalized(text_a),
+            hash_egglog_normalized(text_b),
+            "CustomOpKind with different IDs should hash the same"
+        );
+    }
+
+    #[test]
+    fn test_hash_egglog_normalized_custom_op_different_structure() {
+        // CustomOpKind lines with different input lists should hash differently
+        let text_a = "(let t1 (Op (CustomOpKind 1 (F32)) (ICons t74 (ICons t120 (INil)))))\n";
+        let text_b = "(let t1 (Op (CustomOpKind 1 (F32)) (ICons t74 (ICons t99 (INil)))))\n";
+        assert_ne!(
+            hash_egglog_normalized(text_a),
+            hash_egglog_normalized(text_b),
+            "CustomOpKind with different input lists should hash differently"
+        );
+    }
+
+    #[test]
+    fn test_rolling_op_signature_custom_op_content() {
+        #[derive(Debug)]
+        struct TestCustomOp {
+            #[allow(dead_code)]
+            name: &'static str,
+        }
+        impl CustomOp for TestCustomOp {
+            fn to_llir_op(&self) -> LLIROp {
+                unimplemented!()
+            }
+        }
+
+        // The signature cache is keyed by NodeIndex and only cleared by
+        // best_rolling_candidate; drop entries another test on this thread
+        // may have left behind for the same indices.
+        clear_rolling_sig_cache();
+
+        let mut cx = Graph::new();
+        cx.custom_ops.push(Box::new(TestCustomOp { name: "rope" }));
+        cx.custom_ops.push(Box::new(TestCustomOp { name: "rope" }));
+        cx.custom_ops.push(Box::new(TestCustomOp { name: "topk" }));
+        let ids: Vec<_> = (0..3)
+            .map(|id| {
+                cx.add_op(
+                    CustomOpKind {
+                        id,
+                        dtype: DType::F32,
+                    },
+                    &[],
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            rolling_op_signature(&cx.graph, ids[0], &cx.custom_ops),
+            rolling_op_signature(&cx.graph, ids[1], &cx.custom_ops),
+            "separate instances of the same custom op should sign the same"
+        );
+        assert_ne!(
+            rolling_op_signature(&cx.graph, ids[0], &cx.custom_ops),
+            rolling_op_signature(&cx.graph, ids[2], &cx.custom_ops),
+            "different custom ops should sign differently"
+        );
+    }
+
+    #[test]
+    fn test_auto_roll_loops_prepass_creates_regions_for_chain_recurrence() {
+        let mut cx = Graph::new();
+        let x = cx.tensor(8);
+        let out = x.exp2().sin().exp2().sin().exp2().sin().output();
+
+        let inserted = cx.auto_roll_loops_prepass_with_log(true);
+        assert!(
+            inserted >= 2,
+            "expected at least two loop boundaries for 3 repeated bodies, got {inserted}"
+        );
+
+        let vals = random_vec(8);
+        let mut rt = ReferenceRuntime::default();
+        cx.build_search_space::<ReferenceRuntime>(CompileOptions::default());
+        rt = cx.search(rt, CompileOptions::default().search_graph_limit(1));
+        rt.set_data(x.id, vals.clone());
+        rt.execute(&cx.dyn_map);
+
+        let expected = vals
+            .into_iter()
+            .map(|v| v.exp2().sin().exp2().sin().exp2().sin())
+            .collect::<Vec<f32>>();
+        assert_close(rt.get_f32(out.id), &expected);
+    }
+
+    #[test]
+    fn test_auto_roll_loops_prepass_rolls_recurrence_with_interleaved_outputs() {
+        let mut cx = Graph::new();
+        let x = cx.tensor(8);
+        let mut y = x;
+        for _ in 0..10 {
+            y.exp2().output();
+            y = y.sin();
+        }
+        let y = y.output();
+
+        let before = cx.graph.node_count();
+        let inserted = cx.auto_roll_loops_prepass_with_log(true);
+        let after = cx.graph.node_count();
+        assert!(
+            inserted >= 2,
+            "expected loop markers for recurrence split by Output nodes, got {inserted}"
+        );
+        assert!(
+            after < before,
+            "expected rolling to reduce nodes for recurrence split by Output nodes ({before} -> {after})"
+        );
+
+        let vals = random_vec(8);
+        let mut rt = ReferenceRuntime::default();
+        cx.build_search_space::<ReferenceRuntime>(CompileOptions::default());
+        rt = cx.search(rt, CompileOptions::default().search_graph_limit(1));
+        rt.set_data(x.id, vals.clone());
+        rt.execute(&cx.dyn_map);
+
+        let expected = vals
+            .into_iter()
+            .map(|mut v| {
+                for _ in 0..10 {
+                    v = v.sin();
+                }
+                v
+            })
+            .collect::<Vec<f32>>();
+        assert_close(rt.get_f32(y.id), &expected);
+    }
+
+    #[test]
+    fn test_auto_roll_loops_prepass_skips_non_recurrent_branches() {
+        let mut cx = Graph::new();
+        let x = cx.tensor(8);
+        let y = cx.tensor(8);
+        let _out = (x.exp().sin() + y.exp().sin()).output();
+
+        let inserted = cx.auto_roll_loops_prepass_with_log(true);
+        assert_eq!(inserted, 0, "branch-only reuse should not roll into loops");
+    }
+
+    #[test]
+    fn test_auto_roll_loops_prepass_runs_when_logging_is_disabled() {
+        let mut cx = Graph::new();
+        let x = cx.tensor(8);
+        let out = x.exp2().sin().exp2().sin().exp2().sin().output();
+
+        let before = cx.graph.node_count();
+        let inserted = cx.auto_roll_loops_prepass();
+        let after = cx.graph.node_count();
+
+        assert!(
+            inserted >= 2,
+            "expected loop rolling to run without ROLLING_LOG, got {inserted}"
+        );
+        assert!(
+            after < before,
+            "expected loop rolling to reduce nodes ({before} -> {after})"
+        );
+        assert!(
+            cx.graph
+                .neighbors_directed(out.id, Direction::Outgoing)
+                .next()
+                .is_none(),
+            "output should remain a graph root"
+        );
+    }
+
+    #[test]
+    fn test_nested_loop_rolling_rolls_periodic_layer_pattern() {
+        // Periodic pattern like alternating-attention transformers: blocks
+        // of 3 identical "layers" (sin) closed by a distinct one (exp2),
+        // repeated 4 times. The first pass rolls the 4 blocks; the second
+        // rolls the 3 identical layers inside the surviving body.
+        let mut cx = Graph::new();
+        let x = cx.tensor(8);
+        let mut y = x;
+        for _ in 0..4 {
+            for _ in 0..3 {
+                y = y.sin();
+            }
+            y = y.exp2();
+        }
+        let out = y.output();
+
+        let first = cx.auto_roll_loops_prepass_with_log(true);
+        assert!(first > 0, "expected the block pattern to roll");
+        let second = cx.auto_roll_loops_prepass_with_log(true);
+        assert!(
+            second > 0,
+            "expected the repeated layers inside the rolled body to roll"
+        );
+
+        let loop_ids: FxHashSet<usize> = cx
+            .graph
+            .node_indices()
+            .filter_map(|n| {
+                cx.try_get_op::<crate::hlir::LoopStart>(n)
+                    .map(|ls| ls.loop_id)
+            })
+            .collect();
+        assert_eq!(loop_ids.len(), 2, "expected two distinct loop regions");
+
+        let vals = random_vec(8);
+        let mut rt = ReferenceRuntime::default();
+        cx.build_search_space::<ReferenceRuntime>(CompileOptions::default());
+        rt = cx.search(rt, CompileOptions::default().search_graph_limit(1));
+        rt.set_data(x.id, vals.clone());
+        rt.execute(&cx.dyn_map);
+
+        let expected = vals
+            .into_iter()
+            .map(|mut v| {
+                for _ in 0..4 {
+                    for _ in 0..3 {
+                        v = v.sin();
+                    }
+                    v = v.exp2();
+                }
+                v
+            })
+            .collect::<Vec<f32>>();
+        assert_close(rt.get_f32(out.id), &expected);
+    }
+
+    #[test]
+    fn test_nested_loop_rolling_chained_sibling_inner_regions() {
+        // Mirror of gemma's rolled topology: an outer periodic block whose
+        // body contains multiple distinct repeated runs, chained through
+        // non-repeating ops. The runs roll into sibling regions nested
+        // inside the outer region; unroll must find each sibling innermost.
+        let mut cx = Graph::new();
+        let x = cx.tensor(8);
+        let mut y = x;
+        for _ in 0..4 {
+            for _ in 0..3 {
+                y = y.sin();
+            }
+            y = y.exp2();
+            for _ in 0..4 {
+                y = y.sin();
+            }
+            y = y.reciprocal();
+        }
+        let out = y.output();
+
+        let mut passes = 0;
+        while cx.auto_roll_loops_prepass_with_log(true) > 0 {
+            passes += 1;
+        }
+        assert!(
+            passes >= 3,
+            "expected outer + two sibling inner rolls, got {passes}"
+        );
+
+        let vals = random_vec(8);
+        let mut rt = ReferenceRuntime::default();
+        cx.build_search_space::<ReferenceRuntime>(CompileOptions::default());
+        rt = cx.search(rt, CompileOptions::default().search_graph_limit(1));
+        rt.set_data(x.id, vals.clone());
+        rt.execute(&cx.dyn_map);
+
+        let expected = vals
+            .into_iter()
+            .map(|mut v| {
+                for _ in 0..4 {
+                    for _ in 0..3 {
+                        v = v.sin();
+                    }
+                    v = v.exp2();
+                    for _ in 0..4 {
+                        v = v.sin();
+                    }
+                    v = v.recip();
+                }
+                v
+            })
+            .collect::<Vec<f32>>();
+        assert_close(rt.get_f32(out.id), &expected);
+    }
+
+    #[test]
+    fn test_nested_loop_rolling_with_varying_weights() {
+        // Gemma-shaped: an outer periodic block of 3 identical weighted
+        // layers plus a distinct closer, repeated 4 times, with a DISTINCT
+        // weight tensor per layer. The inner region's per-iteration inputs
+        // are then varying streams fed by the outer region's own LoopInput
+        // markers — the exact structure of per-layer weights in a rolled
+        // transformer.
+        let mut cx = Graph::new();
+        let x = cx.tensor(8);
+        let weights: Vec<GraphTensor> = (0..12).map(|_| cx.tensor(8)).collect();
+        let mut y = x;
+        for block in 0..4 {
+            for layer in 0..3 {
+                y = (y * weights[block * 3 + layer]).sin();
+            }
+            y = y.exp2();
+        }
+        let out = y.output();
+
+        let mut passes = 0;
+        while cx.auto_roll_loops_prepass_with_log(true) > 0 {
+            passes += 1;
+        }
+        assert!(passes >= 2, "expected nested rolls, got {passes}");
+
+        let xv = random_vec(8);
+        let wvs: Vec<Vec<f32>> = (0..12).map(|_| random_vec(8)).collect();
+        let mut rt = ReferenceRuntime::default();
+        cx.build_search_space::<ReferenceRuntime>(CompileOptions::default());
+        rt = cx.search(rt, CompileOptions::default().search_graph_limit(1));
+        rt.set_data(x.id, xv.clone());
+        for (w, wv) in weights.iter().zip(&wvs) {
+            rt.set_data(w.id, wv.clone());
+        }
+        rt.execute(&cx.dyn_map);
+
+        let expected: Vec<f32> = (0..8)
+            .map(|j| {
+                let mut v = xv[j];
+                for block in 0..4 {
+                    for layer in 0..3 {
+                        v = (v * wvs[block * 3 + layer][j]).sin();
+                    }
+                    v = v.exp2();
+                }
+                v
+            })
+            .collect();
+        assert_close(rt.get_f32(out.id), &expected);
+    }
+
+    #[test]
+    fn loop_rolling_stamps_concrete_varying_stream_dtypes() {
+        // A transformer-style recurrence carries F32 activations while every
+        // repeated layer receives a distinct BF16 weight. The weight casts are
+        // part of the repeated body, so the rolled boundary itself must retain
+        // BF16 rather than a placeholder chosen independently of its sources.
+        let mut cx = Graph::new();
+        let x = cx.tensor(8);
+        let weights: Vec<GraphTensor> =
+            (0..4).map(|_| cx.tensor(8).as_dtype(DType::Bf16)).collect();
+        let mut y = x;
+        for weight in weights {
+            y = (y * weight.cast(DType::F32)).sin();
+        }
+        let _ = y.output();
+
+        assert!(
+            cx.auto_roll_loops_prepass_with_log(true) > 0,
+            "expected the repeated weighted recurrence to roll"
+        );
+
+        let loop_inputs: Vec<_> = cx
+            .graph
+            .node_indices()
+            .filter_map(|node| cx.try_get_op::<LoopInput>(node))
+            .collect();
+        assert!(!loop_inputs.is_empty(), "expected a varying weight stream");
+        assert!(
+            loop_inputs.iter().any(|input| input.dtype == DType::Bf16),
+            "expected a concrete BF16 LoopInput, got {loop_inputs:?}"
+        );
+        assert!(
+            cx.graph.node_indices().all(|node| {
+                cx.try_get_op::<LoopStart>(node)
+                    .is_none_or(|start| start.dtype == DType::F32)
+            }),
+            "the carried F32 activation must remain concretely F32"
+        );
+
+        // The concrete field remains the source of truth through egglog
+        // construction; this used to turn every marker field into F32.
+        cx.build_search_space::<ReferenceRuntime>(CompileOptions::default());
+    }
+
+    #[test]
+    fn loop_rolling_preserves_integer_gather_stream_dtypes() {
+        // Regression for mixed-type repeated regions: Gather consumes Int
+        // indexes but produces the dtype of its F32 data input. Both facts
+        // must survive rolling without one eclass overwriting the other.
+        let mut cx = Graph::new();
+        let x = cx.tensor(8);
+        let indexes: Vec<GraphTensor> = (0..4)
+            .map(|layer| {
+                cx.named_tensor(format!("indexes.{layer}"), 8)
+                    .as_dtype(DType::Int)
+            })
+            .collect();
+        let mut y = x;
+        for index in indexes {
+            y = y.gather(index).sin();
+        }
+        let _ = y.output();
+
+        assert!(
+            cx.auto_roll_loops_prepass_with_log(true) > 0,
+            "expected the repeated gather recurrence to roll"
+        );
+
+        let loop_inputs: Vec<_> = cx
+            .graph
+            .node_indices()
+            .filter_map(|node| cx.try_get_op::<LoopInput>(node))
+            .collect();
+        assert!(
+            loop_inputs.iter().any(|input| input.dtype == DType::Int),
+            "expected a concrete Int LoopInput, got {loop_inputs:?}"
+        );
+        assert!(
+            cx.graph.node_indices().all(|node| {
+                cx.try_get_op::<LoopStart>(node)
+                    .is_none_or(|start| start.dtype == DType::F32)
+            }),
+            "Gather must preserve the carried F32 activation dtype"
+        );
+
+        cx.build_search_space::<ReferenceRuntime>(CompileOptions::default());
+    }
+
+    #[test]
+    fn test_nested_loop_rolling_per_layer_outputs_not_permuted() {
+        // Cache-analog regression test: every layer persists a side output
+        // (like per-layer KV caches). Nested rolling + unroll must route each
+        // side output to ITS OWN layer's value — a permutation across layers
+        // corrupts state promotion even when the final output is correct.
+        let mut cx = Graph::new();
+        let x = cx.tensor(8);
+        let weights: Vec<GraphTensor> = (0..24).map(|_| cx.tensor(8)).collect();
+        let mut y = x;
+        let mut side = Vec::new();
+        for block in 0..4 {
+            for layer in 0..5 {
+                y = (y * weights[block * 6 + layer]).sin();
+                side.push((y * 2.0_f32).output());
+            }
+            y = (y * weights[block * 6 + 5]).exp2();
+            side.push((y * 2.0_f32).output());
+        }
+        let out = y.output();
+
+        let mut passes = 0;
+        while cx.auto_roll_loops_prepass_with_log(true) > 0 {
+            passes += 1;
+        }
+        assert!(passes >= 2, "expected nested rolls, got {passes}");
+
+        let xv = random_vec(8);
+        let wvs: Vec<Vec<f32>> = (0..24).map(|_| random_vec(8)).collect();
+        let mut rt = ReferenceRuntime::default();
+        cx.build_search_space::<ReferenceRuntime>(CompileOptions::default());
+        rt = cx.search(rt, CompileOptions::default().search_graph_limit(1));
+        rt.set_data(x.id, xv.clone());
+        for (w, wv) in weights.iter().zip(&wvs) {
+            rt.set_data(w.id, wv.clone());
+        }
+        rt.execute(&cx.dyn_map);
+
+        let mut refs: Vec<Vec<f32>> = Vec::new();
+        let mut v: Vec<f32> = xv.clone();
+        for block in 0..4 {
+            for layer in 0..5 {
+                v = v
+                    .iter()
+                    .zip(&wvs[block * 6 + layer])
+                    .map(|(a, b)| (a * b).sin())
+                    .collect();
+                refs.push(v.iter().map(|a| a * 2.0).collect());
+            }
+            v = v
+                .iter()
+                .zip(&wvs[block * 6 + 5])
+                .map(|(a, b)| (a * b).exp2())
+                .collect();
+            refs.push(v.iter().map(|a| a * 2.0).collect());
+        }
+        let mut permutation = Vec::new();
+        for (idx, t) in side.iter().enumerate() {
+            let got = rt.get_f32(t.id);
+            let matches: Vec<usize> = refs
+                .iter()
+                .enumerate()
+                .filter(|(_, r)| got.iter().zip(*r).all(|(a, b)| (a - b).abs() < 1e-5))
+                .map(|(j, _)| j)
+                .collect();
+            permutation.push((idx, matches));
+        }
+        let bad: Vec<_> = permutation.iter().filter(|(i, m)| !m.contains(i)).collect();
+        assert!(
+            bad.is_empty(),
+            "side outputs carry other layers' values: {permutation:?}"
+        );
+        let final_expected: Vec<f32> = refs.last().unwrap().iter().map(|a| a / 2.0).collect();
+        assert!(
+            rt.get_f32(out.id)
+                .iter()
+                .zip(&final_expected)
+                .all(|(a, b)| (a - b).abs() < 1e-5),
+            "final output mismatch"
+        );
+    }
+
+    #[test]
+    fn test_nested_loop_rolling_handles_disjoint_regions() {
+        // Two independent recurrence chains roll into two disjoint regions
+        // across successive passes; unroll must handle both.
+        let mut cx = Graph::new();
+        let x = cx.tensor(8);
+        let y = cx.tensor(8);
+        let a = x.sin().sin().sin().sin();
+        let b = y.exp2().exp2().exp2().exp2();
+        let out = (a + b).output();
+
+        let mut passes = 0;
+        while cx.auto_roll_loops_prepass_with_log(true) > 0 {
+            passes += 1;
+        }
+        assert!(
+            passes >= 2,
+            "expected both chains to roll, got {passes} passes"
+        );
+
+        let xv = random_vec(8);
+        let yv = random_vec(8);
+        let mut rt = ReferenceRuntime::default();
+        cx.build_search_space::<ReferenceRuntime>(CompileOptions::default());
+        rt = cx.search(rt, CompileOptions::default().search_graph_limit(1));
+        rt.set_data(x.id, xv.clone());
+        rt.set_data(y.id, yv.clone());
+        rt.execute(&cx.dyn_map);
+
+        let expected = xv
+            .into_iter()
+            .zip(yv)
+            .map(|(mut a, mut b)| {
+                for _ in 0..4 {
+                    a = a.sin();
+                    b = b.exp2();
+                }
+                a + b
+            })
+            .collect::<Vec<f32>>();
+        assert_close(rt.get_f32(out.id), &expected);
+    }
+}

--- a/crates/luminal_cuda_lite_hlir/main_core/graph/artifact.rs
+++ b/crates/luminal_cuda_lite_hlir/main_core/graph/artifact.rs
@@ -1,0 +1,281 @@
+use std::{
+    collections::hash_map::DefaultHasher,
+    fmt::Write,
+    hash::{Hash, Hasher},
+};
+
+use petgraph::{
+    algo::toposort,
+    stable_graph::NodeIndex,
+    visit::{EdgeRef, NodeIndexable},
+};
+use rustc_hash::FxHashMap;
+
+use super::{DimBucket, Graph, LLIRGraph};
+use crate::{
+    dtype::DType,
+    egglog_utils::{LlirExtractor, SerializedEGraph},
+    hlir::HLIROps,
+    op::{IntoEgglogOp, Runtime},
+    search::{SearchSpace, SelectedProgram, unroll_packed_llir},
+    shape::{DynMap, Symbol},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
+struct LlirFingerprint(u64, u64);
+
+fn fingerprint_llir(llir: &LLIRGraph) -> LlirFingerprint {
+    fn hash_node(seed: u64, op: &crate::op::LLIROp, inputs: &[LlirFingerprint]) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        seed.hash(&mut hasher);
+        write!(&mut HashWriter(&mut hasher), "{op:?}").unwrap();
+        inputs.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    let mut node_fingerprints = vec![None; llir.node_bound()];
+    for node in toposort(llir, None).expect("LLIR must be acyclic") {
+        let mut incoming = llir
+            .edges_directed(node, petgraph::Direction::Incoming)
+            .map(|edge| (edge.id().index(), edge.source()))
+            .collect::<Vec<_>>();
+        incoming.sort_unstable_by_key(|(edge, _)| *edge);
+        let inputs = incoming
+            .into_iter()
+            .map(|(_, source)| node_fingerprints[source.index()].unwrap())
+            .collect::<Vec<_>>();
+        let op = &llir[node];
+        node_fingerprints[node.index()] = Some(LlirFingerprint(
+            hash_node(0x243f_6a88_85a3_08d3, op, &inputs),
+            hash_node(0x1319_8a2e_0370_7344, op, &inputs),
+        ));
+    }
+
+    let mut nodes = node_fingerprints.into_iter().flatten().collect::<Vec<_>>();
+    nodes.sort_unstable_by_key(|fingerprint| (fingerprint.0, fingerprint.1));
+    let mut first = DefaultHasher::new();
+    let mut second = DefaultHasher::new();
+    0x243f_6a88_85a3_08d3_u64.hash(&mut first);
+    0x1319_8a2e_0370_7344_u64.hash(&mut second);
+    llir.edge_count().hash(&mut first);
+    llir.edge_count().hash(&mut second);
+    nodes.hash(&mut first);
+    nodes.hash(&mut second);
+    LlirFingerprint(first.finish(), second.finish())
+}
+
+struct HashWriter<'a>(&'a mut DefaultHasher);
+
+impl std::fmt::Write for HashWriter<'_> {
+    fn write_str(&mut self, value: &str) -> std::fmt::Result {
+        self.0.write(value.as_bytes());
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct ScheduleBucket {
+    egraph: SerializedEGraph,
+    choices: Vec<(String, String)>,
+    bucket_indices: DynMap,
+    representative_dyn_map: DynMap,
+    unrolled_llir_fingerprint: LlirFingerprint,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct SelectedSchedule {
+    dim_buckets: FxHashMap<Symbol, Vec<DimBucket>>,
+    buckets: Vec<ScheduleBucket>,
+}
+
+impl SelectedSchedule {
+    #[doc(hidden)]
+    pub fn from_search(space: &SearchSpace, selected: &[SelectedProgram]) -> Option<Self> {
+        if !space.custom_ops.is_empty() || selected.len() != space.buckets.len() {
+            return None;
+        }
+        let buckets = space
+            .buckets
+            .iter()
+            .zip(selected)
+            .map(|(bucket, selected)| {
+                let mut extractor = LlirExtractor::new(&bucket.egraph, &space.ops);
+                let choices = extractor.named_choices(&selected.genome);
+                let indexed = extractor.index_named_choices(&choices);
+                let llir = unroll_packed_llir(
+                    extractor.extract_indexed_packed(&indexed, &space.custom_ops),
+                );
+                ScheduleBucket {
+                    egraph: bucket.egraph.clone(),
+                    choices,
+                    bucket_indices: selected.bucket_indices.clone(),
+                    representative_dyn_map: selected.representative_dyn_map.clone(),
+                    unrolled_llir_fingerprint: fingerprint_llir(&llir),
+                }
+            })
+            .collect();
+        Some(Self {
+            dim_buckets: space.dim_buckets.clone(),
+            buckets,
+        })
+    }
+}
+
+impl Graph {
+    pub fn selected_schedule(&self) -> Option<&SelectedSchedule> {
+        self.selected_schedule.as_ref()
+    }
+
+    pub fn from_selected_schedule(
+        dyn_map: DynMap,
+        input_meta: FxHashMap<NodeIndex, (String, DType)>,
+        schedule: SelectedSchedule,
+    ) -> Self {
+        Self {
+            dyn_map,
+            input_meta,
+            selected_schedule: Some(schedule),
+            ..Self::default()
+        }
+    }
+
+    pub fn load_selected_schedule<R: Runtime + 'static>(
+        &self,
+        runtime: &mut R,
+    ) -> Result<(), String> {
+        let schedule = self
+            .selected_schedule
+            .as_ref()
+            .ok_or_else(|| "graph has no selected schedule".to_string())?;
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut ops = R::Ops::into_vec();
+            ops.extend(<HLIROps as IntoEgglogOp>::into_vec());
+            let bucket_llirs = schedule
+                .buckets
+                .iter()
+                .enumerate()
+                .map(|(bucket_idx, bucket)| {
+                    let mut extractor = LlirExtractor::new(&bucket.egraph, &ops);
+                    let choices = extractor.index_named_choices(&bucket.choices);
+                    let packed = extractor.extract_indexed_packed(&choices, &[]);
+                    let llir = unroll_packed_llir(packed);
+                    assert_eq!(
+                        fingerprint_llir(&llir),
+                        bucket.unrolled_llir_fingerprint,
+                        "selected schedule bucket {bucket_idx} unrolled LLIR fingerprint mismatch",
+                    );
+                    (
+                        bucket.bucket_indices.clone(),
+                        bucket.representative_dyn_map.clone(),
+                        llir,
+                    )
+                })
+                .collect::<Vec<_>>();
+            runtime.load_llir_buckets(&schedule.dim_buckets, &bucket_llirs);
+        }));
+        result.map_err(|payload| {
+            let detail = payload
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .or_else(|| payload.downcast_ref::<&str>().copied())
+                .unwrap_or("non-string panic");
+            format!("selected schedule could not be loaded: {detail}")
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{graph::CompileOptions, hlir::ReferenceRuntime};
+
+    fn renumber_llir(llir: &LLIRGraph) -> LLIRGraph {
+        let nodes = llir.node_indices().collect::<Vec<_>>();
+        let mut rebuilt = LLIRGraph::default();
+        let mapping = nodes
+            .iter()
+            .rev()
+            .map(|&node| (node, rebuilt.add_node(llir[node].clone())))
+            .collect::<FxHashMap<_, _>>();
+        for &target in nodes.iter().rev() {
+            let mut incoming = llir
+                .edges_directed(target, petgraph::Direction::Incoming)
+                .map(|edge| (edge.id().index(), edge.source()))
+                .collect::<Vec<_>>();
+            incoming.sort_unstable_by_key(|(edge, _)| *edge);
+            for (_, source) in incoming {
+                rebuilt.add_edge(mapping[&source], mapping[&target], ());
+            }
+        }
+        rebuilt
+    }
+
+    fn selected_schedule() -> (Graph, SelectedSchedule) {
+        let mut graph = Graph::new();
+        let _ = graph.tensor(4).sin().output();
+        graph.build_search_space::<ReferenceRuntime>(CompileOptions::default());
+        let space = graph.search_space().unwrap();
+        let ctx = &space.bucket_contexts(&graph.dyn_map)[0];
+        let mut extractor = LlirExtractor::new(ctx.egraph(), &space.ops);
+        let genome = extractor.random_indexed_choice(&mut rand::rng());
+        let llir = unroll_packed_llir(extractor.extract_indexed_packed(&genome, &[]));
+        let selected = SelectedProgram {
+            bucket_indices: ctx.bucket_indices().clone(),
+            representative_dyn_map: ctx.representative_dyn_map.clone(),
+            genome,
+            llir,
+        };
+        let schedule = SelectedSchedule::from_search(space, &[selected]).unwrap();
+        (graph, schedule)
+    }
+
+    #[test]
+    fn selected_schedule_round_trip_skips_search() {
+        let (graph, schedule) = selected_schedule();
+        let bytes = serde_json::to_vec(&schedule).unwrap();
+        let schedule = serde_json::from_slice(&bytes).unwrap();
+        let loaded = Graph::from_selected_schedule(
+            graph.dyn_map.clone(),
+            graph.input_meta.clone(),
+            schedule,
+        );
+        loaded
+            .load_selected_schedule(&mut ReferenceRuntime::initialize(()))
+            .unwrap();
+    }
+
+    #[test]
+    fn selected_schedule_rejects_changed_llir() {
+        let (graph, mut schedule) = selected_schedule();
+        schedule.buckets[0].unrolled_llir_fingerprint.0 ^= 1;
+        let loaded = Graph::from_selected_schedule(graph.dyn_map, graph.input_meta, schedule);
+        let error = loaded
+            .load_selected_schedule(&mut ReferenceRuntime::initialize(()))
+            .unwrap_err();
+        assert!(error.contains("fingerprint mismatch"), "{error}");
+    }
+
+    #[test]
+    fn reference_compile_retains_selected_schedule() {
+        let mut graph = Graph::new();
+        let _ = graph.tensor(4).sin().output();
+        let _runtime = graph.compile(ReferenceRuntime::initialize(()), CompileOptions::default());
+
+        assert!(graph.selected_schedule().is_some());
+    }
+
+    #[test]
+    fn llir_fingerprint_ignores_graph_allocation_order() {
+        let (graph, _) = selected_schedule();
+        let space = graph.search_space().unwrap();
+        let ctx = &space.bucket_contexts(&graph.dyn_map)[0];
+        let mut extractor = LlirExtractor::new(ctx.egraph(), &space.ops);
+        let genome = extractor.random_indexed_choice(&mut rand::rng());
+        let llir = unroll_packed_llir(extractor.extract_indexed_packed(&genome, &[]));
+
+        assert_eq!(
+            fingerprint_llir(&llir),
+            fingerprint_llir(&renumber_llir(&llir))
+        );
+    }
+}

--- a/crates/luminal_cuda_lite_hlir/main_core/hlir.rs
+++ b/crates/luminal_cuda_lite_hlir/main_core/hlir.rs
@@ -1,0 +1,3592 @@
+use std::fmt::Display;
+use std::{fmt::Debug, sync::Arc};
+
+use crate::egglog_utils::api::{Term, eq, v};
+use crate::egglog_utils::{
+    api::{Action, Rule, SortDef, sort},
+    base::*,
+    *,
+};
+use crate::op::*;
+use crate::prelude::*;
+
+use as_any::AsAny;
+use itertools::Itertools;
+
+// --- Dtype helpers for direct IR variants (Input, Output) ---
+
+/// Helper: build a dtype propagation rule for a direct IR op.
+/// Matches the op, reads dtype from the named IR source field, and sets it on the op.
+fn dtype_propagation_rule(sort: &SortDef, dtype_source: &str) -> Rule {
+    let (args, op_match) = sort.new_call();
+    let e = v("__e");
+    let dty = v("__dty");
+    Rule::new()
+        .fact(eq(e.clone(), op_match))
+        .fact(eq(dty.clone(), dtype(args[dtype_source].clone())))
+        .action(Action::Set(dtype(e), dty))
+        .ruleset("dtype_prop")
+}
+
+/// Helper: build a dtype-from-field rule for a direct IR op.
+fn dtype_from_field_rule(sort: &SortDef, dtype_field: &str) -> Rule {
+    let (args, op_match) = sort.new_call();
+    let e = v("__e");
+    Rule::new()
+        .fact(eq(e.clone(), op_match))
+        .action(Action::Set(dtype(e), args[dtype_field].clone()))
+        .ruleset("dtype_prop")
+}
+
+// --- Dtype helpers for normalized ops (Op OpKind IList) ---
+
+/// Dtype propagation for a normalized op: inherits from first IList input.
+fn dtype_propagation_op(kind_sort: &SortDef) -> Rule {
+    let (_, kind_term) = kind_sort.new_call();
+    let e = v("__e");
+    let first_inp = v("__first_inp");
+    let tail = v("__tail");
+    let dty = v("__dty");
+    Rule::new()
+        .fact(eq(
+            e.clone(),
+            op_term(
+                kind_term,
+                Term::App {
+                    variant: "ICons".to_string(),
+                    args: vec![first_inp.clone(), tail],
+                },
+            ),
+        ))
+        .fact(eq(dty.clone(), dtype(first_inp)))
+        .action(Action::Set(dtype(e), dty))
+        .ruleset("dtype_prop")
+}
+
+/// Dtype from a field on the OpKind (e.g., Cast's dtype field).
+fn dtype_from_kind_field(kind_sort: &SortDef, field_name: &str) -> Rule {
+    let (args, kind_term) = kind_sort.new_call();
+    let e = v("__e");
+    let inputs = v("__inputs");
+    Rule::new()
+        .fact(eq(e.clone(), op_term(kind_term, inputs)))
+        .action(Action::Set(dtype(e), args[field_name].clone()))
+        .ruleset("dtype_prop")
+}
+
+/// Fixed dtype for a normalized op (e.g., Iota always Int).
+fn dtype_fixed_op(kind_sort: &SortDef, dtype_sort: &SortDef) -> Rule {
+    let (_, kind_term) = kind_sort.new_call();
+    let e = v("__e");
+    let inputs = v("__inputs");
+    Rule::new()
+        .fact(eq(e.clone(), op_term(kind_term, inputs)))
+        .action(Action::Set(dtype(e), dtype_sort.call(())))
+        .ruleset("dtype_prop")
+}
+
+/// Validate a structural marker's declared dtype against every tensor source.
+/// Marker metadata is a concrete contract, never an inference placeholder.
+fn marker_output_dtype(op: &dyn Display, declared: DType, inputs: &[DType]) -> DType {
+    assert!(!inputs.is_empty(), "{op} has no tensor source");
+    for (index, &actual) in inputs.iter().enumerate() {
+        assert_eq!(
+            actual, declared,
+            "{op} declares {declared:?}, but input {index} is {actual:?}"
+        );
+    }
+    declared
+}
+
+/// Build an IList egglog string from input variable names.
+fn ilist_egglog(inputs: &[&str]) -> String {
+    list_to_egglog(inputs, "ICons", "INil")
+}
+use num_traits::Float;
+use petgraph::{Direction, algo::toposort, prelude::StableGraph, visit::EdgeRef};
+use rustc_hash::{FxHashMap, FxHashSet};
+use tracing::info_span;
+
+// --- Convenience sort builders for common op patterns ---
+
+/// Unary op kind: (shape: EList, strides: EList, out_strides: EList), IList: [inp]
+pub fn unary_sort(name: &str) -> SortDef {
+    sort(
+        OP_KIND,
+        name,
+        &[("shape", ELIST), ("strides", ELIST), ("out_strides", ELIST)],
+    )
+}
+
+/// Binary op kind: (shape: EList, a_strides: EList, b_strides: EList, out_strides: EList), IList: [inp_a, inp_b]
+pub fn binary_sort(name: &str) -> SortDef {
+    sort(
+        OP_KIND,
+        name,
+        &[
+            ("shape", ELIST),
+            ("a_strides", ELIST),
+            ("b_strides", ELIST),
+            ("out_strides", ELIST),
+        ],
+    )
+}
+
+/// Generate egglog rewrite rules that union a small rolled `body=1, trips=N`
+/// single-binary-op loop with its fully-unrolled equivalent in the same
+/// eclass. Both representations coexist; the cost-based extractor picks
+/// whichever one downstream patterns prefer — the unrolled form when fusions
+/// (e.g. GLUMoE GemmaGELU, CUDA elementwise exp fusion) match through
+/// the flat chain, the rolled form otherwise. Without these unions, rolling
+/// a tiny chain blocks the fusion entirely and the extracted graph is
+/// strictly worse than not rolling.
+///
+/// Register these in `EgglogOp::rewrites()`. The driver feeds this normal
+/// rewrite set into the single egglog run, so the unrolled chain is visible to
+/// fusion patterns (GLUMoE) and kernel rewrites (`direct-exp-fusion`).
+///
+/// Generates 2 rules per iter count (state at body input position 0 vs 1)
+/// for every `n_iters` in `2..=max_trips`. Larger trips stay rolled-only —
+/// real transformer-block rolls are body ≫ 1 anyway, and carrying both
+/// forms beyond a small N adds search-time cost without an upside.
+///
+/// Each rule matches the rolled shape `LoopEnd(body)` where `body` is the
+/// binary op consuming `LoopStart(initial)` and `LoopInput(s0..s_{N-1})`,
+/// and unions `LoopEnd` with the chain
+///   `u0 = <kind>(initial, s0); u1 = <kind>(u0, s1); … u_{N-1}`.
+/// (or symmetric for state at position 1.)
+pub fn binary_op_unroll_rules(op_kind: &str, max_trips: usize) -> Vec<Rule> {
+    let mut rules = Vec::with_capacity((max_trips.saturating_sub(1)) * 2);
+    for n_iters in 2..=max_trips {
+        for state_pos in 0..2 {
+            rules.push(binary_op_unroll_rule(op_kind, n_iters, state_pos));
+        }
+    }
+    rules
+}
+
+fn binary_op_unroll_rule(op_kind: &str, n_iters: usize, state_pos: usize) -> Rule {
+    // Swap (state, per_iter) → (input0, input1) by `state_pos`. Both the
+    // body match pattern and the unrolled chain bodies follow this mapping
+    // so a/b stride positions stay aligned.
+    debug_assert!(state_pos < 2);
+    let order = |state: &str, per_iter: &str| -> String {
+        if state_pos == 0 {
+            format!("(ICons {state} (ICons {per_iter} (INil)))")
+        } else {
+            format!("(ICons {per_iter} (ICons {state} (INil)))")
+        }
+    };
+    let li_sources = (0..n_iters).rev().fold(String::from("(INil)"), |acc, i| {
+        format!("(ICons ?s{i} {acc})")
+    });
+    let chain = (0..n_iters)
+        .map(|i| {
+            let prev = if i == 0 {
+                "?initial".to_string()
+            } else {
+                format!("?u{}", i - 1)
+            };
+            format!(
+                "                (let ?u{i} (Op ({op_kind} ?sh ?as ?bs ?os) {}))",
+                order(&prev, &format!("?s{i}"))
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    Rule::raw(format!(
+        "(rule
+            (
+                (= ?ls (LoopStart ?initial ?loop_id ?slot_idx (MNum {n_iters}) ?dt))
+                (= ?li (Op (LoopInput ?loop_id ?stream ?dt) {li_sources}))
+                (= ?body (Op ({op_kind} ?sh ?as ?bs ?os) {body_pat}))
+                (= ?le (LoopEnd ?body ?loop_id ?slot_idx ?dt))
+            )
+            (
+{chain}
+                (union ?le ?u{last})
+            )
+            :ruleset expr
+            :name \"unroll {op_kind} body trips={n_iters} state={state_pos}\"
+        )",
+        body_pat = order("?ls", "?li"),
+        last = n_iters - 1,
+    ))
+}
+
+/// Reduce op kind: (shape: EList, iters: Expression, strides: EList, iter_stride: Expression, out_strides: EList), IList: [inp]
+pub fn reduce_sort(name: &str) -> SortDef {
+    sort(
+        OP_KIND,
+        name,
+        &[
+            ("shape", ELIST),
+            ("iters", EXPRESSION),
+            ("strides", ELIST),
+            ("iter_stride", EXPRESSION),
+            ("out_strides", ELIST),
+        ],
+    )
+}
+
+pub type HLIROps = (
+    Input,
+    Output,
+    CustomOpKind,
+    LoopStart,
+    LoopEnd,
+    LoopInput,
+    LoopInputStatic,
+    LoopOutput,
+    LoopOutputSelect,
+    Constant,
+    ConstantF64,
+    Cast,
+    Iota,
+    Exp2,
+    Log2,
+    Sin,
+    Recip,
+    Sqrt,
+    Add,
+    Mul,
+    Mod,
+    LessThan,
+    Gather,
+    Scatter,
+    SumReduce,
+    MaxReduce,
+);
+
+#[derive(Default, Debug, Clone)]
+pub struct Input {
+    pub node: usize,
+    pub label: String,
+    pub dtype: DType,
+}
+
+impl Display for Input {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Input({}{})",
+            if self.label.is_empty() {
+                "".to_string()
+            } else {
+                format!("{}; ", self.label)
+            },
+            self.dtype
+        )
+    }
+}
+
+impl EgglogOp for Input {
+    fn sort(&self) -> SortDef {
+        sort(
+            IR,
+            "Input",
+            &[("node", I64), ("label", STRING), ("dtype", DTYPE)],
+        )
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![dtype_from_field_rule(&self.sort(), "dtype")]
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        _: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        _: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        let node = egraph.enodes[kind_children[0]]
+            .0
+            .replace("\"", "")
+            .parse::<usize>()
+            .unwrap();
+        let label = egraph.enodes[kind_children[1]].0.replace("\"", "");
+        (
+            LLIROp::new::<Input>(Box::new(Self {
+                node,
+                label,
+                dtype: extract_dtype(egraph, kind_children[2]),
+            })),
+            vec![],
+        )
+    }
+}
+
+impl HLIROp for Input {
+    fn to_egglog(&self, _: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(Input {} \"{}\" ({:?}))",
+            self.node, self.label, self.dtype
+        )
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        assert!(
+            input_dtypes.is_empty(),
+            "Input cannot consume tensor inputs"
+        );
+        self.dtype
+    }
+}
+
+impl ReferenceOp for Input {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
+        unimplemented!()
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct Output {
+    pub node: usize,
+    /// `persist_only` keeps storage live across executions but does not
+    /// semantically observe a snapshot of the value. This distinction lets
+    /// backends use a proven-safe in-place update without conflating it with a
+    /// user-visible output of the pre-update logical version.
+    pub persist_only: bool,
+}
+
+impl Display for Output {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Output")
+    }
+}
+
+impl EgglogOp for Output {
+    fn sort(&self) -> SortDef {
+        sort(
+            IR,
+            "Output",
+            &[("inp", IR), ("node", I64), ("persist_only", BOOL)],
+        )
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![dtype_propagation_rule(&self.sort(), "inp")]
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        _: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        _: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        (
+            LLIROp::new::<Output>(Box::new(Self {
+                node: egraph.enodes[kind_children[1]]
+                    .0
+                    .replace("\"", "")
+                    .parse::<usize>()
+                    .unwrap(),
+                persist_only: match egraph.enodes[kind_children[2]].0.as_str() {
+                    "true" => true,
+                    "false" => false,
+                    value => panic!("invalid Output persist_only value {value}"),
+                },
+            })),
+            vec![kind_children[0]],
+        )
+    }
+}
+
+impl HLIROp for Output {
+    fn to_egglog(&self, inp: &[(NodeIndex, String)]) -> String {
+        format!("(Output {} {} {})", inp[0].1, self.node, self.persist_only)
+    }
+}
+
+impl ReferenceOp for Output {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
+        unimplemented!()
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct CustomOpKind {
+    pub id: usize,
+    pub dtype: DType,
+}
+
+impl Display for CustomOpKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CustomOp({})", self.dtype)
+    }
+}
+
+impl EgglogOp for CustomOpKind {
+    fn sort(&self) -> SortDef {
+        sort(OP_KIND, "CustomOpKind", &[("id", I64), ("dtype", DTYPE)])
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![dtype_from_kind_field(&self.sort(), "dtype")]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+}
+
+impl HLIROp for CustomOpKind {
+    fn to_egglog(&self, inp: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(Op (CustomOpKind {} ({:?})) {})",
+            self.id,
+            self.dtype,
+            list_to_egglog(&inp.iter().map(|i| &i.1).collect_vec(), "ICons", "INil"),
+        )
+    }
+
+    fn output_dtype(&self, _input_dtypes: &[DType]) -> DType {
+        self.dtype
+    }
+}
+
+impl ReferenceOp for CustomOpKind {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
+        unimplemented!()
+    }
+}
+
+// --- Loop ops ---------------------------------------------------------------
+//
+// Automatic loop-rolling replaces N unrolled copies of a repeating body with
+// a single body plus structural marker ops. All four ops in one loop share a
+// `loop_id`. `iters` lives on `LoopStart` only; every other op references the
+// same loop via `loop_id`.
+//
+//   LoopStart   — one per loop-carried slot; takes the initial value, yields
+//                 the current iteration's value into the body.
+//   LoopEnd     — mirror of LoopStart; takes the body's final value for the
+//                 slot, yields the post-loop value.
+//   LoopInput   — OpKind (variable-arity). Takes N input tensors (one per
+//                 iteration) and yields the current iteration's tensor.
+//   LoopOutput  — OpKind (variable-arity, sink). Takes the body's value + N
+//                 target tensors; writes body[i] -> target[i] each iteration.
+//
+// Execution semantics and iteration driving live in the runtime compilation
+// step; these ops just carry the structure through HLIR/egglog/LLIR.
+
+#[derive(Default, Debug, Clone)]
+pub struct LoopStart {
+    pub loop_id: usize,
+    pub slot_idx: usize,
+    pub iters: Expression,
+    pub dtype: DType,
+}
+
+impl Display for LoopStart {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "LoopStart(id={}, slot={}, iters={:?}, {})",
+            self.loop_id, self.slot_idx, self.iters, self.dtype
+        )
+    }
+}
+
+impl EgglogOp for LoopStart {
+    fn sort(&self) -> SortDef {
+        sort(
+            IR,
+            "LoopStart",
+            &[
+                ("inp", IR),
+                ("loop_id", I64),
+                ("slot_idx", I64),
+                ("iters", EXPRESSION),
+                ("dtype", DTYPE),
+            ],
+        )
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![dtype_from_field_rule(&self.sort(), "dtype")]
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        _: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        let loop_id = egraph.enodes[kind_children[1]]
+            .0
+            .replace("\"", "")
+            .parse::<usize>()
+            .unwrap();
+        let slot_idx = egraph.enodes[kind_children[2]]
+            .0
+            .replace("\"", "")
+            .parse::<usize>()
+            .unwrap();
+        let iters = extract_expr(egraph, kind_children[3], expr_cache).unwrap();
+        let dtype = extract_dtype(egraph, kind_children[4]);
+        (
+            LLIROp::new::<LoopStart>(Box::new(Self {
+                loop_id,
+                slot_idx,
+                iters,
+                dtype,
+            })),
+            vec![kind_children[0]],
+        )
+    }
+}
+
+impl HLIROp for LoopStart {
+    fn to_egglog(&self, inp: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(LoopStart {} {} {} {} ({:?}))",
+            inp[0].1,
+            self.loop_id,
+            self.slot_idx,
+            self.iters.to_egglog(),
+            self.dtype,
+        )
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        marker_output_dtype(self, self.dtype, input_dtypes)
+    }
+}
+
+impl ReferenceOp for LoopStart {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
+        unimplemented!("LoopStart is driven by the runtime loop compiler")
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct LoopEnd {
+    pub loop_id: usize,
+    pub slot_idx: usize,
+    pub dtype: DType,
+}
+
+impl Display for LoopEnd {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "LoopEnd(id={}, slot={}, {})",
+            self.loop_id, self.slot_idx, self.dtype
+        )
+    }
+}
+
+impl EgglogOp for LoopEnd {
+    fn sort(&self) -> SortDef {
+        sort(
+            IR,
+            "LoopEnd",
+            &[
+                ("inp", IR),
+                ("loop_id", I64),
+                ("slot_idx", I64),
+                ("dtype", DTYPE),
+            ],
+        )
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![dtype_from_field_rule(&self.sort(), "dtype")]
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        _: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        _: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        let loop_id = egraph.enodes[kind_children[1]]
+            .0
+            .replace("\"", "")
+            .parse::<usize>()
+            .unwrap();
+        let slot_idx = egraph.enodes[kind_children[2]]
+            .0
+            .replace("\"", "")
+            .parse::<usize>()
+            .unwrap();
+        let dtype = extract_dtype(egraph, kind_children[3]);
+        (
+            LLIROp::new::<LoopEnd>(Box::new(Self {
+                loop_id,
+                slot_idx,
+                dtype,
+            })),
+            vec![kind_children[0]],
+        )
+    }
+}
+
+impl HLIROp for LoopEnd {
+    fn to_egglog(&self, inp: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(LoopEnd {} {} {} ({:?}))",
+            inp[0].1, self.loop_id, self.slot_idx, self.dtype,
+        )
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        marker_output_dtype(self, self.dtype, input_dtypes)
+    }
+}
+
+impl ReferenceOp for LoopEnd {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
+        unimplemented!("LoopEnd is driven by the runtime loop compiler")
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct LoopInput {
+    pub loop_id: usize,
+    pub stream_id: usize,
+    pub dtype: DType,
+}
+
+impl Display for LoopInput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "LoopInput(id={}, stream={}, {})",
+            self.loop_id, self.stream_id, self.dtype
+        )
+    }
+}
+
+impl EgglogOp for LoopInput {
+    fn sort(&self) -> SortDef {
+        sort(
+            OP_KIND,
+            "LoopInput",
+            &[("loop_id", I64), ("stream_id", I64), ("dtype", DTYPE)],
+        )
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        // Declare the `identical_inputs` relation and the three-way unification
+        // chain between `LoopInput`, `LoopInputStatic`, and an inlined source.
+        // Running alongside fusion rules (e.g. GLUMoE) so that fusion patterns
+        // that expect raw op kinds at boundary positions can match via the
+        // unioned eclass.
+        vec![
+            // Loop rolling stamps the concrete stream dtype into the marker;
+            // the field is the same type contract consumed by rewrites and
+            // extracted into LLIR.
+            dtype_from_kind_field(&self.sort(), "dtype"),
+            Rule::raw(
+                r#"
+            (relation identical_inputs (IList))
+
+            ; All four rules live in the `expr` ruleset, which the schedule
+            ; saturates each iteration. Default-ruleset scheduling only runs
+            ; each rule once per outer step, which is not enough to propagate
+            ; `identical_inputs` through an N-element IList.
+
+            ; Base: single-element list is trivially identical.
+            (rule ((= ?l (ICons ?x (INil))))
+                  ((identical_inputs ?l))
+                  :ruleset expr
+                  :name "identical_inputs base")
+
+            ; Inductive: head equals next-head, and the tail starting at next-head is identical.
+            (rule ((= ?l (ICons ?x (ICons ?x ?tail)))
+                   (identical_inputs (ICons ?x ?tail)))
+                  ((identical_inputs ?l))
+                  :ruleset expr
+                  :name "identical_inputs ind")
+
+            ; LoopInput with an identical IList is equivalent to LoopInputStatic over a single copy.
+            (rule ((= ?e (Op (LoopInput ?id ?stream ?dt) (ICons ?x ?cont)))
+                   (identical_inputs (ICons ?x ?cont)))
+                  ((let ?static (Op (LoopInputStatic ?id ?stream ?dt) (ICons ?x (INil))))
+                   (union ?e ?static))
+                  :ruleset expr
+                  :name "LoopInput to LoopInputStatic")
+
+            ; LoopInputStatic is equivalent to its single inner value — collapses the boundary
+            ; wrapper for pattern-matching and extraction purposes.
+            (rule ((= ?e (Op (LoopInputStatic ?id ?stream ?dt) (ICons ?x (INil)))))
+                  ((union ?e ?x))
+                  :ruleset expr
+                  :name "LoopInputStatic inline")
+            "#,
+            ),
+        ]
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        _: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        _: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        let loop_id = egraph.enodes[kind_children[0]]
+            .0
+            .replace("\"", "")
+            .parse::<usize>()
+            .unwrap();
+        let stream_id = egraph.enodes[kind_children[1]]
+            .0
+            .replace("\"", "")
+            .parse::<usize>()
+            .unwrap();
+        let dtype = extract_dtype(egraph, kind_children[2]);
+        (
+            LLIROp::new::<LoopInput>(Box::new(Self {
+                loop_id,
+                stream_id,
+                dtype,
+            })),
+            input_enodes,
+        )
+    }
+}
+
+impl HLIROp for LoopInput {
+    fn to_egglog(&self, inp: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(Op (LoopInput {} {} ({:?})) {})",
+            self.loop_id,
+            self.stream_id,
+            self.dtype,
+            list_to_egglog(&inp.iter().map(|i| &i.1).collect_vec(), "ICons", "INil"),
+        )
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        marker_output_dtype(self, self.dtype, input_dtypes)
+    }
+}
+
+impl ReferenceOp for LoopInput {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
+        unimplemented!("LoopInput is driven by the runtime loop compiler")
+    }
+}
+
+/// Iteration-independent boundary input: the same value flows into every
+/// iteration of a loop. Structurally a `LoopInput` whose per-iteration
+/// sources have all been proven equal (via the `identical_inputs` egglog
+/// relation) collapses into `LoopInputStatic` with a single-element IList,
+/// and that in turn collapses via a further rewrite into just its inner
+/// value — so egglog search can explore any of the three representations.
+/// At unroll time `LoopInputStatic` lowers to a plain edge: every cloned
+/// body node in every iteration references the single shared source.
+#[derive(Default, Debug, Clone)]
+pub struct LoopInputStatic {
+    pub loop_id: usize,
+    pub stream_id: usize,
+    pub dtype: DType,
+}
+
+impl Display for LoopInputStatic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "LoopInputStatic(id={}, stream={}, {})",
+            self.loop_id, self.stream_id, self.dtype
+        )
+    }
+}
+
+impl EgglogOp for LoopInputStatic {
+    fn sort(&self) -> SortDef {
+        sort(
+            OP_KIND,
+            "LoopInputStatic",
+            &[("loop_id", I64), ("stream_id", I64), ("dtype", DTYPE)],
+        )
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![dtype_from_kind_field(&self.sort(), "dtype")]
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        _: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        _: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        let loop_id = egraph.enodes[kind_children[0]]
+            .0
+            .replace("\"", "")
+            .parse::<usize>()
+            .unwrap();
+        let stream_id = egraph.enodes[kind_children[1]]
+            .0
+            .replace("\"", "")
+            .parse::<usize>()
+            .unwrap();
+        let dtype = extract_dtype(egraph, kind_children[2]);
+        (
+            LLIROp::new::<LoopInputStatic>(Box::new(Self {
+                loop_id,
+                stream_id,
+                dtype,
+            })),
+            input_enodes,
+        )
+    }
+}
+
+impl HLIROp for LoopInputStatic {
+    fn to_egglog(&self, inp: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(Op (LoopInputStatic {} {} ({:?})) {})",
+            self.loop_id,
+            self.stream_id,
+            self.dtype,
+            list_to_egglog(&inp.iter().map(|i| &i.1).collect_vec(), "ICons", "INil"),
+        )
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        marker_output_dtype(self, self.dtype, input_dtypes)
+    }
+}
+
+impl ReferenceOp for LoopInputStatic {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
+        unimplemented!("LoopInputStatic is driven by the runtime loop compiler")
+    }
+}
+
+/// Marker for the per-iter output stream of a rolled loop. Mirrors `LoopInput`
+/// in reverse: a single body producer (one incoming edge) feeds the marker, and
+/// `LoopOutputSelect(i)` nodes hang off it to pluck iteration `i`'s value for
+/// downstream consumers (any post-region op — `Output` HLIR, downstream
+/// computation, etc.).
+#[derive(Default, Debug, Clone)]
+pub struct LoopOutput {
+    pub loop_id: usize,
+    pub stream_id: usize,
+    pub dtype: DType,
+}
+
+impl Display for LoopOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "LoopOutput(id={}, stream={}, {})",
+            self.loop_id, self.stream_id, self.dtype
+        )
+    }
+}
+
+impl EgglogOp for LoopOutput {
+    fn sort(&self) -> SortDef {
+        sort(
+            OP_KIND,
+            "LoopOutput",
+            &[("loop_id", I64), ("stream_id", I64), ("dtype", DTYPE)],
+        )
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![dtype_from_kind_field(&self.sort(), "dtype")]
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        _: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        _: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        let loop_id = egraph.enodes[kind_children[0]]
+            .0
+            .replace("\"", "")
+            .parse::<usize>()
+            .unwrap();
+        let stream_id = egraph.enodes[kind_children[1]]
+            .0
+            .replace("\"", "")
+            .parse::<usize>()
+            .unwrap();
+        let dtype = extract_dtype(egraph, kind_children[2]);
+        (
+            LLIROp::new::<LoopOutput>(Box::new(Self {
+                loop_id,
+                stream_id,
+                dtype,
+            })),
+            input_enodes,
+        )
+    }
+}
+
+impl HLIROp for LoopOutput {
+    fn to_egglog(&self, inp: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(Op (LoopOutput {} {} ({:?})) {})",
+            self.loop_id,
+            self.stream_id,
+            self.dtype,
+            list_to_egglog(&inp.iter().map(|i| &i.1).collect_vec(), "ICons", "INil"),
+        )
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        marker_output_dtype(self, self.dtype, input_dtypes)
+    }
+}
+
+impl ReferenceOp for LoopOutput {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
+        unimplemented!("LoopOutput is driven by the runtime loop compiler")
+    }
+}
+
+/// Per-iteration extractor for a `LoopOutput` stream. Mirrors a per-iter
+/// `LoopInput` source slot in reverse: every cross-region edge that originally
+/// went from iteration `i`'s body producer to a post-region consumer is
+/// rewired through `LoopOutputSelect { iter: i, ... }`. At unroll time
+/// `Select(i)` lowers to the iter-`i` body clone's producer; at collapse time
+/// every Select lowers to iter-0's producer.
+#[derive(Default, Debug, Clone)]
+pub struct LoopOutputSelect {
+    pub loop_id: usize,
+    pub stream_id: usize,
+    pub iter: usize,
+    pub dtype: DType,
+}
+
+impl Display for LoopOutputSelect {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "LoopOutputSelect(id={}, stream={}, iter={}, {})",
+            self.loop_id, self.stream_id, self.iter, self.dtype
+        )
+    }
+}
+
+impl EgglogOp for LoopOutputSelect {
+    fn sort(&self) -> SortDef {
+        sort(
+            OP_KIND,
+            "LoopOutputSelect",
+            &[
+                ("loop_id", I64),
+                ("stream_id", I64),
+                ("iter", I64),
+                ("dtype", DTYPE),
+            ],
+        )
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![dtype_from_kind_field(&self.sort(), "dtype")]
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        _: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        _: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        let loop_id = egraph.enodes[kind_children[0]]
+            .0
+            .replace("\"", "")
+            .parse::<usize>()
+            .unwrap();
+        let stream_id = egraph.enodes[kind_children[1]]
+            .0
+            .replace("\"", "")
+            .parse::<usize>()
+            .unwrap();
+        let iter = egraph.enodes[kind_children[2]]
+            .0
+            .replace("\"", "")
+            .parse::<usize>()
+            .unwrap();
+        let dtype = extract_dtype(egraph, kind_children[3]);
+        (
+            LLIROp::new::<LoopOutputSelect>(Box::new(Self {
+                loop_id,
+                stream_id,
+                iter,
+                dtype,
+            })),
+            input_enodes,
+        )
+    }
+}
+
+impl HLIROp for LoopOutputSelect {
+    fn to_egglog(&self, inp: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(Op (LoopOutputSelect {} {} {} ({:?})) {})",
+            self.loop_id,
+            self.stream_id,
+            self.iter,
+            self.dtype,
+            list_to_egglog(&inp.iter().map(|i| &i.1).collect_vec(), "ICons", "INil"),
+        )
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        marker_output_dtype(self, self.dtype, input_dtypes)
+    }
+}
+
+impl ReferenceOp for LoopOutputSelect {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
+        unimplemented!("LoopOutputSelect is driven by the runtime loop compiler")
+    }
+}
+
+/// Produces a single number constant from an expression or a float
+#[derive(Clone, PartialEq, Default)]
+pub struct Constant(pub f32);
+impl Debug for Constant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Constant({:?})", self.0)
+    }
+}
+
+impl Display for Constant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+impl HLIROp for Constant {
+    fn to_egglog(&self, _: &[(NodeIndex, String)]) -> String {
+        format!("(Op (Constant {:?}) (INil))", self.0)
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        assert!(
+            input_dtypes.is_empty(),
+            "Constant cannot consume tensor inputs"
+        );
+        DType::F32
+    }
+}
+
+impl EgglogOp for Constant {
+    fn sort(&self) -> SortDef {
+        sort(OP_KIND, "Constant", &[("value", F64)])
+    }
+    fn cleanup(&self) -> bool {
+        true
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![dtype_fixed_op(&self.sort(), &SORTS.f32_dt)]
+    }
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        _: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        _: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        (
+            LLIROp::new::<dyn ReferenceOp>(Box::new(Self(
+                egraph.enodes[kind_children[0]]
+                    .0
+                    .replace("\"", "")
+                    .parse::<f32>()
+                    .unwrap(),
+            ))),
+            vec![],
+        )
+    }
+}
+
+impl ReferenceOp for Constant {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
+        ReferenceData::F32(vec![self.0])
+    }
+}
+
+/// Produces a single F64 constant without narrowing through F32.
+///
+/// Temporary: delete this op once `Constant` is converted to a typed constant.
+#[derive(Clone, PartialEq, Default)]
+pub struct ConstantF64(pub f64);
+
+impl Debug for ConstantF64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ConstantF64({:?})", self.0)
+    }
+}
+
+impl Display for ConstantF64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+impl HLIROp for ConstantF64 {
+    fn to_egglog(&self, _: &[(NodeIndex, String)]) -> String {
+        format!("(Op (ConstantF64 {:?}) (INil))", self.0)
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        assert!(
+            input_dtypes.is_empty(),
+            "ConstantF64 cannot consume tensor inputs"
+        );
+        DType::F64
+    }
+}
+
+impl EgglogOp for ConstantF64 {
+    fn sort(&self) -> SortDef {
+        sort(OP_KIND, "ConstantF64", &[("value", F64)])
+    }
+
+    fn cleanup(&self) -> bool {
+        true
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![dtype_fixed_op(&self.sort(), &SORTS.f64_dt)]
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        _: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        _: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        (
+            LLIROp::new::<dyn ReferenceOp>(Box::new(Self(
+                egraph.enodes[kind_children[0]]
+                    .0
+                    .replace('"', "")
+                    .parse::<f64>()
+                    .unwrap(),
+            ))),
+            vec![],
+        )
+    }
+}
+
+impl ReferenceOp for ConstantF64 {
+    fn execute(&self, _: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
+        ReferenceData::F64(vec![self.0])
+    }
+}
+
+#[derive(Clone, PartialEq, Debug, Default)]
+pub struct Iota(pub Expression, pub Expression);
+impl Display for Iota {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Iota({}; {})", self.0, self.1)
+    }
+}
+impl HLIROp for Iota {
+    fn to_egglog(&self, _: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(Op (Iota {} {}) (INil))",
+            self.0.to_egglog(),
+            self.1.to_egglog()
+        )
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        assert!(input_dtypes.is_empty(), "Iota cannot consume tensor inputs");
+        DType::Int
+    }
+}
+impl EgglogOp for Iota {
+    fn sort(&self) -> SortDef {
+        sort(
+            OP_KIND,
+            "Iota",
+            &[("expr", EXPRESSION), ("range", EXPRESSION)],
+        )
+    }
+
+    fn cleanup(&self) -> bool {
+        true
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![dtype_fixed_op(&self.sort(), &SORTS.int_dt)]
+    }
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        _: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        (
+            LLIROp::new::<dyn ReferenceOp>(Box::new(Self(
+                extract_expr(egraph, kind_children[0], expr_cache).unwrap(),
+                extract_expr(egraph, kind_children[1], expr_cache).unwrap(),
+            ))),
+            vec![],
+        )
+    }
+}
+impl ReferenceOp for Iota {
+    fn execute(&self, _: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
+        let length = self.1.exec(dyn_map).unwrap();
+        let expr = self.0.resolve_vars(dyn_map);
+        ReferenceData::Int(
+            (0..length)
+                .map(|i| expr.exec_single_var(i) as i32)
+                .collect(),
+        )
+    }
+}
+
+#[derive(Clone, PartialEq, Debug, Default)]
+pub struct Cast(pub Expression, pub DType);
+impl Display for Cast {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Cast({})", self.1)
+    }
+}
+impl HLIROp for Cast {
+    fn to_egglog(&self, inp: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(Op (Cast {} ({:?})) (ICons {} (INil)))",
+            self.0.to_egglog(),
+            self.1,
+            inp[0].1,
+        )
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        assert_eq!(input_dtypes.len(), 1, "Cast must consume one tensor input");
+        self.1
+    }
+}
+impl EgglogOp for Cast {
+    fn sort(&self) -> SortDef {
+        sort(OP_KIND, "Cast", &[("size", EXPRESSION), ("dtype", DTYPE)])
+    }
+
+    fn cleanup(&self) -> bool {
+        true
+    }
+
+    fn n_inputs(&self) -> usize {
+        1
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![dtype_from_kind_field(&self.sort(), "dtype")]
+    }
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        _: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        ec: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        (
+            LLIROp::new::<dyn ReferenceOp>(Box::new(Self(
+                extract_expr(egraph, kind_children[0], ec).unwrap(),
+                extract_dtype(egraph, kind_children[1]),
+            ))),
+            input_enodes,
+        )
+    }
+}
+impl ReferenceOp for Cast {
+    fn execute(&self, input: Vec<&ReferenceData>, _: &DynMap) -> ReferenceData {
+        match self.1 {
+            DType::F32 => ReferenceData::F32(input[0].to_f32_vec()),
+            DType::F64 => ReferenceData::F64(input[0].to_f64_vec()),
+            DType::F16 => ReferenceData::F16(input[0].to_f16_vec()),
+            DType::Bf16 => ReferenceData::Bf16(input[0].to_bf16_vec()),
+            DType::Int => ReferenceData::Int(input[0].to_i32_vec()),
+            DType::I64 => ReferenceData::I64(input[0].to_i64_vec()),
+            DType::I8 => ReferenceData::I8(input[0].to_i8_vec()),
+            DType::U8 => ReferenceData::U8(input[0].to_u8_vec()),
+            DType::I16 => ReferenceData::I16(input[0].to_i16_vec()),
+            DType::Bool => ReferenceData::Bool(input[0].to_bool_vec()),
+            other => {
+                unimplemented!("Cast to {other} is not yet supported in reference interpreter")
+            }
+        }
+    }
+}
+
+// Unary Op (A -> A)
+
+struct UnaryKernels {
+    f32_fn: fn(f32) -> f32,
+    f16_fn: fn(f16) -> f16,
+    bf16_fn: fn(bf16) -> bf16,
+    f64_fn: fn(f64) -> f64,
+}
+
+fn unary_impl(
+    inp: &ReferenceData,
+    shape: &[Expression],
+    strides: &[Expression],
+    dyn_map: &DynMap,
+    kernels: UnaryKernels,
+) -> ReferenceData {
+    let ind = StridedIterator::new(shape, strides, dyn_map);
+    match &inp {
+        ReferenceData::F32(f) => ReferenceData::F32(ind.map(|i| (kernels.f32_fn)(f[i])).collect()),
+        ReferenceData::F16(f) => ReferenceData::F16(ind.map(|i| (kernels.f16_fn)(f[i])).collect()),
+        ReferenceData::Bf16(f) => {
+            ReferenceData::Bf16(ind.map(|i| (kernels.bf16_fn)(f[i])).collect())
+        }
+        ReferenceData::F64(f) => ReferenceData::F64(ind.map(|i| (kernels.f64_fn)(f[i])).collect()),
+        ReferenceData::Int(_) => panic!("unary_impl: no Int kernel — cast to F32 at the call site"),
+        ReferenceData::I64(_) => panic!("unary_impl: no I64 kernel — cast to F32 at the call site"),
+        ReferenceData::I8(_) => panic!("unary_impl: no I8 kernel — cast to F32 at the call site"),
+        ReferenceData::U8(_) => panic!("unary_impl: no U8 kernel — cast to F32 at the call site"),
+        ReferenceData::I16(_) => panic!("unary_impl: no I16 kernel — cast to F32 at the call site"),
+        ReferenceData::Bool(_) => {
+            panic!("unary_impl: no Bool kernel — cast to F32 at the call site")
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Log2 {
+    pub shape: Vec<Expression>,
+    pub strides: Vec<Expression>,
+    pub input_shape: ShapeTracker,
+}
+impl Display for Log2 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Log2")
+    }
+}
+impl HLIROp for Log2 {
+    fn to_egglog(&self, inputs: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(Op (Log2 {} {} {}) {})",
+            elist_to_egglog(&self.input_shape.dims),
+            elist_to_egglog(&self.input_shape.strides),
+            elist_to_egglog(&self.input_shape.contiguous().strides),
+            ilist_egglog(&[&inputs[0].1]),
+        )
+    }
+}
+impl EgglogOp for Log2 {
+    fn sort(&self) -> SortDef {
+        unary_sort("Log2")
+    }
+    fn cleanup(&self) -> bool {
+        true
+    }
+    fn n_inputs(&self) -> usize {
+        1
+    }
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![dtype_propagation_op(&self.sort())]
+    }
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        (
+            LLIROp::new::<dyn ReferenceOp>(Box::new(Self {
+                shape: extract_expr_list(egraph, kind_children[0], list_cache, expr_cache).unwrap(),
+                strides: extract_expr_list(egraph, kind_children[1], list_cache, expr_cache)
+                    .unwrap(),
+                ..Default::default()
+            })),
+            input_enodes,
+        )
+    }
+}
+impl ReferenceOp for Log2 {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
+        unary_impl(
+            inputs[0],
+            &self.shape,
+            &self.strides,
+            dyn_map,
+            UnaryKernels {
+                f32_fn: |f| f.log2(),
+                f16_fn: |f| f.log2(),
+                bf16_fn: |f| f.log2(),
+                f64_fn: |f| f.log2(),
+            },
+        )
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Exp2 {
+    pub shape: Vec<Expression>,
+    pub strides: Vec<Expression>,
+    pub input_shape: ShapeTracker,
+}
+impl Display for Exp2 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Exp2")
+    }
+}
+impl HLIROp for Exp2 {
+    fn to_egglog(&self, inputs: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(Op (Exp2 {} {} {}) {})",
+            elist_to_egglog(&self.input_shape.dims),
+            elist_to_egglog(&self.input_shape.strides),
+            elist_to_egglog(&self.input_shape.contiguous().strides),
+            ilist_egglog(&[&inputs[0].1]),
+        )
+    }
+}
+impl EgglogOp for Exp2 {
+    fn sort(&self) -> SortDef {
+        unary_sort("Exp2")
+    }
+    fn cleanup(&self) -> bool {
+        true
+    }
+    fn n_inputs(&self) -> usize {
+        1
+    }
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![dtype_propagation_op(&self.sort())]
+    }
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        (
+            LLIROp::new::<dyn ReferenceOp>(Box::new(Self {
+                shape: extract_expr_list(egraph, kind_children[0], list_cache, expr_cache).unwrap(),
+                strides: extract_expr_list(egraph, kind_children[1], list_cache, expr_cache)
+                    .unwrap(),
+                ..Default::default()
+            })),
+            input_enodes,
+        )
+    }
+}
+impl ReferenceOp for Exp2 {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
+        unary_impl(
+            inputs[0],
+            &self.shape,
+            &self.strides,
+            dyn_map,
+            UnaryKernels {
+                f32_fn: |f| f.exp2(),
+                f16_fn: |f| f.exp2(),
+                bf16_fn: |f| f.exp2(),
+                f64_fn: |f| f.exp2(),
+            },
+        )
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Sin {
+    pub shape: Vec<Expression>,
+    pub strides: Vec<Expression>,
+    pub input_shape: ShapeTracker,
+}
+impl Display for Sin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Sin")
+    }
+}
+impl HLIROp for Sin {
+    fn to_egglog(&self, inputs: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(Op (Sin {} {} {}) {})",
+            elist_to_egglog(&self.input_shape.dims),
+            elist_to_egglog(&self.input_shape.strides),
+            elist_to_egglog(&self.input_shape.contiguous().strides),
+            ilist_egglog(&[&inputs[0].1]),
+        )
+    }
+}
+
+impl EgglogOp for Sin {
+    fn sort(&self) -> SortDef {
+        unary_sort("Sin")
+    }
+    fn cleanup(&self) -> bool {
+        true
+    }
+    fn n_inputs(&self) -> usize {
+        1
+    }
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![dtype_propagation_op(&self.sort())]
+    }
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        (
+            LLIROp::new::<dyn ReferenceOp>(Box::new(Self {
+                shape: extract_expr_list(egraph, kind_children[0], list_cache, expr_cache).unwrap(),
+                strides: extract_expr_list(egraph, kind_children[1], list_cache, expr_cache)
+                    .unwrap(),
+                ..Default::default()
+            })),
+            input_enodes,
+        )
+    }
+}
+impl ReferenceOp for Sin {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
+        unary_impl(
+            inputs[0],
+            &self.shape,
+            &self.strides,
+            dyn_map,
+            UnaryKernels {
+                f32_fn: |f| f.sin(),
+                f16_fn: |f| f.sin(),
+                bf16_fn: |f| f.sin(),
+                f64_fn: |f| f.sin(),
+            },
+        )
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Recip {
+    pub shape: Vec<Expression>,
+    pub strides: Vec<Expression>,
+    pub input_shape: ShapeTracker,
+}
+impl Display for Recip {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Recip")
+    }
+}
+impl HLIROp for Recip {
+    fn to_egglog(&self, inputs: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(Op (Recip {} {} {}) {})",
+            elist_to_egglog(&self.input_shape.dims),
+            elist_to_egglog(&self.input_shape.strides),
+            elist_to_egglog(&self.input_shape.contiguous().strides),
+            ilist_egglog(&[&inputs[0].1]),
+        )
+    }
+}
+
+impl EgglogOp for Recip {
+    fn sort(&self) -> SortDef {
+        unary_sort("Recip")
+    }
+    fn cleanup(&self) -> bool {
+        true
+    }
+    fn n_inputs(&self) -> usize {
+        1
+    }
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![dtype_propagation_op(&self.sort())]
+    }
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        (
+            LLIROp::new::<dyn ReferenceOp>(Box::new(Self {
+                shape: extract_expr_list(egraph, kind_children[0], list_cache, expr_cache).unwrap(),
+                strides: extract_expr_list(egraph, kind_children[1], list_cache, expr_cache)
+                    .unwrap(),
+                ..Default::default()
+            })),
+            input_enodes,
+        )
+    }
+}
+impl ReferenceOp for Recip {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
+        unary_impl(
+            inputs[0],
+            &self.shape,
+            &self.strides,
+            dyn_map,
+            UnaryKernels {
+                f32_fn: |f| f.recip(),
+                f16_fn: |f| f.recip(),
+                bf16_fn: |f| f.recip(),
+                f64_fn: |f| f.recip(),
+            },
+        )
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Sqrt {
+    pub shape: Vec<Expression>,
+    pub strides: Vec<Expression>,
+    pub input_shape: ShapeTracker,
+}
+impl Display for Sqrt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Sqrt")
+    }
+}
+impl HLIROp for Sqrt {
+    fn to_egglog(&self, inputs: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(Op (Sqrt {} {} {}) {})",
+            elist_to_egglog(&self.input_shape.dims),
+            elist_to_egglog(&self.input_shape.strides),
+            elist_to_egglog(&self.input_shape.contiguous().strides),
+            ilist_egglog(&[&inputs[0].1]),
+        )
+    }
+}
+
+impl EgglogOp for Sqrt {
+    fn sort(&self) -> SortDef {
+        unary_sort("Sqrt")
+    }
+    fn cleanup(&self) -> bool {
+        true
+    }
+    fn n_inputs(&self) -> usize {
+        1
+    }
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![dtype_propagation_op(&self.sort())]
+    }
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        (
+            LLIROp::new::<dyn ReferenceOp>(Box::new(Self {
+                shape: extract_expr_list(egraph, kind_children[0], list_cache, expr_cache).unwrap(),
+                strides: extract_expr_list(egraph, kind_children[1], list_cache, expr_cache)
+                    .unwrap(),
+                ..Default::default()
+            })),
+            input_enodes,
+        )
+    }
+}
+impl ReferenceOp for Sqrt {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
+        unary_impl(
+            inputs[0],
+            &self.shape,
+            &self.strides,
+            dyn_map,
+            UnaryKernels {
+                f32_fn: |f| f.sqrt(),
+                f16_fn: |f| f.sqrt(),
+                bf16_fn: |f| f.sqrt(),
+                f64_fn: |f| f.sqrt(),
+            },
+        )
+    }
+}
+
+// Binary Ops (A x A -> A)
+
+fn bin_fn<A: Copy>(
+    a_ind: StridedIterator,
+    a: &[A],
+    b_ind: StridedIterator,
+    b: &[A],
+    op: impl Fn(A, A) -> A,
+) -> Vec<A> {
+    let a_shape = a_ind.shape.clone();
+    let a_strides = a_ind.strides.clone();
+    let b_shape = b_ind.shape.clone();
+    let b_strides = b_ind.strides.clone();
+    a_ind
+        .zip(b_ind)
+        .map(|(i, j)| {
+            assert!(
+                i < a.len(),
+                "bin_fn: a index {i} out of bounds (a.len={}), shape={a_shape:?}, strides={a_strides:?}",
+                a.len(),
+            );
+            assert!(
+                j < b.len(),
+                "bin_fn: b index {j} out of bounds (b.len={}), shape={b_shape:?}, strides={b_strides:?}",
+                b.len(),
+            );
+            op(a[i], b[j])
+        })
+        .collect()
+}
+
+fn bin_cmp_fn<A: Copy>(
+    a_ind: StridedIterator,
+    a: &[A],
+    b_ind: StridedIterator,
+    b: &[A],
+    op: impl Fn(A, A) -> bool,
+) -> Vec<bool> {
+    let a_shape = a_ind.shape.clone();
+    let a_strides = a_ind.strides.clone();
+    let b_shape = b_ind.shape.clone();
+    let b_strides = b_ind.strides.clone();
+    a_ind
+        .zip(b_ind)
+        .map(|(i, j)| {
+            assert!(
+                i < a.len(),
+                "bin_cmp_fn: a index {i} out of bounds (a.len={}), shape={a_shape:?}, strides={a_strides:?}",
+                a.len(),
+            );
+            assert!(
+                j < b.len(),
+                "bin_cmp_fn: b index {j} out of bounds (b.len={}), shape={b_shape:?}, strides={b_strides:?}",
+                b.len(),
+            );
+            op(a[i], b[j])
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Add {
+    pub shape: Vec<Expression>,
+    pub a_strides: Vec<Expression>,
+    pub b_strides: Vec<Expression>,
+    pub input_shapes: Vec<ShapeTracker>,
+}
+impl Display for Add {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Add")
+    }
+}
+impl HLIROp for Add {
+    fn to_egglog(&self, inputs: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(Op (Add {} {} {} {}) {})",
+            elist_to_egglog(&self.input_shapes[0].dims),
+            elist_to_egglog(&self.input_shapes[0].strides),
+            elist_to_egglog(&self.input_shapes[1].strides),
+            elist_to_egglog(&self.input_shapes[0].contiguous().strides),
+            ilist_egglog(&[&inputs[0].1, &inputs[1].1]),
+        )
+    }
+}
+
+impl EgglogOp for Add {
+    fn sort(&self) -> SortDef {
+        binary_sort("Add")
+    }
+    fn cleanup(&self) -> bool {
+        true
+    }
+    fn n_inputs(&self) -> usize {
+        2
+    }
+    fn rewrites(&self) -> Vec<Rule> {
+        let mut r = vec![dtype_propagation_op(&self.sort())];
+        r.extend(binary_op_unroll_rules("Add", 4));
+        r
+    }
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        (
+            LLIROp::new::<dyn ReferenceOp>(Box::new(Self {
+                shape: extract_expr_list(egraph, kind_children[0], list_cache, expr_cache).unwrap(),
+                a_strides: extract_expr_list(egraph, kind_children[1], list_cache, expr_cache)
+                    .unwrap(),
+                b_strides: extract_expr_list(egraph, kind_children[2], list_cache, expr_cache)
+                    .unwrap(),
+                ..Default::default()
+            })),
+            input_enodes,
+        )
+    }
+}
+
+impl ReferenceOp for Add {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
+        let (a, b) = (inputs[0], inputs[1]);
+        let (a_ind, b_ind) = (
+            StridedIterator::new(&self.shape, &self.a_strides, dyn_map),
+            StridedIterator::new(&self.shape, &self.b_strides, dyn_map),
+        );
+        match (a, b) {
+            (ReferenceData::F32(a), ReferenceData::F32(b)) => {
+                ReferenceData::F32(bin_fn(a_ind, a, b_ind, b, |x, y| x + y))
+            }
+            (ReferenceData::F16(a), ReferenceData::F16(b)) => {
+                ReferenceData::F16(bin_fn(a_ind, a, b_ind, b, |x, y| x + y))
+            }
+            (ReferenceData::Bf16(a), ReferenceData::Bf16(b)) => {
+                ReferenceData::Bf16(bin_fn(a_ind, a, b_ind, b, |x, y| x + y))
+            }
+            (ReferenceData::Int(a), ReferenceData::Int(b)) => {
+                ReferenceData::Int(bin_fn(a_ind, a, b_ind, b, |x, y| x + y))
+            }
+            (ReferenceData::I64(a), ReferenceData::I64(b)) => {
+                ReferenceData::I64(bin_fn(a_ind, a, b_ind, b, |x, y| x + y))
+            }
+            (ReferenceData::I8(a), ReferenceData::I8(b)) => {
+                ReferenceData::I8(bin_fn(a_ind, a, b_ind, b, i8::wrapping_add))
+            }
+            (ReferenceData::U8(a), ReferenceData::U8(b)) => {
+                ReferenceData::U8(bin_fn(a_ind, a, b_ind, b, u8::wrapping_add))
+            }
+            (ReferenceData::I16(a), ReferenceData::I16(b)) => {
+                ReferenceData::I16(bin_fn(a_ind, a, b_ind, b, i16::wrapping_add))
+            }
+            (ReferenceData::F64(a), ReferenceData::F64(b)) => {
+                ReferenceData::F64(bin_fn(a_ind, a, b_ind, b, |x, y| x + y))
+            }
+            (ReferenceData::Bool(_), ReferenceData::Bool(_)) => {
+                panic!("Cannot add Bool tensors, cast to F32 first")
+            }
+            _ => panic!("Add inputs must have the same dtype"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Mul {
+    pub shape: Vec<Expression>,
+    pub a_strides: Vec<Expression>,
+    pub b_strides: Vec<Expression>,
+    pub input_shapes: Vec<ShapeTracker>,
+}
+impl Display for Mul {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Mul")
+    }
+}
+impl HLIROp for Mul {
+    fn to_egglog(&self, inputs: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(Op (Mul {} {} {} {}) {})",
+            elist_to_egglog(&self.input_shapes[0].dims),
+            elist_to_egglog(&self.input_shapes[0].strides),
+            elist_to_egglog(&self.input_shapes[1].strides),
+            elist_to_egglog(&self.input_shapes[0].contiguous().strides),
+            ilist_egglog(&[&inputs[0].1, &inputs[1].1]),
+        )
+    }
+}
+
+impl EgglogOp for Mul {
+    fn sort(&self) -> SortDef {
+        binary_sort("Mul")
+    }
+    fn cleanup(&self) -> bool {
+        true
+    }
+    fn n_inputs(&self) -> usize {
+        2
+    }
+    fn rewrites(&self) -> Vec<Rule> {
+        let mut r = vec![dtype_propagation_op(&self.sort())];
+        r.extend(binary_op_unroll_rules("Mul", 4));
+        r
+    }
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        (
+            LLIROp::new::<dyn ReferenceOp>(Box::new(Self {
+                shape: extract_expr_list(egraph, kind_children[0], list_cache, expr_cache).unwrap(),
+                a_strides: extract_expr_list(egraph, kind_children[1], list_cache, expr_cache)
+                    .unwrap(),
+                b_strides: extract_expr_list(egraph, kind_children[2], list_cache, expr_cache)
+                    .unwrap(),
+                ..Default::default()
+            })),
+            input_enodes,
+        )
+    }
+}
+
+impl ReferenceOp for Mul {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
+        let (a, b) = (inputs[0], inputs[1]);
+        let (a_ind, b_ind) = (
+            StridedIterator::new(&self.shape, &self.a_strides, dyn_map),
+            StridedIterator::new(&self.shape, &self.b_strides, dyn_map),
+        );
+        match (a, b) {
+            (ReferenceData::F32(a), ReferenceData::F32(b)) => {
+                ReferenceData::F32(bin_fn(a_ind, a, b_ind, b, |x, y| x * y))
+            }
+            (ReferenceData::F16(a), ReferenceData::F16(b)) => {
+                ReferenceData::F16(bin_fn(a_ind, a, b_ind, b, |x, y| x * y))
+            }
+            (ReferenceData::Bf16(a), ReferenceData::Bf16(b)) => {
+                ReferenceData::Bf16(bin_fn(a_ind, a, b_ind, b, |x, y| x * y))
+            }
+            (ReferenceData::Int(a), ReferenceData::Int(b)) => {
+                ReferenceData::Int(bin_fn(a_ind, a, b_ind, b, |x, y| x * y))
+            }
+            (ReferenceData::I64(a), ReferenceData::I64(b)) => {
+                ReferenceData::I64(bin_fn(a_ind, a, b_ind, b, |x, y| x * y))
+            }
+            (ReferenceData::I8(a), ReferenceData::I8(b)) => {
+                ReferenceData::I8(bin_fn(a_ind, a, b_ind, b, i8::wrapping_mul))
+            }
+            (ReferenceData::U8(a), ReferenceData::U8(b)) => {
+                ReferenceData::U8(bin_fn(a_ind, a, b_ind, b, u8::wrapping_mul))
+            }
+            (ReferenceData::I16(a), ReferenceData::I16(b)) => {
+                ReferenceData::I16(bin_fn(a_ind, a, b_ind, b, i16::wrapping_mul))
+            }
+            (ReferenceData::F64(a), ReferenceData::F64(b)) => {
+                ReferenceData::F64(bin_fn(a_ind, a, b_ind, b, |x, y| x * y))
+            }
+            (ReferenceData::Bool(_), ReferenceData::Bool(_)) => {
+                panic!("Cannot multiply Bool tensors, cast to F32 first")
+            }
+            _ => panic!("Mul inputs must have the same dtype"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Mod {
+    pub shape: Vec<Expression>,
+    pub a_strides: Vec<Expression>,
+    pub b_strides: Vec<Expression>,
+    pub input_shapes: Vec<ShapeTracker>,
+}
+impl Display for Mod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Mod")
+    }
+}
+impl HLIROp for Mod {
+    fn to_egglog(&self, inputs: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(Op (Mod {} {} {} {}) {})",
+            elist_to_egglog(&self.input_shapes[0].dims),
+            elist_to_egglog(&self.input_shapes[0].strides),
+            elist_to_egglog(&self.input_shapes[1].strides),
+            elist_to_egglog(&self.input_shapes[0].contiguous().strides),
+            ilist_egglog(&[&inputs[0].1, &inputs[1].1]),
+        )
+    }
+}
+
+impl EgglogOp for Mod {
+    fn sort(&self) -> SortDef {
+        binary_sort("Mod")
+    }
+    fn cleanup(&self) -> bool {
+        true
+    }
+    fn n_inputs(&self) -> usize {
+        2
+    }
+    fn rewrites(&self) -> Vec<Rule> {
+        let mut r = vec![dtype_propagation_op(&self.sort())];
+        r.extend(binary_op_unroll_rules("Mod", 4));
+        r
+    }
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        (
+            LLIROp::new::<dyn ReferenceOp>(Box::new(Self {
+                shape: extract_expr_list(egraph, kind_children[0], list_cache, expr_cache).unwrap(),
+                a_strides: extract_expr_list(egraph, kind_children[1], list_cache, expr_cache)
+                    .unwrap(),
+                b_strides: extract_expr_list(egraph, kind_children[2], list_cache, expr_cache)
+                    .unwrap(),
+                ..Default::default()
+            })),
+            input_enodes,
+        )
+    }
+}
+
+impl ReferenceOp for Mod {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
+        let (a, b) = (inputs[0], inputs[1]);
+        let (a_ind, b_ind) = (
+            StridedIterator::new(&self.shape, &self.a_strides, dyn_map),
+            StridedIterator::new(&self.shape, &self.b_strides, dyn_map),
+        );
+        match (a, b) {
+            (ReferenceData::F32(a), ReferenceData::F32(b)) => {
+                ReferenceData::F32(bin_fn(a_ind, a, b_ind, b, |x, y| x % y))
+            }
+            (ReferenceData::F16(a), ReferenceData::F16(b)) => {
+                ReferenceData::F16(bin_fn(a_ind, a, b_ind, b, |x, y| x % y))
+            }
+            (ReferenceData::Bf16(a), ReferenceData::Bf16(b)) => {
+                ReferenceData::Bf16(bin_fn(a_ind, a, b_ind, b, |x, y| x % y))
+            }
+            (ReferenceData::Int(a), ReferenceData::Int(b)) => {
+                ReferenceData::Int(bin_fn(a_ind, a, b_ind, b, |x, y| x % y))
+            }
+            (ReferenceData::I64(a), ReferenceData::I64(b)) => {
+                ReferenceData::I64(bin_fn(a_ind, a, b_ind, b, |x, y| x % y))
+            }
+            (ReferenceData::I8(a), ReferenceData::I8(b)) => {
+                ReferenceData::I8(bin_fn(a_ind, a, b_ind, b, i8::wrapping_rem))
+            }
+            (ReferenceData::U8(a), ReferenceData::U8(b)) => {
+                ReferenceData::U8(bin_fn(a_ind, a, b_ind, b, |x, y| x % y))
+            }
+            (ReferenceData::I16(a), ReferenceData::I16(b)) => {
+                ReferenceData::I16(bin_fn(a_ind, a, b_ind, b, i16::wrapping_rem))
+            }
+            (ReferenceData::F64(a), ReferenceData::F64(b)) => {
+                ReferenceData::F64(bin_fn(a_ind, a, b_ind, b, |x, y| x % y))
+            }
+            (ReferenceData::Bool(_), ReferenceData::Bool(_)) => panic!("Cannot mod Bool tensors"),
+            _ => panic!("Mod inputs must have the same dtype"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct LessThan {
+    pub shape: Vec<Expression>,
+    pub a_strides: Vec<Expression>,
+    pub b_strides: Vec<Expression>,
+    pub input_shapes: Vec<ShapeTracker>,
+}
+impl Display for LessThan {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "LessThan")
+    }
+}
+impl HLIROp for LessThan {
+    fn to_egglog(&self, inputs: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(Op (LessThan {} {} {} {}) {})",
+            elist_to_egglog(&self.input_shapes[0].dims),
+            elist_to_egglog(&self.input_shapes[0].strides),
+            elist_to_egglog(&self.input_shapes[1].strides),
+            elist_to_egglog(&self.input_shapes[0].contiguous().strides),
+            ilist_egglog(&[&inputs[0].1, &inputs[1].1]),
+        )
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        assert_eq!(
+            input_dtypes.len(),
+            2,
+            "LessThan must consume two tensor inputs"
+        );
+        assert_eq!(
+            input_dtypes[0], input_dtypes[1],
+            "LessThan inputs must have the same concrete dtype"
+        );
+        DType::Bool
+    }
+}
+
+impl EgglogOp for LessThan {
+    fn sort(&self) -> SortDef {
+        binary_sort("LessThan")
+    }
+    fn cleanup(&self) -> bool {
+        true
+    }
+    fn n_inputs(&self) -> usize {
+        2
+    }
+    fn rewrites(&self) -> Vec<Rule> {
+        // Comparisons output Bool, not the input dtype.
+        let mut r = vec![dtype_fixed_op(&self.sort(), &SORTS.bool_dt)];
+        r.extend(binary_op_unroll_rules("LessThan", 4));
+        r
+    }
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        (
+            LLIROp::new::<dyn ReferenceOp>(Box::new(Self {
+                shape: extract_expr_list(egraph, kind_children[0], list_cache, expr_cache).unwrap(),
+                a_strides: extract_expr_list(egraph, kind_children[1], list_cache, expr_cache)
+                    .unwrap(),
+                b_strides: extract_expr_list(egraph, kind_children[2], list_cache, expr_cache)
+                    .unwrap(),
+                ..Default::default()
+            })),
+            input_enodes,
+        )
+    }
+}
+
+impl ReferenceOp for LessThan {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
+        let (a, b) = (inputs[0], inputs[1]);
+        let (a_ind, b_ind) = (
+            StridedIterator::new(&self.shape, &self.a_strides, dyn_map),
+            StridedIterator::new(&self.shape, &self.b_strides, dyn_map),
+        );
+        match (a, b) {
+            (ReferenceData::F32(a), ReferenceData::F32(b)) => {
+                ReferenceData::Bool(bin_cmp_fn(a_ind, a, b_ind, b, |x, y| x < y))
+            }
+            (ReferenceData::F16(a), ReferenceData::F16(b)) => {
+                ReferenceData::Bool(bin_cmp_fn(a_ind, a, b_ind, b, |x, y| x < y))
+            }
+            (ReferenceData::Bf16(a), ReferenceData::Bf16(b)) => {
+                ReferenceData::Bool(bin_cmp_fn(a_ind, a, b_ind, b, |x, y| x < y))
+            }
+            (ReferenceData::Int(a), ReferenceData::Int(b)) => {
+                ReferenceData::Bool(bin_cmp_fn(a_ind, a, b_ind, b, |x, y| x < y))
+            }
+            (ReferenceData::I64(a), ReferenceData::I64(b)) => {
+                ReferenceData::Bool(bin_cmp_fn(a_ind, a, b_ind, b, |x, y| x < y))
+            }
+            (ReferenceData::I8(a), ReferenceData::I8(b)) => {
+                ReferenceData::Bool(bin_cmp_fn(a_ind, a, b_ind, b, |x, y| x < y))
+            }
+            (ReferenceData::U8(a), ReferenceData::U8(b)) => {
+                ReferenceData::Bool(bin_cmp_fn(a_ind, a, b_ind, b, |x, y| x < y))
+            }
+            (ReferenceData::I16(a), ReferenceData::I16(b)) => {
+                ReferenceData::Bool(bin_cmp_fn(a_ind, a, b_ind, b, |x, y| x < y))
+            }
+            (ReferenceData::F64(a), ReferenceData::F64(b)) => {
+                ReferenceData::Bool(bin_cmp_fn(a_ind, a, b_ind, b, |x, y| x < y))
+            }
+            (ReferenceData::Bool(a), ReferenceData::Bool(b)) => {
+                ReferenceData::Bool(bin_cmp_fn(a_ind, a, b_ind, b, |x, y| !x & y))
+            }
+            _ => panic!("LessThan inputs must have the same dtype"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Gather {
+    pub index_shape: Vec<Expression>,
+    pub data_shape: Vec<Expression>,
+    pub index_strides: Vec<Expression>,
+    pub data_strides: Vec<Expression>,
+    pub input_shapes: Vec<ShapeTracker>,
+}
+impl Display for Gather {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Gather")
+    }
+}
+impl HLIROp for Gather {
+    fn to_egglog(&self, inputs: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(Op (Gather {} {} {} {}) {})",
+            elist_to_egglog(&self.input_shapes[0].dims),
+            elist_to_egglog(&self.input_shapes[0].strides),
+            elist_to_egglog(&self.input_shapes[1].dims),
+            elist_to_egglog(&self.input_shapes[1].strides),
+            ilist_egglog(&[&inputs[0].1, &inputs[1].1]),
+        )
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        *input_dtypes
+            .get(1)
+            .unwrap_or_else(|| panic!("Gather has no data input at position 1"))
+    }
+}
+
+impl EgglogOp for Gather {
+    fn sort(&self) -> SortDef {
+        sort(
+            OP_KIND,
+            "Gather",
+            &[
+                ("index_shape", ELIST),
+                ("index_strides", ELIST),
+                ("data_shape", ELIST),
+                ("data_strides", ELIST),
+            ],
+        )
+    }
+    fn cleanup(&self) -> bool {
+        true
+    }
+    fn n_inputs(&self) -> usize {
+        2
+    }
+    fn rewrites(&self) -> Vec<Rule> {
+        // Gather inherits dtype from second input (data), not first (indexes).
+        // Use a custom rule instead of the generic first-input propagation.
+        // **Must be in `dtype_prop` ruleset** — without it, Gather dtype
+        // propagation only advances one Gather per `(run)` iteration of
+        // the schedule, so deep stacks of Gathers (e.g. YOLO's per-conv
+        // padding gathers + per-concat make_contiguous gathers) leave the
+        // outermost Gathers with no dtype set, which in turn blocks the
+        // KernelGather kernel-rewrite from firing.
+        let (_, kind_term) = self.sort().new_call();
+        let e = v("__e");
+        let indexes = v("__indexes");
+        let data = v("__data");
+        let tail = v("__tail");
+        let dty = v("__dty");
+        vec![
+            Rule::new()
+                .fact(eq(
+                    e.clone(),
+                    op_term(
+                        kind_term,
+                        Term::App {
+                            variant: "ICons".to_string(),
+                            args: vec![
+                                indexes,
+                                Term::App {
+                                    variant: "ICons".to_string(),
+                                    args: vec![data.clone(), tail],
+                                },
+                            ],
+                        },
+                    ),
+                ))
+                .fact(eq(dty.clone(), dtype(data)))
+                .action(Action::Set(dtype(e), dty))
+                .ruleset("dtype_prop"),
+        ]
+    }
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        (
+            LLIROp::new::<dyn ReferenceOp>(Box::new(Self {
+                index_shape: extract_expr_list(egraph, kind_children[0], list_cache, expr_cache)
+                    .unwrap(),
+                index_strides: extract_expr_list(egraph, kind_children[1], list_cache, expr_cache)
+                    .unwrap(),
+                data_shape: extract_expr_list(egraph, kind_children[2], list_cache, expr_cache)
+                    .unwrap(),
+                data_strides: extract_expr_list(egraph, kind_children[3], list_cache, expr_cache)
+                    .unwrap(),
+                ..Default::default()
+            })),
+            input_enodes,
+        )
+    }
+}
+impl ReferenceOp for Gather {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
+        let (indexes, data) = (inputs[0], inputs[1]);
+        let indexes_ind = StridedIterator::new(&self.index_shape, &self.index_strides, dyn_map);
+        let data_ind =
+            StridedIterator::new(&self.data_shape, &self.data_strides, dyn_map).collect_vec();
+        let ReferenceData::Int(indexes) = indexes else {
+            panic!("indexes must be int!")
+        };
+        match data {
+            ReferenceData::F32(a) => ReferenceData::F32(
+                indexes_ind
+                    .map(|i| a[data_ind[indexes[i] as usize]])
+                    .collect(),
+            ),
+            ReferenceData::F16(a) => ReferenceData::F16(
+                indexes_ind
+                    .map(|i| a[data_ind[indexes[i] as usize]])
+                    .collect(),
+            ),
+            ReferenceData::Bf16(a) => ReferenceData::Bf16(
+                indexes_ind
+                    .map(|i| a[data_ind[indexes[i] as usize]])
+                    .collect(),
+            ),
+            ReferenceData::Int(a) => ReferenceData::Int(
+                indexes_ind
+                    .map(|i| a[data_ind[indexes[i] as usize]])
+                    .collect(),
+            ),
+            ReferenceData::I64(a) => ReferenceData::I64(
+                indexes_ind
+                    .map(|i| a[data_ind[indexes[i] as usize]])
+                    .collect(),
+            ),
+            ReferenceData::I8(a) => ReferenceData::I8(
+                indexes_ind
+                    .map(|i| a[data_ind[indexes[i] as usize]])
+                    .collect(),
+            ),
+            ReferenceData::U8(a) => ReferenceData::U8(
+                indexes_ind
+                    .map(|i| a[data_ind[indexes[i] as usize]])
+                    .collect(),
+            ),
+            ReferenceData::I16(a) => ReferenceData::I16(
+                indexes_ind
+                    .map(|i| a[data_ind[indexes[i] as usize]])
+                    .collect(),
+            ),
+            ReferenceData::F64(a) => ReferenceData::F64(
+                indexes_ind
+                    .map(|i| a[data_ind[indexes[i] as usize]])
+                    .collect(),
+            ),
+            ReferenceData::Bool(a) => ReferenceData::Bool(
+                indexes_ind
+                    .map(|i| a[data_ind[indexes[i] as usize]])
+                    .collect(),
+            ),
+        }
+    }
+}
+
+// Scatter Op (inverse of Gather)
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Scatter {
+    pub dest_shape: Vec<Expression>,
+    pub dest_strides: Vec<Expression>,
+    pub index_shape: Vec<Expression>,
+    pub index_strides: Vec<Expression>,
+    pub src_strides: Vec<Expression>,
+}
+impl Display for Scatter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Scatter")
+    }
+}
+impl HLIROp for Scatter {
+    fn to_egglog(&self, inputs: &[(NodeIndex, String)]) -> String {
+        format!(
+            "(Op (Scatter {} {} {} {} {}) {})",
+            elist_to_egglog(&self.dest_shape),
+            elist_to_egglog(&self.dest_strides),
+            elist_to_egglog(&self.index_shape),
+            elist_to_egglog(&self.index_strides),
+            elist_to_egglog(&self.src_strides),
+            ilist_egglog(&[&inputs[0].1, &inputs[1].1, &inputs[2].1]),
+        )
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        *input_dtypes
+            .get(2)
+            .unwrap_or_else(|| panic!("Scatter has no source input at position 2"))
+    }
+}
+
+impl EgglogOp for Scatter {
+    fn sort(&self) -> SortDef {
+        sort(
+            OP_KIND,
+            "Scatter",
+            &[
+                ("dest_shape", ELIST),
+                ("dest_strides", ELIST),
+                ("index_shape", ELIST),
+                ("index_strides", ELIST),
+                ("src_strides", ELIST),
+            ],
+        )
+    }
+    fn cleanup(&self) -> bool {
+        true
+    }
+    fn n_inputs(&self) -> usize {
+        3
+    }
+    fn rewrites(&self) -> Vec<Rule> {
+        // Scatter inherits dtype from third input (src), not first (dest).
+        let (_, kind_term) = self.sort().new_call();
+        let e = v("__e");
+        let dest = v("__dest");
+        let indexes = v("__indexes");
+        let src = v("__src");
+        let tail = v("__tail");
+        let dty = v("__dty");
+        vec![
+            Rule::new()
+                .fact(eq(
+                    e.clone(),
+                    op_term(
+                        kind_term,
+                        Term::App {
+                            variant: "ICons".to_string(),
+                            args: vec![
+                                dest,
+                                Term::App {
+                                    variant: "ICons".to_string(),
+                                    args: vec![
+                                        indexes,
+                                        Term::App {
+                                            variant: "ICons".to_string(),
+                                            args: vec![src.clone(), tail],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ),
+                ))
+                .fact(eq(dty.clone(), dtype(src)))
+                .action(Action::Set(dtype(e), dty))
+                .ruleset("dtype_prop"),
+        ]
+    }
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        (
+            LLIROp::new::<dyn ReferenceOp>(Box::new(Self {
+                dest_shape: extract_expr_list(egraph, kind_children[0], list_cache, expr_cache)
+                    .unwrap(),
+                dest_strides: extract_expr_list(egraph, kind_children[1], list_cache, expr_cache)
+                    .unwrap(),
+                index_shape: extract_expr_list(egraph, kind_children[2], list_cache, expr_cache)
+                    .unwrap(),
+                index_strides: extract_expr_list(egraph, kind_children[3], list_cache, expr_cache)
+                    .unwrap(),
+                src_strides: extract_expr_list(egraph, kind_children[4], list_cache, expr_cache)
+                    .unwrap(),
+            })),
+            input_enodes,
+        )
+    }
+}
+impl ReferenceOp for Scatter {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
+        let (dest, indexes, src) = (inputs[0], inputs[1], inputs[2]);
+        let dest_ind =
+            StridedIterator::new(&self.dest_shape, &self.dest_strides, dyn_map).collect_vec();
+        let index_ind = StridedIterator::new(&self.index_shape, &self.index_strides, dyn_map);
+        let src_ind =
+            StridedIterator::new(&self.index_shape, &self.src_strides, dyn_map).collect_vec();
+        let ReferenceData::Int(indexes) = indexes else {
+            panic!("indexes must be int!")
+        };
+        macro_rules! scatter_impl {
+            ($variant:ident, $dest_data:expr, $src_data:expr) => {{
+                let mut output: Vec<_> = dest_ind.iter().map(|&i| $dest_data[i]).collect();
+                for (src_idx, flat_i) in index_ind.enumerate() {
+                    let idx = indexes[flat_i] as usize;
+                    if idx < output.len() {
+                        output[idx] = $src_data[src_ind[src_idx]];
+                    }
+                }
+                ReferenceData::$variant(output)
+            }};
+        }
+        match (dest, src) {
+            (ReferenceData::F32(d), ReferenceData::F32(s)) => scatter_impl!(F32, d, s),
+            (ReferenceData::F64(d), ReferenceData::F64(s)) => scatter_impl!(F64, d, s),
+            (ReferenceData::F16(d), ReferenceData::F16(s)) => scatter_impl!(F16, d, s),
+            (ReferenceData::Bf16(d), ReferenceData::Bf16(s)) => scatter_impl!(Bf16, d, s),
+            (ReferenceData::Int(d), ReferenceData::Int(s)) => scatter_impl!(Int, d, s),
+            (ReferenceData::I64(d), ReferenceData::I64(s)) => scatter_impl!(I64, d, s),
+            (ReferenceData::I8(d), ReferenceData::I8(s)) => scatter_impl!(I8, d, s),
+            (ReferenceData::U8(d), ReferenceData::U8(s)) => scatter_impl!(U8, d, s),
+            (ReferenceData::I16(d), ReferenceData::I16(s)) => scatter_impl!(I16, d, s),
+            (ReferenceData::Bool(d), ReferenceData::Bool(s)) => scatter_impl!(Bool, d, s),
+            _ => panic!("dest and src must have the same dtype!"),
+        }
+    }
+}
+
+// Reduce Ops (A -> B (different shape))
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct SumReduce {
+    pub dim: usize,
+    pub shape: Vec<Expression>,
+    pub strides: Vec<Expression>,
+    pub iters: Expression,
+    pub iter_stride: Expression,
+    pub input_shape: ShapeTracker,
+}
+impl Display for SumReduce {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SumReduce(dim={})", self.dim)
+    }
+}
+impl HLIROp for SumReduce {
+    fn to_egglog(&self, inputs: &[(NodeIndex, String)]) -> String {
+        let mut reduced_shape = self.input_shape;
+        reduced_shape.remove_dim(self.dim);
+        let reduced_dim = self.input_shape.dims[self.dim];
+        let reduced_stride = self.input_shape.strides[self.dim];
+        let mut reduced_strides = self.input_shape.strides;
+        reduced_strides.remove(self.dim);
+
+        format!(
+            "(Op (Sum {} {} {} {} {}) {})",
+            elist_to_egglog(&reduced_shape.dims),
+            reduced_dim.to_egglog(),
+            elist_to_egglog(&reduced_strides),
+            reduced_stride.to_egglog(),
+            elist_to_egglog(&reduced_shape.contiguous().strides),
+            ilist_egglog(&[&inputs[0].1]),
+        )
+    }
+}
+
+impl EgglogOp for SumReduce {
+    fn sort(&self) -> SortDef {
+        reduce_sort("Sum")
+    }
+    fn cleanup(&self) -> bool {
+        true
+    }
+    fn n_inputs(&self) -> usize {
+        1
+    }
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![
+            dtype_propagation_op(&self.sort()),
+            // Batch-collapse rules: rewrite N-dim Mul+Sum → (N-1)-dim Mul+Sum
+            // so that 2D cuBLAS rules can match. Fires recursively.
+            Rule::raw(include_str!("egglog_utils/matmul_flattening/squeeze.egg")),
+            Rule::raw(include_str!(
+                "egglog_utils/matmul_flattening/batch_merge_a_contig.egg"
+            )),
+            Rule::raw(include_str!(
+                "egglog_utils/matmul_flattening/batch_merge_b_contig.egg"
+            )),
+        ]
+    }
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        (
+            LLIROp::new::<dyn ReferenceOp>(Box::new(Self {
+                dim: 0,
+                shape: extract_expr_list(egraph, kind_children[0], list_cache, expr_cache).unwrap(),
+                iters: extract_expr(egraph, kind_children[1], expr_cache).unwrap(),
+                strides: extract_expr_list(egraph, kind_children[2], list_cache, expr_cache)
+                    .unwrap(),
+                iter_stride: extract_expr(egraph, kind_children[3], expr_cache).unwrap(),
+                ..Default::default()
+            })),
+            input_enodes,
+        )
+    }
+}
+
+impl ReferenceOp for SumReduce {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
+        let ind = StridedIterator::new(&self.shape, &self.strides, dyn_map);
+        // Resolve dyn vars in iter_stride, then evaluate z-stride at each iteration
+        let mut resolved_stride = self.iter_stride;
+        for (&var, &val) in dyn_map {
+            resolved_stride = resolved_stride.substitute(var, Expression::from(val as i32));
+        }
+        let iters = self.iters.exec(dyn_map).unwrap();
+        match inputs[0] {
+            ReferenceData::F32(a) => ReferenceData::F32(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .sum()
+                })
+                .collect(),
+            ),
+            ReferenceData::F16(a) => ReferenceData::F16(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .sum()
+                })
+                .collect(),
+            ),
+            ReferenceData::Bf16(a) => ReferenceData::Bf16(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .sum()
+                })
+                .collect(),
+            ),
+            ReferenceData::Int(a) => ReferenceData::Int(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .sum()
+                })
+                .collect(),
+            ),
+            ReferenceData::I64(a) => ReferenceData::I64(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .sum::<i64>()
+                })
+                .collect(),
+            ),
+            ReferenceData::I8(a) => ReferenceData::I8(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .fold(0i8, i8::wrapping_add)
+                })
+                .collect(),
+            ),
+            ReferenceData::U8(a) => ReferenceData::U8(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .fold(0u8, u8::wrapping_add)
+                })
+                .collect(),
+            ),
+            ReferenceData::I16(a) => ReferenceData::I16(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .fold(0i16, i16::wrapping_add)
+                })
+                .collect(),
+            ),
+            ReferenceData::F64(a) => ReferenceData::F64(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .sum::<f64>()
+                })
+                .collect(),
+            ),
+            ReferenceData::Bool(_) => panic!("Cannot sum Bool tensors, cast to F32 first"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct MaxReduce {
+    pub dim: usize,
+    pub shape: Vec<Expression>,
+    pub strides: Vec<Expression>,
+    pub iters: Expression,
+    pub iter_stride: Expression,
+    pub input_shape: ShapeTracker,
+}
+impl Display for MaxReduce {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MaxReduce(dim={})", self.dim)
+    }
+}
+impl HLIROp for MaxReduce {
+    fn to_egglog(&self, inputs: &[(NodeIndex, String)]) -> String {
+        let mut reduced_shape = self.input_shape;
+        reduced_shape.remove_dim(self.dim);
+        let reduced_dim = self.input_shape.dims[self.dim];
+        let reduced_stride = self.input_shape.strides[self.dim];
+        let mut reduced_strides = self.input_shape.strides;
+        reduced_strides.remove(self.dim);
+        format!(
+            "(Op (Max {} {} {} {} {}) {})",
+            elist_to_egglog(&reduced_shape.dims),
+            reduced_dim.to_egglog(),
+            elist_to_egglog(&reduced_strides),
+            reduced_stride.to_egglog(),
+            elist_to_egglog(&reduced_shape.contiguous().strides),
+            ilist_egglog(&[&inputs[0].1]),
+        )
+    }
+}
+
+impl EgglogOp for MaxReduce {
+    fn sort(&self) -> SortDef {
+        reduce_sort("Max")
+    }
+    fn cleanup(&self) -> bool {
+        true
+    }
+    fn n_inputs(&self) -> usize {
+        1
+    }
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![dtype_propagation_op(&self.sort())]
+    }
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        (
+            LLIROp::new::<dyn ReferenceOp>(Box::new(Self {
+                dim: 0,
+                shape: extract_expr_list(egraph, kind_children[0], list_cache, expr_cache).unwrap(),
+                iters: extract_expr(egraph, kind_children[1], expr_cache).unwrap(),
+                strides: extract_expr_list(egraph, kind_children[2], list_cache, expr_cache)
+                    .unwrap(),
+                iter_stride: extract_expr(egraph, kind_children[3], expr_cache).unwrap(),
+                ..Default::default()
+            })),
+            input_enodes,
+        )
+    }
+}
+
+impl ReferenceOp for MaxReduce {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData {
+        let ind = StridedIterator::new(&self.shape, &self.strides, dyn_map);
+        // Resolve dyn vars in iter_stride, then evaluate z-stride at each iteration
+        let mut resolved_stride = self.iter_stride;
+        for (&var, &val) in dyn_map {
+            resolved_stride = resolved_stride.substitute(var, Expression::from(val as i32));
+        }
+        let iters = self.iters.exec(dyn_map).unwrap();
+        match inputs[0] {
+            ReferenceData::F32(a) => ReferenceData::F32(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .max_by(|a, b| a.total_cmp(b))
+                        .unwrap_or_default()
+                })
+                .collect(),
+            ),
+            ReferenceData::F16(a) => ReferenceData::F16(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .max_by(|a, b| a.total_cmp(b))
+                        .unwrap_or_default()
+                })
+                .collect(),
+            ),
+            ReferenceData::Bf16(a) => ReferenceData::Bf16(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .max_by(|a, b| a.total_cmp(b))
+                        .unwrap_or_default()
+                })
+                .collect(),
+            ),
+            ReferenceData::Int(a) => ReferenceData::Int(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .max()
+                        .unwrap_or_default()
+                })
+                .collect(),
+            ),
+            ReferenceData::I64(a) => ReferenceData::I64(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .max()
+                        .unwrap_or_default()
+                })
+                .collect(),
+            ),
+            ReferenceData::I8(a) => ReferenceData::I8(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .max()
+                        .unwrap_or_default()
+                })
+                .collect(),
+            ),
+            ReferenceData::U8(a) => ReferenceData::U8(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .max()
+                        .unwrap_or_default()
+                })
+                .collect(),
+            ),
+            ReferenceData::I16(a) => ReferenceData::I16(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .max()
+                        .unwrap_or_default()
+                })
+                .collect(),
+            ),
+            ReferenceData::F64(a) => ReferenceData::F64(
+                ind.map(|start| {
+                    (0..iters)
+                        .map(|i| a[start + resolved_stride.exec_single_var(i)])
+                        .max_by(|a, b| a.total_cmp(b))
+                        .unwrap_or_default()
+                })
+                .collect(),
+            ),
+            ReferenceData::Bool(_) => panic!("Cannot max-reduce Bool tensors"),
+        }
+    }
+}
+
+pub trait ReferenceOp: Debug + AsAny + Send + Sync {
+    fn execute(&self, inputs: Vec<&ReferenceData>, dyn_map: &DynMap) -> ReferenceData;
+}
+
+#[derive(Debug, Clone)]
+pub enum ReferenceData {
+    F32(Vec<f32>),
+    F16(Vec<f16>),
+    Bf16(Vec<bf16>),
+    Int(Vec<i32>),
+    I64(Vec<i64>),
+    I8(Vec<i8>),
+    U8(Vec<u8>),
+    I16(Vec<i16>),
+    F64(Vec<f64>),
+    Bool(Vec<bool>),
+}
+
+impl ReferenceData {
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    pub fn len(&self) -> usize {
+        match self {
+            ReferenceData::F32(v) => v.len(),
+            ReferenceData::F16(v) => v.len(),
+            ReferenceData::Bf16(v) => v.len(),
+            ReferenceData::Int(v) => v.len(),
+            ReferenceData::I64(v) => v.len(),
+            ReferenceData::I8(v) => v.len(),
+            ReferenceData::U8(v) => v.len(),
+            ReferenceData::I16(v) => v.len(),
+            ReferenceData::F64(v) => v.len(),
+            ReferenceData::Bool(v) => v.len(),
+        }
+    }
+    pub fn to_f32_vec(&self) -> Vec<f32> {
+        match self {
+            ReferenceData::F32(v) => v.clone(),
+            ReferenceData::F16(v) => v.iter().map(|v| v.to_f32()).collect(),
+            ReferenceData::Bf16(v) => v.iter().map(|v| v.to_f32()).collect(),
+            ReferenceData::Int(v) => v.iter().map(|v| *v as f32).collect(),
+            ReferenceData::I64(v) => v.iter().map(|v| *v as f32).collect(),
+            ReferenceData::I8(v) => v.iter().map(|v| *v as f32).collect(),
+            ReferenceData::U8(v) => v.iter().map(|v| *v as f32).collect(),
+            ReferenceData::I16(v) => v.iter().map(|v| *v as f32).collect(),
+            ReferenceData::F64(v) => v.iter().map(|v| *v as f32).collect(),
+            ReferenceData::Bool(v) => v.iter().map(|v| if *v { 1.0 } else { 0.0 }).collect(),
+        }
+    }
+
+    pub fn to_f64_vec(&self) -> Vec<f64> {
+        match self {
+            ReferenceData::F32(v) => v.iter().map(|v| *v as f64).collect(),
+            ReferenceData::F16(v) => v.iter().map(|v| v.to_f32() as f64).collect(),
+            ReferenceData::Bf16(v) => v.iter().map(|v| v.to_f32() as f64).collect(),
+            ReferenceData::Int(v) => v.iter().map(|v| *v as f64).collect(),
+            ReferenceData::I64(v) => v.iter().map(|v| *v as f64).collect(),
+            ReferenceData::I8(v) => v.iter().map(|v| *v as f64).collect(),
+            ReferenceData::U8(v) => v.iter().map(|v| *v as f64).collect(),
+            ReferenceData::I16(v) => v.iter().map(|v| *v as f64).collect(),
+            ReferenceData::F64(v) => v.clone(),
+            ReferenceData::Bool(v) => v.iter().map(|v| if *v { 1.0 } else { 0.0 }).collect(),
+        }
+    }
+
+    pub fn to_f16_vec(&self) -> Vec<f16> {
+        match self {
+            ReferenceData::F32(v) => v.iter().copied().map(f16::from_f32).collect(),
+            ReferenceData::F16(v) => v.clone(),
+            ReferenceData::Bf16(v) => v.iter().map(|v| f16::from_f32(v.to_f32())).collect(),
+            ReferenceData::Int(v) => v.iter().map(|v| f16::from_f32(*v as f32)).collect(),
+            ReferenceData::I64(v) => v.iter().map(|v| f16::from_f32(*v as f32)).collect(),
+            ReferenceData::I8(v) => v.iter().map(|v| f16::from_f32(*v as f32)).collect(),
+            ReferenceData::U8(v) => v.iter().map(|v| f16::from_f32(*v as f32)).collect(),
+            ReferenceData::I16(v) => v.iter().map(|v| f16::from_f32(*v as f32)).collect(),
+            ReferenceData::F64(v) => v.iter().map(|v| f16::from_f64(*v)).collect(),
+            ReferenceData::Bool(v) => v
+                .iter()
+                .map(|v| f16::from_f32(if *v { 1.0 } else { 0.0 }))
+                .collect(),
+        }
+    }
+
+    pub fn to_bf16_vec(&self) -> Vec<bf16> {
+        match self {
+            ReferenceData::F32(v) => v.iter().copied().map(bf16::from_f32).collect(),
+            ReferenceData::F16(v) => v.iter().map(|v| bf16::from_f32(v.to_f32())).collect(),
+            ReferenceData::Bf16(v) => v.clone(),
+            ReferenceData::Int(v) => v.iter().map(|v| bf16::from_f32(*v as f32)).collect(),
+            ReferenceData::I64(v) => v.iter().map(|v| bf16::from_f32(*v as f32)).collect(),
+            ReferenceData::I8(v) => v.iter().map(|v| bf16::from_f32(*v as f32)).collect(),
+            ReferenceData::U8(v) => v.iter().map(|v| bf16::from_f32(*v as f32)).collect(),
+            ReferenceData::I16(v) => v.iter().map(|v| bf16::from_f32(*v as f32)).collect(),
+            ReferenceData::F64(v) => v.iter().map(|v| bf16::from_f64(*v)).collect(),
+            ReferenceData::Bool(v) => v
+                .iter()
+                .map(|v| bf16::from_f32(if *v { 1.0 } else { 0.0 }))
+                .collect(),
+        }
+    }
+
+    pub fn to_i32_vec(&self) -> Vec<i32> {
+        match self {
+            ReferenceData::F32(v) => v.iter().map(|v| *v as i32).collect(),
+            ReferenceData::F16(v) => v.iter().map(|v| v.to_f32() as i32).collect(),
+            ReferenceData::Bf16(v) => v.iter().map(|v| v.to_f32() as i32).collect(),
+            ReferenceData::Int(v) => v.clone(),
+            ReferenceData::I64(v) => v.iter().map(|v| *v as i32).collect(),
+            ReferenceData::I8(v) => v.iter().map(|v| *v as i32).collect(),
+            ReferenceData::U8(v) => v.iter().map(|v| *v as i32).collect(),
+            ReferenceData::I16(v) => v.iter().map(|v| *v as i32).collect(),
+            ReferenceData::F64(v) => v.iter().map(|v| *v as i32).collect(),
+            ReferenceData::Bool(v) => v.iter().map(|v| if *v { 1 } else { 0 }).collect(),
+        }
+    }
+
+    pub fn to_i64_vec(&self) -> Vec<i64> {
+        match self {
+            ReferenceData::F32(v) => v.iter().map(|v| *v as i64).collect(),
+            ReferenceData::F16(v) => v.iter().map(|v| v.to_f32() as i64).collect(),
+            ReferenceData::Bf16(v) => v.iter().map(|v| v.to_f32() as i64).collect(),
+            ReferenceData::Int(v) => v.iter().map(|v| *v as i64).collect(),
+            ReferenceData::I64(v) => v.clone(),
+            ReferenceData::I8(v) => v.iter().map(|v| *v as i64).collect(),
+            ReferenceData::U8(v) => v.iter().map(|v| *v as i64).collect(),
+            ReferenceData::I16(v) => v.iter().map(|v| *v as i64).collect(),
+            ReferenceData::F64(v) => v.iter().map(|v| *v as i64).collect(),
+            ReferenceData::Bool(v) => v.iter().map(|v| if *v { 1 } else { 0 }).collect(),
+        }
+    }
+
+    pub fn to_i8_vec(&self) -> Vec<i8> {
+        self.to_i64_vec().into_iter().map(|v| v as i8).collect()
+    }
+
+    pub fn to_u8_vec(&self) -> Vec<u8> {
+        self.to_i64_vec().into_iter().map(|v| v as u8).collect()
+    }
+
+    pub fn to_i16_vec(&self) -> Vec<i16> {
+        self.to_i64_vec().into_iter().map(|v| v as i16).collect()
+    }
+
+    pub fn to_bool_vec(&self) -> Vec<bool> {
+        match self {
+            ReferenceData::F32(v) => v.iter().map(|v| *v != 0.0).collect(),
+            ReferenceData::F16(v) => v.iter().map(|v| v.to_f32() != 0.0).collect(),
+            ReferenceData::Bf16(v) => v.iter().map(|v| v.to_f32() != 0.0).collect(),
+            ReferenceData::Int(v) => v.iter().map(|v| *v != 0).collect(),
+            ReferenceData::I64(v) => v.iter().map(|v| *v != 0).collect(),
+            ReferenceData::I8(v) => v.iter().map(|v| *v != 0).collect(),
+            ReferenceData::U8(v) => v.iter().map(|v| *v != 0).collect(),
+            ReferenceData::I16(v) => v.iter().map(|v| *v != 0).collect(),
+            ReferenceData::F64(v) => v.iter().map(|v| *v != 0.0).collect(),
+            ReferenceData::Bool(v) => v.clone(),
+        }
+    }
+}
+
+impl From<Vec<f32>> for ReferenceData {
+    fn from(value: Vec<f32>) -> Self {
+        ReferenceData::F32(value)
+    }
+}
+impl From<Vec<f16>> for ReferenceData {
+    fn from(value: Vec<f16>) -> Self {
+        ReferenceData::F16(value)
+    }
+}
+impl From<Vec<bf16>> for ReferenceData {
+    fn from(value: Vec<bf16>) -> Self {
+        ReferenceData::Bf16(value)
+    }
+}
+impl From<Vec<i32>> for ReferenceData {
+    fn from(value: Vec<i32>) -> Self {
+        ReferenceData::Int(value)
+    }
+}
+impl From<Vec<i64>> for ReferenceData {
+    fn from(value: Vec<i64>) -> Self {
+        ReferenceData::I64(value)
+    }
+}
+impl From<Vec<i8>> for ReferenceData {
+    fn from(value: Vec<i8>) -> Self {
+        ReferenceData::I8(value)
+    }
+}
+impl From<Vec<u8>> for ReferenceData {
+    fn from(value: Vec<u8>) -> Self {
+        ReferenceData::U8(value)
+    }
+}
+impl From<Vec<i16>> for ReferenceData {
+    fn from(value: Vec<i16>) -> Self {
+        ReferenceData::I16(value)
+    }
+}
+// No `From<Vec<f64>> for ReferenceData` impl. Adding it makes plain
+// float literals (`vec![1.0, 2.0, 3.0]` passed to `set_data`)
+// ambiguous between `Vec<f32>` and `Vec<f64>` and forces every test
+// site to spell out `Vec::<f32>::from([...])`. Callers that need to
+// construct an F64 buffer can do `ReferenceData::F64(my_vec)` directly.
+impl From<Vec<bool>> for ReferenceData {
+    fn from(value: Vec<bool>) -> Self {
+        ReferenceData::Bool(value)
+    }
+}
+
+macro_rules! impl_reference_data_from_ref {
+    ($ty:ty, $variant:ident) => {
+        impl From<&[$ty]> for ReferenceData {
+            fn from(value: &[$ty]) -> Self {
+                ReferenceData::$variant(value.to_vec())
+            }
+        }
+
+        impl From<&Vec<$ty>> for ReferenceData {
+            fn from(value: &Vec<$ty>) -> Self {
+                ReferenceData::$variant(value.clone())
+            }
+        }
+    };
+}
+
+macro_rules! impl_reference_data_from_array_ref {
+    ($ty:ty, $variant:ident) => {
+        impl<const N: usize> From<&[$ty; N]> for ReferenceData {
+            fn from(value: &[$ty; N]) -> Self {
+                ReferenceData::$variant(value.to_vec())
+            }
+        }
+    };
+}
+
+impl_reference_data_from_ref!(f32, F32);
+impl_reference_data_from_ref!(f16, F16);
+impl_reference_data_from_ref!(bf16, Bf16);
+impl_reference_data_from_ref!(i32, Int);
+impl_reference_data_from_ref!(i8, I8);
+impl_reference_data_from_ref!(u8, U8);
+impl_reference_data_from_ref!(i16, I16);
+impl_reference_data_from_ref!(bool, Bool);
+
+impl_reference_data_from_array_ref!(f32, F32);
+impl_reference_data_from_array_ref!(f16, F16);
+impl_reference_data_from_array_ref!(bf16, Bf16);
+impl_reference_data_from_array_ref!(i32, Int);
+impl_reference_data_from_array_ref!(i8, I8);
+impl_reference_data_from_array_ref!(u8, U8);
+impl_reference_data_from_array_ref!(i16, I16);
+impl_reference_data_from_array_ref!(bool, Bool);
+
+#[derive(Default)]
+pub struct ReferenceRuntime {
+    pub buffers: FxHashMap<NodeIndex, ReferenceData>,
+    pub graph: StableGraph<Arc<Box<dyn ReferenceOp>>, ()>,
+    selected_schedule: Option<crate::graph::SelectedSchedule>,
+}
+
+impl ReferenceRuntime {
+    pub fn set_data(&mut self, id: impl ToId, data: impl Into<ReferenceData>) {
+        let id = id.to_id();
+        let local_id = self
+            .graph
+            .node_indices()
+            .find(|n| {
+                if let Some(Input { node, .. }) = (**self.graph[*n]).as_any().downcast_ref() {
+                    *node == id.index()
+                } else {
+                    false
+                }
+            })
+            .unwrap_or_else(|| panic!("{id:?} is not an Input node in the graph"));
+        self.buffers.insert(local_id, data.into());
+    }
+}
+
+impl Runtime for ReferenceRuntime {
+    type Ops = ();
+    type CompileArg = ();
+    type ExecReturn = ();
+    /// Reference LLIR is HLIR; keep it extractable.
+    const CLEANUP_HLIR: bool = false;
+
+    fn initialize(_: Self::CompileArg) -> Self {
+        Self {
+            buffers: Default::default(),
+            graph: Default::default(),
+            selected_schedule: None,
+        }
+    }
+
+    /// No search: every extractable program is correct by contract and a CPU
+    /// reference has nothing to rank on, so extract one and load it. HLIR
+    /// programs are valid over the whole dynamic domain, so the first
+    /// bucket's program serves every bucket.
+    fn compile(
+        &mut self,
+        space: &crate::search::SearchSpace,
+        dyn_map: &DynMap,
+        _options: &CompileOptions,
+        rng: &mut dyn rand::RngCore,
+    ) {
+        let contexts = space.bucket_contexts(dyn_map);
+        let selected = contexts
+            .iter()
+            .map(|ctx| crate::search::extract_one_selected(space, ctx, rng))
+            .collect::<Vec<_>>();
+        self.load_llir(&selected[0].llir);
+        self.selected_schedule = crate::graph::SelectedSchedule::from_search(space, &selected);
+    }
+
+    fn selected_schedule(&self) -> Option<crate::graph::SelectedSchedule> {
+        self.selected_schedule.clone()
+    }
+
+    fn load_llir(&mut self, llir_graph: &LLIRGraph) {
+        // Extract reference-op graph
+        let mut graph = StableGraph::new();
+        for node in llir_graph.node_weights() {
+            if let Some(op) = node.to_dialect::<dyn ReferenceOp>() {
+                graph.add_node(op.clone());
+            } else if let Some(input) = node.to_op::<Input>() {
+                graph.add_node(Arc::new(Box::new(input.clone())));
+            } else {
+                let output = node.to_op::<Output>().unwrap();
+                graph.add_node(Arc::new(Box::new(output.clone())));
+            }
+        }
+        for edge in llir_graph.edge_indices() {
+            let (start, end) = llir_graph.edge_endpoints(edge).unwrap();
+            graph.add_edge(start, end, ());
+        }
+
+        self.graph = graph;
+    }
+
+    fn load_llir_buckets(
+        &mut self,
+        _dim_buckets: &FxHashMap<Symbol, Vec<crate::graph::DimBucket>>,
+        bucket_llirs: &[crate::graph::BucketLLIR],
+    ) {
+        self.load_llir(&bucket_llirs[0].2);
+    }
+
+    fn execute(&mut self, dyn_map: &DynMap) -> Self::ExecReturn {
+        for node in toposort(&self.graph, None).unwrap() {
+            if (**self.graph[node]).as_any().is::<Input>() {
+                continue;
+            }
+
+            if (**self.graph[node]).as_any().is::<Output>() {
+                // Copy source buffer into Output node's own slot
+                let source = self
+                    .graph
+                    .edges_directed(node, Direction::Incoming)
+                    .sorted_by_key(|e| e.id())
+                    .next()
+                    .unwrap()
+                    .source();
+                let data = self.buffers[&source].clone();
+                self.buffers.insert(node, data);
+                continue;
+            }
+
+            let span = info_span!("reference_op", op = %format!("{:?}", self.graph[node]));
+            let _entered = span.enter();
+            let inputs = self
+                .graph
+                .edges_directed(node, Direction::Incoming)
+                .sorted_by_key(|e| e.id())
+                .map(|e| &self.buffers[&e.source()])
+                .collect_vec();
+            let output = self.graph[node].execute(inputs, dyn_map);
+            self.buffers.insert(node, output);
+        }
+
+        // Consume all non-Output buffers (inputs + intermediates)
+        let output_nodes: FxHashSet<NodeIndex> = self
+            .graph
+            .node_indices()
+            .filter(|n| (**self.graph[*n]).as_any().is::<Output>())
+            .collect();
+        self.buffers.retain(|k, _| output_nodes.contains(k));
+    }
+}
+
+impl ReferenceRuntime {
+    pub fn get_f32(&self, id: impl ToId) -> &Vec<f32> {
+        let id = id.to_id();
+        let output_id = self
+            .graph
+            .node_indices()
+            .find(|n| {
+                if let Some(Output { node, .. }) =
+                    (**self.graph[*n]).as_any().downcast_ref::<Output>()
+                {
+                    *node == id.index()
+                } else {
+                    false
+                }
+            })
+            .unwrap();
+        let ReferenceData::F32(f) = self.buffers.get(&output_id).unwrap() else {
+            panic!()
+        };
+        f
+    }
+}
+
+struct StridedIterator {
+    shape: Vec<usize>,
+    strides: Vec<Expression>,
+    index: Vec<usize>,
+    done: bool,
+}
+
+impl StridedIterator {
+    fn new(shape: &[Expression], strides: &[Expression], dyn_map: &DynMap) -> Self {
+        let shape: Vec<usize> = shape.iter().map(|e| e.exec(dyn_map).unwrap()).collect();
+        // Resolve dynamic vars in strides but keep 'z' as a variable
+        let strides: Vec<Expression> = strides
+            .iter()
+            .copied()
+            .map(|e| e.resolve_vars(dyn_map))
+            .collect();
+        Self {
+            index: vec![0; shape.len()],
+            strides,
+            done: shape.contains(&0),
+            shape,
+        }
+    }
+}
+
+impl Iterator for StridedIterator {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
+        let fin = self
+            .strides
+            .iter()
+            .zip(self.index.iter())
+            .map(|(s, &idx)| s.exec_single_var(idx))
+            .sum();
+
+        for i in (0..self.shape.len()).rev() {
+            self.index[i] += 1;
+            if self.index[i] < self.shape[i] {
+                return Some(fin);
+            }
+            self.index[i] = 0;
+        }
+
+        self.done = true;
+        Some(fin)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_f64_unary(op: &dyn ReferenceOp, input: &[f64], expected_fn: fn(f64) -> f64) {
+        let input_data = ReferenceData::F64(input.to_vec());
+        let actual = op.execute(vec![&input_data], &FxHashMap::default());
+        let ReferenceData::F64(actual) = actual else {
+            panic!("F64 unary input must produce an F64 reference buffer")
+        };
+        let expected: Vec<f64> = input.iter().copied().map(expected_fn).collect();
+
+        assert_eq!(actual.len(), expected.len());
+        for (actual, expected) in actual.into_iter().zip(expected) {
+            assert_eq!(actual.to_bits(), expected.to_bits());
+        }
+    }
+
+    #[test]
+    fn reference_unary_ops_execute_f64_natively() {
+        let input = [0.25, 0.5, 1.0, 2.0, 4.0];
+        let shape = vec![input.len().into()];
+        let strides = vec!['z'.into()];
+
+        assert_f64_unary(
+            &Log2 {
+                shape: shape.clone(),
+                strides: strides.clone(),
+                ..Default::default()
+            },
+            &input,
+            f64::log2,
+        );
+        assert_f64_unary(
+            &Exp2 {
+                shape: shape.clone(),
+                strides: strides.clone(),
+                ..Default::default()
+            },
+            &input,
+            f64::exp2,
+        );
+        assert_f64_unary(
+            &Sin {
+                shape: shape.clone(),
+                strides: strides.clone(),
+                ..Default::default()
+            },
+            &input,
+            f64::sin,
+        );
+        assert_f64_unary(
+            &Recip {
+                shape: shape.clone(),
+                strides: strides.clone(),
+                ..Default::default()
+            },
+            &input,
+            f64::recip,
+        );
+        assert_f64_unary(
+            &Sqrt {
+                shape,
+                strides,
+                ..Default::default()
+            },
+            &input,
+            f64::sqrt,
+        );
+    }
+
+    #[test]
+    fn reference_narrow_integer_casts_preserve_native_widths() {
+        let source = ReferenceData::Int(vec![-32_769, -129, -128, -1, 0, 127, 128, 255, 256]);
+        let dyn_map = FxHashMap::default();
+
+        let i8_data = Cast(9.into(), DType::I8).execute(vec![&source], &dyn_map);
+        assert!(matches!(
+            i8_data,
+            ReferenceData::I8(ref values)
+                if values == &[-1, 127, -128, -1, 0, 127, -128, -1, 0]
+        ));
+
+        let u8_data = Cast(9.into(), DType::U8).execute(vec![&source], &dyn_map);
+        assert!(matches!(
+            u8_data,
+            ReferenceData::U8(ref values)
+                if values == &[255, 127, 128, 255, 0, 127, 128, 255, 0]
+        ));
+
+        let i16_data = Cast(9.into(), DType::I16).execute(vec![&source], &dyn_map);
+        assert!(matches!(
+            i16_data,
+            ReferenceData::I16(ref values)
+                if values == &[32767, -129, -128, -1, 0, 127, 128, 255, 256]
+        ));
+    }
+
+    #[test]
+    fn reference_narrow_integer_add_wraps_in_declared_dtype() {
+        let op = Add {
+            shape: vec![2.into()],
+            a_strides: vec!['z'.into()],
+            b_strides: vec!['z'.into()],
+            ..Default::default()
+        };
+        let dyn_map = FxHashMap::default();
+
+        let i8_lhs = ReferenceData::I8(vec![127, -128]);
+        let i8_rhs = ReferenceData::I8(vec![1, -1]);
+        assert!(matches!(
+            op.execute(vec![&i8_lhs, &i8_rhs], &dyn_map),
+            ReferenceData::I8(values) if values == [-128, 127]
+        ));
+
+        let u8_lhs = ReferenceData::U8(vec![255, 0]);
+        let u8_rhs = ReferenceData::U8(vec![1, 255]);
+        assert!(matches!(
+            op.execute(vec![&u8_lhs, &u8_rhs], &dyn_map),
+            ReferenceData::U8(values) if values == [0, 255]
+        ));
+
+        let i16_lhs = ReferenceData::I16(vec![32_767, -32_768]);
+        let i16_rhs = ReferenceData::I16(vec![1, -1]);
+        assert!(matches!(
+            op.execute(vec![&i16_lhs, &i16_rhs], &dyn_map),
+            ReferenceData::I16(values) if values == [-32_768, 32_767]
+        ));
+    }
+
+    fn round_tripped(v: f32) -> f32 {
+        let s = Constant(v).to_egglog(&[]);
+        let inner = &s["(Op (Constant ".len()..s.len() - ") (INil))".len()];
+        // The egglog Constant sort stores f64: text -> f64 -> f32 is the
+        // path a constant takes through the e-graph and back.
+        inner
+            .parse::<f64>()
+            .unwrap_or_else(|_| panic!("unparseable constant text {inner:?}")) as f32
+    }
+
+    /// f32 -> serialized text -> f64 (egglog) -> f32 must be the identity.
+    /// `{:.6}` zeroed sub-5e-7 constants (gelu's sign epsilon -> NaN at
+    /// x==0) and shifted transcendental coefficients (LUM-631).
+    #[test]
+    fn constant_to_egglog_round_trips_exactly() {
+        let adversarial = [
+            0.0f32,
+            -0.0,
+            1e-10,
+            -1e-10,
+            f32::EPSILON,
+            f32::MIN_POSITIVE,
+            1e-45,       // smallest subnormal
+            1.595_769_2, // tanh-gelu outer coeff (frontend 1.5957691216 as f32)
+            0.044715,
+            std::f32::consts::LOG2_E,
+            std::f32::consts::FRAC_PI_2,
+            std::f32::consts::PI,
+            1e38,
+            -1e-38,
+            0.1,
+            1.0 / 3.0,
+        ];
+        for &v in &adversarial {
+            assert_eq!(round_tripped(v).to_bits(), v.to_bits(), "constant {v:?}");
+        }
+    }
+
+    #[test]
+    fn f64_constant_to_egglog_round_trips_exactly() {
+        let adversarial = [
+            0.0f64,
+            -0.0,
+            1.000_000_000_000_000_2,
+            f64::EPSILON,
+            f64::MIN_POSITIVE,
+            f64::from_bits(1),
+            std::f64::consts::PI,
+            1e300,
+            -1e-300,
+        ];
+
+        for value in adversarial {
+            let serialized = ConstantF64(value).to_egglog(&[]);
+            let prefix = "(Op (ConstantF64 ";
+            let suffix = ") (INil))";
+            let inner = &serialized[prefix.len()..serialized.len() - suffix.len()];
+            let round_tripped = inner
+                .parse::<f64>()
+                .unwrap_or_else(|_| panic!("unparseable F64 constant text {inner:?}"));
+            assert_eq!(
+                round_tripped.to_bits(),
+                value.to_bits(),
+                "F64 constant changed across egglog serialization: {value:?}"
+            );
+        }
+    }
+}

--- a/crates/luminal_cuda_lite_hlir/main_core/op.rs
+++ b/crates/luminal_cuda_lite_hlir/main_core/op.rs
@@ -1,0 +1,453 @@
+use std::{
+    fmt::{Debug, Display},
+    sync::Arc,
+};
+
+use crate::prelude::*;
+use crate::search::SearchSpace;
+use as_any::{AsAny, Downcast};
+use rustc_hash::FxHashMap;
+
+/// A backend: the ops and rewrites that lower HLIR into its LLIR, a search
+/// strategy over the saturated e-graphs core hands it, and execution of the
+/// programs it selects.
+pub trait Runtime {
+    type Ops: IntoEgglogOp;
+    type CompileArg;
+    type ExecReturn;
+    /// Whether HLIR ops are deleted from the e-graph after saturation so
+    /// only lowered LLIR is extractable. The reference runtime, whose LLIR
+    /// *is* HLIR, sets this to `false`.
+    const CLEANUP_HLIR: bool = true;
+    /// Backend-provided egglog layers that run after the normal full-egraph
+    /// cleanup schedule. Core keeps this empty; runtimes can use it for
+    /// backend-specific analyses and cleanup passes without adding those rules
+    /// to Luminal core.
+    fn late_egglog_passes(
+        _ops: &[Arc<Box<dyn EgglogOp>>],
+        _options: &crate::graph::CompileOptions,
+        _dyn_map: &DynMap,
+    ) -> Vec<crate::egglog_utils::LateEgglogPass>
+    where
+        Self: Sized,
+    {
+        vec![]
+    }
+    /// Backend-provided egglog text spliced after the op constructor and
+    /// op-owned declarations, before the rewrite rules. Core keeps this empty;
+    /// runtimes can use it for backend-wide program text that is not naturally
+    /// owned by one registered op, without adding it to Luminal core.
+    fn extra_egglog() -> String
+    where
+        Self: Sized,
+    {
+        String::new()
+    }
+    fn initialize(arg: Self::CompileArg) -> Self;
+    /// Choose one program per bucket of `space` — by any strategy — and leave
+    /// the runtime ready to [`Runtime::execute`].
+    ///
+    /// `dyn_map` is the graph's dyn map after `options.search_dims`; the
+    /// representative values of each bucket come from
+    /// [`SearchSpace::bucket_contexts`]. `rng` is the caller's (possibly
+    /// seeded) RNG. Core ships the building blocks in [`crate::search`]:
+    /// [`crate::search::extract_one`] for a runtime with nothing to rank on,
+    /// [`crate::search::GeneticSearch`] and friends for a runtime that
+    /// profiles, and [`crate::search::genetic_search`] composing them into
+    /// the stock strategy.
+    fn compile(
+        &mut self,
+        space: &SearchSpace,
+        dyn_map: &DynMap,
+        options: &crate::graph::CompileOptions,
+        rng: &mut dyn rand::RngCore,
+    );
+    fn selected_schedule(&self) -> Option<crate::graph::SelectedSchedule> {
+        None
+    }
+    /// Load one LLIR graph as the executable. [`Runtime::compile`] normally
+    /// loads what it selects; this is the direct path for callers that
+    /// already hold an LLIR graph.
+    fn load_llir(&mut self, llir_graph: &LLIRGraph);
+    fn load_llir_buckets(
+        &mut self,
+        _dim_buckets: &FxHashMap<Symbol, Vec<crate::graph::DimBucket>>,
+        bucket_llirs: &[crate::graph::BucketLLIR],
+    ) {
+        assert_eq!(
+            bucket_llirs.len(),
+            1,
+            "runtime does not support LLIR buckets"
+        );
+        self.load_llir(&bucket_llirs[0].2);
+    }
+    fn execute(&mut self, dyn_map: &DynMap) -> Self::ExecReturn;
+}
+
+/// Optional runtime instrumentation for collecting execution statistics.
+pub trait RuntimeStats: Runtime {
+    fn execute_with_stats(&mut self, dyn_map: &DynMap) -> Option<ExecutionStats>;
+}
+
+/// Shared early-stop predicate for duration-metric runtimes: true once a
+/// candidate's running mean trial time exceeds `best * factor`, i.e. the
+/// candidate has already lost by at least the configured margin and further
+/// trials can only refine a metric that is out of contention.
+pub fn early_stop_exceeded(
+    mean: std::time::Duration,
+    best: std::time::Duration,
+    factor: f64,
+) -> bool {
+    mean.as_secs_f64() > best.as_secs_f64() * factor
+}
+
+/// Timing method used for execution statistics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TimingMethod {
+    /// Device-side timing (e.g. GPU timestamps / CUDA events).
+    DeviceTimestamp,
+    /// Host-side wall-clock timing.
+    /// Includes any host/device synchronization overhead.
+    #[default]
+    WallClock,
+}
+
+impl std::fmt::Display for TimingMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TimingMethod::DeviceTimestamp => write!(f, "Device"),
+            TimingMethod::WallClock => write!(f, "Wall"),
+        }
+    }
+}
+
+/// Detailed execution statistics from a single run.
+///
+/// This struct captures basic counters and timing.
+#[derive(Debug, Clone, Default)]
+pub struct ExecutionStats {
+    /// Execution time in microseconds.
+    pub execution_time_us: f64,
+    /// Total bytes read.
+    pub bytes_loaded: usize,
+    /// Total bytes written.
+    pub bytes_stored: usize,
+    /// Total floating-point operations.
+    pub flops: usize,
+    /// Timing method used for this measurement.
+    pub timing_method: TimingMethod,
+}
+
+impl ExecutionStats {
+    pub fn new(
+        execution_time_us: f64,
+        bytes_loaded: usize,
+        bytes_stored: usize,
+        flops: usize,
+    ) -> Self {
+        Self {
+            execution_time_us,
+            bytes_loaded,
+            bytes_stored,
+            flops,
+            timing_method: TimingMethod::DeviceTimestamp,
+        }
+    }
+
+    /// Create new execution stats with explicit timing method.
+    pub fn with_timing_method(
+        execution_time_us: f64,
+        bytes_loaded: usize,
+        bytes_stored: usize,
+        flops: usize,
+        timing_method: TimingMethod,
+    ) -> Self {
+        Self {
+            execution_time_us,
+            bytes_loaded,
+            bytes_stored,
+            flops,
+            timing_method,
+        }
+    }
+
+    /// Total bytes transferred (loaded + stored).
+    pub fn total_bytes(&self) -> usize {
+        self.bytes_loaded + self.bytes_stored
+    }
+
+    pub fn merge(&mut self, other: &ExecutionStats) {
+        self.execution_time_us += other.execution_time_us;
+        self.bytes_loaded += other.bytes_loaded;
+        self.bytes_stored += other.bytes_stored;
+        self.flops += other.flops;
+    }
+}
+
+impl std::fmt::Display for ExecutionStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ExecutionStats {{ time: {:.2}µs ({}), bytes: {:.2}MB, flops: {:.2}M }}",
+            self.execution_time_us,
+            self.timing_method,
+            self.total_bytes() as f64 / 1_000_000.0,
+            self.flops as f64 / 1_000_000.0
+        )
+    }
+}
+
+pub trait EgglogOp: Debug {
+    fn sort(&self) -> crate::egglog_utils::api::SortDef;
+
+    /// Shared egglog declarations required by this op's rewrites. These are
+    /// emitted once, before any rewrite text, so relations/functions shared by
+    /// multiple ops do not depend on tuple registration order. Identical
+    /// declaration strings are deduplicated while preserving first-seen order.
+    fn egglog_declarations(&self) -> Vec<String> {
+        vec![]
+    }
+
+    fn rewrites(&self) -> Vec<crate::egglog_utils::api::Rule> {
+        vec![]
+    }
+    fn cleanup(&self) -> bool;
+
+    /// Additional IR datatype variants this op needs (e.g. `"(ConsumedBuffer IR)"`).
+    /// These are injected into the IR datatype definition.
+    fn ir_defs(&self) -> Vec<String> {
+        vec![]
+    }
+
+    /// Number of IR inputs this op takes (from IList).
+    /// Used by generic IList walking during extraction.
+    fn n_inputs(&self) -> usize {
+        0
+    }
+
+    /// Extract this op from the egraph.
+    /// - `kind_children`: metadata fields from OpKind enode (shapes, strides, dtypes, etc.)
+    /// - `input_enodes`: IR inputs from IList, already walked and resolved
+    #[allow(unused_variables)]
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        panic!("Extraction not implemented for {self:?}!");
+    }
+}
+
+crate::impl_into_ops!(EgglogOp);
+
+pub trait CustomOp: Debug {
+    fn to_llir_op(&self) -> LLIROp;
+}
+
+/// The main HLIROp trait.
+///
+/// Defines an HLIROp that implements a logical operation.
+pub trait HLIROp: Debug + Display + as_any::AsAny {
+    fn to_egglog(&self, inputs: &[(NodeIndex, String)]) -> String;
+
+    /// Return this operation's concrete output dtype from the concrete dtypes
+    /// of its ordered inputs.
+    ///
+    /// Most logical operations preserve the dtype of their first input.
+    /// Operations with different dtype semantics override this method. Keeping
+    /// the rule on the operation makes graph transforms such as loop rolling
+    /// consume the same type contract as the op itself instead of maintaining
+    /// a second opcode-specific inference table.
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        *input_dtypes
+            .first()
+            .unwrap_or_else(|| panic!("{self} has no input and does not declare an output dtype"))
+    }
+}
+
+impl<T: HLIROp> HLIROp for Box<T> {
+    fn to_egglog(&self, inputs: &[(NodeIndex, String)]) -> String {
+        <T as HLIROp>::to_egglog(self, inputs)
+    }
+
+    fn output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        <T as HLIROp>::output_dtype(self, input_dtypes)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LLIROp(Arc<Box<dyn DialectOpTrait>>);
+
+impl LLIROp {
+    /// Store an op in a generic LLIR op. **Make sure to erase type into your dialect trait!** i.e. `as Box<dyn BlockOp>`
+    pub fn new<T: ?Sized>(op: Box<T>) -> Self
+    where
+        Box<T>: Debug + 'static,
+    {
+        assert!(
+            op.type_name().contains("dyn")
+                || op.type_name().contains("Input")
+                || op.type_name().contains("Output")
+                || op.type_name().contains("LoopStart")
+                || op.type_name().contains("LoopEnd")
+                || op.type_name().contains("LoopInput")
+                || op.type_name().contains("LoopOutput"),
+            "op types must be erased into dialect traits for dialect casting to work!"
+        );
+        Self(Arc::new(Box::new(DialectOp::new(op))))
+    }
+
+    pub fn to_dialect<T: ?Sized + 'static>(&self) -> Option<&Arc<Box<T>>> {
+        (**self.0).downcast_ref::<DialectOp<Box<T>>>().map(|i| &i.0)
+    }
+
+    pub fn to_op<T: 'static>(&self) -> Option<&T> {
+        (**self.0)
+            .downcast_ref::<DialectOp<Box<T>>>()
+            .map(|d| &**d.0)
+    }
+}
+
+impl std::fmt::Display for LLIROp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Debug)]
+struct DialectOp<T>(pub Arc<T>);
+
+impl<T> DialectOp<T> {
+    pub fn new(op: T) -> Self {
+        Self(Arc::new(op))
+    }
+}
+
+impl<T: Debug + 'static> DialectOpTrait for DialectOp<T> {}
+
+pub trait DialectOpTrait: AsAny + Debug {}
+
+#[macro_export]
+macro_rules! __impl_tuple_into_dyn_arcbox_concat_arity {
+    ($tr:ident; $($T:ident),+ $(,)?) => {
+        $crate::paste!{
+        impl<$($T),+> [<Into $tr>] for ($($T,)+)
+        where
+            $(
+                $T: [<Into $tr>],
+            )+
+        {
+            #[inline]
+            fn append_into(
+                out: &mut ::std::vec::Vec<
+                    ::std::sync::Arc<::std::boxed::Box<dyn $tr + 'static>>
+                >
+            ) {
+                $(
+                    <$T as [<Into $tr>]>::append_into(out);
+                )+
+            }
+        }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_into_ops {
+    ($tr:ident) => {
+        $crate::paste!{
+        pub trait [<Into $tr>] {
+            fn append_into(
+                out: &mut ::std::vec::Vec<
+                    ::std::sync::Arc<::std::boxed::Box<dyn $tr + 'static>>
+                >
+            );
+
+            #[inline]
+            fn into_vec() -> ::std::vec::Vec<
+                ::std::sync::Arc<::std::boxed::Box<dyn $tr + 'static>>
+            > {
+                let mut out = ::std::vec::Vec::new();
+                Self::append_into(&mut out);
+                out
+            }
+        }
+
+        // base
+        impl [<Into $tr>] for () {
+            #[inline]
+            fn append_into(
+                _out: &mut ::std::vec::Vec<
+                    ::std::sync::Arc<::std::boxed::Box<dyn $tr + 'static>>
+                >
+            ) {}
+        }
+
+        // leaf: any concrete op type
+        impl<T> [<Into $tr>] for T
+        where
+            T: $tr + ::std::default::Default + 'static,
+        {
+            #[inline]
+            fn append_into(
+                out: &mut ::std::vec::Vec<
+                    ::std::sync::Arc<::std::boxed::Box<dyn $tr + 'static>>
+                >
+            ) {
+                out.push(::std::sync::Arc::new(::std::boxed::Box::new(
+                    <T as ::std::default::Default>::default(),
+                )));
+            }
+        }
+        }
+
+        // tuple concatenation impls (extend arity list as needed)
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I, J);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I, J, K);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I, J, K, L);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I, J, K, L, M);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I, J, K, L, M, N);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y);
+        $crate::__impl_tuple_into_dyn_arcbox_concat_arity!($tr; A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
+    };
+}
+
+#[cfg(test)]
+mod early_stop_tests {
+    use super::early_stop_exceeded;
+    use std::time::Duration;
+
+    #[test]
+    fn test_early_stop_exceeded() {
+        let best = Duration::from_millis(5);
+        // 2x cutoff: 10ms mean is at the boundary, not over it.
+        assert!(!early_stop_exceeded(Duration::from_millis(10), best, 2.0));
+        assert!(early_stop_exceeded(Duration::from_millis(11), best, 2.0));
+        // A candidate faster than best never stops early.
+        assert!(!early_stop_exceeded(Duration::from_millis(4), best, 2.0));
+        // Factor 1.0 stops anything slower than best.
+        assert!(early_stop_exceeded(Duration::from_millis(6), best, 1.0));
+    }
+}

--- a/crates/luminal_cuda_lite_hlir/main_core/search/finalist.rs
+++ b/crates/luminal_cuda_lite_hlir/main_core/search/finalist.rs
@@ -1,0 +1,308 @@
+//! Lazy materialization of ranked genomes into hard-filtered deployment
+//! graphs.
+//!
+//! Ranked genomes stay compact e-graph choices; a full graph is extracted
+//! only when the selection actually reaches its rank, and only kept when it
+//! passes the runtime's hard filter. Pull-style: [`Finalists::extract_next`] hands
+//! out the next ranked candidate, the runtime validates it, and
+//! [`Finalists::accept`] / [`Finalists::reject`] record the verdict.
+
+use std::fmt::Debug;
+use std::time::Instant;
+
+use colored::Colorize;
+
+use super::diagnostics::maybe_dump_selected_llir;
+use super::genetic::Ranked;
+use super::unroll::unroll_packed_llir;
+use super::{BucketContext, SearchSpace};
+use crate::egglog_utils::{IndexedChoiceSet, LlirExtractor};
+use crate::graph::{CompileOptions, LLIRGraph};
+use crate::shape::DynMap;
+
+/// Hard filter a runtime applies to a re-extracted finalist.
+pub type FinalistValidator<'v, M> =
+    dyn FnMut(&PendingFinalist<M>, &BucketContext<'_>) -> Result<(), String> + 'v;
+
+/// A viable deployment graph and the metric its genome measured.
+pub struct Finalist<M> {
+    pub metric: M,
+    pub genome: IndexedChoiceSet,
+    pub llir: LLIRGraph,
+    /// Rolled graph before unrolling, kept only under `LLIR_DUMP_PRE_UNROLL`.
+    pub pre_unroll: Option<LLIRGraph>,
+}
+
+/// A ranked genome, re-extracted and unrolled, awaiting the hard filter.
+pub struct PendingFinalist<M> {
+    /// 1-based rank among the measured genomes.
+    pub rank: usize,
+    pub metric: M,
+    pub genome: IndexedChoiceSet,
+    pub llir: LLIRGraph,
+    /// Dyn values the hard filter should judge the graph at: the bucket
+    /// representative when bucketed, otherwise the profiling dyn map.
+    pub dyn_map: DynMap,
+    pre_unroll: Option<LLIRGraph>,
+    started_at: Instant,
+}
+
+pub struct Finalists<'a, M> {
+    ctx: &'a BucketContext<'a>,
+    options: &'a CompileOptions,
+    search_started_at: Instant,
+    extractor: LlirExtractor<'a>,
+    custom_ops: &'a [crate::op::LLIROp],
+    ranked: Ranked<M>,
+    next_ranked: usize,
+    finalists: Vec<Finalist<M>>,
+    filter_dyn_map: DynMap,
+    dump_pre_unroll: bool,
+    search_log: bool,
+    pub rejections: usize,
+    pub last_rejection: Option<String>,
+    pub stopped_reason: Option<String>,
+}
+
+impl<'a, M: Clone + Debug> Finalists<'a, M> {
+    pub fn new(
+        ranked: Ranked<M>,
+        space: &'a SearchSpace,
+        ctx: &'a BucketContext<'a>,
+        options: &'a CompileOptions,
+        search_started_at: Instant,
+    ) -> Self {
+        let filter_dyn_map = if ctx.is_bucketed() {
+            ctx.representative_dyn_map.clone()
+        } else {
+            ctx.profile_dyn_map(options)
+        };
+        Self {
+            ctx,
+            options,
+            search_started_at,
+            extractor: LlirExtractor::new(ctx.egraph(), &space.ops),
+            custom_ops: &space.custom_ops,
+            ranked,
+            next_ranked: 0,
+            finalists: Vec::new(),
+            filter_dyn_map,
+            dump_pre_unroll: std::env::var_os("LLIR_DUMP_PRE_UNROLL").is_some(),
+            search_log: options.search_log_enabled(),
+            rejections: 0,
+            last_rejection: None,
+            stopped_reason: None,
+        }
+    }
+
+    pub fn bucket_context(&self) -> &'a BucketContext<'a> {
+        self.ctx
+    }
+
+    /// Viable finalists materialized so far, fastest first.
+    pub fn len(&self) -> usize {
+        self.finalists.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.finalists.is_empty()
+    }
+
+    pub fn get(&self, index: usize) -> &Finalist<M> {
+        &self.finalists[index]
+    }
+
+    /// Take finalist `index` out, dumping it under `LLIR_DUMP_DIR`.
+    pub fn take(mut self, index: usize) -> Finalist<M> {
+        let finalist = self.finalists.swap_remove(index);
+        let bucket_progress = self.ctx.progress();
+        if let Some(pre_unroll) = &finalist.pre_unroll {
+            let dump_label = bucket_progress
+                .map(|(bucket_idx, n_buckets)| {
+                    format!("pre-unroll-bucket-{:02}-of-{n_buckets:02}", bucket_idx + 1)
+                })
+                .unwrap_or_else(|| "pre-unroll-single".to_string());
+            maybe_dump_selected_llir(&dump_label, &self.ctx.representative_dyn_map, pre_unroll);
+        }
+        let dump_label = bucket_progress
+            .map(|(bucket_idx, n_buckets)| {
+                format!("bucket-{:02}-of-{n_buckets:02}", bucket_idx + 1)
+            })
+            .unwrap_or_else(|| "single".to_string());
+        maybe_dump_selected_llir(
+            &dump_label,
+            &self.ctx.representative_dyn_map,
+            &finalist.llir,
+        );
+        finalist
+    }
+
+    /// Re-extract the next ranked genome. `None` once every genome has been
+    /// tried or the search time limit expired (the fastest genome always
+    /// gets one attempt). Extraction panics are recorded as rejections and
+    /// skipped.
+    pub fn extract_next(&mut self) -> Option<PendingFinalist<M>> {
+        loop {
+            if self.next_ranked >= self.ranked.len() {
+                return None;
+            }
+            // Always give the fastest profiled genome one finalization
+            // attempt. Later fallbacks respect the overall search budget.
+            if self.next_ranked > 0
+                && self.search_started_at.elapsed() >= self.options.search_time_limit
+            {
+                self.stopped_reason = Some(format!(
+                    "search time limit expired before finalizing ranked candidate {}",
+                    self.next_ranked + 1
+                ));
+                return None;
+            }
+
+            let started_at = Instant::now();
+            let (metric, genome) = &self.ranked[self.next_ranked];
+            let metric = metric.clone();
+            let genome: IndexedChoiceSet = genome.clone();
+            self.next_ranked += 1;
+            let rank = self.next_ranked;
+
+            let extracted = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let packed = self
+                    .extractor
+                    .extract_indexed_packed(&genome, self.custom_ops);
+                let pre_unroll = self.dump_pre_unroll.then(|| packed.to_stable());
+                (pre_unroll, unroll_packed_llir(packed))
+            }));
+            match extracted {
+                Ok((pre_unroll, llir)) => {
+                    return Some(PendingFinalist {
+                        rank,
+                        metric,
+                        genome,
+                        llir,
+                        dyn_map: self.filter_dyn_map.clone(),
+                        pre_unroll,
+                        started_at,
+                    });
+                }
+                Err(payload) => {
+                    crate::mask_events::CANDIDATE_PANIC
+                        .record_with(|| crate::mask_events::panic_payload(payload.as_ref()));
+                    self.rejections += 1;
+                    self.last_rejection =
+                        Some("final extraction or loop unroll panicked".to_string());
+                    if self.search_log {
+                        println!(
+                            "   {:>6}  finalist reject ranked #{rank}: final extraction or loop unroll panicked",
+                            "Search".yellow().bold(),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn timed_out(&self, pending: &PendingFinalist<M>) -> bool {
+        self.options
+            .candidate_timeout
+            .is_some_and(|timeout| pending.started_at.elapsed() >= timeout)
+    }
+
+    fn record_timeout(&mut self, pending: &PendingFinalist<M>) {
+        self.rejections += 1;
+        self.last_rejection = Some(format!(
+            "candidate timeout expired while finalizing ranked candidate {}",
+            pending.rank
+        ));
+        if self.search_log {
+            println!(
+                "   {:>6}  finalist reject ranked #{}: finalization timeout after {:?}",
+                "Search".yellow().bold(),
+                pending.rank,
+                pending.started_at.elapsed(),
+            );
+        }
+    }
+
+    /// The pending candidate passed the hard filter. Returns `false` (and
+    /// records a rejection instead) when the candidate timeout expired while
+    /// it was being validated.
+    pub fn accept(&mut self, pending: PendingFinalist<M>) -> bool {
+        if self.timed_out(&pending) {
+            self.record_timeout(&pending);
+            return false;
+        }
+        // Falling past rank #1 silently substitutes a slower-profiled graph;
+        // make the substitution visible.
+        if self.search_log && pending.rank > 1 {
+            println!(
+                "   {:>6}  finalist fallback: loading ranked #{} after {} rejection(s)",
+                "Search".yellow().bold(),
+                pending.rank,
+                self.rejections,
+            );
+        }
+        self.finalists.push(Finalist {
+            metric: pending.metric,
+            genome: pending.genome,
+            pre_unroll: pending.pre_unroll,
+            llir: pending.llir,
+        });
+        true
+    }
+
+    /// The pending candidate failed the hard filter.
+    pub fn reject(&mut self, pending: PendingFinalist<M>, reason: String) {
+        if self.timed_out(&pending) {
+            self.record_timeout(&pending);
+            return;
+        }
+        self.rejections += 1;
+        crate::mask_events::FINALIST_REJECT.record_with(|| reason.clone());
+        if self.search_log {
+            println!(
+                "   {:>6}  finalist reject ranked #{}: {reason}",
+                "Search".yellow().bold(),
+                pending.rank,
+            );
+        }
+        self.last_rejection = Some(reason);
+    }
+
+    /// Materialize viable finalists until index `target` exists, validating
+    /// each with `validate`. Panics inside `validate` are rejections.
+    pub fn ensure(&mut self, target: usize, validate: &mut FinalistValidator<'_, M>) -> bool {
+        while self.finalists.len() <= target {
+            let Some(pending) = self.extract_next() else {
+                return false;
+            };
+            let verdict = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                validate(&pending, self.ctx)
+            }))
+            .unwrap_or_else(|_| Err("final candidate filter panicked".to_string()));
+            match verdict {
+                Ok(()) => {
+                    self.accept(pending);
+                }
+                Err(reason) => self.reject(pending, reason),
+            }
+        }
+        true
+    }
+
+    /// Why no (further) finalist could be materialized.
+    pub fn failure_message(&self) -> String {
+        if let Some(stopped_reason) = &self.stopped_reason {
+            return format!(
+                "no viable final graph after {} hard-filter rejections: {stopped_reason}",
+                self.rejections
+            );
+        }
+        format!(
+            "no viable final graph after hard-filtering {} profiled candidates: {}",
+            self.rejections,
+            self.last_rejection
+                .as_deref()
+                .unwrap_or("no rejection reason")
+        )
+    }
+}

--- a/crates/luminal_cuda_lite_hlir/main_core/search/genetic.rs
+++ b/crates/luminal_cuda_lite_hlir/main_core/search/genetic.rs
@@ -1,0 +1,620 @@
+//! Luminal's genetic search over one bucket's e-graph, as a pull-style
+//! state machine.
+//!
+//! The runtime drives it: [`GeneticSearch::next_candidate`] hands out a
+//! fully-unrolled deployment graph, the runtime evaluates it by whatever
+//! means it has, and [`GeneticSearch::report`] feeds the [`Outcome`] back.
+//! The state machine owns everything else the search has always owned —
+//! initial-genome retries, generations and mutation, stagnation kicks and
+//! resampling, genome and program dedup, the graph limit, the search time
+//! limit, the candidate timeout, the early-stop hint, progress bars, and the
+//! `LLIR_DUMP_DIR` / `LUMINAL_LOG_LLIR` / `LUMINAL_CANDIDATE_OPS` hooks.
+
+use std::collections::VecDeque;
+use std::fmt::Debug;
+use std::time::Instant;
+
+use colored::Colorize;
+use rand::RngCore;
+use rustc_hash::FxHashSet;
+
+use super::diagnostics::{
+    ProgressBars, log_best_llir, log_candidate_ops, panic_initial_filter_limit,
+};
+use super::packed::LlirFingerprint;
+use super::unroll::unroll_packed_llir;
+use super::{BucketContext, SearchSpace};
+use crate::egglog_utils::{IndexedChoiceSet, LlirExtractor, count_choice_sets_up_to};
+use crate::graph::{CompileOptions, LLIRGraph};
+use crate::shape::DynMap;
+
+/// Identifies a handed-out [`Candidate`] so it can only be reported once.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CandidateId(u64);
+
+/// A deployment graph the search wants evaluated.
+pub struct Candidate<M> {
+    pub id: CandidateId,
+    /// Fully unrolled — the graph that would be deployed if selected.
+    pub llir: LLIRGraph,
+    /// Dyn values to evaluate with: the bucket representative with
+    /// `profile_dims` applied.
+    pub profile_dyn_map: DynMap,
+    /// `Some((best_metric, factor))` once a best candidate exists: an
+    /// evaluator may stop early once this candidate's running metric
+    /// exceeds `best * factor`. The truncated metric is ranked normally.
+    pub early_stop: Option<(M, f64)>,
+    pre_collapse: Option<LLIRGraph>,
+    timer: Instant,
+}
+
+impl<M> Candidate<M> {
+    /// Restart the clock the search checks `candidate_timeout` against. By
+    /// default it runs from hand-out to report; a runtime whose evaluation
+    /// has a phase the timeout should not cover (e.g. compilation) restarts
+    /// it before the phase it should.
+    pub fn restart_timer(&mut self) {
+        self.timer = Instant::now();
+    }
+
+    /// The rolled graph before loop unrolling, retained only when
+    /// `LLIR_DUMP_DIR` is set, for post-mortem dumps.
+    pub fn pre_collapse(&self) -> Option<&LLIRGraph> {
+        self.pre_collapse.as_ref()
+    }
+}
+
+/// What happened to a [`Candidate`].
+#[derive(Debug, Clone)]
+pub enum Outcome<M> {
+    /// Evaluated. Counts toward the graph limit and is ranked by the metric
+    /// unless the candidate timeout expired.
+    Measured(M, String),
+    /// Not viable before evaluation (failed to compile, over a resource cap).
+    /// Does not count toward the graph limit.
+    Rejected(String),
+    /// Evaluation started but produced no usable metric. Counts toward the
+    /// graph limit; never ranked.
+    Invalid(String),
+}
+
+/// Every measured genome of a finished search, fastest first.
+pub type Ranked<M> = Vec<(M, IndexedChoiceSet)>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    /// Looking for the first viable genome.
+    Initial,
+    /// Evolving from the initial genome.
+    Evolving,
+    Done,
+}
+
+const MAX_INVALID_INITIAL_ATTEMPTS: usize = 100;
+
+pub struct GeneticSearch<'a, M> {
+    space: &'a SearchSpace,
+    ctx: &'a BucketContext<'a>,
+    options: &'a CompileOptions,
+    extractor: LlirExtractor<'a>,
+    profile_dyn_map: DynMap,
+    search_limit: usize,
+    started_at: Instant,
+    search_started_at: Instant,
+    search_log: bool,
+    bars: ProgressBars,
+    keep_pre_collapse: bool,
+
+    prev_selected: FxHashSet<u64>,
+    explored_llir_hashes: FxHashSet<LlirFingerprint>,
+    phase: Phase,
+    next_id: u64,
+    outstanding: Option<(CandidateId, IndexedChoiceSet)>,
+
+    // Initial phase.
+    invalid_attempts: usize,
+    filter_fails: usize,
+    max_filter_fails: usize,
+    last_filter_rejection: Option<String>,
+    n_timed_out: usize,
+    n_invalid_profile: usize,
+
+    // Evolving phase.
+    pending: VecDeque<IndexedChoiceSet>,
+    generation_open: bool,
+    ranked: Ranked<M>,
+    parents: Vec<(M, IndexedChoiceSet)>,
+    best_metric: Option<M>,
+    n_graphs: usize,
+    resample_generation: bool,
+    stagnant_generations: usize,
+    generation_found_non_timeout: bool,
+    generation_found_new_best: bool,
+    slower_since_faster: usize,
+    slower_line_visible: bool,
+}
+
+impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
+    /// `search_started_at` is the start of the whole compile, shared by
+    /// every bucket, against which `options.search_time_limit` is checked.
+    pub fn new(
+        space: &'a SearchSpace,
+        ctx: &'a BucketContext<'a>,
+        options: &'a CompileOptions,
+        search_started_at: Instant,
+    ) -> Self {
+        let search_log = options.search_log_enabled();
+        let bucket_progress = ctx.progress();
+        if search_log {
+            if let Some((index, n_buckets)) = bucket_progress {
+                println!(
+                    "   {:>6}  Group {}/{}: {}",
+                    "Search".cyan().bold(),
+                    index + 1,
+                    n_buckets,
+                    ctx.label(),
+                );
+            }
+        }
+        let max_filter_fails = options
+            .limit
+            .max(1)
+            .saturating_mul(options.generation_size.max(1))
+            .saturating_mul(100)
+            .max(10_000);
+        Self {
+            space,
+            ctx,
+            options,
+            extractor: LlirExtractor::new(ctx.egraph(), &space.ops),
+            profile_dyn_map: ctx.profile_dyn_map(options),
+            search_limit: count_choice_sets_up_to(ctx.egraph(), options.limit),
+            started_at: Instant::now(),
+            search_started_at,
+            search_log,
+            bars: ProgressBars::new(bucket_progress),
+            keep_pre_collapse: std::env::var_os("LLIR_DUMP_DIR").is_some(),
+            prev_selected: FxHashSet::default(),
+            explored_llir_hashes: FxHashSet::default(),
+            phase: Phase::Initial,
+            next_id: 0,
+            outstanding: None,
+            invalid_attempts: 0,
+            filter_fails: 0,
+            max_filter_fails,
+            last_filter_rejection: None,
+            n_timed_out: 0,
+            n_invalid_profile: 0,
+            pending: VecDeque::new(),
+            generation_open: false,
+            ranked: Vec::new(),
+            parents: Vec::new(),
+            best_metric: None,
+            n_graphs: 0,
+            resample_generation: false,
+            stagnant_generations: 0,
+            generation_found_non_timeout: false,
+            generation_found_new_best: false,
+            slower_since_faster: 0,
+            slower_line_visible: false,
+        }
+    }
+
+    pub fn bucket_context(&self) -> &'a BucketContext<'a> {
+        self.ctx
+    }
+
+    /// Dyn values candidates should be evaluated with.
+    pub fn profile_dyn_map(&self) -> &DynMap {
+        &self.profile_dyn_map
+    }
+
+    /// Best metric measured so far.
+    pub fn best(&self) -> Option<&M> {
+        self.best_metric.as_ref()
+    }
+
+    /// Candidates measured so far (the count the graph limit applies to).
+    pub fn measured(&self) -> usize {
+        self.n_graphs
+    }
+
+    fn time_limit_reached(&self) -> bool {
+        self.search_started_at.elapsed() >= self.options.search_time_limit
+    }
+
+    /// The next candidate to evaluate, or `None` once the graph limit, the
+    /// search time limit, or the space itself is exhausted. The previous
+    /// candidate must have been reported.
+    pub fn next_candidate(&mut self, rng: &mut dyn RngCore) -> Option<Candidate<M>> {
+        assert!(
+            self.outstanding.is_none(),
+            "report the outstanding candidate before requesting another"
+        );
+        loop {
+            match self.phase {
+                Phase::Done => return None,
+                Phase::Initial => {
+                    let mut generation =
+                        self.extractor
+                            .random_indexed_generation(1, &mut self.prev_selected, rng);
+                    let Some(genome) = generation.pop() else {
+                        panic_initial_filter_limit(
+                            self.filter_fails,
+                            self.last_filter_rejection.as_deref(),
+                        );
+                    };
+                    match self.extract(&genome) {
+                        Ok(Some((_, llir))) => return Some(self.hand_out(genome, llir, None)),
+                        Ok(None) => continue,
+                        Err(()) => {
+                            self.invalid_attempts += 1;
+                            if self.invalid_attempts > MAX_INVALID_INITIAL_ATTEMPTS {
+                                panic!(
+                                    "Failed to find a viable initial genome after {MAX_INVALID_INITIAL_ATTEMPTS} invalid attempts"
+                                );
+                            }
+                            continue;
+                        }
+                    }
+                }
+                Phase::Evolving => {
+                    if self.pending.is_empty() {
+                        if self.generation_open {
+                            self.close_generation();
+                        }
+                        if self.n_graphs >= self.search_limit || self.time_limit_reached() {
+                            self.finish();
+                            return None;
+                        }
+                        self.breed(rng);
+                        if self.pending.is_empty() {
+                            self.finish();
+                            return None;
+                        }
+                        self.generation_open = true;
+                    }
+                    if self.time_limit_reached() {
+                        self.close_generation();
+                        self.finish();
+                        return None;
+                    }
+                    let genome = self.pending.pop_front().unwrap();
+                    match self.extract(&genome) {
+                        Ok(Some((pre_collapse, llir))) => {
+                            return Some(self.hand_out(genome, llir, pre_collapse));
+                        }
+                        Ok(None) => continue,
+                        Err(()) => {
+                            if self.search_log {
+                                self.bars.redraw(self.n_graphs, self.search_limit);
+                            }
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Extract and unroll a genome. `Ok(None)` when the program was already
+    /// explored; `Err` when extraction or unrolling panicked.
+    #[allow(clippy::type_complexity)]
+    fn extract(
+        &mut self,
+        genome: &IndexedChoiceSet,
+    ) -> Result<Option<(Option<LLIRGraph>, LLIRGraph)>, ()> {
+        let keep_pre_collapse = self.keep_pre_collapse && self.phase == Phase::Evolving;
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let packed = self
+                .extractor
+                .extract_indexed_packed(genome, &self.space.custom_ops);
+            if !self.explored_llir_hashes.insert(packed.fingerprint()) {
+                return None;
+            }
+            let pre_collapse = keep_pre_collapse.then(|| packed.to_stable());
+            // Profile the deployment graph itself: fully unrolled. Every
+            // scaled-down proxy (collapsed bodies, trip-count differencing)
+            // leaked family-dependent costs and inverted rankings; measuring
+            // the real graph is slower per candidate but cannot misorder
+            // families.
+            Some((pre_collapse, unroll_packed_llir(packed)))
+        }));
+        match result {
+            Ok(extracted) => Ok(extracted),
+            Err(payload) => {
+                if self.phase == Phase::Evolving {
+                    crate::mask_events::CANDIDATE_PANIC
+                        .record_with(|| crate::mask_events::panic_payload(payload.as_ref()));
+                }
+                Err(())
+            }
+        }
+    }
+
+    fn hand_out(
+        &mut self,
+        genome: IndexedChoiceSet,
+        llir: LLIRGraph,
+        pre_collapse: Option<LLIRGraph>,
+    ) -> Candidate<M> {
+        let id = CandidateId(self.next_id);
+        self.next_id += 1;
+        self.outstanding = Some((id, genome));
+        // Losers are the most expensive candidates to evaluate: a candidate
+        // whose running metric is already `factor ×` worse than the best can
+        // stop early — its partial metric is ranked normally and cannot win.
+        let early_stop = self.best_metric.clone().zip(self.options.early_stop_factor);
+        Candidate {
+            id,
+            llir,
+            profile_dyn_map: self.profile_dyn_map.clone(),
+            early_stop,
+            pre_collapse,
+            timer: Instant::now(),
+        }
+    }
+
+    /// Report the outcome of the outstanding candidate.
+    pub fn report(&mut self, candidate: Candidate<M>, outcome: Outcome<M>) {
+        let (id, genome) = self
+            .outstanding
+            .take()
+            .expect("no outstanding candidate to report");
+        assert_eq!(
+            id, candidate.id,
+            "reported candidate is not the outstanding one"
+        );
+        let timed_out = self
+            .options
+            .candidate_timeout
+            .is_some_and(|timeout| candidate.timer.elapsed() >= timeout);
+        match self.phase {
+            Phase::Initial => self.report_initial(genome, candidate, outcome, timed_out),
+            Phase::Evolving => self.report_evolving(genome, candidate, outcome, timed_out),
+            Phase::Done => panic!("report after the search finished"),
+        }
+    }
+
+    fn report_initial(
+        &mut self,
+        genome: IndexedChoiceSet,
+        candidate: Candidate<M>,
+        outcome: Outcome<M>,
+        timed_out: bool,
+    ) {
+        match outcome {
+            // Runtime-rejected candidates are dry failures, not searched
+            // graphs: they are never ranked and do not count toward the
+            // graph search limit.
+            Outcome::Rejected(reason) => {
+                self.filter_fails += 1;
+                // Rejections are otherwise silent until the 10k-fail panic;
+                // surface them early — a structural rejection (e.g. every
+                // candidate over the memory cap) loops here for hours
+                // looking like a hang.
+                if self.filter_fails <= 5 || self.filter_fails % 100 == 0 {
+                    eprintln!(
+                        "   Search  initial-genome filter reject #{}: {reason}",
+                        self.filter_fails
+                    );
+                }
+                self.last_filter_rejection = Some(reason);
+                if self.filter_fails >= self.max_filter_fails {
+                    panic_initial_filter_limit(
+                        self.filter_fails,
+                        self.last_filter_rejection.as_deref(),
+                    );
+                }
+                return;
+            }
+            Outcome::Measured(metric, display) if !timed_out => {
+                log_best_llir(&candidate.llir, &format!("candidate=0 {display}"));
+                self.best_metric = Some(metric.clone());
+                self.ranked = vec![(metric.clone(), genome.clone())];
+                self.parents = vec![(metric, genome)];
+                self.n_graphs = 1;
+                if self.search_log {
+                    println!("   {:>6} {}", "Start".cyan().bold(), display);
+                    self.bars.render(self.n_graphs, self.search_limit);
+                }
+                self.phase = Phase::Evolving;
+                return;
+            }
+            Outcome::Measured(..) => self.n_timed_out += 1,
+            Outcome::Invalid(_) => self.n_invalid_profile += 1,
+        }
+        self.invalid_attempts += 1;
+        if self.invalid_attempts > MAX_INVALID_INITIAL_ATTEMPTS {
+            panic!(
+                "Failed to find a viable initial genome after {MAX_INVALID_INITIAL_ATTEMPTS} invalid attempts \
+                 (candidate_timed_out={} invalid_profile={})",
+                self.n_timed_out, self.n_invalid_profile
+            );
+        }
+    }
+
+    fn report_evolving(
+        &mut self,
+        genome: IndexedChoiceSet,
+        candidate: Candidate<M>,
+        outcome: Outcome<M>,
+        timed_out: bool,
+    ) {
+        let (new_metric, display_metric) = match outcome {
+            Outcome::Rejected(_) => return,
+            Outcome::Invalid(_) => {
+                self.n_graphs += 1;
+                if self.search_log {
+                    self.bars.redraw(self.n_graphs, self.search_limit);
+                }
+                return;
+            }
+            Outcome::Measured(metric, display) => {
+                self.n_graphs += 1;
+                if timed_out {
+                    if self.search_log {
+                        self.bars.redraw(self.n_graphs, self.search_limit);
+                    }
+                    return;
+                }
+                self.generation_found_non_timeout = true;
+                (metric, display)
+            }
+        };
+
+        let rank = self
+            .ranked
+            .iter()
+            .position(|(metric, _)| {
+                new_metric
+                    .partial_cmp(metric)
+                    .is_some_and(|ordering| ordering == std::cmp::Ordering::Less)
+            })
+            .unwrap_or(self.ranked.len());
+        self.ranked
+            .insert(rank, (new_metric.clone(), genome.clone()));
+
+        // Update parents list (keep top-N for next generation)
+        let dominated_by_all = self.parents.len() >= self.options.keep_best
+            && !self.parents.last().unwrap().0.gt(&new_metric);
+        if !dominated_by_all {
+            let pos = self
+                .parents
+                .iter()
+                .position(|(m, _)| {
+                    new_metric
+                        .partial_cmp(m)
+                        .is_some_and(|o| o == std::cmp::Ordering::Less)
+                })
+                .unwrap_or(self.parents.len());
+            self.parents.insert(pos, (new_metric.clone(), genome));
+            if self.parents.len() > self.options.keep_best {
+                self.parents.truncate(self.options.keep_best);
+            }
+        }
+
+        log_candidate_ops(
+            &candidate.llir,
+            &format!("cand={} {display_metric}", self.n_graphs),
+        );
+        let new_best = self
+            .best_metric
+            .as_ref()
+            .is_some_and(|best| best.gt(&new_metric));
+        if new_best {
+            self.generation_found_new_best = true;
+            self.best_metric = Some(new_metric);
+            log_best_llir(
+                &candidate.llir,
+                &format!("candidate={} {display_metric}", self.n_graphs),
+            );
+        }
+
+        let msg = if new_best {
+            self.slower_since_faster = 0;
+            format!("   {:>6} {display_metric}", "Faster".green().bold())
+        } else {
+            self.slower_since_faster += 1;
+            format!(
+                "   {:>6} x{}",
+                "Slower".yellow().bold(),
+                self.slower_since_faster
+            )
+        };
+        if self.search_log {
+            self.bars
+                .print_message(&msg, self.slower_line_visible && !new_best);
+            self.slower_line_visible = !new_best;
+            self.bars.render(self.n_graphs, self.search_limit);
+        }
+    }
+
+    /// End-of-generation bookkeeping: stagnation tracking and whether the
+    /// next generation resamples from fresh random genomes.
+    fn close_generation(&mut self) {
+        if self.generation_found_new_best {
+            self.stagnant_generations = 0;
+        } else {
+            self.stagnant_generations += 1;
+        }
+        // Every other stagnant generation past the threshold explores from
+        // fresh random genomes instead of the converged parents.
+        let stagnation_resample = self.options.restart_stagnation > 0
+            && self.stagnant_generations >= self.options.restart_stagnation
+            && self.stagnant_generations % 2 == 0;
+        self.resample_generation = !self.generation_found_non_timeout || stagnation_resample;
+        self.generation_found_non_timeout = false;
+        self.generation_found_new_best = false;
+        self.generation_open = false;
+    }
+
+    /// Generate the next generation's offspring from all parents, dividing
+    /// the remaining budget evenly.
+    fn breed(&mut self, rng: &mut dyn RngCore) {
+        let options = self.options;
+        let budget = (self.search_limit - self.n_graphs).min(options.generation_size);
+        let offspring = if self.resample_generation {
+            self.extractor
+                .random_indexed_generation(budget, &mut self.prev_selected, rng)
+        } else {
+            let per_parent = budget.div_ceil(self.parents.len());
+            let mut offspring = Vec::new();
+            for (_, parent_genome) in &self.parents {
+                let remaining = budget.saturating_sub(offspring.len());
+                if remaining == 0 {
+                    break;
+                }
+                // Stagnation kick: escaping a family basin needs multi-gene
+                // jumps, so mutation counts escalate with consecutive
+                // stagnant generations (capped 16x).
+                let kick = if options.restart_stagnation > 0
+                    && self.stagnant_generations >= options.restart_stagnation
+                {
+                    (1 + self.stagnant_generations - options.restart_stagnation).min(16)
+                } else {
+                    1
+                };
+                offspring.extend(self.extractor.extract_reachable_indexed_generation(
+                    parent_genome,
+                    per_parent.min(remaining),
+                    options.mutations * kick,
+                    &mut self.prev_selected,
+                    rng,
+                ));
+            }
+            offspring
+        };
+        self.pending.extend(offspring);
+    }
+
+    fn finish(&mut self) {
+        if self.phase == Phase::Done {
+            return;
+        }
+        let was_evolving = self.phase == Phase::Evolving;
+        self.phase = Phase::Done;
+        if self.search_log && was_evolving {
+            self.bars.clear();
+            println!(
+                "   {:>6}  in {}",
+                "Searched".green().bold(),
+                pretty_duration::pretty_duration(&self.started_at.elapsed(), None)
+            );
+        }
+    }
+
+    /// Finish the search (if the caller stopped early) and return every
+    /// measured genome, fastest first.
+    pub fn into_ranked(mut self) -> Ranked<M> {
+        assert!(
+            self.outstanding.is_none(),
+            "report the outstanding candidate before finishing the search"
+        );
+        if self.phase == Phase::Evolving && self.generation_open {
+            self.close_generation();
+        }
+        self.finish();
+        std::mem::take(&mut self.ranked)
+    }
+}

--- a/crates/luminal_cuda_lite_hlir/main_core/search/lattice.rs
+++ b/crates/luminal_cuda_lite_hlir/main_core/search/lattice.rs
@@ -1,0 +1,284 @@
+//! Best-first selection of one finalist per bucket under an aggregate
+//! constraint.
+//!
+//! Each bucket's finalists are individually viable, but a runtime may have
+//! resources (persistent buffers, retained kernels) that every retained
+//! bucket shares. [`BucketLattice`] walks the Cartesian lattice of per-bucket
+//! finalist ranks fastest-aggregate-first: [`BucketLattice::next`] proposes
+//! a set, the runtime validates it, and [`BucketLattice::reject`] opens the
+//! set's one-coordinate-slower successors — materializing deeper finalists
+//! only when a rejection actually reaches them.
+
+use std::fmt::Debug;
+use std::time::Instant;
+
+use colored::Colorize;
+use rustc_hash::FxHashSet;
+
+use super::finalist::{FinalistValidator, Finalists};
+use super::{BucketLLIR, BucketLLIRRef};
+use crate::graph::CompileOptions;
+
+/// Combines one metric per bucket into the value the lattice walk minimizes.
+pub type AggregateFn<'a, M> = Box<dyn Fn(&[M]) -> M + 'a>;
+
+/// One finalist rank per bucket, proposed by [`BucketLattice::next`].
+pub struct BucketSet {
+    /// Finalist index per bucket, in bucket order.
+    pub indices: Vec<usize>,
+    proposed_at: Instant,
+}
+
+pub struct BucketLattice<'a, M> {
+    buckets: Vec<Finalists<'a, M>>,
+    aggregate: AggregateFn<'a, M>,
+    options: &'a CompileOptions,
+    search_started_at: Instant,
+    search_log: bool,
+    initialized: bool,
+    frontier: Vec<(M, Vec<usize>)>,
+    visited: FxHashSet<Vec<usize>>,
+    attempts: usize,
+    rejections: usize,
+    last_rejection: Option<String>,
+    stopped_reason: Option<String>,
+}
+
+impl<'a, M: PartialOrd + Clone + Debug> BucketLattice<'a, M> {
+    /// `aggregate` combines one metric per bucket into the value the walk
+    /// minimizes. It must be coordinate-monotone: replacing any input with a
+    /// greater metric must not make the aggregate compare less.
+    pub fn new(
+        buckets: Vec<Finalists<'a, M>>,
+        aggregate: impl Fn(&[M]) -> M + 'a,
+        options: &'a CompileOptions,
+        search_started_at: Instant,
+    ) -> Self {
+        assert!(
+            !buckets.is_empty(),
+            "bucket lattice needs at least one bucket"
+        );
+        Self {
+            buckets,
+            aggregate: Box::new(aggregate),
+            options,
+            search_started_at,
+            search_log: options.search_log_enabled(),
+            initialized: false,
+            frontier: Vec::new(),
+            visited: FxHashSet::default(),
+            attempts: 0,
+            rejections: 0,
+            last_rejection: None,
+            stopped_reason: None,
+        }
+    }
+
+    /// Bucket sets proposed so far.
+    pub fn attempts(&self) -> usize {
+        self.attempts
+    }
+
+    pub fn rejections(&self) -> usize {
+        self.rejections
+    }
+
+    pub fn buckets(&self) -> &[Finalists<'a, M>] {
+        &self.buckets
+    }
+
+    fn label(&self, bucket_idx: usize) -> String {
+        self.buckets[bucket_idx].bucket_context().label()
+    }
+
+    fn metrics(&self, indices: &[usize]) -> M {
+        let metrics: Vec<M> = self
+            .buckets
+            .iter()
+            .zip(indices)
+            .map(|(bucket, &idx)| bucket.get(idx).metric.clone())
+            .collect();
+        (self.aggregate)(&metrics)
+    }
+
+    /// Materialize the fastest individually viable finalist of every bucket
+    /// to seed the walk. Slower finalists are extracted only when an
+    /// aggregate rejection makes their coordinate reachable.
+    fn initialize(&mut self, validate: &mut FinalistValidator<'_, M>) -> bool {
+        self.initialized = true;
+        for bucket_idx in 0..self.buckets.len() {
+            if !self.buckets[bucket_idx].ensure(0, validate) {
+                let message = self.buckets[bucket_idx].failure_message();
+                self.stopped_reason = Some(
+                    if self.buckets[bucket_idx].bucket_context().is_bucketed() {
+                        format!(
+                            "Failed to find a viable final graph for bucket {bucket_idx} ({}): {message}",
+                            self.label(bucket_idx)
+                        )
+                    } else {
+                        format!("Failed to find a viable final graph: {message}")
+                    },
+                );
+                return false;
+            }
+        }
+        let initial = vec![0usize; self.buckets.len()];
+        self.frontier = vec![(self.metrics(&initial), initial.clone())];
+        self.visited.insert(initial);
+        true
+    }
+
+    /// Propose the fastest unvisited bucket set. `validate` hard-filters
+    /// finalists that have to be materialized to get there. `None` when no
+    /// viable set remains or the search time limit expired; see
+    /// [`BucketLattice::failure_message`].
+    pub fn next(&mut self, validate: &mut FinalistValidator<'_, M>) -> Option<BucketSet> {
+        if !self.initialized && !self.initialize(validate) {
+            return None;
+        }
+        if self.attempts > 0 && self.search_started_at.elapsed() >= self.options.search_time_limit {
+            self.stopped_reason =
+                Some("search time limit expired during aggregate bucket finalization".to_string());
+            return None;
+        }
+        if self.frontier.is_empty() {
+            return None;
+        }
+        let best_pos = (1..self.frontier.len()).fold(0, |best, candidate| {
+            if self.frontier[candidate]
+                .0
+                .partial_cmp(&self.frontier[best].0)
+                .is_some_and(|ordering| ordering == std::cmp::Ordering::Less)
+            {
+                candidate
+            } else {
+                best
+            }
+        });
+        let (_, indices) = self.frontier.swap_remove(best_pos);
+        self.attempts += 1;
+        Some(BucketSet {
+            indices,
+            proposed_at: Instant::now(),
+        })
+    }
+
+    /// The proposed set's LLIRs, in bucket order.
+    pub fn llirs(&self, set: &BucketSet) -> Vec<BucketLLIRRef<'_>> {
+        self.buckets
+            .iter()
+            .zip(&set.indices)
+            .map(|(bucket, &idx)| bucket.bucket_context().llir_ref(&bucket.get(idx).llir))
+            .collect()
+    }
+
+    /// Whether `candidate_timeout` expired since the set was proposed.
+    pub fn timed_out(&self, set: &BucketSet) -> bool {
+        self.options
+            .candidate_timeout
+            .is_some_and(|timeout| set.proposed_at.elapsed() >= timeout)
+    }
+
+    /// The set is not viable together. Opens its one-coordinate successors.
+    pub fn reject(
+        &mut self,
+        set: BucketSet,
+        reason: String,
+        validate: &mut FinalistValidator<'_, M>,
+    ) {
+        self.rejections += 1;
+        crate::mask_events::AGGREGATE_REJECT.record();
+        if self.search_log {
+            println!(
+                "   {:>6}  aggregate reject per-bucket finalist ranks {:?}: {reason}",
+                "Search".yellow().bold(),
+                set.indices,
+            );
+        }
+        self.last_rejection = Some(reason);
+
+        // Any one-coordinate successor is the next possible slower
+        // combination. A visited set prevents duplicate lattice paths.
+        for bucket_idx in 0..self.buckets.len() {
+            let mut successor = set.indices.clone();
+            successor[bucket_idx] += 1;
+            if !self.visited.insert(successor.clone()) {
+                continue;
+            }
+            if !self.buckets[bucket_idx].ensure(successor[bucket_idx], validate) {
+                let bucket = &self.buckets[bucket_idx];
+                if bucket.stopped_reason.is_some()
+                    || bucket
+                        .last_rejection
+                        .as_deref()
+                        .is_some_and(|reason| reason.contains("timeout"))
+                {
+                    let message = bucket.failure_message();
+                    let label = self.label(bucket_idx);
+                    self.stopped_reason.get_or_insert_with(|| {
+                        format!("bucket {bucket_idx} ({label}) fallback stopped: {message}")
+                    });
+                }
+                continue;
+            }
+            let metric = self.metrics(&successor);
+            self.frontier.push((metric, successor));
+        }
+    }
+
+    /// The set is viable. Takes the selected finalists (dumping them under
+    /// `LLIR_DUMP_DIR`) as `(bucket_indices, representative_dyn_map, llir)`
+    /// per bucket.
+    pub fn select(self, set: BucketSet) -> Vec<BucketLLIR> {
+        self.select_with_genomes(set)
+            .into_iter()
+            .map(super::SelectedProgram::into_bucket_llir)
+            .collect()
+    }
+
+    pub fn select_with_genomes(self, set: BucketSet) -> Vec<super::SelectedProgram> {
+        if self.search_log && self.rejections > 0 {
+            println!(
+                "   {:>6}  aggregate fallback: selected per-bucket finalist ranks {:?} after {} rejection(s)",
+                "Search".yellow().bold(),
+                set.indices,
+                self.rejections,
+            );
+        }
+        self.buckets
+            .into_iter()
+            .zip(set.indices)
+            .map(|(bucket, idx)| {
+                let ctx = bucket.bucket_context();
+                let finalist = bucket.take(idx);
+                super::SelectedProgram {
+                    bucket_indices: ctx.bucket_indices().clone(),
+                    representative_dyn_map: ctx.representative_dyn_map.clone(),
+                    genome: finalist.genome,
+                    llir: finalist.llir,
+                }
+            })
+            .collect()
+    }
+
+    /// Why no viable set could be proposed.
+    pub fn failure_message(&self) -> String {
+        if !self.initialized
+            || self.attempts == 0 && self.frontier.is_empty() && self.rejections == 0
+        {
+            return self
+                .stopped_reason
+                .clone()
+                .unwrap_or_else(|| "no viable final graph".to_string());
+        }
+        let reason = self
+            .stopped_reason
+            .clone()
+            .or_else(|| self.last_rejection.clone())
+            .unwrap_or_else(|| "no aggregate candidate combinations remain".to_string());
+        format!(
+            "Failed to find a viable aggregate bucket set after {} rejections: {reason}",
+            self.rejections
+        )
+    }
+}

--- a/crates/luminal_cuda_lite_hlir/main_core/search/mod.rs
+++ b/crates/luminal_cuda_lite_hlir/main_core/search/mod.rs
@@ -1,0 +1,341 @@
+//! Everything after egglog saturation.
+//!
+//! Core stops at a [`SearchSpace`]: one saturated e-graph per dynamic-dim
+//! bucket combination. Choosing a program from it is the runtime's job
+//! ([`crate::op::Runtime::compile`]); this module is the toolkit a runtime
+//! can build that choice from, and core never invokes any of it:
+//!
+//! - [`extract_one`] / [`LlirExtractor`]: extraction. A runtime that does
+//!   not rank candidates (the reference runtime) needs nothing else.
+//! - [`GeneticSearch`]: Luminal's genetic search as a pull-style state
+//!   machine. The runtime asks for the next candidate, evaluates it however
+//!   it likes (profile it, statically cost it, look it up in a cache), and
+//!   reports the [`Outcome`]. The state machine owns generations, mutation,
+//!   dedup, budgets, and progress output.
+//! - [`Finalists`]: lazy re-extraction of ranked genomes into deployment
+//!   graphs under a hard filter.
+//! - [`BucketLattice`]: best-first selection of one finalist per bucket
+//!   under an aggregate constraint.
+//! - [`genetic_search`]: closure sugar composing the three above into the
+//!   stock strategy, for runtimes with nothing special to do between steps.
+
+pub mod diagnostics;
+pub mod finalist;
+pub mod genetic;
+pub mod lattice;
+pub mod packed;
+#[cfg(test)]
+mod tests;
+pub mod unroll;
+
+use std::sync::Arc;
+
+use rand::RngCore;
+use rustc_hash::FxHashMap;
+
+use crate::egglog_utils::SerializedEGraph;
+pub use crate::egglog_utils::{IndexedChoiceSet, LlirExtractor};
+pub use crate::graph::{BucketLLIR, BucketLLIRRef, DimBucket};
+use crate::graph::{CompileOptions, LLIRGraph};
+use crate::op::{EgglogOp, LLIROp};
+use crate::shape::{DynDimIntervals, DynMap, Symbol};
+pub use finalist::{Finalist, FinalistValidator, Finalists, PendingFinalist};
+pub use genetic::{Candidate, CandidateId, GeneticSearch, Outcome, Ranked};
+pub use lattice::{AggregateFn, BucketLattice, BucketSet};
+pub use packed::{LlirFingerprint, PackedLLIRGraph};
+pub use unroll::{collapse_loops_to_first_iter, unroll_loops_in_llir, unroll_packed_llir};
+
+pub struct SelectedProgram {
+    pub bucket_indices: DynMap,
+    pub representative_dyn_map: DynMap,
+    pub genome: IndexedChoiceSet,
+    pub llir: LLIRGraph,
+}
+
+impl SelectedProgram {
+    pub fn into_bucket_llir(self) -> BucketLLIR {
+        (self.bucket_indices, self.representative_dyn_map, self.llir)
+    }
+}
+
+/// What core hands the runtime: the saturated e-graph of every bucket
+/// combination plus everything needed to extract programs from them.
+#[derive(Debug)]
+pub struct SearchSpace {
+    /// One entry per bucket combination; exactly one when unbucketed.
+    pub buckets: Vec<BucketSearchSpace>,
+    /// Registered egglog ops (backend ops plus HLIR), used for extraction.
+    pub ops: Vec<Arc<Box<dyn EgglogOp>>>,
+    /// [`crate::graph::Graph::custom_ops`] resolved to LLIR at build time,
+    /// indexed by custom-op id.
+    pub custom_ops: Vec<LLIROp>,
+    /// Bucket definitions the space was built with. Empty when unbucketed.
+    pub dim_buckets: FxHashMap<Symbol, Vec<DimBucket>>,
+}
+
+/// The saturated e-graph for one bucket combination.
+#[derive(Debug)]
+pub struct BucketSearchSpace {
+    pub egraph: SerializedEGraph,
+    /// dim → index into `SearchSpace::dim_buckets[dim]`. Empty when
+    /// unbucketed.
+    pub bucket_indices: DynMap,
+    /// Dynamic-dim intervals saturation assumed for this bucket.
+    pub intervals: DynDimIntervals,
+}
+
+/// One bucket of a [`SearchSpace`] together with the dynamic-dim values a
+/// search should treat as representative of it.
+#[derive(Clone)]
+pub struct BucketContext<'a> {
+    pub space: &'a SearchSpace,
+    pub index: usize,
+    /// The base dyn map (after `search_dims`) with this bucket's
+    /// representative values applied.
+    pub representative_dyn_map: DynMap,
+}
+
+impl<'a> BucketContext<'a> {
+    pub fn bucket(&self) -> &'a BucketSearchSpace {
+        &self.space.buckets[self.index]
+    }
+
+    pub fn egraph(&self) -> &'a SerializedEGraph {
+        &self.bucket().egraph
+    }
+
+    pub fn bucket_indices(&self) -> &'a DynMap {
+        &self.bucket().bucket_indices
+    }
+
+    pub fn dim_buckets(&self) -> &'a FxHashMap<Symbol, Vec<DimBucket>> {
+        &self.space.dim_buckets
+    }
+
+    pub fn is_bucketed(&self) -> bool {
+        !self.space.dim_buckets.is_empty()
+    }
+
+    /// `(bucket index, bucket count)` for progress display when bucketed.
+    pub fn progress(&self) -> Option<(usize, usize)> {
+        self.is_bucketed()
+            .then_some((self.index, self.space.buckets.len()))
+    }
+
+    /// Human-readable label such as `s=1, c=[1,4096]@512`.
+    pub fn label(&self) -> String {
+        format_bucket_label(&self.space.dim_buckets, self.bucket_indices())
+    }
+
+    /// The representative dyn map with `options.profile_dims` applied — the
+    /// values a profiling search should execute candidates with.
+    pub fn profile_dyn_map(&self, options: &CompileOptions) -> DynMap {
+        let mut profile_dyn_map = self.representative_dyn_map.clone();
+        for (&dim, &value) in &options.profile_dims {
+            profile_dyn_map.insert(dim, value);
+        }
+        profile_dyn_map
+    }
+
+    /// Borrowed view of a selected LLIR for this bucket.
+    pub fn llir_ref<'l>(&'l self, llir: &'l LLIRGraph) -> BucketLLIRRef<'l> {
+        BucketLLIRRef {
+            bucket_indices: self.bucket_indices(),
+            representative_dyn_map: &self.representative_dyn_map,
+            llir,
+        }
+    }
+}
+
+impl SearchSpace {
+    /// One context per bucket, in bucket order. Representative dyn maps are
+    /// derived here, at search time, so `base_dyn_map` (the graph's dyn map
+    /// after `search_dims`) provides the values for unbucketed dimensions and
+    /// bucket representatives override it per bucket.
+    pub fn bucket_contexts(&self, base_dyn_map: &DynMap) -> Vec<BucketContext<'_>> {
+        self.buckets
+            .iter()
+            .enumerate()
+            .map(|(index, bucket)| {
+                let mut representative_dyn_map = base_dyn_map.clone();
+                let mut dims: Vec<_> = bucket.bucket_indices.iter().collect();
+                dims.sort_by_key(|(dim, _)| **dim);
+                for (dim, &bucket_idx) in dims {
+                    representative_dyn_map.insert(
+                        *dim,
+                        self.dim_buckets[dim][bucket_idx].representative_value(),
+                    );
+                }
+                BucketContext {
+                    space: self,
+                    index,
+                    representative_dyn_map,
+                }
+            })
+            .collect()
+    }
+}
+
+/// Cartesian product of bucket indices over all bucketed dims, in a stable
+/// order (dims sorted by name, earlier dims outermost). One empty map when
+/// there are no buckets.
+pub fn bucket_index_combinations(dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>) -> Vec<DynMap> {
+    let mut dims: Vec<(Symbol, &Vec<DimBucket>)> =
+        dim_buckets.iter().map(|(c, b)| (*c, b)).collect();
+    dims.sort_by_key(|(c, _)| *c);
+
+    let mut combos: Vec<DynMap> = vec![FxHashMap::default()];
+    for (dim, buckets) in &dims {
+        let mut new_combos = Vec::new();
+        for existing in &combos {
+            for bucket_idx in 0..buckets.len() {
+                let mut indices = existing.clone();
+                indices.insert(*dim, bucket_idx);
+                new_combos.push(indices);
+            }
+        }
+        combos = new_combos;
+    }
+    combos
+}
+
+/// Format a human-readable label for a bucket combination.
+pub fn format_bucket_label(
+    dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
+    bucket_indices: &DynMap,
+) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    let mut dims: Vec<_> = bucket_indices.iter().collect();
+    dims.sort_by_key(|(c, _)| **c);
+    for (dim, &idx) in dims {
+        let bucket = &dim_buckets[dim][idx];
+        if bucket.min == bucket.max {
+            parts.push(format!("{}={}", dim, bucket.min));
+        } else {
+            parts.push(format!(
+                "{}=[{},{}]@{}",
+                dim,
+                bucket.min,
+                bucket.max,
+                bucket.representative_value()
+            ));
+        }
+    }
+    parts.join(", ")
+}
+
+/// Extract one valid deployment graph from a bucket: a cycle-repaired random
+/// choice set, extracted and fully unrolled. Every extractable program is
+/// semantically equivalent by contract, so this is a complete "search" for a
+/// runtime that has nothing to rank on.
+pub fn extract_one(
+    space: &SearchSpace,
+    ctx: &BucketContext<'_>,
+    rng: &mut dyn RngCore,
+) -> LLIRGraph {
+    extract_one_selected(space, ctx, rng).llir
+}
+
+pub fn extract_one_selected(
+    space: &SearchSpace,
+    ctx: &BucketContext<'_>,
+    rng: &mut dyn RngCore,
+) -> SelectedProgram {
+    let mut extractor = LlirExtractor::new(ctx.egraph(), &space.ops);
+    let genome = extractor.random_indexed_choice(rng);
+    let llir = unroll_packed_llir(extractor.extract_indexed_packed(&genome, &space.custom_ops));
+    SelectedProgram {
+        bucket_indices: ctx.bucket_indices().clone(),
+        representative_dyn_map: ctx.representative_dyn_map.clone(),
+        genome,
+        llir,
+    }
+}
+
+/// The stock strategy: genetic search in every bucket, lazy finalists under
+/// `validate_finalist`, and best-first bucket-set selection under
+/// `validate_set`. Returns the selected LLIR per bucket; the caller loads it.
+///
+/// `state` is threaded through the closures so a runtime can pass `self`
+/// without three closures competing for one mutable borrow. Panics inside
+/// `evaluate`, `validate_finalist`, and `validate_set` are caught and
+/// treated as rejections, as the search always has.
+///
+/// Panics when no viable program (or bucket set) exists, with the same
+/// diagnostics the search has always produced.
+#[allow(clippy::too_many_arguments)]
+pub fn genetic_search<S, M>(
+    space: &SearchSpace,
+    dyn_map: &DynMap,
+    options: &CompileOptions,
+    rng: &mut dyn RngCore,
+    state: &mut S,
+    mut evaluate: impl FnMut(&mut S, &mut Candidate<M>, &BucketContext<'_>) -> Outcome<M>,
+    mut validate_finalist: impl FnMut(
+        &mut S,
+        &PendingFinalist<M>,
+        &BucketContext<'_>,
+    ) -> Result<(), String>,
+    mut validate_set: impl FnMut(&mut S, &[BucketLLIRRef<'_>]) -> Result<(), String>,
+    aggregate: impl Fn(&[M]) -> M,
+) -> Vec<BucketLLIR>
+where
+    M: PartialOrd + Clone + std::fmt::Debug,
+{
+    let search_started_at = std::time::Instant::now();
+    let contexts = space.bucket_contexts(dyn_map);
+    let mut finalists = Vec::with_capacity(contexts.len());
+    for ctx in &contexts {
+        let mut search = GeneticSearch::new(space, ctx, options, search_started_at);
+        while let Some(mut candidate) = search.next_candidate(rng) {
+            let outcome = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                evaluate(state, &mut candidate, ctx)
+            })) {
+                Ok(outcome) => outcome,
+                Err(payload) => {
+                    crate::mask_events::CANDIDATE_PANIC
+                        .record_with(|| crate::mask_events::panic_payload(payload.as_ref()));
+                    diagnostics::dump_failed_candidate(&candidate, &ctx.representative_dyn_map);
+                    Outcome::Rejected("candidate compile panicked".to_string())
+                }
+            };
+            search.report(candidate, outcome);
+        }
+        finalists.push(Finalists::new(
+            search.into_ranked(),
+            space,
+            ctx,
+            options,
+            search_started_at,
+        ));
+    }
+
+    let mut lattice = BucketLattice::new(finalists, aggregate, options, search_started_at);
+    loop {
+        let Some(set) = lattice.next(&mut |pending, ctx| validate_finalist(state, pending, ctx))
+        else {
+            panic!("{}", lattice.failure_message());
+        };
+        let refs = lattice.llirs(&set);
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| validate_set(state, &refs)))
+                .unwrap_or_else(|_| Err("aggregate bucket candidate filter panicked".to_string()));
+        drop(refs);
+        let result = if lattice.timed_out(&set) {
+            Err(format!(
+                "candidate timeout expired while filtering aggregate bucket set {}",
+                lattice.attempts()
+            ))
+        } else {
+            result
+        };
+        match result {
+            Ok(()) => return lattice.select(set),
+            Err(reason) => {
+                lattice.reject(set, reason, &mut |pending, ctx| {
+                    validate_finalist(state, pending, ctx)
+                });
+            }
+        }
+    }
+}

--- a/crates/luminal_cuda_lite_hlir/src/artifact.rs
+++ b/crates/luminal_cuda_lite_hlir/src/artifact.rs
@@ -1,0 +1,293 @@
+//! CUDA module artifact capture, serialization, and loading.
+
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use cudarc::driver::CudaContext;
+use luminal::op::IntoEgglogOp;
+use luminal::prelude::Graph;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{cuda_nvrtc_compile_options, loaded_nvrtc_version, runtime::CudaRuntimeImpl};
+
+thread_local! {
+    static MODULE_ARTIFACT_SESSION: RefCell<Option<Arc<Mutex<ModuleArtifact>>>> =
+        const { RefCell::new(None) };
+}
+
+const MODULE_ARTIFACT_VERSION: u32 = 2;
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+struct ModuleArtifactSignature {
+    target_arch: String,
+    nvrtc_options: Vec<String>,
+    nvrtc_version: Option<u32>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct SerializedModuleArtifact {
+    version: u32,
+    signature: ModuleArtifactSignature,
+    images: HashMap<String, String>,
+}
+
+pub(crate) struct ModuleArtifact {
+    signature: ModuleArtifactSignature,
+    images: HashMap<String, Vec<u8>>,
+    loading: bool,
+    capturing: bool,
+}
+
+pub(crate) enum ModuleImageLookup {
+    Compile,
+    Hit(Vec<u8>),
+    Missing { available: usize },
+}
+
+pub(crate) fn module_artifact_session(
+    ctx: &Arc<CudaContext>,
+    data: Option<&str>,
+) -> Result<Arc<Mutex<ModuleArtifact>>, String> {
+    let signature = module_artifact_signature(ctx)?;
+    let artifact = if let Some(data) = data {
+        deserialize_module_artifact(data, signature)?
+    } else {
+        ModuleArtifact {
+            signature,
+            images: HashMap::new(),
+            loading: false,
+            capturing: false,
+        }
+    };
+    Ok(Arc::new(Mutex::new(artifact)))
+}
+
+pub(crate) fn with_module_artifact_session<T>(
+    session: Arc<Mutex<ModuleArtifact>>,
+    run: impl FnOnce() -> T,
+) -> T {
+    struct SessionGuard(Option<Arc<Mutex<ModuleArtifact>>>);
+    impl Drop for SessionGuard {
+        fn drop(&mut self) {
+            MODULE_ARTIFACT_SESSION.with(|current| current.replace(self.0.take()));
+        }
+    }
+
+    let previous = MODULE_ARTIFACT_SESSION.with(|current| current.replace(Some(session)));
+    let _guard = SessionGuard(previous);
+    run()
+}
+
+pub(crate) fn serialize_module_artifact(session: &Mutex<ModuleArtifact>) -> String {
+    let artifact = session.lock().unwrap();
+    let serialized = SerializedModuleArtifact {
+        version: MODULE_ARTIFACT_VERSION,
+        signature: artifact.signature.clone(),
+        images: artifact
+            .images
+            .iter()
+            .map(|(key, image)| (key.clone(), BASE64.encode(image)))
+            .collect(),
+    };
+    serde_json::to_string(&serialized).unwrap()
+}
+
+pub(crate) fn module_artifact_is_loading(artifact: &Mutex<ModuleArtifact>) -> bool {
+    artifact.lock().unwrap().loading
+}
+
+pub(crate) fn begin_module_artifact_capture(artifact: &Mutex<ModuleArtifact>) {
+    let mut artifact = artifact.lock().unwrap();
+    artifact.images.clear();
+    artifact.loading = false;
+    artifact.capturing = true;
+}
+
+pub(crate) fn finish_module_artifact_capture(artifact: &Mutex<ModuleArtifact>) {
+    let mut artifact = artifact.lock().unwrap();
+    artifact.loading = true;
+    artifact.capturing = false;
+}
+
+/// Recompile the selected schedule into a fresh capture so rejected search
+/// candidates are not included in the saved artifact.
+pub(crate) fn capture_selected_schedule<O: IntoEgglogOp + 'static>(
+    graph: &mut Graph,
+    runtime: &mut CudaRuntimeImpl<O>,
+    artifact: &Mutex<ModuleArtifact>,
+) -> Result<(), String> {
+    if module_artifact_is_loading(artifact) {
+        return Ok(());
+    }
+
+    begin_module_artifact_capture(artifact);
+    runtime.clear_kernel_cache();
+    graph.load_selected_schedule(runtime)?;
+    finish_module_artifact_capture(artifact);
+    Ok(())
+}
+
+pub(crate) fn module_key(source: &str) -> String {
+    format!("{:x}", Sha256::digest(source.as_bytes()))
+}
+
+pub(crate) fn lookup_module_image(key: &str) -> ModuleImageLookup {
+    MODULE_ARTIFACT_SESSION.with(|current| {
+        let session = current.borrow();
+        let Some(session) = session.as_ref() else {
+            return ModuleImageLookup::Compile;
+        };
+        let artifact = session.lock().unwrap();
+        match artifact.images.get(key) {
+            Some(image) => ModuleImageLookup::Hit(image.clone()),
+            None if artifact.loading => ModuleImageLookup::Missing {
+                available: artifact.images.len(),
+            },
+            None => ModuleImageLookup::Compile,
+        }
+    })
+}
+
+pub(crate) fn record_module_image(key: &str, image: &[u8]) {
+    MODULE_ARTIFACT_SESSION.with(|current| {
+        if let Some(session) = current.borrow().as_ref() {
+            let mut artifact = session.lock().unwrap();
+            if artifact.capturing {
+                artifact.images.insert(key.to_owned(), image.to_vec());
+            }
+        }
+    });
+}
+
+fn module_artifact_signature(ctx: &Arc<CudaContext>) -> Result<ModuleArtifactSignature, String> {
+    let (major, minor) = ctx
+        .compute_capability()
+        .map_err(|error| error.to_string())?;
+    let target_arch = format!("sm_{major}{minor}");
+    Ok(ModuleArtifactSignature {
+        nvrtc_options: cuda_nvrtc_compile_options(&target_arch),
+        target_arch,
+        nvrtc_version: loaded_nvrtc_version(),
+    })
+}
+
+fn deserialize_module_artifact(
+    data: &str,
+    signature: ModuleArtifactSignature,
+) -> Result<ModuleArtifact, String> {
+    let serialized: SerializedModuleArtifact =
+        serde_json::from_str(data).map_err(|error| error.to_string())?;
+    if serialized.version != MODULE_ARTIFACT_VERSION {
+        return Err(format!(
+            "unsupported CUDA module artifact version {}, expected {}",
+            serialized.version, MODULE_ARTIFACT_VERSION
+        ));
+    }
+    if serialized.signature != signature {
+        return Err("CUDA module artifact is incompatible with this device".to_string());
+    }
+    let images = serialized
+        .images
+        .into_iter()
+        .map(|(key, image)| {
+            BASE64
+                .decode(image)
+                .map(|image| (key, image))
+                .map_err(|error| error.to_string())
+        })
+        .collect::<Result<_, _>>()?;
+    Ok(ModuleArtifact {
+        signature,
+        images,
+        loading: true,
+        capturing: false,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn signature() -> ModuleArtifactSignature {
+        ModuleArtifactSignature {
+            target_arch: "sm_90".to_string(),
+            nvrtc_options: vec!["--gpu-architecture=sm_90".to_string()],
+            nvrtc_version: Some(12080),
+        }
+    }
+
+    #[test]
+    fn module_artifact_round_trip() {
+        let session = Mutex::new(ModuleArtifact {
+            signature: signature(),
+            images: HashMap::from([("kernel".to_string(), vec![1, 2, 3])]),
+            loading: false,
+            capturing: false,
+        });
+
+        let data = serialize_module_artifact(&session);
+        let loaded = deserialize_module_artifact(&data, signature()).unwrap();
+
+        assert!(loaded.loading);
+        assert_eq!(loaded.images["kernel"], [1, 2, 3]);
+    }
+
+    #[test]
+    fn module_artifact_rejects_incompatible_device() {
+        let session = Mutex::new(ModuleArtifact {
+            signature: signature(),
+            images: HashMap::new(),
+            loading: false,
+            capturing: false,
+        });
+        let data = serialize_module_artifact(&session);
+        let mut incompatible = signature();
+        incompatible.target_arch = "sm_80".to_string();
+
+        assert!(deserialize_module_artifact(&data, incompatible).is_err());
+    }
+
+    #[test]
+    fn loaded_artifact_does_not_fall_back_to_compilation() {
+        let session = Arc::new(Mutex::new(ModuleArtifact {
+            signature: signature(),
+            images: HashMap::new(),
+            loading: true,
+            capturing: false,
+        }));
+
+        with_module_artifact_session(session, || {
+            assert!(matches!(
+                lookup_module_image("missing"),
+                ModuleImageLookup::Missing { available: 0 }
+            ));
+        });
+    }
+
+    #[test]
+    fn selected_capture_discards_search_candidates() {
+        let session = Mutex::new(ModuleArtifact {
+            signature: signature(),
+            images: HashMap::from([("candidate".to_string(), vec![1])]),
+            loading: false,
+            capturing: false,
+        });
+
+        begin_module_artifact_capture(&session);
+        {
+            let artifact = session.lock().unwrap();
+            assert!(artifact.images.is_empty());
+            assert!(artifact.capturing);
+        }
+
+        finish_module_artifact_capture(&session);
+        let artifact = session.lock().unwrap();
+        assert!(artifact.loading);
+        assert!(!artifact.capturing);
+    }
+}

--- a/crates/luminal_cuda_lite_hlir/src/dyn_backend.rs
+++ b/crates/luminal_cuda_lite_hlir/src/dyn_backend.rs
@@ -5,6 +5,12 @@ use luminal::dyn_backend::{BackendCompileArgs, DynBackend, compile_backend};
 use luminal::op::IntoEgglogOp;
 use luminal::prelude::*;
 
+use std::sync::{Arc, Mutex};
+
+use crate::artifact::{
+    ModuleArtifact, capture_selected_schedule, module_artifact_session, serialize_module_artifact,
+    with_module_artifact_session,
+};
 use crate::cudarc::driver::CudaContext;
 use crate::runtime::{CudaRuntimeImpl, DefaultCudaOps};
 
@@ -12,11 +18,15 @@ use crate::runtime::{CudaRuntimeImpl, DefaultCudaOps};
 pub struct CudaDynBackend<O = DefaultCudaOps> {
     pub runtime: CudaRuntimeImpl<O>,
     backend_name: &'static str,
+    module_artifact: Arc<Mutex<ModuleArtifact>>,
 }
 
 impl<O: IntoEgglogOp + 'static> DynBackend for CudaDynBackend<O> {
     fn name(&self) -> &str {
         self.backend_name
+    }
+    fn artifact_data(&self) -> Option<String> {
+        Some(serialize_module_artifact(&self.module_artifact))
     }
     fn device_type(&self) -> &str {
         "cuda"
@@ -110,25 +120,32 @@ pub fn cuda_factory_for<O: IntoEgglogOp + 'static>(
     let cuda_ctx = CudaContext::new(device_index).map_err(|e| format!("CUDA init failed: {e}"))?;
     let stream = cuda_ctx.default_stream();
     let external_cuda_graph = args.external_cuda_graph;
-    compile_backend::<CudaRuntimeImpl<O>>(
-        graph,
-        args,
-        || {
-            let mut runtime = CudaRuntimeImpl::<O>::initialize(stream);
-            runtime.set_external_cuda_graph(external_cuda_graph);
-            Ok(runtime)
-        },
-        |rt, node, bytes, _dtype| {
-            rt.set_data(node, bytes);
-        },
-        Some(&|rt, node, ptr, n| unsafe { rt.set_device_ptr(node, ptr, n) }),
-        |rt| {
-            Box::new(CudaDynBackend {
-                runtime: rt,
-                backend_name,
-            })
-        },
-    )
+    let module_artifact = module_artifact_session(&cuda_ctx, args.backend_artifact.as_deref())?;
+    let backend_artifact = Arc::clone(&module_artifact);
+    let capture_artifact = Arc::clone(&module_artifact);
+    with_module_artifact_session(module_artifact, || {
+        compile_backend::<CudaRuntimeImpl<O>>(
+            graph,
+            args,
+            || {
+                let mut runtime = CudaRuntimeImpl::<O>::initialize(stream);
+                runtime.set_external_cuda_graph(external_cuda_graph);
+                Ok(runtime)
+            },
+            |rt, node, bytes, _dtype| {
+                rt.set_data(node, bytes);
+            },
+            Some(&|rt, node, ptr, n| unsafe { rt.set_device_ptr(node, ptr, n) }),
+            |graph, rt| capture_selected_schedule(graph, rt, &capture_artifact),
+            |rt| {
+                Box::new(CudaDynBackend {
+                    runtime: rt,
+                    backend_name,
+                    module_artifact: backend_artifact,
+                })
+            },
+        )
+    })
 }
 
 pub type CudaLiteDynBackend = CudaDynBackend<DefaultCudaOps>;

--- a/crates/luminal_cuda_lite_hlir/src/kernel/fusion/region_codegen.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/fusion/region_codegen.rs
@@ -447,42 +447,24 @@ fn singleton_region(llir_graph: &LLIRGraph, fe_node: NodeIndex) -> Option<Region
 }
 
 fn compare_fusion_starts(llir_graph: &LLIRGraph, a: NodeIndex, b: NodeIndex) -> std::cmp::Ordering {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-
     let fusion_start = |node: NodeIndex| {
         let op = llir_graph[node].to_dialect::<dyn KernelOp>().unwrap();
         (***op).downcast_ref::<FusionStart>().unwrap()
     };
     let a_start = fusion_start(a);
     let b_start = fusion_start(b);
-    let hash = |start: &FusionStart| {
-        let mut hasher = DefaultHasher::new();
-        for stride in &start.strides {
-            stride.hash_intern_id(&mut hasher);
-        }
-        dtype_program_tag(start.dtype).hash(&mut hasher);
-        hasher.finish()
-    };
-    hash(a_start).cmp(&hash(b_start)).then_with(|| {
-        if a_start.dtype == b_start.dtype
-            && same_expression_slice(&a_start.strides, &b_start.strides)
-        {
-            return std::cmp::Ordering::Equal;
-        }
-        // Resolve the vanishingly rare identity-hash collision structurally.
-        a_start
-            .strides
-            .iter()
-            .map(|expression| expression.to_kernel())
-            .cmp(
-                b_start
-                    .strides
-                    .iter()
-                    .map(|expression| expression.to_kernel()),
-            )
-            .then_with(|| cuda_dtype(a_start.dtype).cmp(cuda_dtype(b_start.dtype)))
-    })
+    a_start
+        .strides
+        .iter()
+        .map(|expression| expression.to_kernel())
+        .cmp(
+            b_start
+                .strides
+                .iter()
+                .map(|expression| expression.to_kernel()),
+        )
+        .then_with(|| cuda_dtype(a_start.dtype).cmp(cuda_dtype(b_start.dtype)))
+        .then_with(|| a.index().cmp(&b.index()))
 }
 
 // =========================================================================
@@ -1453,6 +1435,31 @@ mod tests {
         assert!(source.contains("const float *in0"));
         assert!(!source.contains("in1"));
         assert!(source.contains("v_0 + v_0"));
+    }
+
+    #[test]
+    fn singleton_region_orders_inputs_by_structure() {
+        let shape = vec![8.into()];
+        let mut graph = LLIRGraph::default();
+        let indexed = graph.add_node(llir_of(FusionStart {
+            shape: shape.clone(),
+            strides: vec![IntExpr::from('z')],
+            dtype: DType::F32,
+        }));
+        let broadcast = graph.add_node(llir_of(FusionStart {
+            shape,
+            strides: vec![0.into()],
+            dtype: DType::F32,
+        }));
+
+        assert_eq!(
+            compare_fusion_starts(&graph, broadcast, indexed),
+            std::cmp::Ordering::Less,
+        );
+        assert_eq!(
+            compare_fusion_starts(&graph, indexed, broadcast),
+            std::cmp::Ordering::Greater,
+        );
     }
 
     #[test]

--- a/crates/luminal_cuda_lite_hlir/src/lib.rs
+++ b/crates/luminal_cuda_lite_hlir/src/lib.rs
@@ -3,6 +3,7 @@
 // `use luminal_cuda_lite::...` imports.
 extern crate self as luminal_cuda_lite;
 
+mod artifact;
 pub mod dyn_backend;
 pub mod host;
 pub mod kernel;
@@ -24,6 +25,7 @@ use cudarc::{cublaslt::CudaBlasLT, driver::CudaStream};
 #[cfg(test)]
 mod tests;
 
+use artifact::{ModuleImageLookup, lookup_module_image, module_key, record_module_image};
 use cudarc::{
     driver::{CudaContext, DriverError, sys as driver_sys},
     nvrtc::{
@@ -118,6 +120,10 @@ pub enum CudaModuleImageCompileFailure {
         error: NvrtcError,
     },
     NoModuleImageProduced,
+    ArtifactMiss {
+        key: String,
+        available: usize,
+    },
 }
 
 #[doc(hidden)]
@@ -146,6 +152,12 @@ impl std::fmt::Display for CudaModuleImageCompileError {
             }
             CudaModuleImageCompileFailure::NoModuleImageProduced => {
                 write!(f, ": NVRTC produced no CUBIN for the selected target")?;
+            }
+            CudaModuleImageCompileFailure::ArtifactMiss { key, available } => {
+                write!(
+                    f,
+                    ": CUBIN {key} is missing from the artifact ({available} saved)"
+                )?;
             }
         }
         if let Some(version) = self.driver_version {
@@ -522,6 +534,25 @@ pub fn compile_module_image_for_current_device<S: AsRef<str>>(
     })?;
     let target_arch = format!("sm_{major}{minor}");
     let nvrtc_options = cuda_nvrtc_compile_options(&target_arch);
+    let source = src.as_ref();
+    let module_key = module_key(source);
+    match lookup_module_image(&module_key) {
+        ModuleImageLookup::Hit(image) => return Ok(Ptx::from_binary(image)),
+        ModuleImageLookup::Missing { available } => {
+            return Err(build_module_image_compile_error(
+                Some(target_arch),
+                driver_version,
+                runtime_version,
+                &nvrtc_options,
+                None,
+                CudaModuleImageCompileFailure::ArtifactMiss {
+                    key: module_key,
+                    available,
+                },
+            ));
+        }
+        ModuleImageLookup::Compile => {}
+    }
 
     // NVRTC compile time grows super-linearly with source size. The active
     // runtime installs its configured budget around compilation; direct calls
@@ -612,6 +643,7 @@ pub fn compile_module_image_for_current_device<S: AsRef<str>>(
         ));
     }
 
+    record_module_image(&module_key, &cubin);
     Ok(Ptx::from_binary(cubin))
 }
 

--- a/crates/luminal_cuda_lite_hlir/src/runtime.rs
+++ b/crates/luminal_cuda_lite_hlir/src/runtime.rs
@@ -436,6 +436,7 @@ pub type DefaultCudaOps = (crate::kernel::Ops, crate::host::Ops);
 
 pub struct CudaRuntimeImpl<O> {
     _ops: PhantomData<fn() -> O>,
+    pub(crate) selected_schedule: Option<luminal::graph::SelectedSchedule>,
     // Shared state across all buckets
     // Keep this private: every mutation must go through the buffer APIs so
     // `changed_hlir` and resource-input validation stay in sync with the map.
@@ -571,6 +572,10 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
     /// caller-owned CUDA graph can capture them.
     pub fn set_external_cuda_graph(&mut self, enabled: bool) {
         self.external_cuda_graph = enabled;
+    }
+
+    pub(crate) fn clear_kernel_cache(&mut self) {
+        self.kernel_cache.clear();
     }
 
     fn select_execution_stream(&mut self, stream: Arc<CudaStream>) {
@@ -4857,6 +4862,7 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
             .expect("failed to create CUDA profiling end event");
         Self {
             _ops: PhantomData,
+            selected_schedule: None,
             hlir_buffers: FxHashMap::default(),
             hlir_host_mirrors: FxHashMap::default(),
             owned_stream: Arc::clone(&stream),
@@ -4907,9 +4913,21 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
         self.search_and_load(space, dyn_map, options, rng);
     }
 
+    fn selected_schedule(&self) -> Option<luminal::graph::SelectedSchedule> {
+        self.selected_schedule.clone()
+    }
+
     #[tracing::instrument(skip_all)]
     fn load_llir(&mut self, llir_graph: &LLIRGraph) {
         self.try_load_llir(llir_graph).unwrap();
+    }
+
+    fn load_llir_buckets(
+        &mut self,
+        dim_buckets: &FxHashMap<Symbol, Vec<DimBucket>>,
+        bucket_llirs: &[BucketLLIR],
+    ) {
+        CudaRuntimeImpl::load_llir_buckets(self, dim_buckets, bucket_llirs);
     }
 
     #[tracing::instrument(skip_all)]

--- a/crates/luminal_cuda_lite_hlir/src/search.rs
+++ b/crates/luminal_cuda_lite_hlir/src/search.rs
@@ -74,7 +74,9 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             };
             match compiled {
                 Ok(validated) => {
-                    let _selected = lattice.select(set);
+                    let selected = lattice.select_with_genomes(set);
+                    self.selected_schedule =
+                        luminal::graph::SelectedSchedule::from_search(space, &selected);
                     self.install_validated_bucket_set(&space.dim_buckets, validated)
                         .unwrap_or_else(|error| {
                             panic!("failed to install the selected CUDA bucket set: {error}")

--- a/crates/luminal_metal/src/dyn_backend.rs
+++ b/crates/luminal_metal/src/dyn_backend.rs
@@ -77,6 +77,7 @@ pub fn metal_factory(
             rt.set_data(node, bytes_to_reference_data(bytes, dtype));
         },
         None,
+        |_, _| Ok(()),
         |rt| Box::new(MetalDynBackend { runtime: rt }),
     )
 }

--- a/crates/luminal_python/rust/src/compiled_graph.rs
+++ b/crates/luminal_python/rust/src/compiled_graph.rs
@@ -10,6 +10,9 @@ use std::collections::HashMap;
 
 use crate::typed_data::TypedData;
 
+mod artifact;
+pub(crate) use artifact::load_compiled_artifact;
+
 /// Copy a CPU buffer into Rust-owned storage.
 ///
 /// PyTorch legitimately reports `data_ptr() == 0` for an empty tensor, so a
@@ -178,6 +181,9 @@ pub struct CompiledGraph {
     pub dim_bounds: DimBoundsMap,
     /// See [`GraphTranslation::writeback_outputs`].
     pub writeback_outputs: Vec<(usize, String)>,
+    tensor_sizes: HashMap<String, usize>,
+    external_cuda_graph: bool,
+    serializable: bool,
 }
 
 impl CompiledGraph {
@@ -213,6 +219,8 @@ impl CompiledGraph {
             tensor_sizes,
             device_ptrs,
         } = weight_data;
+        let serializable = weights.is_empty() && device_ptrs.is_empty();
+        let artifact_tensor_sizes = tensor_sizes.clone();
 
         // Build compile args from WeightData.
         let compile_args = BackendCompileArgs {
@@ -225,6 +233,7 @@ impl CompiledGraph {
                 .collect(),
             tensor_sizes,
             device_ptrs,
+            backend_artifact: None,
         };
 
         // Create backend via the factory directly
@@ -261,6 +270,9 @@ impl CompiledGraph {
             dim_param_map,
             dim_bounds,
             writeback_outputs,
+            tensor_sizes: artifact_tensor_sizes,
+            external_cuda_graph,
+            serializable,
         })
     }
 
@@ -295,6 +307,17 @@ impl CompiledGraph {
 
 #[pymethods]
 impl CompiledGraph {
+    #[pyo3(signature = (cache_key=None))]
+    fn serialize_artifact<'py>(
+        &self,
+        py: Python<'py>,
+        cache_key: Option<String>,
+    ) -> PyResult<Bound<'py, PyBytes>> {
+        let bytes = artifact::serialize(self, cache_key)
+            .map_err(pyo3::exceptions::PyRuntimeError::new_err)?;
+        Ok(PyBytes::new(py, &bytes))
+    }
+
     /// Get the list of input tensor names.
     #[getter]
     fn input_names(&self) -> Vec<String> {

--- a/crates/luminal_python/rust/src/compiled_graph/artifact.rs
+++ b/crates/luminal_python/rust/src/compiled_graph/artifact.rs
@@ -1,0 +1,209 @@
+//! Serialization and loading for compiled graph artifacts.
+
+use std::collections::HashMap;
+
+use luminal::{
+    dyn_backend::{BackendCompileArgs, BackendFactory},
+    prelude::*,
+    shape::IntExpr,
+};
+use pyo3::{prelude::*, types::PyCapsule};
+use serde::{Deserialize, Serialize};
+
+use super::{CompiledGraph, DimBoundsMap, DimParamMap};
+use crate::pt2_compiled_model::backend_factory;
+
+const ARTIFACT_SCHEMA_VERSION: u32 = 4;
+
+#[derive(Deserialize, Serialize)]
+struct CompiledArtifactData {
+    schema_version: u32,
+    #[serde(default, rename = "luminal_artifact_key")]
+    cache_key: Option<String>,
+    backend: String,
+    #[serde(default)]
+    backend_artifact: Option<String>,
+    device_index: Option<usize>,
+    external_cuda_graph: bool,
+    dyn_map: DynMap,
+    input_meta: Vec<(usize, String, DType)>,
+    tensor_sizes: HashMap<String, usize>,
+    tensor_ids: Vec<(String, usize)>,
+    input_names: Vec<String>,
+    input_dtypes: Vec<u32>,
+    output_names: Vec<String>,
+    output_ids: Vec<usize>,
+    output_shapes: Vec<Vec<usize>>,
+    output_shape_exprs: Vec<Vec<IntExpr>>,
+    output_dtypes: Vec<u32>,
+    input_shape_exprs: Vec<Vec<IntExpr>>,
+    dim_param_map: DimParamMap,
+    dim_bounds: DimBoundsMap,
+    writeback_outputs: Vec<(usize, String)>,
+    schedule: luminal::graph::SelectedSchedule,
+}
+
+pub(super) fn serialize(
+    graph: &CompiledGraph,
+    cache_key: Option<String>,
+) -> Result<Vec<u8>, String> {
+    if !graph.serializable {
+        return Err(
+            "compiled artifacts with bound weights or input pointers are not serializable"
+                .to_string(),
+        );
+    }
+    let schedule = graph
+        .graph
+        .selected_schedule()
+        .cloned()
+        .ok_or_else(|| "compiled graph has no selected schedule".to_string())?;
+    let mut input_meta = graph
+        .graph
+        .input_meta
+        .iter()
+        .map(|(node, (label, dtype))| (node.index(), label.clone(), *dtype))
+        .collect::<Vec<_>>();
+    input_meta.sort_by_key(|(node, _, _)| *node);
+    let mut tensor_ids = graph
+        .tensor_ids
+        .iter()
+        .map(|(name, node)| (name.clone(), node.index()))
+        .collect::<Vec<_>>();
+    tensor_ids.sort_by(|left, right| left.0.cmp(&right.0));
+
+    serde_json::to_vec(&CompiledArtifactData {
+        schema_version: ARTIFACT_SCHEMA_VERSION,
+        cache_key,
+        backend: graph.runtime.name().to_string(),
+        backend_artifact: graph.runtime.artifact_data(),
+        device_index: graph.runtime.device_index(),
+        external_cuda_graph: graph.external_cuda_graph,
+        dyn_map: graph.graph.dyn_map.clone(),
+        input_meta,
+        tensor_sizes: graph.tensor_sizes.clone(),
+        tensor_ids,
+        input_names: graph.input_names.clone(),
+        input_dtypes: graph.input_dtypes.clone(),
+        output_names: graph.output_names.clone(),
+        output_ids: graph.output_ids.iter().map(|node| node.index()).collect(),
+        output_shapes: graph.output_shapes.clone(),
+        output_shape_exprs: graph.output_shape_exprs.clone(),
+        output_dtypes: graph.output_dtypes.clone(),
+        input_shape_exprs: graph.input_shape_exprs.clone(),
+        dim_param_map: graph.dim_param_map.clone(),
+        dim_bounds: graph.dim_bounds.clone(),
+        writeback_outputs: graph.writeback_outputs.clone(),
+        schedule,
+    })
+    .map_err(|error| error.to_string())
+}
+
+fn deserialize(
+    bytes: &[u8],
+    factory: BackendFactory,
+    device_ptrs: HashMap<String, (u64, usize)>,
+    device_index: Option<usize>,
+    external_cuda_graph: bool,
+) -> Result<CompiledGraph, String> {
+    let serializable = device_ptrs.is_empty();
+    let artifact: CompiledArtifactData =
+        serde_json::from_slice(bytes).map_err(|error| error.to_string())?;
+    if artifact.schema_version != ARTIFACT_SCHEMA_VERSION {
+        return Err(format!(
+            "unsupported artifact schema {}, expected {}",
+            artifact.schema_version, ARTIFACT_SCHEMA_VERSION
+        ));
+    }
+    if artifact.device_index != device_index {
+        return Err(format!(
+            "artifact device {:?} does not match requested device {:?}",
+            artifact.device_index, device_index
+        ));
+    }
+    if artifact.external_cuda_graph != external_cuda_graph {
+        return Err("artifact CUDA graph mode does not match requested mode".to_string());
+    }
+
+    let input_meta = artifact
+        .input_meta
+        .iter()
+        .map(|(node, label, dtype)| (NodeIndex::new(*node), (label.clone(), *dtype)))
+        .collect();
+    let mut graph = Graph::from_selected_schedule(artifact.dyn_map, input_meta, artifact.schedule);
+    let runtime = luminal::dyn_backend::compile_backend_from_factory(
+        factory,
+        &mut graph,
+        BackendCompileArgs {
+            search_iters: 0,
+            device_index,
+            external_cuda_graph,
+            weights: Vec::new(),
+            tensor_sizes: artifact.tensor_sizes.clone(),
+            device_ptrs,
+            backend_artifact: artifact.backend_artifact,
+        },
+    )?;
+    if runtime.name() != artifact.backend {
+        return Err(format!(
+            "artifact backend '{}' does not match loaded backend '{}'",
+            artifact.backend,
+            runtime.name()
+        ));
+    }
+
+    let label_map = luminal::dyn_backend::build_label_map(&graph);
+    Ok(CompiledGraph {
+        graph,
+        runtime,
+        tensor_ids: artifact
+            .tensor_ids
+            .into_iter()
+            .map(|(name, node)| (name, NodeIndex::new(node)))
+            .collect(),
+        label_map,
+        input_names: artifact.input_names,
+        input_dtypes: artifact.input_dtypes,
+        output_names: artifact.output_names,
+        output_ids: artifact
+            .output_ids
+            .into_iter()
+            .map(NodeIndex::new)
+            .collect(),
+        output_shapes: artifact.output_shapes,
+        output_shape_exprs: artifact.output_shape_exprs,
+        output_dtypes: artifact.output_dtypes,
+        input_shape_exprs: artifact.input_shape_exprs,
+        dim_param_map: artifact.dim_param_map,
+        dim_bounds: artifact.dim_bounds,
+        writeback_outputs: artifact.writeback_outputs,
+        tensor_sizes: artifact.tensor_sizes,
+        external_cuda_graph,
+        serializable,
+    })
+}
+
+#[pyfunction]
+#[pyo3(signature = (
+    artifact,
+    factory_capsule,
+    weight_device_ptrs=None,
+    device_index=None,
+    external_cuda_graph=false,
+))]
+pub(crate) fn load_compiled_artifact(
+    artifact: &[u8],
+    factory_capsule: &Bound<'_, PyCapsule>,
+    weight_device_ptrs: Option<HashMap<String, (u64, usize)>>,
+    device_index: Option<usize>,
+    external_cuda_graph: bool,
+) -> PyResult<CompiledGraph> {
+    deserialize(
+        artifact,
+        backend_factory(factory_capsule)?,
+        weight_device_ptrs.unwrap_or_default(),
+        device_index,
+        external_cuda_graph,
+    )
+    .map_err(pyo3::exceptions::PyRuntimeError::new_err)
+}

--- a/crates/luminal_python/rust/src/lib.rs
+++ b/crates/luminal_python/rust/src/lib.rs
@@ -11,7 +11,7 @@ pub mod pt2_schema;
 mod pt2_util;
 pub mod translator;
 
-use compiled_graph::CompiledGraph;
+use compiled_graph::{CompiledGraph, load_compiled_artifact};
 use pt2_compiled_model::{TranslatedModule, process_pt2, translate_module};
 use pyo3::prelude::*;
 use pyo3::types::PyCapsule;
@@ -21,6 +21,7 @@ use torch_dtype::TorchDType;
 #[pymodule]
 pub fn luminal(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(process_pt2, m)?)?;
+    m.add_function(wrap_pyfunction!(load_compiled_artifact, m)?)?;
     m.add_function(wrap_pyfunction!(translate_module, m)?)?;
     m.add_class::<TranslatedModule>()?;
     m.add_class::<CompiledGraph>()?;

--- a/crates/luminal_python/rust/src/pt2_compiled_model.rs
+++ b/crates/luminal_python/rust/src/pt2_compiled_model.rs
@@ -145,41 +145,7 @@ pub fn process_pt2(
     device_index: Option<usize>,
     external_cuda_graph: bool,
 ) -> PyResult<CompiledGraph> {
-    let factory: BackendFactory = {
-        let expected = ::luminal::dyn_backend::BACKEND_FACTORY_CAPSULE_NAME;
-        match factory_capsule.name()? {
-            Some(name) => {
-                // SAFETY: the &CStr is used immediately (for a byte-wise
-                // comparison) and never stored; the capsule is borrowed for
-                // the duration of this function, so the name pointer stays
-                // valid for as long as we read it here.
-                let actual = unsafe { name.as_cstr() };
-                if actual != expected {
-                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                        "factory_capsule has wrong name: expected {:?}, got {:?}",
-                        expected, actual,
-                    )));
-                }
-            }
-            None => {
-                return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                    "factory_capsule has no name; expected {:?}",
-                    expected
-                )));
-            }
-        }
-        let wrapper_ptr = factory_capsule
-            .pointer_checked(Some(expected))
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("{e}")))?
-            .as_ptr() as *const *const std::ffi::c_void;
-        let fn_ptr = unsafe { *wrapper_ptr };
-        if fn_ptr.is_null() {
-            return Err(pyo3::exceptions::PyValueError::new_err(
-                "factory_capsule inner function pointer is null",
-            ));
-        }
-        unsafe { std::mem::transmute(fn_ptr) }
-    };
+    let factory = backend_factory(factory_capsule)?;
     compile_pt2(
         pt2_path,
         weights_path,
@@ -190,6 +156,39 @@ pub fn process_pt2(
         external_cuda_graph,
     )
     .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#}")))
+}
+
+pub(crate) fn backend_factory(factory_capsule: &Bound<'_, PyCapsule>) -> PyResult<BackendFactory> {
+    let expected = ::luminal::dyn_backend::BACKEND_FACTORY_CAPSULE_NAME;
+    match factory_capsule.name()? {
+        Some(name) => {
+            // SAFETY: the capsule owns its name for the duration of this call.
+            let actual = unsafe { name.as_cstr() };
+            if actual != expected {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "factory_capsule has wrong name: expected {:?}, got {:?}",
+                    expected, actual,
+                )));
+            }
+        }
+        None => {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "factory_capsule has no name; expected {:?}",
+                expected
+            )));
+        }
+    }
+    let wrapper_ptr = factory_capsule
+        .pointer_checked(Some(expected))
+        .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?
+        .as_ptr() as *const *const std::ffi::c_void;
+    let fn_ptr = unsafe { *wrapper_ptr };
+    if fn_ptr.is_null() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "factory_capsule inner function pointer is null",
+        ));
+    }
+    Ok(unsafe { std::mem::transmute::<*const std::ffi::c_void, BackendFactory>(fn_ptr) })
 }
 
 fn compile_pt2(

--- a/crates/luminal_python/src/luminal/__init__.py
+++ b/crates/luminal_python/src/luminal/__init__.py
@@ -2,14 +2,18 @@
 
 # Import Python components
 # Register DynamicCache pytree serialization once at import time
-from .artifact_cache import ArtifactCacheStats, artifact_cache_stats
+from .artifact_cache import (
+    ArtifactCacheStats,
+    artifact_cache_stats,
+    clear_artifact_cache,
+)
 from .cache_utils import _register_cache_serialization
 from .compiled_model import CompiledModel
 
 # Import Rust extension components (built by maturin)
 from .luminal import CompiledGraph, process_pt2
 from .main import luminal_backend, register_backend
-from .region_compile import compile_region
+from .region_compile import compile_region, load_region_artifact
 
 _register_cache_serialization()
 
@@ -18,9 +22,11 @@ __all__ = [
     "CompiledModel",
     "ArtifactCacheStats",
     "artifact_cache_stats",
+    "clear_artifact_cache",
     "luminal_backend",
     "register_backend",
     "CompiledGraph",
     "compile_region",
+    "load_region_artifact",
     "process_pt2",
 ]

--- a/crates/luminal_python/src/luminal/artifact_cache.py
+++ b/crates/luminal_python/src/luminal/artifact_cache.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import re
+import time
 from dataclasses import dataclass
 
 import torch
@@ -15,6 +17,11 @@ _SYMBOL = re.compile(r"\b[su]\d+\b")
 _artifacts: dict[str, CompiledArtifact] = {}
 _reuse_hits = 0
 _searches = 0
+_loads = 0
+_load_reuse_hits = 0
+_search_seconds = 0.0
+_load_seconds = 0.0
+_CACHE_KEY_FIELD = "luminal_artifact_key"
 
 
 @dataclass(frozen=True)
@@ -22,14 +29,19 @@ class ArtifactCacheStats:
     unique_artifacts: int
     reuse_hits: int
     searches: int
+    loads: int = 0
+    load_reuse_hits: int = 0
+    search_seconds: float = 0.0
+    load_seconds: float = 0.0
 
 
 class CompiledArtifact:
     """Compiled runtime shared by separate positional tensor bindings."""
 
-    def __init__(self, graph, weight_refs=()):
+    def __init__(self, graph, weight_refs=(), cache_key=None):
         self.graph = graph
         self.weight_refs = tuple(weight_refs)
+        self.cache_key = cache_key
         self._active_binding = None
 
     def bind(self, **kwargs):
@@ -44,6 +56,32 @@ class CompiledArtifact:
         changed = self._active_binding is not binding
         self._active_binding = binding
         return changed
+
+    def serialize(self) -> bytes:
+        if self.weight_refs:
+            raise RuntimeError(
+                "compiled artifacts with bound weights are not serializable"
+            )
+        return bytes(self.graph.serialize_artifact(self.cache_key))
+
+    @classmethod
+    def deserialize(
+        cls,
+        data,
+        factory,
+        *,
+        device_index=None,
+        external_cuda_graph=False,
+    ):
+        from .luminal import load_compiled_artifact
+
+        graph = load_compiled_artifact(
+            data,
+            factory,
+            device_index=device_index,
+            external_cuda_graph=external_cuda_graph,
+        )
+        return cls(graph)
 
 
 def region_artifact_key(program, **options) -> str | None:
@@ -108,23 +146,74 @@ def region_artifact_key(program, **options) -> str | None:
 
 
 def get_or_compile(key, compile_artifact):
-    global _reuse_hits, _searches
+    global _reuse_hits, _searches, _search_seconds
     artifact = _artifacts.get(key)
     if artifact is not None:
         _reuse_hits += 1
         return artifact
+    started = time.perf_counter()
     artifact = compile_artifact()
+    _search_seconds += time.perf_counter() - started
+    if isinstance(artifact, CompiledArtifact):
+        artifact.cache_key = key
     _artifacts[key] = artifact
     _searches += 1
     return artifact
 
 
+def get_or_load(data, load_artifact, **options):
+    """Load identical serialized artifacts only once per process."""
+
+    global _loads, _load_reuse_hits, _load_seconds
+
+    data = bytes(data)
+    payload = json.loads(data)
+    identity = payload.get(_CACHE_KEY_FIELD)
+    if identity is None:
+        identity = hashlib.sha256(data).hexdigest()
+
+    compatibility = (
+        payload.get("schema_version"),
+        payload.get("backend"),
+        payload.get("device_index"),
+        payload.get("external_cuda_graph"),
+    )
+    digest = hashlib.sha256(repr((identity, compatibility)).encode())
+    digest.update(repr(sorted(options.items())).encode())
+    key = f"loaded:{digest.hexdigest()}"
+
+    artifact = _artifacts.get(key)
+    if artifact is not None:
+        _load_reuse_hits += 1
+        return artifact
+
+    started = time.perf_counter()
+    artifact = load_artifact()
+    _load_seconds += time.perf_counter() - started
+    _loads += 1
+    _artifacts[key] = artifact
+    return artifact
+
+
 def artifact_cache_stats() -> ArtifactCacheStats:
-    return ArtifactCacheStats(len(_artifacts), _reuse_hits, _searches)
+    return ArtifactCacheStats(
+        len(_artifacts),
+        _reuse_hits,
+        _searches,
+        _loads,
+        _load_reuse_hits,
+        _search_seconds,
+        _load_seconds,
+    )
 
 
 def clear_artifact_cache() -> None:
-    global _reuse_hits, _searches
+    global _reuse_hits, _searches, _loads, _load_reuse_hits
+    global _search_seconds, _load_seconds
     _artifacts.clear()
     _reuse_hits = 0
     _searches = 0
+    _loads = 0
+    _load_reuse_hits = 0
+    _search_seconds = 0.0
+    _load_seconds = 0.0

--- a/crates/luminal_python/src/luminal/compiled_model.py
+++ b/crates/luminal_python/src/luminal/compiled_model.py
@@ -123,6 +123,11 @@ class CompiledModel:
         """Set a dynamic dimension value by its param name."""
         self._graph.set_dim(param_name, value)
 
+    def serialize_artifact(self) -> bytes:
+        if self._artifact is None:
+            raise RuntimeError("compiled model has no serializable artifact")
+        return self._artifact.serialize()
+
     @property
     def writeback_inputs(self) -> dict:
         """{output name: input name it writes back to} for the in-place input

--- a/crates/luminal_python/src/luminal/region_compile.py
+++ b/crates/luminal_python/src/luminal/region_compile.py
@@ -2,10 +2,20 @@
 
 from __future__ import annotations
 
-from .artifact_cache import region_artifact_key
+from .artifact_cache import CompiledArtifact, get_or_load, region_artifact_key
 from .compiled_model import CompiledModel
 from .pt2 import _save_and_compile
 from .region_export import RegionExport
+
+
+def _cuda_factory():
+    try:
+        from .luminal import _cuda_lite_factory_capsule
+    except (ImportError, AttributeError) as error:
+        raise RuntimeError(
+            "region compilation requires luminal_python built with CUDA support"
+        ) from error
+    return _cuda_lite_factory_capsule()
 
 
 def compile_region(
@@ -33,13 +43,6 @@ def compile_region(
             f"got {region.device_index}"
         )
 
-    try:
-        from .luminal import _cuda_lite_factory_capsule
-    except (ImportError, AttributeError) as error:
-        raise RuntimeError(
-            "region compilation requires luminal_python built with CUDA support"
-        ) from error
-
     artifact_key = region_artifact_key(
         region.program,
         device_type=device_type,
@@ -50,7 +53,7 @@ def compile_region(
 
     return _save_and_compile(
         region.program,
-        _cuda_lite_factory_capsule(),
+        _cuda_factory(),
         search_iterations,
         user_indices=region.input_indices,
         output_spec=region.output_spec,
@@ -60,4 +63,33 @@ def compile_region(
         static_outputs=static_outputs,
         external_cuda_graph=external_cuda_graph,
         artifact_key=artifact_key,
+    )
+
+
+def load_region_artifact(
+    data,
+    *,
+    input_indices,
+    output_spec,
+    device_index,
+    static_outputs=False,
+    external_cuda_graph=False,
+) -> CompiledModel:
+    artifact = get_or_load(
+        data,
+        lambda: CompiledArtifact.deserialize(
+            data,
+            _cuda_factory(),
+            device_index=device_index,
+            external_cuda_graph=external_cuda_graph,
+        ),
+        backend="cuda",
+        device_index=device_index,
+        external_cuda_graph=external_cuda_graph,
+    )
+    return artifact.bind(
+        user_indices=input_indices,
+        output_spec=output_spec,
+        use_current_stream=True,
+        static_outputs=static_outputs,
     )

--- a/crates/luminal_python/tests/test_region_compile.py
+++ b/crates/luminal_python/tests/test_region_compile.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import json
+import subprocess
+import sys
+import textwrap
 import time
 
 import pytest
@@ -8,15 +12,15 @@ from torch import fx
 
 import luminal.region_compile as region_compile_module
 from luminal.artifact_cache import (
-    ArtifactCacheStats,
     CompiledArtifact,
     artifact_cache_stats,
     clear_artifact_cache,
     get_or_compile,
+    get_or_load,
     region_artifact_key,
 )
 from luminal.compiled_model import CompiledModel
-from luminal.region_compile import compile_region
+from luminal.region_compile import compile_region, load_region_artifact
 from luminal.region_export import export_region
 
 
@@ -121,12 +125,140 @@ def test_artifact_cache_compiles_once() -> None:
     assert get_or_compile("region", compile_artifact) is artifact
     assert get_or_compile("region", compile_artifact) is artifact
     assert calls == 1
-    assert artifact_cache_stats() == ArtifactCacheStats(
-        unique_artifacts=1,
-        reuse_hits=1,
-        searches=1,
-    )
+    stats = artifact_cache_stats()
+    assert (stats.unique_artifacts, stats.reuse_hits, stats.searches) == (1, 1, 1)
+    assert stats.search_seconds > 0
     clear_artifact_cache()
+
+
+def test_region_artifact_loads_once_and_binds_each_model(monkeypatch) -> None:
+    clear_artifact_cache()
+    bindings = []
+
+    class Artifact:
+        def bind(self, **kwargs):
+            bindings.append(kwargs)
+            return len(bindings)
+
+    artifact = Artifact()
+    loads = 0
+
+    def deserialize(*args, **kwargs):
+        nonlocal loads
+        loads += 1
+        return artifact
+
+    monkeypatch.setattr(CompiledArtifact, "deserialize", deserialize)
+    monkeypatch.setattr(region_compile_module, "_cuda_factory", object)
+
+    common = {"device_index": 0, "external_cuda_graph": True}
+    assert (
+        load_region_artifact(b"{}", input_indices=(0,), output_spec="first", **common)
+        == 1
+    )
+    assert (
+        load_region_artifact(b"{}", input_indices=(1,), output_spec="second", **common)
+        == 2
+    )
+    assert loads == 1
+    assert [binding["user_indices"] for binding in bindings] == [(0,), (1,)]
+    stats = artifact_cache_stats()
+    assert (stats.loads, stats.load_reuse_hits) == (1, 1)
+    assert stats.load_seconds > 0
+    clear_artifact_cache()
+
+
+def test_loaded_artifact_uses_structural_identity() -> None:
+    clear_artifact_cache()
+    common = {
+        "luminal_artifact_key": "region",
+        "schema_version": 4,
+        "backend": "cuda_lite",
+    }
+    first = json.dumps({**common, "value": 1}).encode()
+    second = json.dumps({**common, "value": 2}).encode()
+    artifact = object()
+
+    assert get_or_load(first, lambda: artifact, device_index=0) is artifact
+    assert get_or_load(second, lambda: object(), device_index=0) is artifact
+    clear_artifact_cache()
+
+
+def test_loaded_artifact_identity_includes_compatibility() -> None:
+    clear_artifact_cache()
+    first = json.dumps(
+        {"luminal_artifact_key": "region", "schema_version": 4, "backend": "cuda_lite"}
+    ).encode()
+    second = json.dumps(
+        {"luminal_artifact_key": "region", "schema_version": 4, "backend": "reference"}
+    ).encode()
+    artifacts = [object(), object()]
+
+    assert get_or_load(first, lambda: artifacts[0]) is artifacts[0]
+    assert get_or_load(second, lambda: artifacts[1]) is artifacts[1]
+    clear_artifact_cache()
+
+
+def test_compiled_artifact_serializes_structural_identity() -> None:
+    clear_artifact_cache()
+
+    class Graph:
+        def serialize_artifact(self, cache_key=None):
+            return json.dumps({"luminal_artifact_key": cache_key}).encode()
+
+    graph = Graph()
+    artifact = get_or_compile("region", lambda: CompiledArtifact(graph))
+
+    assert json.loads(artifact.serialize())["luminal_artifact_key"] == "region"
+    clear_artifact_cache()
+
+
+def test_compiled_artifact_round_trip_cpu() -> None:
+    from luminal.luminal import _reference_factory_capsule
+    from luminal.pt2 import compile as luminal_compile
+
+    inputs = [torch.randn(2, 4), torch.randn(2, 4)]
+    compiled = luminal_compile(_add_graph(), inputs, search_iterations=1)
+    loaded = CompiledArtifact.deserialize(
+        compiled.serialize_artifact(),
+        _reference_factory_capsule(),
+    ).bind()
+
+    (actual,) = loaded(*inputs)
+    torch.testing.assert_close(actual, inputs[0] + inputs[1])
+
+
+def test_compiled_artifact_rejects_bound_weights() -> None:
+    from luminal.pt2 import compile as luminal_compile
+
+    class Weighted(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.register_buffer("weight", torch.randn(4))
+
+        def forward(self, value):
+            return value * self.weight
+
+    compiled = luminal_compile(Weighted(), [torch.randn(4)], search_iterations=1)
+
+    with pytest.raises(RuntimeError, match="bound weights"):
+        compiled.serialize_artifact()
+
+
+def test_compiled_artifact_rejects_old_schema() -> None:
+    from luminal.luminal import _reference_factory_capsule
+    from luminal.pt2 import compile as luminal_compile
+
+    inputs = [torch.randn(2, 4), torch.randn(2, 4)]
+    compiled = luminal_compile(_add_graph(), inputs, search_iterations=1)
+    artifact = json.loads(compiled.serialize_artifact())
+    artifact["schema_version"] = 1
+
+    with pytest.raises(RuntimeError, match="unsupported artifact schema 1"):
+        CompiledArtifact.deserialize(
+            json.dumps(artifact).encode(),
+            _reference_factory_capsule(),
+        )
 
 
 def test_shared_artifact_rebinds_inputs_between_models() -> None:
@@ -348,6 +480,100 @@ def test_compile_region_from_fake_cuda_metadata() -> None:
     ]
     (actual,) = compiled(*real_inputs)
     torch.testing.assert_close(actual, real_inputs[0] + real_inputs[1])
+
+
+@pytest.mark.skipif(
+    _CUDA_SKIP_REASON is not None, reason=_CUDA_SKIP_REASON or "CUDA is unavailable"
+)
+def test_region_artifact_round_trip_without_cuda_recompile() -> None:
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        fake_inputs = [
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+        ]
+        region = export_region(_add_graph(), fake_inputs)
+
+    compiled = compile_region(region, search_iterations=1)
+    artifact = compiled.serialize_artifact()
+    payload = json.loads(artifact)
+    assert payload["schema_version"] == 4
+    backend_artifact = json.loads(payload["backend_artifact"])
+    assert backend_artifact["version"] == 2
+    assert backend_artifact["images"]
+    loaded = load_region_artifact(
+        artifact,
+        input_indices=region.input_indices,
+        output_spec=region.output_spec,
+        device_index=region.device_index,
+    )
+    inputs = [torch.randn((2, 4), device="cuda", dtype=torch.float16) for _ in range(2)]
+
+    (actual,) = loaded(*inputs)
+    torch.testing.assert_close(actual, inputs[0] + inputs[1])
+
+
+@pytest.mark.skipif(
+    _CUDA_SKIP_REASON is not None, reason=_CUDA_SKIP_REASON or "CUDA is unavailable"
+)
+def test_region_artifact_loads_in_fresh_process(tmp_path) -> None:
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        fake_inputs = [
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+            torch.empty((2, 4), device="cuda", dtype=torch.float16),
+        ]
+        region = export_region(_add_graph(), fake_inputs)
+
+    artifact_path = tmp_path / "region.luminal"
+    artifact_path.write_bytes(
+        compile_region(region, search_iterations=1).serialize_artifact()
+    )
+    script = textwrap.dedent(
+        """
+        import sys
+        from pathlib import Path
+
+        import torch
+        from torch import fx
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from luminal.region_compile import load_region_artifact
+        from luminal.region_export import export_region
+
+        graph = fx.Graph()
+        left = graph.placeholder("left")
+        right = graph.placeholder("right")
+        result = graph.call_function(torch.ops.aten.add.Tensor, (left, right))
+        graph.output((result,))
+        module = fx.GraphModule(torch.nn.Module(), graph)
+        with FakeTensorMode():
+            fake_inputs = [
+                torch.empty((2, 4), device="cuda", dtype=torch.float16),
+                torch.empty((2, 4), device="cuda", dtype=torch.float16),
+            ]
+            region = export_region(module, fake_inputs)
+        model = load_region_artifact(
+            Path(sys.argv[1]).read_bytes(),
+            input_indices=region.input_indices,
+            output_spec=region.output_spec,
+            device_index=region.device_index,
+        )
+        inputs = [
+            torch.randn((2, 4), device="cuda", dtype=torch.float16)
+            for _ in range(2)
+        ]
+        (actual,) = model(*inputs)
+        torch.testing.assert_close(actual, inputs[0] + inputs[1])
+        """
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", script, str(artifact_path)],
+        check=True,
+        text=True,
+    )
 
 
 @pytest.mark.skipif(

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -52,6 +52,7 @@ Dispositions:
 | `f285d229` | #420 | Move post-saturation search into the runtime | FILE-LEVEL (3 files into the `cuda_lite_hlir` park + 1 metal-park file) + INTENT-ONLY (15 core/doc files, nothing applied) + DROPPED (all loop unroll / roll / packed machinery, main's `Runtime` trait shape) | branch `rejoin/p0-record-and-park` | RULED 2026-09-03: *"we're going to ignore all the loop unrolling, loop rolling stuff, but we're going to follow all the other aspects and move all of that functionality out of core and into the runtimes."* The boundary move is the program's thesis and lands in later phases; THIS row is record-and-park — see **#420 search into the runtime** below |
 | `598e5ca7` | #422 | Share reusable CUDA runtime through Lite | FILE-LEVEL (41 files into the `cuda_lite_hlir` park, incl. 5 deletions + 1 non-gating `ci/` file) + INTENT-ONLY at walk — DELIVERED by Phase 3 (arena) and PARTIALLY by Phase 2 (runtime-configurable op/matcher selection: the registry half; the execution face still PUNTED) + PUNTED-TO-PARK (fusion, attention, cuda-heavy composition) + DROPPED (the `subsume` fusion rule and the four `delete` rules, `CudaRuntimeImpl<O>`) | branch `rejoin/p0-record-and-park` | RULED 2026-09-03: *"put these fusion changes in hlir and punt on them temporarily"*, *"we're going to copy it into the hlir folder and then actually implement it once we're caught up"* (attention/FA3), *"Update the hlir_folder so we have a record of what the target code looks like"* (full-CUDA downstream), *"no code for now"* (zero-copy rebinding) — see **#422 reusable CUDA runtime** below |
 | `e7f9127a` | #430 | Restore CUDA dyn dims buffer on graph rebuild | FILE-LEVEL (1 file into the `cuda_lite_hlir` park) | branch `merge/main-430-487-cuda-graph-parks` (1st commit) | — nothing live corresponds: this branch's `crates/luminal_cuda_lite` captures no CUDA graphs at all, so there is no rebuild path to fix — see **#430 dyn-dims on rebuild** below, which says that once for the whole eight-commit line |
+| `188e92e8` | #435 | Add persistent compiled artifact reuse for Python and CUDA backends | FILE-LEVEL (7 files into the `cuda_lite_hlir` park + 1 metal-park file + 9 python-park files, 2 re-spelled `Expression` -> `IntExpr`) + FULL-FILE PARK (11 core files, post-#435, into `crates/luminal_cuda_lite_hlir/main_core/`) | branch `merge/main-cuda-graph-line-parks-wip` (2nd commit) | **PARITY REQUIRED — LUM-806** (https://linear.app/luminalai/issue/LUM-806). RULED 2026-09-04: *"you'll have to park it in the HLIR copy and then record that we need to get to feature parity for this. It is something we absolutely need to have eventually."* A compiled artifact must persist the SELECTED SCHEDULE so a fresh process runs without re-running the genetic search — see **#435 persistent compiled artifacts** below |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -4029,6 +4030,48 @@ park TRACKS so the target CL must eventually reach keeps moving. When CL grows
 graph capture, this section and the seven below it are the list of hazards main
 has already paid for; until then they are records only, and nothing here is
 compiled — `crates/luminal_cuda_lite_hlir` is not a workspace member.
+
+## #435 persistent compiled artifacts — parked whole, parity owed (LUM-806)
+
+Main's `188e92e8` (28 files, +1526/-132) makes a compiled graph SURVIVE THE
+PROCESS: core gains `src/graph/artifact.rs` and a `SelectedSchedule` — per
+dyn-dim bucket, the saturated program's identity plus the chosen genome — that
+serializes beside the backend's own artifact (`crates/luminal_cuda_lite/src/artifact.rs`),
+so a later run deserializes the schedule, rebuilds the plan and executes it
+instead of re-running the genetic search; the Python side keys and reuses those
+artifacts across FX regions (`artifact_cache.py`, `region_compile.py`,
+`rust/src/compiled_graph/artifact.rs`, schema version 4). Seventeen of its
+twenty-eight files are park files and applied cleanly — 7 path-rewritten from
+main's `crates/luminal_cuda_lite/` into `crates/luminal_cuda_lite_hlir/`, 1
+metal-park signature line, 9 python-park files — with two lines re-spelled to
+the parks' vocabulary (`Expression` -> `IntExpr` in
+`crates/luminal_cuda_lite_hlir/src/kernel/fusion/region_codegen.rs:1446` and
+three times in the new `crates/luminal_python/rust/src/compiled_graph/artifact.rs`);
+the diff-of-diffs over the crates half is identical to main's hunk set modulo
+exactly those two respellings. The other eleven files are main's CORE
+(`src/{dtype,dyn_backend,hlir,op,graph}.rs`, `src/graph/artifact.rs`,
+`src/egglog_utils/mod.rs`, `src/search/{mod,finalist,genetic,lattice}.rs`) and
+no diff can apply: on this branch `hlir.rs`, `op.rs`, `dyn_backend.rs`,
+`egglog_utils/` and the whole `src/search/` tree are DELETED, and `graph.rs` and
+`dtype.rs` are different files (the recorder, and this branch's dtype ontology),
+so per Austin's ruling the post-#435 FULL FILES are parked verbatim under
+`crates/luminal_cuda_lite_hlir/main_core/` at main's relative paths — a record,
+documented in that crate's README, compiled by nothing and touching no live file.
+
+**THE PARITY REQUIREMENT (Austin, 2026-09-04 — LUM-806).** This branch must
+eventually ship a compiled artifact that persists the selected schedule: per
+bucket, the saturated program's identity or fingerprint plus the chosen
+genome/plan, such that a fresh process loads it and runs without re-running the
+genetic search. Where it attaches here is already visible: the runtime-owned
+search outcome is `crates/luminal_cuda_lite`'s `CudaPlan`
+(`crates/luminal_cuda_lite/src/lib.rs:90`, held as `FinalistEntry::plan` in
+`finalists.rs:73`), with the reference runtime's plan as its mirror, and the
+selection itself is core's shared `luminal::extraction::Genome`
+(`src/extraction.rs:538`) — a `HashMap<ClassId, ProducerChoice>` keyed by class
+NAME, not by a positional index, so no index-determinism fix is owed for the
+serialization itself. (Whether those class names reproduce across processes is
+the separate, already-recorded class-id stability question, and it is the first
+thing a schedule-loading implementation has to answer.)
 
 ## #406 pad — the select construction REVERTED (2026-09-03)
 


### PR DESCRIPTION
Main's 188e92e8 makes a compiled graph survive the process. Core gains a
SelectedSchedule -- per dyn-dim bucket, the saturated program's identity plus
the chosen genome -- serialized beside the backend's own artifact, so a later
run rebuilds the plan instead of re-running the genetic search; the Python side
keys and reuses those artifacts across FX regions at schema version 4.

Seventeen of its twenty-eight files are park files and applied cleanly: 7
path-rewritten into crates/luminal_cuda_lite_hlir, 1 metal-park signature line,
9 python-park files. Two lines needed the parks' vocabulary -- Expression ->
IntExpr in the hlir park's kernel/fusion/region_codegen.rs and three times in
the new python-park compiled_graph/artifact.rs. Diff-of-diffs over the crates
half: identical to main's hunk set modulo exactly those respellings.

The other eleven files are main's core and no diff can apply -- hlir.rs, op.rs,
dyn_backend.rs, egglog_utils/ and the whole src/search/ tree are deleted here,
and graph.rs and dtype.rs are different files. Per Austin ("you'll have to park
it in the HLIR copy and then record that we need to get to feature parity for
this. It is something we absolutely need to have eventually.") the post-#435
full files are parked under crates/luminal_cuda_lite_hlir/main_core/ at main's
relative paths, a record documented in that crate's README, compiled by nothing.

The parity requirement is LUM-806, written into the ledger with its attach
points: the runtime search outcome is CudaPlan (finalists.rs FinalistEntry), the
reference runtime's plan mirrors it, and the selection is core's shared
luminal::extraction::Genome, a HashMap<ClassId, ProducerChoice> keyed by class
name rather than positional index -- so no index-determinism fix is owed for the
serialization, only the already-recorded class-id stability question.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
(cherry picked from commit 66328f45852147f7cdf93739a0adb462f8288d2c)

Stacked on \`merge/main-430-cuda-dyn-dims-on-graph-rebuild\`. One main commit, parked/recorded per the ledger row and section in this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)