### PR TITLE
Trim CUDA pools after graph recapture (#472): parked

### DIFF
--- a/crates/luminal_cuda_lite_hlir/src/kernel/to_host.rs
+++ b/crates/luminal_cuda_lite_hlir/src/kernel/to_host.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use cudarc::driver::{
-    CudaFunction, CudaModule, CudaSlice, CudaStream, DevicePtr,
+    CudaFunction, CudaModule, CudaSlice, CudaStream, DevicePtr, result,
     sys::{self, CUgraphNode},
 };
 use fixedbitset::FixedBitSet;
@@ -938,6 +938,27 @@ impl CudaGraphArenaOrdering {
 }
 
 impl CudaGraphOp {
+    /// Return allocations retired by graph recapture to CUDA. Prepared
+    /// library state is allocated from the stream-ordered pool, while graph
+    /// executable updates use the separate device graph pool. Shape-changing
+    /// serving workloads can otherwise leave each generation cached in a
+    /// different pool until the process exhausts the device.
+    fn trim_recapture_memory(stream: &Arc<CudaStream>) -> anyhow::Result<()> {
+        stream.synchronize()?;
+        let context = stream.context();
+        context.bind_to_thread()?;
+        if context.has_async_alloc() {
+            let pool = unsafe { result::device::get_mem_pool(context.cu_device())? };
+            unsafe {
+                result::mem_pool::trim_to(pool, 0)?;
+            }
+        }
+        unsafe {
+            sys::cuDeviceGraphMemTrim(context.cu_device()).result()?;
+        }
+        Ok(())
+    }
+
     /// Destroy an executable that rejected a source-graph update before
     /// allocating its replacement. CUDA can retain a model-sized graph
     /// allocation until both the executable is destroyed and the device graph
@@ -948,11 +969,7 @@ impl CudaGraphOp {
     ) -> anyhow::Result<()> {
         stream.synchronize()?;
         drop(exec);
-        stream.context().bind_to_thread()?;
-        unsafe {
-            sys::cuDeviceGraphMemTrim(stream.context().cu_device()).result()?;
-        }
-        Ok(())
+        Self::trim_recapture_memory(stream)
     }
 
     /// Whether this packaged graph currently owns both a mutable source graph
@@ -3109,6 +3126,11 @@ impl CudaGraphOp {
                         profile.instantiate_count += 1;
                     }
                 }
+                // Replacing captured library plans drops their prior device
+                // buffers only after the executable points at the new graph.
+                // Reclaim those now-unused allocations before the next shape
+                // change prepares another complete generation.
+                Self::trim_recapture_memory(stream)?;
             } else {
                 // No topology/capture mutation happened; update the executable
                 // kernel nodes directly.

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -61,6 +61,7 @@ Dispositions:
 | `dd3d6633` | #453 | Raise Qwen3 MoE TTFT CI limit | IGNORED (nothing applied; `ci/example_output.py` deliberately NOT synced) | — | RULED 2026-09-04: *"just ignore the number in CI for now, we're eventually going to move these tests out of CI/CD into their own system"* — this reverses the earlier sync-main's-numbers decision (ruling 1 of 2026-09-02) for this one line — see **#453 qwen3_moe TTFT** below |
 | `e891a57e` | #466 | Report memory state on CUDA graph capture failure | FILE-LEVEL (1 file into the `cuda_lite_hlir` park) | branch `merge/main-cuda-graph-line-parks-wip` (7th commit) | — nothing live corresponds (no materialization to fail; see **#430 dyn-dims on rebuild**) — see **#466 capture-failure diagnostics** below |
 | `fbe47db7` | #467 | Reclaim CUDA memory before graph replacement | FILE-LEVEL (2 files into the `cuda_lite_hlir` park) | branch `merge/main-cuda-graph-line-parks-wip` (8th commit) | — nothing live corresponds (no graph executables, no stream-ordered pool use; see **#430 dyn-dims on rebuild**) — see **#467 reclaim before replacement** below |
+| `9614ddef` | #472 | Trim CUDA pools after graph recapture | FILE-LEVEL (1 file into the `cuda_lite_hlir` park) | branch `merge/main-cuda-graph-line-parks-wip` (9th commit) | — nothing live corresponds (no recapture path, no async-alloc pool use; see **#430 dyn-dims on rebuild**) — see **#472 trim after recapture** below |
 
 ## #391 progress UI — re-expressed in `src/implementation_search.rs`
 
@@ -4240,6 +4241,25 @@ pools, both trimmed. Note the dependency: this builds on #450's
 path-rewritten only** — applied verbatim to
 `crates/luminal_cuda_lite_hlir/src/kernel/to_host.rs` and `.../src/runtime.rs`;
 diff-of-diffs identical.
+
+## #472 trim after recapture — parked
+
+Main's `9614ddef` (+28/-6, one file) generalizes #467's one-shot reclaim into a
+reusable `CudaGraphOp::trim_recapture_memory(stream)`: synchronize, bind the
+context, and — when the device supports async allocation
+(`context.has_async_alloc()`) — `mem_pool::trim_to(pool, 0)` on the device's
+stream-ordered pool, then `cuDeviceGraphMemTrim` on the separate device graph
+pool. Both pools matter because prepared library state comes from the
+stream-ordered pool while graph executable updates come from the graph pool, and
+a shape-changing serving workload otherwise leaves EACH GENERATION cached in a
+different pool until the device is exhausted. `retire_failed_graph_exec` is
+rewritten to call it, and it is additionally called at the end of the successful
+recapture path — replacing captured library plans releases their prior device
+buffers only once the executable points at the new graph, so the reclaim has to
+happen after that, before the next shape change prepares another complete
+generation. **Disposition: FILE-LEVEL park, path-rewritten only** — applied
+verbatim to `crates/luminal_cuda_lite_hlir/src/kernel/to_host.rs`; diff-of-diffs
+identical.
 
 ## #406 pad — the select construction REVERTED (2026-09-03)
 


### PR DESCRIPTION
#467's one-shot reclaim becomes a reusable trim_recapture_memory(stream):
synchronize, bind the context, and -- when the device supports async allocation
-- trim_to(pool, 0) on the stream-ordered pool, then cuDeviceGraphMemTrim on the
separate device graph pool. Both matter: prepared library state comes from the
stream-ordered pool, graph executable updates from the graph pool, and a
shape-changing serving workload otherwise leaves each generation cached in a
different pool until the device is exhausted.

retire_failed_graph_exec is rewritten to call it, and the successful recapture
path calls it too. Replacing captured library plans releases their prior device
buffers only once the executable points at the new graph, so the reclaim belongs
after that and before the next shape change prepares another generation.

One file, applied verbatim into the hlir park under the path rewrite;
diff-of-diffs identical. Nothing live corresponds -- see the #430 section.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
(cherry picked from commit 564139a97ba8ab081802b24148e92fbefc413c4a)

Stacked on \`merge/main-467-reclaim-cuda-memory-before-graph-replace\`. One main commit, parked/recorded per the ledger row and section in this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)