### PR TITLE
Bound CUDA graph bucket residency (#450): parked

### DIFF
--- a/crates/luminal_cuda_lite_hlir/src/runtime.rs
+++ b/crates/luminal_cuda_lite_hlir/src/runtime.rs
@@ -71,6 +71,32 @@ const MIN_SEARCH_CACHE_EVICTION_HEADROOM_BYTES: usize = 1024 * 1024 * 1024;
 const SEARCH_CACHE_EVICTION_HEADROOM_DIVISOR: usize = 50;
 const MIN_SEARCH_CANDIDATE_NODE_ALLOWANCE: usize = 1024;
 
+fn materialized_bucket_evictions(
+    materialized: &[bool],
+    lru: &VecDeque<usize>,
+    keep: usize,
+    capacity: usize,
+) -> Vec<usize> {
+    let projected = materialized.iter().filter(|resident| **resident).count()
+        + usize::from(!materialized.get(keep).copied().unwrap_or(false));
+    let mut remaining = projected.saturating_sub(capacity);
+    let mut evictions = Vec::with_capacity(remaining);
+
+    for candidate in lru.iter().copied().chain(0..materialized.len()) {
+        if remaining == 0 {
+            break;
+        }
+        if candidate != keep
+            && materialized.get(candidate).copied().unwrap_or(false)
+            && !evictions.contains(&candidate)
+        {
+            evictions.push(candidate);
+            remaining -= 1;
+        }
+    }
+    evictions
+}
+
 fn search_candidate_node_limit(baseline_nodes: usize) -> usize {
     baseline_nodes.saturating_add(MIN_SEARCH_CANDIDATE_NODE_ALLOWANCE)
 }
@@ -501,6 +527,11 @@ pub struct CudaRuntimeImpl<O> {
     // Per-bucket compiled state
     compiled_buckets: Vec<CompiledBucket>,
     active_bucket: usize,
+    /// Optional cap on concurrently materialized bucket CUDA graphs. Compiled
+    /// kernels and the shared arena remain resident; only driver graph state
+    /// is evicted and rebuilt when an older bucket is needed again.
+    max_materialized_buckets: Option<usize>,
+    materialized_bucket_lru: VecDeque<usize>,
     /// Bucket definitions per dimension (empty = single-bucket mode)
     dim_buckets: FxHashMap<Symbol, Vec<DimBucket>>,
 
@@ -644,6 +675,27 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         self.set_max_memory_bytes(Some(max_memory_gib.saturating_mul(1024 * 1024 * 1024)));
     }
 
+    /// Bound the number of compiled buckets that retain materialized CUDA
+    /// graph executables. This is useful for large serving models whose
+    /// kernels and shared intermediate arena fit comfortably, but whose many
+    /// scheduler shapes otherwise accumulate excessive CUDA driver graph
+    /// memory. A value of `None` preserves the default unbounded residency;
+    /// `Some(0)` is invalid because the active bucket must remain usable.
+    pub fn set_max_materialized_buckets(&mut self, max_buckets: Option<usize>) {
+        assert!(
+            max_buckets != Some(0),
+            "materialized bucket capacity must be positive"
+        );
+        self.max_materialized_buckets = max_buckets;
+        self.materialized_bucket_lru
+            .retain(|bucket_idx| *bucket_idx < self.compiled_buckets.len());
+    }
+
+    pub fn with_max_materialized_buckets(mut self, max_buckets: usize) -> Self {
+        self.set_max_materialized_buckets(Some(max_buckets));
+        self
+    }
+
     /// Configure a hard per-kernel generated CUDA source limit. The runtime
     /// defaults to 512 KiB because NVRTC compilation is synchronous and cannot
     /// be interrupted by `candidate_timeout`; pass `None` to the setter below
@@ -783,6 +835,60 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         for bucket_idx in 0..self.compiled_buckets.len() {
             self.release_bucket_cuda_graphs(bucket_idx);
         }
+        self.materialized_bucket_lru.clear();
+    }
+
+    fn bucket_has_materialized_cuda_graphs(&self, bucket_idx: usize) -> bool {
+        self.compiled_buckets[bucket_idx]
+            .exec_graph
+            .node_weights()
+            .any(|exec_op| {
+                exec_op
+                    .internal
+                    .as_any()
+                    .downcast_ref::<CudaGraphOp>()
+                    .is_some_and(CudaGraphOp::is_materialized)
+            })
+    }
+
+    /// Make room for the active bucket before it materializes. Eviction is
+    /// deliberately performed before construction so peak driver graph memory
+    /// never includes both the old resident set and its replacement.
+    fn prepare_materialized_bucket_slot(&mut self, bucket_idx: usize) {
+        let Some(capacity) = self.max_materialized_buckets else {
+            return;
+        };
+
+        self.materialized_bucket_lru
+            .retain(|resident| *resident != bucket_idx && *resident < self.compiled_buckets.len());
+        self.materialized_bucket_lru.push_back(bucket_idx);
+
+        let materialized = (0..self.compiled_buckets.len())
+            .map(|idx| self.bucket_has_materialized_cuda_graphs(idx))
+            .collect::<Vec<_>>();
+        let evictions = materialized_bucket_evictions(
+            &materialized,
+            &self.materialized_bucket_lru,
+            bucket_idx,
+            capacity,
+        );
+        if evictions.is_empty() {
+            return;
+        }
+
+        self.cuda_stream
+            .synchronize()
+            .expect("failed to synchronize before evicting bucket CUDA graphs");
+        for &evicted in &evictions {
+            self.release_bucket_cuda_graphs(evicted);
+        }
+        self.materialized_bucket_lru
+            .retain(|resident| !evictions.contains(resident));
+        self.cuda_stream
+            .synchronize()
+            .expect("failed to synchronize after evicting bucket CUDA graphs");
+        Self::trim_device_graph_memory(&self.cuda_stream)
+            .expect("failed to trim CUDA graph memory after bucket eviction");
     }
 
     fn release_all_arenas(&mut self) {
@@ -4892,6 +4998,8 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
             validated_resource_signatures: FxHashSet::default(),
             compiled_buckets: vec![CompiledBucket::new()],
             active_bucket: 0,
+            max_materialized_buckets: None,
+            materialized_bucket_lru: VecDeque::new(),
             dim_buckets: FxHashMap::default(),
             output_ptr_registrations: FxHashMap::default(),
             dirty_output_ptr_registrations: FxHashSet::default(),
@@ -5011,6 +5119,7 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
             self.prepare_bucket_direct_profile(self.active_bucket, dyn_map)
                 .unwrap_or_else(|e| panic!("direct CUDA candidate preparation failed: {e}"));
         } else if !external_capture {
+            self.prepare_materialized_bucket_slot(self.active_bucket);
             self.materialize_bucket_cuda_graphs(self.active_bucket, dyn_map, false)
                 .unwrap_or_else(|e| panic!("CUDA graph materialization failed: {e}"));
         }
@@ -6176,6 +6285,25 @@ mod arena_plan_tests {
         assert!(search_cache_under_pressure(gib, 100 * gib));
         assert!(!search_cache_under_pressure(2 * gib, 24 * gib));
         assert!(search_cache_under_pressure(900 * 1024 * 1024, 24 * gib));
+    }
+
+    #[test]
+    fn materialized_bucket_capacity_evicts_lru_before_new_bucket() {
+        let materialized = [true, true, false];
+        let lru = VecDeque::from([1, 0, 2]);
+
+        assert_eq!(
+            materialized_bucket_evictions(&materialized, &lru, 2, 1),
+            vec![1, 0]
+        );
+        assert_eq!(
+            materialized_bucket_evictions(&materialized, &lru, 2, 2),
+            vec![1]
+        );
+        assert_eq!(
+            materialized_bucket_evictions(&materialized, &lru, 1, 1),
+            vec![0]
+        );
     }
 
     #[test]

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -57,6 +57,7 @@ Dispositions:
 | `2b368a29` | #440 | Make cuBLASLt capture cache capacity configurable | FILE-LEVEL (1 file into the `cuda_lite_hlir` park) | branch `merge/main-cuda-graph-line-parks-wip` (3rd commit) | — nothing live corresponds (no capture cache exists here; see **#430 dyn-dims on rebuild** for the once-stated reason) — see **#440 capture cache capacity** below |
 | `e8780fc8` | #441 | Lower inference native batch norm | FILE-LEVEL | branch `merge/main-python-parks-wip` | the search-space argument is a REQUIREMENT on the M4 re-attachment: an eval-mode BatchNorm must emit no batch reductions at all, not dead ones the extractor still has to cost — see **#441 inference batch norm** below |
 | `cb8d270d` | #442 | Evict cached cuBLASLt graphs before recapture | FILE-LEVEL (1 file into the `cuda_lite_hlir` park) | branch `merge/main-cuda-graph-line-parks-wip` (4th commit) | — nothing live corresponds (no capture cache exists here; see **#430 dyn-dims on rebuild**) — see **#440 capture cache capacity** and **#442 evict before recapture** below |
+| `fb6bf0a4` | #450 | Bound serving CUDA graph bucket residency | FILE-LEVEL (1 file into the `cuda_lite_hlir` park) | branch `merge/main-cuda-graph-line-parks-wip` (5th commit) | — nothing live corresponds: this branch has no per-bucket CUDA graph residency to bound (see **#430 dyn-dims on rebuild**) — see **#450 bucket residency** below |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -4166,6 +4167,29 @@ exceed it. The fresh-prepare site needs a small scoped borrow
 path-rewritten only** — applied verbatim, no re-expression was needed because
 the park had just taken #440 verbatim and so carried main's exact preimage,
 evict-after-push at both sites included; diff-of-diffs identical.
+
+## #450 bucket residency — parked
+
+Main's `fb6bf0a4` (+128, one file) caps how many compiled buckets may hold
+materialized CUDA graph executables at once. A serving model whose kernels and
+shared arena fit comfortably can still accumulate ruinous CUDA DRIVER graph
+memory across many scheduler shapes, so `CudaRuntimeImpl` gains
+`max_materialized_buckets: Option<usize>` (`None` = today's unbounded default,
+`Some(0)` asserted invalid because the active bucket must stay usable) plus a
+`materialized_bucket_lru: VecDeque<usize>`, the setter/builder pair
+`set_max_materialized_buckets` / `with_max_materialized_buckets`, and
+`prepare_materialized_bucket_slot`, which is called BEFORE the active bucket
+materializes so peak driver memory never holds the old resident set and its
+replacement together. The eviction choice itself is factored into a pure
+function, `materialized_bucket_evictions(materialized, lru, keep, capacity)` —
+projected residency minus capacity, walking the LRU and then the bucket order,
+never evicting `keep` — and that is what the commit's one unit test pins; the
+eviction path synchronizes the stream on both sides of
+`release_bucket_cuda_graphs` and then trims driver graph memory. Only driver
+graph state is released: compiled kernels and the shared arena stay resident and
+the bucket rebuilds its graphs if it is needed again. **Disposition: FILE-LEVEL
+park, path-rewritten only** — applied verbatim to
+`crates/luminal_cuda_lite_hlir/src/runtime.rs`; diff-of-diffs identical.
 
 ## #406 pad — the select construction REVERTED (2026-09-03)
 


### PR DESCRIPTION
A serving model whose kernels and shared arena fit comfortably can still
accumulate ruinous CUDA driver graph memory across many scheduler shapes.
CudaRuntimeImpl gains max_materialized_buckets (None = unbounded default,
Some(0) asserted invalid since the active bucket must stay usable), a
materialized_bucket_lru, the setter/builder pair, and
prepare_materialized_bucket_slot -- called before the active bucket
materializes, so peak driver memory never holds the old resident set and its
replacement at once.

The eviction choice is a pure function, materialized_bucket_evictions(
materialized, lru, keep, capacity): projected residency minus capacity, walking
the LRU then bucket order, never evicting keep. That is what the commit's unit
test pins. The eviction path synchronizes either side of
release_bucket_cuda_graphs and trims driver graph memory; only graph state goes,
kernels and the arena stay resident and the bucket rebuilds if needed again.

One file, applied verbatim into the hlir park under the path rewrite;
diff-of-diffs identical. Nothing live corresponds -- see the #430 section.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
(cherry picked from commit a2c1ca0b74b632db892201e9bdde5b8397ea8387)

Stacked on \`merge/main-442-evict-cublaslt-graphs-before-recapture\`. One main commit, parked/recorded per the ledger row and section in this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)