### PR TITLE
reduce_max: the -inf seed goes through cuda_f64_literal

### DIFF
--- a/crates/luminal_cuda_lite/src/kernels.rs
+++ b/crates/luminal_cuda_lite/src/kernels.rs
@@ -668,11 +668,12 @@ pub(crate) fn cuda_type(dtype: PlanDtype) -> Result<&'static str> {
 /// The non-finite cases go through bit patterns rather than the
 /// `INFINITY`/`NAN` macros because this runtime compiles kernels with
 /// NVRTC (`cudarc::nvrtc::compile_ptx`, see `device.rs`), which has no
-/// host math headers, so those macros do not exist there — the same
-/// reason, and the same technique, as the `-inf` reduction identity in
-/// [`crate::ops::reduce_max`]. The bit patterns are `float`-typed; the
-/// caller's existing `({to})` cast converts to the destination type
-/// exactly as it does for a finite literal.
+/// host math headers, so those macros do not exist there. This function
+/// is the ONLY place in the crate where a non-finite literal is spelled:
+/// every emitter that needs one calls it, including the `-inf` seed of
+/// the reduction identity in [`crate::ops::reduce_max`]. The bit patterns
+/// are `float`-typed; the caller's existing `({to})` cast converts to the
+/// destination type exactly as it does for a finite literal.
 pub(crate) fn cuda_f64_literal(v: f64) -> String {
     if v.is_nan() {
         return "__uint_as_float(0x7fc00000u)".to_string();

--- a/crates/luminal_cuda_lite/src/ops/reduce_max/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/reduce_max/mod.rs
@@ -11,7 +11,7 @@ use luminal::layout_ir::{
     AliasInfo, Bufferizable, ExtractionSite, LayoutIrOp, OpMatcher, Sharing, ToDps,
 };
 
-use crate::kernels::{CodegenCtx, KernelSource, reduce};
+use crate::kernels::{CodegenCtx, KernelSource, cuda_f64_literal, reduce};
 use anyhow::{Context, Result, bail};
 
 /// `ReduceMaxGeneric(input) -> out` — pure dataflow form.
@@ -97,9 +97,17 @@ pub(crate) fn codegen(op: &dyn BufferTensorIrOp, ctx: &CodegenCtx) -> Result<Vec
         bail!("reduce_max codegen reached with a non-ReduceMax op");
     };
     let axis = usize::try_from(r.axis).context("negative reduce axis")?;
-    // NVRTC compiles the program with no math headers, so the INFINITY macro
-    // does not exist there; this intrinsic is IEEE -inf by bit pattern.
-    reduce(ctx, axis, "__int_as_float(0xff800000)", "v > acc ? v : acc")
+    // NVRTC compiles the program with no math headers, so the INFINITY
+    // macro does not exist there and -inf has to be spelled by bit
+    // pattern. That spelling is NOT repeated here: [`cuda_f64_literal`]
+    // is the crate's single place where non-finite literals are written,
+    // and this reduction identity goes through it like any other.
+    reduce(
+        ctx,
+        axis,
+        &cuda_f64_literal(f64::NEG_INFINITY),
+        "v > acc ? v : acc",
+    )
 }
 
 /// Matches `LayoutTensorOpReduceMaxGeneric` and produces this


### PR DESCRIPTION
Follow-up to #490. That PR gave the CUDA-lite crate a single non-finite literal emitter, `cuda_f64_literal`, for the constant op. reduce_max still hand-spelled its own -inf next to a comment repeating the same NVRTC reasoning. It now calls the helper.

## The change

`crates/luminal_cuda_lite/src/ops/reduce_max/mod.rs` — the reduction identity:

- was: `reduce(ctx, axis, "__int_as_float(0xff800000)", "v > acc ? v : acc")`
- now: the seed is `&cuda_f64_literal(f64::NEG_INFINITY)`

so the **emitted kernel text changes** from `__int_as_float(0xff800000)` to `__uint_as_float(0xff800000u)`. Same IEEE -inf, and better typed: `0xff800000` is past `INT_MAX`, so C gives that constant type `unsigned int`, which the old form then passed to an `int` parameter. No test pinned the old text, so nothing needed updating; the tests in `ops/constant/mod.rs` that pin `__uint_as_float(0xff800000u)` are pinning the helper's output and still pass.

`reduce` already took `init: &str`, so **no signature change** was needed and no string leaks.

The comment stays but now points at the helper rather than re-explaining the bit pattern, and `cuda_f64_literal`'s doc comment says it is the only place in the crate a non-finite literal is spelled, reduce_max's seed included.

## Sweep

`grep -rn '__int_as_float\|__uint_as_float\|0xff800000' crates/luminal_cuda_lite` found exactly one hand-spelled pattern outside the helper — the reduce_max seed above. Post-change, bit patterns appear only inside `cuda_f64_literal` and in the tests that pin its output. A wider sweep for `INFINITY`, `NAN`, `FLT_MAX`, `__float_as_*` and large-magnitude sentinels in emitted source turned up nothing else to route.

## Gate (minimal, macOS host)

```
cargo build -p luminal_cuda_lite --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 28.08s

cargo check -p luminal_cuda_lite --features device --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.63s

cargo test -p luminal_cuda_lite
    all suites ok — 0 failed (3 pre-existing device-gated ignores)

cargo clippy -p luminal_cuda_lite --all-targets --features device
    warning: very complex type used. Consider factoring parts into `type` definitions
    warning: `luminal_cuda_lite` (test "device_profile") generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.38s

cargo fmt --all -- --check
    clean
```

The one clippy warning is the known pre-existing `type_complexity` at `device_profile.rs:46`.

**The device run is pending** — this changes emitted kernel text, so the NVRTC compile and the reduce_max numerics want an A100 confirmation before merge. #490's `constant_extreme_literals` device test already exercises `__uint_as_float(0xff800000u)` under NVRTC, which is the same token this now emits.

Based on `fix/cuda-float-literal-emission`; the diff collapses to the single commit once #490 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
