### PR TITLE
Signed integral pow (#437): banked; the frontend defect fixed in #491

### DIFF
--- a/crates/luminal_python/rust/src/translator/binary.rs
+++ b/crates/luminal_python/rust/src/translator/binary.rs
@@ -234,6 +234,50 @@ impl<'a> Translator<'a> {
         Ok(result)
     }
 
+    pub(crate) fn translate_tensor_scalar_pow(&mut self, node: &Node) -> Result<GraphTensor> {
+        let output_dtype = self.output_meta_dtype(node)?;
+        let base = self.get_input_tensor(node, 0)?.cast(output_dtype);
+        let exponent = self.get_float_arg(node, 1)?;
+
+        // GraphTensor::pow implements the general real-valued approximation
+        // through abs(base).log(), which loses the sign of negative bases.
+        // Integral scalar exponents have exact multiplication semantics, so
+        // lower them structurally and preserve odd-power signs. Exponentiation
+        // by squaring keeps the graph logarithmic in the exponent.
+        if exponent.is_finite() && exponent.fract() == 0.0 && exponent.abs() < i64::MAX as f64 {
+            let exponent = exponent as i64;
+            if exponent == 0 {
+                return Ok(self.constant_like(base, 1.0));
+            }
+
+            let reciprocal = exponent < 0;
+            let mut remaining = exponent.unsigned_abs();
+            let mut factor = base;
+            let mut result = None;
+            while remaining > 0 {
+                if remaining & 1 == 1 {
+                    result = Some(match result {
+                        Some(value) => value * factor,
+                        None => factor,
+                    });
+                }
+                remaining >>= 1;
+                if remaining > 0 {
+                    factor = factor * factor;
+                }
+            }
+
+            let result = result.expect("nonzero integral exponent must produce a power");
+            return Ok(if reciprocal {
+                result.reciprocal()
+            } else {
+                result
+            });
+        }
+
+        Ok(base.pow(exponent as f32))
+    }
+
     /// Lower boolean OR through numeric HLIR ops until HLIR has native logical ops.
     pub(crate) fn apply_bool_or(&mut self, a: GraphTensor, b: GraphTensor) -> GraphTensor {
         let a = a.cast(DType::F32);

--- a/crates/luminal_python/rust/src/translator/dispatch.rs
+++ b/crates/luminal_python/rust/src/translator/dispatch.rs
@@ -408,15 +408,7 @@ impl<'a> Translator<'a> {
             "torch.ops.aten.masked_fill.Scalar" => self.translate_masked_fill_scalar(node)?,
 
             // Pow
-            "torch.ops.aten.pow.Tensor_Scalar" => {
-                let a = self.get_input_tensor(node, 0)?;
-                let exp = self.get_float_arg(node, 1)?;
-                if (exp - 2.0).abs() < f64::EPSILON {
-                    a * a
-                } else {
-                    a.pow(exp as f32)
-                }
-            }
+            "torch.ops.aten.pow.Tensor_Scalar" => self.translate_tensor_scalar_pow(node)?,
             "torch.ops.aten.pow.Tensor_Tensor" => {
                 let a = self.get_input_tensor(node, 0)?;
                 let b = self.get_input_tensor(node, 1)?;

--- a/crates/luminal_python/tests/test_hlir_ops.py
+++ b/crates/luminal_python/tests/test_hlir_ops.py
@@ -85,6 +85,7 @@ from test_models import (
     # GELU models
     GeluTestModel,
     GeluTanhModel,
+    Gpt2ApproxGeluModel,
     LinearGeluBatchedModel,
     # LayerNormalization model
     ConvGroupNormSiLUModel,
@@ -125,6 +126,7 @@ from test_models import (
     # Or model
     OrTestModel,
     PowByConstantModel,
+    PowByScalarModel,
     # Pow models
     PowTestModel,
     ReduceMax3DAxis1Model,
@@ -1490,6 +1492,38 @@ def test_pow_by_constant(device: torch.device):
     original: torch.Tensor = model(x)
     output: torch.Tensor = model_compiled(x)
     assert torch.allclose(output, original, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("exponent", [0.0, 1.0, 2.0, 3.0, 4.0, -3.0])
+def test_pow_by_integral_scalar_preserves_sign(device: torch.device, exponent: float):
+    """Integral scalar powers preserve negative bases and reciprocal signs."""
+    model: torch.nn.Module = PowByScalarModel(exponent).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.tensor([-3.0, -1.0, -0.5, 0.5, 1.0, 3.0], device=device)
+    original = model(x)
+    output = model_compiled(x)
+    assert torch.allclose(output, original, rtol=1e-4, atol=1e-4)
+
+
+def test_pow_by_float_scalar_promotes_integer_base(device: torch.device):
+    """A float scalar exponent promotes an integer tensor to PyTorch's output dtype."""
+    model: torch.nn.Module = PowByScalarModel(3.0).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.tensor([-3, -1, 1, 3], dtype=torch.int32, device=device)
+    original = model(x)
+    output = model_compiled(x)
+    assert output.dtype == original.dtype
+    assert torch.equal(output, original)
+
+
+def test_gpt2_approx_gelu_preserves_cubic_sign(device: torch.device):
+    """Regression for GPT-2 logits corrupted by lowering x.pow(3) as abs(x)^3."""
+    model: torch.nn.Module = Gpt2ApproxGeluModel().to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.linspace(-5.0, 5.0, 129, device=device)
+    original = model(x)
+    output = model_compiled(x)
+    assert torch.allclose(output, original, rtol=1e-5, atol=1e-5)
 
 
 # ========== PT2 Where Node Tests ==========

--- a/crates/luminal_python/tests/test_models.py
+++ b/crates/luminal_python/tests/test_models.py
@@ -1139,6 +1139,25 @@ class PowByConstantModel(torch.nn.Module):
         return x**constant
 
 
+class PowByScalarModel(torch.nn.Module):
+    """Tests aten.pow.Tensor_Scalar with a compile-time scalar exponent."""
+
+    def __init__(self, exponent: float) -> None:
+        super().__init__()
+        self.exponent = exponent
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x.pow(self.exponent)
+
+
+class Gpt2ApproxGeluModel(torch.nn.Module):
+    """GPT-2's GELU formula, whose cubic term must preserve negative signs."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        cubic = x.pow(3.0)
+        return 0.5 * x * (1.0 + torch.tanh(0.7978845608028654 * (x + 0.044715 * cubic)))
+
+
 # ========== Where Node Test Models ==========
 
 

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -53,6 +53,7 @@ Dispositions:
 | `598e5ca7` | #422 | Share reusable CUDA runtime through Lite | FILE-LEVEL (41 files into the `cuda_lite_hlir` park, incl. 5 deletions + 1 non-gating `ci/` file) + INTENT-ONLY at walk — DELIVERED by Phase 3 (arena) and PARTIALLY by Phase 2 (runtime-configurable op/matcher selection: the registry half; the execution face still PUNTED) + PUNTED-TO-PARK (fusion, attention, cuda-heavy composition) + DROPPED (the `subsume` fusion rule and the four `delete` rules, `CudaRuntimeImpl<O>`) | branch `rejoin/p0-record-and-park` | RULED 2026-09-03: *"put these fusion changes in hlir and punt on them temporarily"*, *"we're going to copy it into the hlir folder and then actually implement it once we're caught up"* (attention/FA3), *"Update the hlir_folder so we have a record of what the target code looks like"* (full-CUDA downstream), *"no code for now"* (zero-copy rebinding) — see **#422 reusable CUDA runtime** below |
 | `e7f9127a` | #430 | Restore CUDA dyn dims buffer on graph rebuild | FILE-LEVEL (1 file into the `cuda_lite_hlir` park) | branch `merge/main-430-487-cuda-graph-parks` (1st commit) | — nothing live corresponds: this branch's `crates/luminal_cuda_lite` captures no CUDA graphs at all, so there is no rebuild path to fix — see **#430 dyn-dims on rebuild** below, which says that once for the whole eight-commit line |
 | `188e92e8` | #435 | Add persistent compiled artifact reuse for Python and CUDA backends | FILE-LEVEL (7 files into the `cuda_lite_hlir` park + 1 metal-park file + 9 python-park files, 2 re-spelled `Expression` -> `IntExpr`) + FULL-FILE PARK (11 core files, post-#435, into `crates/luminal_cuda_lite_hlir/main_core/`) | branch `merge/main-cuda-graph-line-parks-wip` (2nd commit) | **PARITY REQUIRED — LUM-806** (https://linear.app/luminalai/issue/LUM-806). RULED 2026-09-04: *"you'll have to park it in the HLIR copy and then record that we need to get to feature parity for this. It is something we absolutely need to have eventually."* A compiled artifact must persist the SELECTED SCHEDULE so a fresh process runs without re-running the genetic search — see **#435 persistent compiled artifacts** below |
+| `a3c5df9f` | #437 | Fix signed integral aten.pow.Tensor_Scalar lowering | FILE-LEVEL | branch `merge/main-python-parks-wip` | the defect main fixes in the translator is LIVE in this branch's own frontend — `GraphTensor::pow` at `src/frontend/binary.rs:395` is the same `abs().log().mul(e).exp()`; RULED 2026-09-04 *"fix the front end"*, delivered as PR #491 — see **#437 signed integral pow** below |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -4072,6 +4073,37 @@ NAME, not by a positional index, so no index-determinism fix is owed for the
 serialization itself. (Whether those class names reproduce across processes is
 the separate, already-recorded class-id stability question, and it is the first
 thing a schedule-loading implementation has to answer.)
+## #437 signed integral pow — banked, and the same defect fixed in the frontend
+
+Main's `a3c5df9f` replaces the `aten.pow.Tensor_Scalar` arm's one special case
+(`exp == 2` becomes `a * a`) with `translate_tensor_scalar_pow`, which lowers
+every finite whole-number scalar exponent by exponentiation by squaring —
+reciprocal for negative exponents, a ones constant at zero — and falls through
+to `GraphTensor::pow` only for non-integral exponents. All four files applied
+3-way with no conflict and the diff-of-diffs against `a3c5df9f` is EMPTY: this
+commit needed no re-spelling, because everything it reaches for
+(`output_meta_dtype`, `get_float_arg`, `constant_like`,
+`GraphTensor::reciprocal`) already exists here under main's name and no hunk
+touches a `ShapeTracker`, a `.shape` or an `Expression`.
+
+The reason main needed it is live in this branch too, and not only in the park:
+`GraphTensor::pow` at `src/frontend/binary.rs:395` was the identical
+sign-dropping approximation, `self.abs().log().mul(e).exp()`, so `(-2)^3`
+answered `+8` for every caller and GPT-2's approximate GELU — whose cubic term
+is `x.pow(3)` — was corrupted on every negative input. Austin ruled 2026-09-04
+*"fix the front end"*, and that fix is **PR #491**: a `PowExponent` trait whose
+`f32` impl lowers finite whole-number exponents structurally (capped at
+`|e| <= 64`) while tensor exponents and non-whole scalars keep the
+approximation. With #491 landed the park's own workaround becomes redundant
+rather than wrong — the M4 translator re-attachment can drop
+`translate_tensor_scalar_pow` and call `pow` directly, and that is the
+follow-up this row owes.
+
+Nothing was rebuilt or rerun for the park: `crates/luminal_python` is not a
+workspace member here, so main's pytest verification (the parametrised
+`test_pow_by_integral_scalar_preserves_sign`, the integer-base dtype promotion
+check, and the GPT-2 GELU regression) remains main's, measured against main's
+HLIR backend.
 
 ## #406 pad — the select construction REVERTED (2026-09-03)
 


### PR DESCRIPTION
Carries main's a3c5df9f ("Fix signed integral aten.pow.Tensor_Scalar
lowering", #437) file-level into the parked crate. All four files applied
3-way with no conflict and the diff-of-diffs against a3c5df9f is EMPTY —
no re-spelling was needed, because every symbol the new
translate_tensor_scalar_pow reaches for (output_meta_dtype, get_float_arg,
constant_like, GraphTensor::reciprocal) already exists here under main's
name, and no hunk touches a ShapeTracker, a .shape or an Expression.

What it fixes: the aten.pow.Tensor_Scalar arm special-cased exp == 2 to
a * a and sent everything else through GraphTensor::pow, which is
abs().log().mul(e).exp() and therefore answers |x|^e. Main's replacement
lowers every finite whole-number exponent by exponentiation by squaring
(reciprocal for negative, a ones constant at zero) and falls through to
pow only for non-integral exponents.

The reason this carries more than a bank: the same defect was live in this
branch's own frontend at src/frontend/binary.rs:395, so (-2)^3 answered +8
for every caller and GPT-2's approximate GELU was corrupted on every
negative input. Austin ruled 2026-09-04 "fix the front end"; that fix is
PR #491 (a PowExponent trait, structural for integral f32 exponents up to
|e| <= 64). With #491 landed the park's workaround is redundant rather than
wrong, and the M4 re-attachment can drop translate_tensor_scalar_pow.

Nothing was rebuilt or rerun: crates/luminal_python is not a workspace
member here, so main's pytest verification remains main's, measured against
main's HLIR backend.

(cherry picked from commit a3c5df9f644b1d333afec93faac998c6c0dfc1e6)

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
(cherry picked from commit de2b76942bd1653c5f84a6e048f636881ae18a88)

Stacked on \`merge/main-435-persistent-compiled-artifacts\`. One main commit, parked/recorded per the ledger row and section in this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)