### PR TITLE
Inference batch norm (#441): banked; the dead-reduction argument recorded

### DIFF
--- a/crates/luminal_python/rust/src/translator/dispatch.rs
+++ b/crates/luminal_python/rust/src/translator/dispatch.rs
@@ -393,6 +393,7 @@ impl<'a> Translator<'a> {
             "torch.ops.aten.grid_sampler_2d.default" => self.translate_grid_sampler(node, 2)?,
             "torch.ops.aten.grid_sampler_3d.default" => self.translate_grid_sampler(node, 3)?,
             "torch.ops.aten._native_batch_norm_legit.no_stats"
+            | "torch.ops.aten._native_batch_norm_legit_no_training.default"
             | "torch.ops.aten._native_batch_norm_legit_functional.default"
             | "torch.ops.aten._batch_norm_with_update_functional.default" => {
                 self.translate_batch_norm_functional(node)?;

--- a/crates/luminal_python/rust/src/translator/pooling.rs
+++ b/crates/luminal_python/rust/src/translator/pooling.rs
@@ -816,15 +816,23 @@ impl<'a> Translator<'a> {
         );
         let output_names = Self::tensor_output_names(node);
         anyhow::ensure!(!output_names.is_empty(), "batch norm has no tensor outputs");
-        let functional = node.target != "torch.ops.aten._native_batch_norm_legit.no_stats";
+        let no_training =
+            node.target == "torch.ops.aten._native_batch_norm_legit_no_training.default";
+        let functional = matches!(
+            node.target.as_str(),
+            "torch.ops.aten._native_batch_norm_legit_functional.default"
+                | "torch.ops.aten._batch_norm_with_update_functional.default"
+        );
         let training = if node.target == "torch.ops.aten._batch_norm_with_update_functional.default"
         {
             true
+        } else if no_training {
+            false
         } else {
             self.named_bool_arg(node, "training").unwrap_or(true)
         };
         anyhow::ensure!(
-            training || functional,
+            training || functional || no_training,
             "batch norm without running stats requires training=true"
         );
         let momentum = self.named_float_arg(node, "momentum").unwrap_or(0.1);
@@ -839,15 +847,26 @@ impl<'a> Translator<'a> {
         let axes = (0..input.legacy_tracker_ref().len())
             .filter(|&axis| axis != 1)
             .collect::<Vec<_>>();
-        let batch_mean = compute.mean(axes.clone());
-        let expanded_mean = batch_mean.expand_to_shape_on_axes(compute.dims(), axes.clone());
-        let centered = compute - expanded_mean;
-        let batch_var = centered.square().mean(axes.clone());
+        let (batch_mean, batch_var) = if training {
+            let batch_mean = compute.mean(axes.clone());
+            let expanded_mean = batch_mean.expand_to_shape_on_axes(compute.dims(), axes.clone());
+            let centered = compute - expanded_mean;
+            let batch_var = centered.square().mean(axes.clone());
+            (Some(batch_mean), Some(batch_var))
+        } else {
+            // Inference uses only the stored running statistics. Besides being
+            // dead work, adding batch reductions here makes every eval-mode
+            // BatchNorm layer unnecessarily enlarge the compiler search space.
+            (None, None)
+        };
 
         let running_mean = self.named_tensor_arg(node, "running_mean")?;
         let running_var = self.named_tensor_arg(node, "running_var")?;
         let (mean, variance) = if training {
-            (batch_mean, batch_var)
+            (
+                batch_mean.context("training batch norm requires batch mean")?,
+                batch_var.context("training batch norm requires batch variance")?,
+            )
         } else {
             (
                 running_mean
@@ -879,10 +898,13 @@ impl<'a> Translator<'a> {
         self.tensors
             .insert(output_names[0].clone(), output.cast(input.dtype));
 
-        for (index, statistic) in [(1, batch_mean), (2, invstd)] {
+        for (index, statistic) in [(1, batch_mean), (2, Some(invstd))] {
             if output_names.len() > index {
                 if training {
-                    self.tensors.insert(output_names[index].clone(), statistic);
+                    self.tensors.insert(
+                        output_names[index].clone(),
+                        statistic.context("training batch norm statistic is missing")?,
+                    );
                 } else {
                     self.store_zero_for_output(&output_names[index])?;
                 }
@@ -898,6 +920,8 @@ impl<'a> Translator<'a> {
                 running_mean.context("functional batch norm requires running_mean")?;
             let running_var = running_var.context("functional batch norm requires running_var")?;
             let (mean_out, var_out) = if training {
+                let batch_mean = batch_mean.context("training batch norm requires batch mean")?;
+                let batch_var = batch_var.context("training batch norm requires batch variance")?;
                 let mean_out = running_mean * (1.0 - momentum as f32)
                     + batch_mean.cast(running_mean.dtype) * momentum as f32;
                 let count = product_of_dims(axes.iter().map(|&axis| input.dims()[axis]));

--- a/crates/luminal_python/tests/test_remaining_existing_hlir_lowerings.py
+++ b/crates/luminal_python/tests/test_remaining_existing_hlir_lowerings.py
@@ -529,6 +529,42 @@ def test_functional_batch_norm_returns_stats_and_updates() -> None:
     _check(module, *inputs)
 
 
+class InferenceBatchNorm(torch.nn.Module):
+    def __init__(self, affine: bool):
+        super().__init__()
+        self.affine = affine
+
+    def forward(self, value, weight, bias, running_mean, running_var):
+        return torch.ops.aten._native_batch_norm_legit_no_training.default(
+            value,
+            weight if self.affine else None,
+            bias if self.affine else None,
+            running_mean,
+            running_var,
+            0.2,
+            1e-5,
+        )
+
+
+def test_inference_batch_norm_uses_running_stats_and_returns_empty_saved_stats() -> (
+    None
+):
+    torch.manual_seed(11)
+    inputs = (
+        torch.randn(2, 3, 4, 5),
+        torch.randn(3),
+        torch.randn(3),
+        torch.randn(3) + 3.0,
+        torch.rand(3) + 0.5,
+    )
+    for affine in (False, True):
+        module = InferenceBatchNorm(affine)
+        expected = module(*inputs)
+        assert expected[1].numel() == 0
+        assert expected[2].numel() == 0
+        _check(module, *inputs)
+
+
 class OrderingAndDistances(torch.nn.Module):
     def forward(self, value, other, points, points2):
         return (

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -55,6 +55,7 @@ Dispositions:
 | `188e92e8` | #435 | Add persistent compiled artifact reuse for Python and CUDA backends | FILE-LEVEL (7 files into the `cuda_lite_hlir` park + 1 metal-park file + 9 python-park files, 2 re-spelled `Expression` -> `IntExpr`) + FULL-FILE PARK (11 core files, post-#435, into `crates/luminal_cuda_lite_hlir/main_core/`) | branch `merge/main-cuda-graph-line-parks-wip` (2nd commit) | **PARITY REQUIRED — LUM-806** (https://linear.app/luminalai/issue/LUM-806). RULED 2026-09-04: *"you'll have to park it in the HLIR copy and then record that we need to get to feature parity for this. It is something we absolutely need to have eventually."* A compiled artifact must persist the SELECTED SCHEDULE so a fresh process runs without re-running the genetic search — see **#435 persistent compiled artifacts** below |
 | `a3c5df9f` | #437 | Fix signed integral aten.pow.Tensor_Scalar lowering | FILE-LEVEL | branch `merge/main-python-parks-wip` | the defect main fixes in the translator is LIVE in this branch's own frontend — `GraphTensor::pow` at `src/frontend/binary.rs:395` is the same `abs().log().mul(e).exp()`; RULED 2026-09-04 *"fix the front end"*, delivered as PR #491 — see **#437 signed integral pow** below |
 | `2b368a29` | #440 | Make cuBLASLt capture cache capacity configurable | FILE-LEVEL (1 file into the `cuda_lite_hlir` park) | branch `merge/main-cuda-graph-line-parks-wip` (3rd commit) | — nothing live corresponds (no capture cache exists here; see **#430 dyn-dims on rebuild** for the once-stated reason) — see **#440 capture cache capacity** below |
+| `e8780fc8` | #441 | Lower inference native batch norm | FILE-LEVEL | branch `merge/main-python-parks-wip` | the search-space argument is a REQUIREMENT on the M4 re-attachment: an eval-mode BatchNorm must emit no batch reductions at all, not dead ones the extractor still has to cost — see **#441 inference batch norm** below |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -4122,6 +4123,33 @@ that has already grown still evicts instead of silently retaining forever.
 `crates/luminal_cuda_lite_hlir/src/kernel/to_host.rs` (const at `:123`, the
 reader at `:125`, the multiply at `:1337`, the eviction checks at `:3472` and
 `:3890`); diff-of-diffs identical.
+## #441 inference batch norm — banked; the dead-reduction argument recorded
+
+Main's `e8780fc8` routes
+`torch.ops.aten._native_batch_norm_legit_no_training.default` into
+`translate_batch_norm_functional` and makes that function honest about what
+inference needs: `training` is forced false for the new overload, the
+`training || functional` guard admits it, and `batch_mean` / `batch_var` become
+`Option`s computed only on the training path, with every later use taking them
+through `.context(..)`. The three files applied 3-way with one conflict, in
+`pooling.rs`, on park drift alone — main's `compute.shape` is `compute.dims()`
+here — resolved to main's content in the park's spelling; the diff-of-diffs
+against `e8780fc8` is then EMPTY modulo exactly that substitution. (`#414`'s
+other known respelling in this function, `input.shape.len()` ->
+`input.legacy_tracker_ref().len()`, sat in the hunk's context and needed no
+hand work.)
+
+The reason worth keeping is main's own comment, and it is a compiler argument
+rather than a lowering one: an eval-mode BatchNorm that still computes a batch
+mean and variance is not merely doing dead work, it *enlarges the search
+space*, because those reductions are real nodes the extractor has to cost
+before discovering nothing consumes them. That is a REQUIREMENT on the M4
+translator re-attachment — refuse to record the reductions, do not rely on
+downstream elimination — and it generalises past batch norm to every
+training/inference-forked lowering. Nothing was rebuilt or rerun:
+`crates/luminal_python` is not a workspace member here, so main's pytest
+(`test_inference_batch_norm_uses_running_stats_and_returns_empty_saved_stats`,
+affine and non-affine) remains main's.
 
 ## #406 pad — the select construction REVERTED (2026-09-03)
 


### PR DESCRIPTION
Carries main's e8780fc8 ("Lower inference native batch norm", #441)
file-level into the parked crate. dispatch.rs routes
torch.ops.aten._native_batch_norm_legit_no_training.default into
translate_batch_norm_functional; that function forces training false for
the new overload, widens the training || functional guard to admit it, and
makes batch_mean / batch_var Options computed only on the training path,
with each later use taking them through .context(..).

One hunk in pooling.rs conflicted, on park drift alone: main's
compute.shape is compute.dims() here. Resolved to main's content in the
park's spelling, and the diff-of-diffs against e8780fc8 is then EMPTY
modulo exactly that substitution. #414's other known respelling in this
function, input.shape.len() -> input.legacy_tracker_ref().len(), sat in
the hunk's context and needed no hand work.

The ledger records main's own reason as an M4 requirement, because it is a
compiler argument rather than a lowering one: an eval-mode BatchNorm that
still computes a batch mean and variance does not merely do dead work, it
enlarges the search space, since those reductions are real nodes the
extractor has to cost before discovering nothing consumes them. Refuse to
record them; do not rely on downstream elimination.

Nothing was rebuilt or rerun: crates/luminal_python is not a workspace
member here, so main's pytest remains main's.

(cherry picked from commit e8780fc8c28067d1df51b6f4fc53ff0660d790a1)

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
(cherry picked from commit ffcbeee769135e1dc00d36ad0612bc3abffe8f78)

Stacked on \`merge/main-440-cublaslt-capture-cache-capacity\`. One main commit, parked/recorded per the ledger row and section in this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)