### PR TITLE
Reclaim CUDA memory before graph replacement (#467): parked

### DIFF
--- a/crates/luminal_cuda_lite_hlir/src/kernel/to_host.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/to_host.rs
@@ -11,7 +11,8 @@ use std::{
 };
 
 use cudarc::driver::{
-    CudaFunction, CudaModule, CudaSlice, CudaStream, DevicePtr, sys::CUgraphNode,
+    CudaFunction, CudaModule, CudaSlice, CudaStream, DevicePtr,
+    sys::{self, CUgraphNode},
 };
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
@@ -937,6 +938,23 @@ impl CudaGraphArenaOrdering {
 }
 
 impl CudaGraphOp {
+    /// Destroy an executable that rejected a source-graph update before
+    /// allocating its replacement. CUDA can retain a model-sized graph
+    /// allocation until both the executable is destroyed and the device graph
+    /// pool is trimmed; instantiating first transiently requires both copies.
+    fn retire_failed_graph_exec(
+        stream: &Arc<CudaStream>,
+        exec: CudaGraphExecHandle,
+    ) -> anyhow::Result<()> {
+        stream.synchronize()?;
+        drop(exec);
+        stream.context().bind_to_thread()?;
+        unsafe {
+            sys::cuDeviceGraphMemTrim(stream.context().cu_device()).result()?;
+        }
+        Ok(())
+    }
+
     /// Whether this packaged graph currently owns both a mutable source graph
     /// and an executable instance. Bucket-LRU eviction deliberately releases
     /// both while retaining the compiled operation descriptions.
@@ -3069,6 +3087,14 @@ impl CudaGraphOp {
                                 "CudaGraph cuBLASLt exec update failed after recapture; reinstantiating executable graph: {err:?}",
                             );
                         }
+                        // `exec` still owns the rejected executable. Retire it
+                        // before instantiating the replacement so peak graph
+                        // memory is one executable, not two.
+                        Self::retire_failed_graph_exec(
+                            stream,
+                            exec.take()
+                                .expect("failed graph update lost its executable"),
+                        )?;
                         let timer = Instant::now();
                         state.cuda_graph_exec =
                             Some(state.cuda_graph.as_ref().unwrap().instantiate()?);
@@ -3999,7 +4025,13 @@ impl CudaGraphOp {
         let exec = if let Some(mut exec) = old_exec {
             match exec.update_from_graph(&graph) {
                 Ok(()) => exec,
-                Err(_) => graph.instantiate()?,
+                Err(_) => {
+                    // The rejected executable may own most of the device graph
+                    // pool. It must be destroyed and the unused pool returned
+                    // before allocating the replacement.
+                    Self::retire_failed_graph_exec(stream, exec)?;
+                    graph.instantiate()?
+                }
             }
         } else {
             graph.instantiate()?

--- a/crates/luminal_cuda_lite_hlir/src/runtime.rs
+++ b/crates/luminal_cuda_lite_hlir/src/runtime.rs
@@ -887,6 +887,12 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         self.cuda_stream
             .synchronize()
             .expect("failed to synchronize after evicting bucket CUDA graphs");
+        // Releasing a bucket also drops prepared library workspaces and
+        // internal buffers allocated from CUDA's stream-ordered pool. The
+        // graph allocator cannot reuse pages retained there, so trim both
+        // independent pools before materializing the replacement bucket.
+        Self::trim_current_memory_pool(&self.cuda_stream)
+            .expect("failed to trim CUDA memory pool after bucket eviction");
         Self::trim_device_graph_memory(&self.cuda_stream)
             .expect("failed to trim CUDA graph memory after bucket eviction");
     }

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -60,6 +60,7 @@ Dispositions:
 | `fb6bf0a4` | #450 | Bound serving CUDA graph bucket residency | FILE-LEVEL (1 file into the `cuda_lite_hlir` park) | branch `merge/main-cuda-graph-line-parks-wip` (5th commit) | — nothing live corresponds: this branch has no per-bucket CUDA graph residency to bound (see **#430 dyn-dims on rebuild**) — see **#450 bucket residency** below |
 | `dd3d6633` | #453 | Raise Qwen3 MoE TTFT CI limit | IGNORED (nothing applied; `ci/example_output.py` deliberately NOT synced) | — | RULED 2026-09-04: *"just ignore the number in CI for now, we're eventually going to move these tests out of CI/CD into their own system"* — this reverses the earlier sync-main's-numbers decision (ruling 1 of 2026-09-02) for this one line — see **#453 qwen3_moe TTFT** below |
 | `e891a57e` | #466 | Report memory state on CUDA graph capture failure | FILE-LEVEL (1 file into the `cuda_lite_hlir` park) | branch `merge/main-cuda-graph-line-parks-wip` (7th commit) | — nothing live corresponds (no materialization to fail; see **#430 dyn-dims on rebuild**) — see **#466 capture-failure diagnostics** below |
+| `fbe47db7` | #467 | Reclaim CUDA memory before graph replacement | FILE-LEVEL (2 files into the `cuda_lite_hlir` park) | branch `merge/main-cuda-graph-line-parks-wip` (8th commit) | — nothing live corresponds (no graph executables, no stream-ordered pool use; see **#430 dyn-dims on rebuild**) — see **#467 reclaim before replacement** below |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -4217,6 +4218,27 @@ The point is that the failures worth debugging here are OOMs caused by
 residency policy, and the residency state (#450) is exactly what the old
 message omitted. **Disposition: FILE-LEVEL park, path-rewritten only** —
 applied verbatim to `crates/luminal_cuda_lite_hlir/src/runtime.rs`;
+diff-of-diffs identical.
+
+## #467 reclaim before replacement — parked
+
+Main's `fbe47db7` (+40/-2, two files) applies #442's principle — never hold the
+old thing and its replacement at once — to CUDA graph EXECUTABLES and to the two
+independent driver pools. `CudaGraphOp::retire_failed_graph_exec` synchronizes,
+drops the executable that just rejected an `update_from_graph`, binds the
+context and calls `cuDeviceGraphMemTrim` BEFORE the replacement is instantiated,
+because CUDA can retain a model-sized graph allocation until both the executable
+is destroyed and the graph pool is trimmed; it is wired into both
+re-instantiation sites (the cuBLASLt post-recapture update and the generic
+`old_exec` update path, which previously just fell through to
+`graph.instantiate()?`). In `runtime.rs`, bucket eviction additionally calls
+`trim_current_memory_pool` before `trim_device_graph_memory`, since releasing a
+bucket also drops prepared library workspaces and internal buffers from the
+STREAM-ORDERED pool, whose retained pages the graph allocator cannot reuse — two
+pools, both trimmed. Note the dependency: this builds on #450's
+`prepare_materialized_bucket_slot`, not on #466. **Disposition: FILE-LEVEL park,
+path-rewritten only** — applied verbatim to
+`crates/luminal_cuda_lite_hlir/src/kernel/to_host.rs` and `.../src/runtime.rs`;
 diff-of-diffs identical.
 
 ## #406 pad — the select construction REVERTED (2026-09-03)


### PR DESCRIPTION
#442's principle -- never hold the old thing and its replacement at once --
applied to graph executables and to the two independent driver pools.
retire_failed_graph_exec synchronizes, drops the executable that just rejected
an update_from_graph, binds the context and calls cuDeviceGraphMemTrim before
the replacement is instantiated, because CUDA can retain a model-sized graph
allocation until both the executable is destroyed and the graph pool is trimmed.
It is wired into both re-instantiation sites: the cuBLASLt post-recapture update
and the generic old_exec path, which previously fell straight through to
graph.instantiate().

In runtime.rs, bucket eviction now trims the stream-ordered pool before the
graph pool. Releasing a bucket also drops prepared library workspaces and
internal buffers from that pool, and the graph allocator cannot reuse pages
retained there.

Two files, applied verbatim into the hlir park under the path rewrite;
diff-of-diffs identical. Depends on #450's prepare_materialized_bucket_slot, not
on #466. Nothing live corresponds -- see the #430 section.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
(cherry picked from commit 5bcbd67e6ffcc6463904ce904298db25d9effb3a)

Stacked on \`merge/main-466-memory-state-on-cuda-graph-capture-failu\`. One main commit, parked/recorded per the ledger row and section in this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)