### PR TITLE
cuBLASLt on by default: full registry, once-initialized workspace

### DIFF
--- a/crates/luminal_cuda_lite/src/lib.rs
+++ b/crates/luminal_cuda_lite/src/lib.rs
@@ -9,8 +9,10 @@
 //! THE OP SET IS CHOSEN AT INITIALIZATION (ruling 2026-09-03, #420/#422
 //! rejoin Phase 2): a runtime's matcher vocabulary and its derived allow
 //! list come from the `Vec<RegisteredOp>` handed to
-//! [`CudaRuntime::load_with_registry`] — [`cuda_registry`] and
-//! [`cuda_registry_with_cublaslt`] are presets, and
+//! [`CudaRuntime::load_with_registry`] — [`cuda_registry`] (the DEFAULT:
+//! every row this crate ships, cuBLASLt markers included since the
+//! 2026-09-04 ruling) and [`cuda_registry_without_cublaslt`] (the
+//! decomposed route on purpose) are the presets, and
 //! [`cuda_registry_filtered`] narrows either without editing this crate.
 //!
 //! THIS CRATE OWNS ITS SEARCH (ruling 2026-09-03, #420/#422 rejoin
@@ -88,7 +90,9 @@ pub mod profile;
 pub use bindings::CudaBindings;
 pub use host_buffer::HostBuffer;
 pub use layouts::CudaPlan;
-pub use ops::{RegisteredOp, cuda_registry, cuda_registry_filtered, cuda_registry_with_cublaslt};
+pub use ops::{
+    RegisteredOp, cuda_registry, cuda_registry_filtered, cuda_registry_without_cublaslt,
+};
 pub use runtime::CudaRuntime;
 pub use search::{CompileOptions, Evaluator, SearchOutcome, harness_search_options};
 

--- a/crates/luminal_cuda_lite/src/ops/cublaslt/device_call.rs
+++ b/crates/luminal_cuda_lite/src/ops/cublaslt/device_call.rs
@@ -18,14 +18,18 @@
 //! (alpha = 1.0f const; beta in {0.0f, 1.0f} structural); strict
 //! CUBLAS_COMPUTE_32F with a startup detector at handle creation; a
 //! valid Cdesc on every call; workspace OWNED explicitly (allocated by
-//! us, sized into the heuristic preference — no silent fallback: zero
-//! heuristic results is a loud bail); stream-ordered on the CALLER's
-//! stream (the same stream the surrounding NVRTC kernels run on).
+//! us ONCE per CUDA context and reused by every dispatch — see
+//! [`workspace_slab`] — sized into the heuristic preference; no silent
+//! fallback: zero heuristic results is a loud bail); stream-ordered on
+//! the CALLER's stream (the same stream the surrounding NVRTC kernels
+//! run on).
 
 use anyhow::{Context, Result, anyhow};
 use cudarc::cublaslt::result as lt;
 use cudarc::cublaslt::sys;
-use cudarc::driver::{CudaStream, DevicePtr};
+use cudarc::driver::{CudaSlice, CudaStream, DevicePtr};
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use super::exec::{CSource, LtCall, LtDesc, LtOrder};
@@ -118,6 +122,47 @@ fn handle() -> Result<&'static Mutex<LtHandle>> {
 /// dispatch on this process is refused.
 pub fn assert_compute_strictness() -> Result<()> {
     handle().map(|_| ())
+}
+
+/// THE cuBLASLt WORKSPACE SLAB: [`WORKSPACE_BYTES`] allocated ONCE per
+/// CUDA context and held for the life of the process, reached the same
+/// way [`handle`] is (a `static OnceLock` behind a `Mutex`).
+///
+/// WHY ONCE — SEARCH-TIME ELECTION BIAS. This used to be an
+/// `alloc_zeros` on EVERY dispatch. The search calls dispatch once per
+/// candidate genome per profiling round, so a 32 MiB allocation was
+/// charged to the marker on every measurement while the decomposed
+/// route it competes against pays nothing of the kind: the op is then
+/// ranked on its allocator cost, not its matmul. That is exactly the
+/// failure main's FlashInfer host op documents — "global workspaces
+/// (`static OnceLock`) are shared across all instances ... without this,
+/// the GA never selects FlashInfer because the first-run allocation cost
+/// dwarfs the kernel time" — and main's cuBLASLt handle cache
+/// (`try_create_cublaslt`) is the same shape for the same reason.
+///
+/// WHY KEYED BY CONTEXT, NOT BY STREAM. A `CudaSlice` is memory in the
+/// context its stream belongs to, so the key has to separate contexts.
+/// Main keys its handle cache by `stream.cu_stream()`, which cannot work
+/// here: `CudaDevice::new` takes `ctx.default_stream()`, whose
+/// `cu_stream` is the NULL stream for every ordinal, so a stream key
+/// would hand a context-A allocation to a context-B dispatch. Keying on
+/// `cu_ctx` is the faithful adaptation. Within one context CL issues
+/// everything on that one NULL stream (see `device.rs`), so a shared
+/// slab cannot be touched by two overlapping matmuls.
+///
+/// The map holds each slice PERMANENTLY and a `CudaSlice` owns an
+/// `Arc<CudaStream>`, which owns its `Arc<CudaContext>` — so a live
+/// entry pins its own context and the `cu_ctx` address behind a key can
+/// never be recycled by a different context. The cost of that is 32 MiB
+/// per context, never freed; main accepts the same trade for the same
+/// reason.
+///
+/// LOCK ORDER: [`dispatch`] takes the handle mutex and then this one,
+/// and it is the only site that holds both. Nothing takes them the other
+/// way round.
+fn workspace_slab() -> &'static Mutex<HashMap<usize, CudaSlice<u8>>> {
+    static WORKSPACES: OnceLock<Mutex<HashMap<usize, CudaSlice<u8>>>> = OnceLock::new();
+    WORKSPACES.get_or_init(Default::default)
 }
 
 /// RAII matrix layout. CUBLASLT_MATRIX_LAYOUT_ORDER is ALWAYS declared
@@ -295,9 +340,23 @@ pub fn dispatch(
     // Workspace: OURS, explicitly, sized into the preference so the
     // heuristic can only pick algos that fit it. Zero heuristic hits is
     // a loud bail (the result layer maps that to NOT_SUPPORTED).
-    let workspace = stream
-        .alloc_zeros::<u8>(WORKSPACE_BYTES)
-        .context("cuBLASLt workspace alloc")?;
+    //
+    // Allocated ONCE per CUDA context and reused by every dispatch (see
+    // `workspace_slab`), never per call — a per-call 32 MiB alloc priced
+    // the marker out of its own search. Zeroed only at creation:
+    // cuBLASLt treats the workspace as scratch and neither reads it
+    // before writing nor requires it clean between calls.
+    let mut workspaces = workspace_slab()
+        .lock()
+        .map_err(|_| anyhow!("cuBLASLt workspace mutex poisoned"))?;
+    let workspace = match workspaces.entry(stream.context().cu_ctx() as usize) {
+        Entry::Occupied(slot) => slot.into_mut(),
+        Entry::Vacant(slot) => slot.insert(
+            stream
+                .alloc_zeros::<u8>(WORKSPACE_BYTES)
+                .context("cuBLASLt workspace alloc")?,
+        ),
+    };
     let pref =
         lt::create_matmul_pref().map_err(|e| anyhow!("cublasLtMatmulPreferenceCreate: {e:?}"))?;
     struct Pref {

--- a/crates/luminal_cuda_lite/src/ops/cublaslt/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/cublaslt/mod.rs
@@ -48,6 +48,27 @@
 //! orientation). Split sources + Ruling 1: m/n/k AND every ld may be
 //! symbolic (bound at execute time from the dyn map); static pitches are
 //! read from the layout.
+//!
+//! CONDITIONAL SOUNDNESS — THE STANDING CAVEAT (recorded 2026-09-04,
+//! when the markers became part of the default registry). Electing a
+//! marker replaces a decomposed multiply/reduce chain with
+//! `cublasLtMatmul`, and the two are NOT bit-identical. cuBLASLt picks
+//! its own REDUCTION ORDER (split-k, tile shape and the serialization
+//! of partial sums are per-algo and per-shape choices the heuristic
+//! makes for us), and it CONTRACTS multiply-add pairs into FMA where
+//! our emitted NVRTC kernels need not. So the matmul rewrites this
+//! estate mints are equalities only up to float reassociation and
+//! contraction: sound for a real-arithmetic reading of the graph,
+//! CONDITIONALLY sound for the machine one.
+//!
+//! The e-graph has no approximate-equality stratum today — every union
+//! it holds claims exactness — so nothing here distinguishes the two.
+//! Building that stratum (an explicit approximate-rewrite pass carrying
+//! its own tolerance account, so an approximate union can never be
+//! mistaken for an exact one) is DEFERRED by ruling 2026-09-04. Until
+//! it lands, every marker election carries this caveat, and the
+//! device-side check is the TOLERANCE comparison in
+//! `tests/cublaslt_contracts.rs` — never a bit-for-bit one.
 
 use luminal::buffer_tensor_ir::{BufferTensorIrOp, OpSlotNames};
 use luminal::layout_ir::{

--- a/crates/luminal_cuda_lite/src/ops/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/mod.rs
@@ -13,8 +13,8 @@
 //! rejoin Phase 2: *"you should select the allowed ops when you
 //! initialize the runtime ... You should not need to edit CL in order to
 //! modify this. It should be configurable."*). [`cuda_registry`] and
-//! [`cuda_registry_with_cublaslt`] are just the two PRESETS this crate
-//! ships; what a [`crate::CudaRuntime`] assembles, saturates, searches
+//! [`cuda_registry_without_cublaslt`] are just the two PRESETS this
+//! crate ships; what a [`crate::CudaRuntime`] assembles, saturates, searches
 //! and claims with is the `Vec<RegisteredOp>` it was handed at
 //! [`crate::CudaRuntime::load_with_registry`]. A caller narrows the
 //! vocabulary with [`cuda_registry_filtered`] over
@@ -113,10 +113,52 @@ impl RegisteredOp {
     }
 }
 
-/// The registry this runtime assembles, extracts, and derives claims
-/// with: every matcher paired with a prototype of the (functional-form)
-/// op its `extract` produces.
+/// THE DEFAULT REGISTRY (cuBLASLt ON BY DEFAULT, ruling 2026-09-04):
+/// every matcher this crate ships, paired with a prototype of the
+/// (functional-form) op its `extract` produces — the kernel-bearing and
+/// plan-transparent rows of [`cuda_registry_without_cublaslt`] PLUS the
+/// four fixed-arity cuBLASLt marker contracts, whose execution row is a
+/// HOST LIBRARY CALL (`cublasLtMatmul`), never an NVRTC kernel (the
+/// third claim class — see [`crate::CudaRuntime::allow_list`]).
+///
+/// WHY THE MARKERS USED TO SIT BEHIND AN EXPLICIT SEAM, and why they no
+/// longer do. Splicing the marker vocabulary into every assembly once
+/// detonated the `view-arity-lock` (`Illegal merge attempted`) on all
+/// seven minis, because that lock keyed a ROUTE fact (an apply's parent
+/// rank) on a VALUE (its output class) and the collapse rule's sound
+/// union `x ≡ Tᵀ(x)` put two different-parent-rank spellings in one
+/// class; the check now lives on the `IndexMapLit` (entry count == rank
+/// of the source-shape tag) and saturation succeeds. What kept the
+/// default at the Train-2 set after that was the SEARCH BUDGET: the same
+/// union is a re-description 2-cycle, and at the 2×4 harness budget the
+/// sampler exhausts on unfit genomes on real graphs (they elect at
+/// 12×16). Both are settled, so the markers are simply part of what a
+/// default CL runtime searches with.
+///
+/// A caller who wants the DECOMPOSED route on purpose asks for
+/// [`cuda_registry_without_cublaslt`]; see [`cuda_registry_filtered`]
+/// for row-by-row narrowing (and for why the four marker rows are ONE
+/// estate that must be kept or dropped together).
 pub fn cuda_registry() -> Vec<RegisteredOp> {
+    let mut registry = cuda_registry_without_cublaslt();
+    for form in cublaslt::CublasLtForm::ALL {
+        registry.push(RegisteredOp {
+            matcher: Box::new(cublaslt::CublasLtMarkerMatcher { form }),
+            prototype: Box::new(cublaslt::CublasLt { form, spec: None }),
+        });
+    }
+    registry
+}
+
+/// The registry WITHOUT the cuBLASLt estate: the kernel-bearing and
+/// plan-transparent rows only, so every matmul keeps its DECOMPOSED
+/// spelling (the multiply/reduce chain CL's own NVRTC kernels execute).
+///
+/// This is for callers that want the decomposed route ON PURPOSE — the
+/// marker-vs-decomposed tolerance comparisons, the kernel-count pins,
+/// and anyone measuring what the library call is worth. It is NOT the
+/// default: [`cuda_registry`] is.
+pub fn cuda_registry_without_cublaslt() -> Vec<RegisteredOp> {
     fn reg(
         matcher: impl OpMatcher + 'static,
         prototype: impl LayoutIrOp + 'static,
@@ -180,45 +222,6 @@ pub fn cuda_registry() -> Vec<RegisteredOp> {
     ]
 }
 
-/// The registry WITH the cuBLASLt estate (Train 3): the four
-/// fixed-arity marker contracts, registered as real CL ops whose
-/// execution row is a HOST LIBRARY CALL (`cublasLtMatmul`), never an
-/// NVRTC kernel — the third claim class (see `CudaRuntime::allow_list`).
-///
-/// WHY A SEPARATE SURFACE, as of 2026-09-01: the marker is RULED
-/// always-on, and the tripwire that blocked it is fixed — splicing the
-/// marker vocabulary into every assembly used to detonate the
-/// `view-arity-lock` (`Illegal merge attempted`) on all seven minis,
-/// because that lock keyed a ROUTE fact (an apply's parent rank) on a
-/// VALUE (its output class) and the collapse rule's sound union
-/// `x ≡ Tᵀ(x)` put two different-parent-rank spellings in one class.
-/// The check now lives on the `IndexMapLit` (entry count == rank of the
-/// source-shape tag) and saturation succeeds. What still keeps the
-/// default vocabulary at the Train-2 set is the SEARCH: the same union
-/// is a re-description 2-cycle, and at the 2×4 harness budget the
-/// sampler exhausts on unfit genomes on real graphs (they elect at
-/// 12×16). Until the budget/sampler decision lands, the marker joins an
-/// assembly through this EXPLICIT seam
-/// ([`crate::CudaRuntime::load_with_cublaslt`]), and the 2D
-/// canonical-form election pin runs marker-enabled.
-///
-/// AS OF PHASE 2 this preset is nothing but a registry VALUE: it is what
-/// [`crate::CudaRuntime::load_with_cublaslt`] hands to
-/// [`crate::CudaRuntime::load_with_registry`], and any caller can build
-/// the same list (or half of it) with [`cuda_registry_filtered`]. The
-/// default's Train-2 set is a BUDGET decision, not a capability one, and
-/// it now costs a caller one argument to overrule.
-pub fn cuda_registry_with_cublaslt() -> Vec<RegisteredOp> {
-    let mut registry = cuda_registry();
-    for form in cublaslt::CublasLtForm::ALL {
-        registry.push(RegisteredOp {
-            matcher: Box::new(cublaslt::CublasLtMarkerMatcher { form }),
-            prototype: Box::new(cublaslt::CublasLt { form, spec: None }),
-        });
-    }
-    registry
-}
-
 /// THE CONFIGURATION SEAM: the FULL registry (every row this crate
 /// ships, cuBLASLt markers included) narrowed by the caller's own
 /// predicate. This is how a vocabulary is chosen without editing CL:
@@ -234,10 +237,10 @@ pub fn cuda_registry_with_cublaslt() -> Vec<RegisteredOp> {
 /// # Ok::<(), anyhow::Error>(())
 /// ```
 ///
-/// It starts from the marker-enabled superset ON PURPOSE, so one
-/// predicate can opt a row IN as easily as OUT — `keep` sees every row
-/// that exists. The two presets remain available whole
-/// ([`cuda_registry`], [`cuda_registry_with_cublaslt`]).
+/// It starts from the FULL registry ON PURPOSE, so one predicate can
+/// opt a row IN as easily as OUT — `keep` sees every row that exists.
+/// The two presets remain available whole ([`cuda_registry`],
+/// [`cuda_registry_without_cublaslt`]).
 ///
 /// THE FOUR cuBLASLt MARKER ROWS ARE ONE ESTATE, not four independent
 /// ones: the Base row's snippets declare all four constructors and mint
@@ -254,25 +257,18 @@ pub fn cuda_registry_with_cublaslt() -> Vec<RegisteredOp> {
 /// load-bearing; labels carry their `Generic` suffix (see
 /// [`RegisteredOp::label`]).
 pub fn cuda_registry_filtered(keep: impl Fn(&RegisteredOp) -> bool) -> Vec<RegisteredOp> {
-    cuda_registry_with_cublaslt()
+    cuda_registry()
         .into_iter()
         .filter(|entry| keep(entry))
         .collect()
 }
 
 /// The matcher set the DEFAULT preset assembles and extracts with — the
-/// registry's matcher column. An instance's own column is derived from
-/// the registry it was loaded with, never from this.
+/// registry's matcher column, cuBLASLt markers included. An instance's
+/// own column is derived from the registry it was loaded with, never
+/// from this.
 pub fn cuda_matchers() -> Vec<Box<dyn OpMatcher>> {
     cuda_registry()
-        .into_iter()
-        .map(|entry| entry.matcher)
-        .collect()
-}
-
-/// The matcher column of [`cuda_registry_with_cublaslt`].
-pub fn cuda_matchers_with_cublaslt() -> Vec<Box<dyn OpMatcher>> {
-    cuda_registry_with_cublaslt()
         .into_iter()
         .map(|entry| entry.matcher)
         .collect()

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -41,8 +41,8 @@ struct NativeParts {
 /// A `Default` instance holds NO program and NO op vocabulary: every
 /// ladder method past `load` refuses it by name (`load before search`),
 /// so the empty registry a default carries is never the thing a caller
-/// searches under. `load`/`load_with_cublaslt`/`load_with_registry` are
-/// the only ways to get a usable one.
+/// searches under. `load`/`load_with_registry` are the only ways to get
+/// a usable one.
 #[derive(Default)]
 pub struct CudaRuntime {
     native: Option<NativeParts>,
@@ -103,27 +103,16 @@ pub struct CudaRuntime {
 
 impl CudaRuntime {
     /// Record the graph's native program under the DEFAULT op registry
-    /// ([`crate::ops::cuda_registry`]). Saturation happens in
-    /// [`CudaRuntime::search`].
+    /// ([`crate::ops::cuda_registry`]) — which since the 2026-09-04
+    /// ruling INCLUDES the four cuBLASLt marker contracts, so a default
+    /// search assembles the marker's egg snippets and may elect the
+    /// host-call route. Saturation happens in [`CudaRuntime::search`].
+    ///
+    /// For the DECOMPOSED route on purpose (every matmul as CL's own
+    /// multiply/reduce kernels), load with
+    /// [`crate::ops::cuda_registry_without_cublaslt`].
     pub fn load(graph: &graph::Graph) -> Result<Self> {
         Self::load_with_registry(graph, crate::ops::cuda_registry())
-    }
-
-    /// [`CudaRuntime::load`] with the cuBLASLt marker vocabulary
-    /// enabled: search assembles the marker's egg snippets and may
-    /// elect the four host-call contracts. EXPLICIT OPT-IN for now: the
-    /// view-arity tripwire that used to kill saturation on real graphs
-    /// is fixed (it now checks the map literal); at the 2×4 harness
-    /// budget the search can still die of exhaustion on the collapse's
-    /// re-description 2-cycle — loudly, never a wrong plan. The 2D
-    /// canonical matmul form searches and elects green; real graphs
-    /// elect at 12×16.
-    ///
-    /// It is now exactly [`CudaRuntime::load_with_registry`] over the
-    /// [`crate::ops::cuda_registry_with_cublaslt`] preset — a named
-    /// convenience, not a mode.
-    pub fn load_with_cublaslt(graph: &graph::Graph) -> Result<Self> {
-        Self::load_with_registry(graph, crate::ops::cuda_registry_with_cublaslt())
     }
 
     /// THE CONFIGURABLE LOAD (ruling 2026-09-03: *"you should select the
@@ -364,17 +353,14 @@ impl CudaRuntime {
     ///    [`crate::ops::cublaslt::host_dispatchable`]).
     ///
     /// THIS STATIC IS THE DEFAULT PRESET'S claim set — the same
-    /// derivation over [`crate::ops::cuda_registry`], for callers with no
-    /// graph in hand. A LOADED instance claims what its own registry
-    /// derives: [`CudaRuntime::active_allow_list`].
+    /// derivation over [`crate::ops::cuda_registry`] (markers included),
+    /// for callers with no graph in hand. A LOADED instance claims what
+    /// its own registry derives: [`CudaRuntime::active_allow_list`]. For
+    /// the decomposed preset's claim set, load with
+    /// [`crate::ops::cuda_registry_without_cublaslt`] and read that
+    /// instance's `active_allow_list`.
     pub fn allow_list() -> Vec<&'static str> {
         Self::allow_list_over(&crate::ops::cuda_registry())
-    }
-
-    /// [`CudaRuntime::allow_list`] over the marker-enabled registry —
-    /// the claim set a [`CudaRuntime::load_with_cublaslt`] search uses.
-    pub fn allow_list_with_cublaslt() -> Vec<&'static str> {
-        Self::allow_list_over(&crate::ops::cuda_registry_with_cublaslt())
     }
 
     fn allow_list_over(registry: &[crate::ops::RegisteredOp]) -> Vec<&'static str> {

--- a/crates/luminal_cuda_lite/tests/codegen_identity.rs
+++ b/crates/luminal_cuda_lite/tests/codegen_identity.rs
@@ -18,7 +18,7 @@ use luminal::bufferize::{BufferId, BufferIrGraph, BufferNode};
 use luminal::dtype::{DType, PlanDtype};
 use luminal::prelude::FxHashMap;
 use luminal_cuda_lite::kernels::Coords;
-use luminal_cuda_lite::{CudaRuntime, kernels};
+use luminal_cuda_lite::{CudaRuntime, cuda_registry_without_cublaslt, kernels};
 use std::collections::HashMap;
 
 /// Does this layout's read, taken at coordinates that ARE `i`
@@ -124,7 +124,13 @@ fn searched_plan(
 ) -> BufferIrGraph<luminal::layouts::DecodedLayout> {
     let mut cx = luminal::graph::Graph::new();
     let data = build(&mut cx);
-    let mut rt = CudaRuntime::load(&cx).expect("load");
+    // THE DECOMPOSED ROUTE ON PURPOSE: these pins compare two ways of
+    // deriving CUDA CODEGEN geometry, so every elected node must have a
+    // codegen row. A cuBLASLt marker (default since 2026-09-04) is a
+    // host library call with no codegen row at all — it would take the
+    // matmul fixture out of the comparison entirely.
+    let mut rt =
+        CudaRuntime::load_with_registry(&cx, cuda_registry_without_cublaslt()).expect("load");
     let outcome = rt
         .search(&data, &luminal_cuda_lite::harness_search_options())
         .expect("search under the CUDA allow list");

--- a/crates/luminal_cuda_lite/tests/cublaslt_bias_premise.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_bias_premise.rs
@@ -122,7 +122,7 @@ fn report_forms(egraph: &EGraph, what: &str) -> (usize, usize, usize, usize) {
 #[test]
 fn linear_with_bias_mints_the_bias_form_on_a_left_major_d() {
     let (cx, _x, _w, _b, _out) = linear_with_bias();
-    let rt = CudaRuntime::load_with_cublaslt(&cx).expect("load");
+    let rt = CudaRuntime::load(&cx).expect("load");
     let egraph = rt.saturated_egraph().expect("saturation");
 
     let (base, bias, _acc, _acc_bias) = report_forms(&egraph, "linear(4x8 . 8x3)+b[3]");
@@ -225,7 +225,7 @@ fn search_elects_the_bias_form_and_binds_a_col_d() {
             search_log: false,
             ..Default::default()
         };
-        let mut rt = CudaRuntime::load_with_cublaslt(&cx).expect("load");
+        let mut rt = CudaRuntime::load(&cx).expect("load");
         let outcome = match rt.search(&data, &options) {
             Ok(outcome) => outcome,
             Err(e) => {
@@ -349,7 +349,7 @@ fn per_row_bias_does_not_mint_the_bias_form() {
     // cannot express this for the sibling call (its bias runs along the
     // sibling's rows = the recorder's COLUMNS).
     let _out = (x.matmul(w) + b_rows.expand_dim(1, N)).output();
-    let rt = CudaRuntime::load_with_cublaslt(&cx).expect("load");
+    let rt = CudaRuntime::load(&cx).expect("load");
     let egraph = rt.saturated_egraph().expect("saturation");
     let (base, bias, _acc, acc_bias) = report_forms(&egraph, "matmul + per-ROW b[4]");
     assert!(base > 0, "the matmul itself still assembles");

--- a/crates/luminal_cuda_lite/tests/cublaslt_contracts.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_contracts.rs
@@ -395,7 +395,7 @@ fn marker_elected_bias_plan_matches_decomposed_route_tolerance_based() {
     };
 
     let (cx, x, w, b, out) = build();
-    let mut fused = CudaRuntime::load_with_cublaslt(&cx).expect("load fused");
+    let mut fused = CudaRuntime::load(&cx).expect("load fused");
     fused
         .search(&data_for(x, w, b), &options)
         .expect("fused search");
@@ -417,8 +417,13 @@ fn marker_elected_bias_plan_matches_decomposed_route_tolerance_based() {
         .expect("fused execute (bias epilogue under COL D)");
     let got = walked_dense(&fused, out);
 
+    // THE DECOMPOSED ROUTE ON PURPOSE: this half of the comparison has
+    // to be the multiply/reduce chain, so it loads the registry that has
+    // no marker in it (the DEFAULT registry does, since 2026-09-04).
     let (cx, x, w, b, out) = build();
-    let mut plain = CudaRuntime::load(&cx).expect("load plain");
+    let mut plain =
+        CudaRuntime::load_with_registry(&cx, luminal_cuda_lite::cuda_registry_without_cublaslt())
+            .expect("load plain");
     plain
         .search(
             &data_for(x, w, b),
@@ -436,7 +441,8 @@ fn marker_elected_bias_plan_matches_decomposed_route_tolerance_based() {
 
 /// Item 4 END TO END: the marker-elected plan (searched with the
 /// marker vocabulary, executed through the host-call arm) against the
-/// decomposed route (default vocabulary, NVRTC kernels), tolerance-based
+/// decomposed route (`cuda_registry_without_cublaslt`, NVRTC kernels),
+/// tolerance-based
 /// per the reduction-order contract in `assert_close`.
 #[test]
 fn marker_elected_plan_matches_decomposed_route_tolerance_based() {
@@ -469,7 +475,7 @@ fn marker_elected_plan_matches_decomposed_route_tolerance_based() {
 
     // Marker-elected route.
     let (cx, a, b, out) = build();
-    let mut fused = CudaRuntime::load_with_cublaslt(&cx).expect("load fused");
+    let mut fused = CudaRuntime::load(&cx).expect("load fused");
     let data = data_for(a.id, b.id);
     fused.search(&data, &options).expect("fused search");
     let elected =
@@ -488,9 +494,14 @@ fn marker_elected_plan_matches_decomposed_route_tolerance_based() {
     // disclosed layout (get_f32 refuses non-row-major backings by design).
     let got = walked_dense(&fused, out.id);
 
-    // Decomposed route (default vocabulary — no marker in the assembly).
+    // Decomposed route ON PURPOSE — the registry with no marker in the
+    // assembly. (The DEFAULT registry carries the marker since
+    // 2026-09-04, so this side must ask for the plain one by name or the
+    // comparison degenerates to marker-vs-marker.)
     let (cx, a, b, out) = build();
-    let mut plain = CudaRuntime::load(&cx).expect("load plain");
+    let mut plain =
+        CudaRuntime::load_with_registry(&cx, luminal_cuda_lite::cuda_registry_without_cublaslt())
+            .expect("load plain");
     let data = data_for(a.id, b.id);
     plain
         .search(&data, &luminal_cuda_lite::harness_search_options())

--- a/crates/luminal_cuda_lite/tests/cublaslt_election.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_election.rs
@@ -76,7 +76,7 @@ fn search_and_count_opts(
     pairs: &[(NodeIndex, HostBuffer)],
     options: &luminal_cuda_lite::CompileOptions,
 ) -> Row {
-    let mut rt = CudaRuntime::load_with_cublaslt(cx).expect("load");
+    let mut rt = CudaRuntime::load(cx).expect("load");
     let mut vars: Vec<_> = cx.dyn_map.iter().collect();
     vars.sort();
     for (var, value) in vars {
@@ -134,28 +134,40 @@ fn search_and_count_opts(
 
 // ---------------------------------------------------------------------------
 // REGISTRY MEMBERSHIP: the four contracts are registered CL ops and the
-// marker-enabled claim set admits them through the host-call class
-// (never a codegen row, never plan-transparency). The DEFAULT claim set
-// excludes them FOR NOW — the tripwire that blocked always-on is fixed;
-// what remains is that at the 2×4 harness budget the collapse's
-// re-description 2-cycle exhausts the sampler on real graphs (they elect
-// at 12×16). Always-on lands with the budget/sampler decision.
+// DEFAULT claim set admits them through the host-call class (never a
+// codegen row, never plan-transparency). ALWAYS-ON SINCE 2026-09-04: the
+// tripwire that blocked it was fixed on the map literal and the search
+// budget no longer decides the preset, so the marker vocabulary is what
+// a plain `load` searches with. The registry that excludes them is now
+// the one you ask for by name.
 // ---------------------------------------------------------------------------
 
 #[test]
 fn cublaslt_contracts_are_registered_host_call_claims() {
-    let with = CudaRuntime::allow_list_with_cublaslt();
     let default = CudaRuntime::allow_list();
+
+    // The DECOMPOSED preset's claim set, read off an instance loaded
+    // with it — the same derivation `allow_list` runs, over the registry
+    // a caller picks when it wants the multiply/reduce route.
+    let mut cx = Graph::new();
+    let a = cx.tensor((2usize, 3usize), DType::F32);
+    let b = cx.tensor((2usize, 3usize), DType::F32);
+    let _out = (a + b).output();
+    let decomposed =
+        CudaRuntime::load_with_registry(&cx, luminal_cuda_lite::cuda_registry_without_cublaslt())
+            .expect("load decomposed");
+
     for form in luminal_cuda_lite::ops::cublaslt::CublasLtForm::ALL {
         let ctor = form.constructor_name();
         assert!(
-            with.contains(&ctor),
-            "{ctor} missing from the marker-enabled claim set"
+            default.contains(&ctor),
+            "{ctor} missing from the DEFAULT claim set — the marker vocabulary \
+             is on by default (ruling 2026-09-04)"
         );
         assert!(
-            !default.contains(&ctor),
-            "{ctor} in the DEFAULT claim set — the marker vocabulary stays \
-             opt-in until the budget/sampler decision lands (always-on is ruled)"
+            !decomposed.active_allow_list().contains(&ctor),
+            "{ctor} claimed by `cuda_registry_without_cublaslt` — that preset is \
+             exactly the one with no marker in it"
         );
     }
     // The claim is host-call-derived: no codegen row exists for the labels.

--- a/crates/luminal_cuda_lite/tests/device_view_differentials.rs
+++ b/crates/luminal_cuda_lite/tests/device_view_differentials.rs
@@ -78,7 +78,17 @@ fn run_differential(
     let want = reference.get_f32(out).expect("reference output").clone();
 
     // CUDA side: search under the CL allow list (view electable).
-    let mut rt = CudaRuntime::load(cx).expect("cuda load");
+    //
+    // THE DECOMPOSED ROUTE ON PURPOSE: the differential below asserts
+    // BYTE equality against the reference's materialize route, which
+    // only the NVRTC multiply/reduce kernels can hold. A cuBLASLt marker
+    // (default since 2026-09-04) picks its own reduction order and
+    // contracts FMAs, so the matmul fixtures would be compared
+    // bit-for-bit against a route that is only tolerance-equal — see the
+    // reduction-order contract in `tests/cublaslt_contracts.rs`.
+    let mut rt =
+        CudaRuntime::load_with_registry(cx, luminal_cuda_lite::cuda_registry_without_cublaslt())
+            .expect("cuda load");
     // THE TWO RUNTIMES TAKE DIFFERENT HOST PAYLOADS (ruling D4,
     // 2026-09-03): the reference side stages `TypedBuffer` (its kernels
     // read typed slices), the CL side `HostBuffer` (bytes plus a dtype

--- a/crates/luminal_cuda_lite/tests/finalists_lattice.rs
+++ b/crates/luminal_cuda_lite/tests/finalists_lattice.rs
@@ -178,8 +178,17 @@ fn bucketed_options(budget: Option<usize>) -> CompileOptions {
 fn a_device_budget_forces_the_lattice_to_a_slower_set() {
     let cx = bucketed_fixture();
 
+    // THE DECOMPOSED ROUTE ON PURPOSE: this pin is about the LATTICE's
+    // budget fallback, which needs a bucket whose ranked finalists
+    // differ in slab size. Under the default (marker) vocabulary every
+    // finalist of this fixture elects the same host call and needs the
+    // same slab, so "one byte under the winner" admits nothing and the
+    // walk correctly runs out — a true refusal, but not this test's
+    // subject.
     // Pass 1: what does the winning set need?
-    let mut baseline = CudaRuntime::load(&cx).expect("cuda load");
+    let mut baseline =
+        CudaRuntime::load_with_registry(&cx, luminal_cuda_lite::cuda_registry_without_cublaslt())
+            .expect("cuda load");
     baseline
         .bind_dim_buckets('a', vec![DimBucket::new(2, 4), DimBucket::new(9, 11)])
         .expect("disjoint sorted buckets bind");
@@ -204,7 +213,9 @@ fn a_device_budget_forces_the_lattice_to_a_slower_set() {
 
     // Pass 2: one byte too little for the winning set.
     let budget = peak - 1;
-    let mut rt = CudaRuntime::load(&cx).expect("cuda load");
+    let mut rt =
+        CudaRuntime::load_with_registry(&cx, luminal_cuda_lite::cuda_registry_without_cublaslt())
+            .expect("cuda load");
     rt.bind_dim_buckets('a', vec![DimBucket::new(2, 4), DimBucket::new(9, 11)])
         .expect("disjoint sorted buckets bind");
     let outcome = rt

--- a/crates/luminal_cuda_lite/tests/input_producer_cleanup.rs
+++ b/crates/luminal_cuda_lite/tests/input_producer_cleanup.rs
@@ -173,7 +173,7 @@ fn op_lit_outputs(egraph: &EGraph) -> Vec<(ClassId, Vec<ClassId>)> {
 #[test]
 fn cleanup_marks_exactly_the_ops_that_produce_an_input_layout_tensor() {
     let (cx, _a, _b) = marker_matmul();
-    let rt = CudaRuntime::load_with_cublaslt(&cx).expect("load");
+    let rt = CudaRuntime::load(&cx).expect("load");
     let egraph = rt.saturated_egraph().expect("saturation");
 
     let marked = input_producer_ops(&egraph);
@@ -264,7 +264,7 @@ fn cleanup_marks_exactly_the_ops_that_produce_an_input_layout_tensor() {
 #[test]
 fn marked_ops_produce_only_input_terminals() {
     let (cx, _a, _b) = marker_matmul();
-    let rt = CudaRuntime::load_with_cublaslt(&cx).expect("load");
+    let rt = CudaRuntime::load(&cx).expect("load");
     let egraph = rt.saturated_egraph().expect("saturation");
 
     let marked = input_producer_ops(&egraph);
@@ -291,12 +291,12 @@ fn marked_ops_produce_only_input_terminals() {
 #[test]
 fn the_producer_index_offers_no_producer_for_an_input_terminal() {
     let (cx, _a, _b) = marker_matmul();
-    let rt = CudaRuntime::load_with_cublaslt(&cx).expect("load");
+    let rt = CudaRuntime::load(&cx).expect("load");
     let egraph = rt.saturated_egraph().expect("saturation");
 
     let index = luminal_cuda_lite::extractor::producer_index_with_matchers(
         &egraph,
-        &luminal_cuda_lite::ops::cuda_matchers_with_cublaslt(),
+        &luminal_cuda_lite::ops::cuda_matchers(),
     );
 
     // Holds under #444's retain alone; pinned here because the stratum
@@ -347,7 +347,7 @@ fn sampled_genomes_never_hand_bufferize_a_cyclic_graph() {
 
     for seed in 0..SEEDS {
         let (cx, a, b) = marker_matmul();
-        let mut rt = CudaRuntime::load_with_cublaslt(&cx).expect("load");
+        let mut rt = CudaRuntime::load(&cx).expect("load");
         let data: FxHashMap<NodeIndex, HostBuffer> =
             [(a, weights(32, 1).into()), (b, weights(24, 2).into())]
                 .into_iter()
@@ -430,9 +430,7 @@ fn saturate_with_schedule(cx: &Graph, schedule: &str) -> EGraph {
         .expect("bound parts");
     let full = format!(
         "{}\n\n{pre_schedule}{schedule}{post_checks}",
-        luminal::egglog_snippet::assembled_program_for(
-            &luminal_cuda_lite::ops::cuda_matchers_with_cublaslt()
-        )
+        luminal::egglog_snippet::assembled_program_for(&luminal_cuda_lite::ops::cuda_matchers())
     );
     let mut egraph = luminal::egglog_snippet::new_egraph();
     egraph
@@ -518,7 +516,7 @@ fn subsumed_ops(egraph: &EGraph) -> BTreeMap<String, usize> {
 #[test]
 fn named_input_keeps_its_name_bearing_spellings() {
     let cx = named_marker_matmul();
-    let rt = CudaRuntime::load_with_cublaslt(&cx).expect("load");
+    let rt = CudaRuntime::load(&cx).expect("load");
     let egraph = rt.saturated_egraph().expect("saturation");
 
     // ---- (a) the name-bearing spellings are present and LIVE. ----

--- a/crates/luminal_cuda_lite/tests/registry_selection.rs
+++ b/crates/luminal_cuda_lite/tests/registry_selection.rs
@@ -14,8 +14,8 @@ use luminal::dtype::DType;
 use luminal::prelude::FxHashMap;
 use luminal_cuda_lite::ops::cublaslt::{CublasLt, CublasLtForm, CublasLtMarkerMatcher};
 use luminal_cuda_lite::{
-    CudaRuntime, RegisteredOp, cuda_registry, cuda_registry_filtered, cuda_registry_with_cublaslt,
-    harness_search_options,
+    CudaRuntime, RegisteredOp, cuda_registry, cuda_registry_filtered,
+    cuda_registry_without_cublaslt, harness_search_options,
 };
 
 const ADD: &str = "LayoutTensorOpAddFunctionalGeneric";
@@ -46,9 +46,10 @@ fn payloads(
 }
 
 /// (b) The two shipped presets are ordinary registry VALUES: `load` is
-/// `load_with_registry(cuda_registry())` and `load_with_cublaslt` is the
-/// marker preset — in the claim set each instance actually derives, not
-/// merely by construction.
+/// `load_with_registry(cuda_registry())`, and `cuda_registry()` is the
+/// FULL one — markers included, since the 2026-09-04 always-on ruling.
+/// Asserted in the claim set each instance actually derives, not merely
+/// by construction.
 #[test]
 fn the_presets_are_just_registries() {
     let (cx, _a, _b) = add_graph();
@@ -66,40 +67,32 @@ fn the_presets_are_just_registries() {
         "the instance claim set must be the default preset's static one"
     );
 
-    let marker = CudaRuntime::load_with_cublaslt(&cx).expect("load marker");
-    let marker_explicit =
-        CudaRuntime::load_with_registry(&cx, cuda_registry_with_cublaslt()).expect("load explicit");
-    assert_eq!(
-        marker.active_allow_list(),
-        marker_explicit.active_allow_list(),
-        "`load_with_cublaslt` must be `load_with_registry(cuda_registry_with_cublaslt())`"
-    );
-    assert_eq!(
-        marker.active_allow_list(),
-        CudaRuntime::allow_list_with_cublaslt(),
-    );
+    let decomposed = CudaRuntime::load_with_registry(&cx, cuda_registry_without_cublaslt())
+        .expect("load decomposed");
 
-    // The marker preset is the default plus the four host-call
+    // The default is the decomposed preset plus the four host-call
     // contracts, and nothing is lost on the way.
-    for claimed in default.active_allow_list() {
+    for claimed in decomposed.active_allow_list() {
         assert!(
-            marker.active_allow_list().contains(claimed),
-            "the marker preset dropped {claimed}"
+            default.active_allow_list().contains(claimed),
+            "the default preset dropped {claimed}"
         );
     }
     for form in CublasLtForm::ALL {
         assert!(
-            marker
+            default
                 .active_allow_list()
                 .contains(&form.constructor_name()),
-            "the marker preset does not claim {}",
+            "the DEFAULT preset does not claim {} — the marker vocabulary is \
+             on by default (ruling 2026-09-04)",
             form.constructor_name()
         );
         assert!(
-            !default
+            !decomposed
                 .active_allow_list()
                 .contains(&form.constructor_name()),
-            "the DEFAULT preset claims {} — it is opt-in",
+            "`cuda_registry_without_cublaslt` claims {} — that preset is exactly \
+             the one with no marker in it",
             form.constructor_name()
         );
     }
@@ -118,7 +111,7 @@ fn a_filtered_registry_withholds_the_op_and_the_search_refuses() {
     // The narrowing is REAL, not a predicate that matched nothing.
     assert_eq!(
         without_add.len() + 1,
-        cuda_registry_with_cublaslt().len(),
+        cuda_registry().len(),
         "the filter must have removed exactly the add row"
     );
 
@@ -162,7 +155,10 @@ fn a_filtered_registry_withholds_the_op_and_the_search_refuses() {
 fn a_row_registered_from_outside_joins_the_claim_set() {
     let (cx, _a, _b) = add_graph();
 
-    let mut registry = cuda_registry();
+    // The BASE this row is added to is the decomposed preset: the
+    // default already ships all four marker rows, so adding one there
+    // would be a duplicate, not an outside registration.
+    let mut registry = cuda_registry_without_cublaslt();
     registry.push(RegisteredOp::new(
         Box::new(CublasLtMarkerMatcher {
             form: CublasLtForm::Base,
@@ -174,7 +170,8 @@ fn a_row_registered_from_outside_joins_the_claim_set() {
     ));
 
     let rt = CudaRuntime::load_with_registry(&cx, registry).expect("load");
-    let default = CudaRuntime::load(&cx).expect("load default");
+    let default = CudaRuntime::load_with_registry(&cx, cuda_registry_without_cublaslt())
+        .expect("load decomposed");
 
     assert!(
         rt.active_allow_list()
@@ -182,7 +179,7 @@ fn a_row_registered_from_outside_joins_the_claim_set() {
         "the hand-registered row is not claimed: {:?}",
         rt.active_allow_list()
     );
-    // Exactly one row more than the default, and the other three marker
+    // Exactly one row more than the base, and the other three marker
     // forms stayed out — the caller chose the vocabulary row by row.
     assert_eq!(
         rt.active_allow_list().len(),
@@ -203,7 +200,7 @@ fn a_row_registered_from_outside_joins_the_claim_set() {
 /// must not drift.
 #[test]
 fn registry_labels_agree_with_the_prototypes() {
-    for entry in cuda_registry_with_cublaslt() {
+    for entry in cuda_registry() {
         assert!(
             entry.constructor().starts_with("LayoutTensorOp"),
             "{} is not a LayoutTensorOp constructor",
@@ -229,7 +226,7 @@ fn registry_labels_agree_with_the_prototypes() {
 fn a_non_base_cublaslt_row_without_base_is_refused_at_load() {
     let (cx, _a, _b) = add_graph();
 
-    let mut registry = cuda_registry();
+    let mut registry = cuda_registry_without_cublaslt();
     registry.push(RegisteredOp::new(
         Box::new(CublasLtMarkerMatcher {
             form: CublasLtForm::Bias,
@@ -263,9 +260,8 @@ fn a_non_base_cublaslt_row_without_base_is_refused_at_load() {
 
     // Base alone, and all four together, both load.
     let (cx, _a, _b) = add_graph();
-    CudaRuntime::load_with_registry(&cx, cuda_registry_with_cublaslt())
-        .expect("the whole marker estate loads");
-    let mut base_only = cuda_registry();
+    CudaRuntime::load_with_registry(&cx, cuda_registry()).expect("the whole marker estate loads");
+    let mut base_only = cuda_registry_without_cublaslt();
     base_only.push(RegisteredOp::new(
         Box::new(CublasLtMarkerMatcher {
             form: CublasLtForm::Base,

--- a/crates/luminal_cuda_lite/tests/scc_sampler_marker.rs
+++ b/crates/luminal_cuda_lite/tests/scc_sampler_marker.rs
@@ -38,7 +38,7 @@ fn canonical_2d_matmul_searches_green_at_the_harness_budget() {
     let b = cx.tensor((8usize, 3usize), DType::F32);
     let _out = a.matmul(b).output();
 
-    let mut rt = CudaRuntime::load_with_cublaslt(&cx).expect("load");
+    let mut rt = CudaRuntime::load(&cx).expect("load");
     let data: FxHashMap<NodeIndex, HostBuffer> =
         [(a.id, weights(32, 1).into()), (b.id, weights(24, 2).into())]
             .into_iter()

--- a/crates/luminal_cuda_lite/tests/view_admission.rs
+++ b/crates/luminal_cuda_lite/tests/view_admission.rs
@@ -56,7 +56,15 @@ fn plan_for(
     cx: &Graph,
     inputs: &[(NodeIndex, HostBuffer)],
 ) -> BufferIrGraph<luminal::layouts::DecodedLayout> {
-    let mut rt = CudaRuntime::load(cx).expect("cuda load");
+    // THE DECOMPOSED ROUTE ON PURPOSE: this file audits the NVRTC plan
+    // SHAPE (materialize/copy/buffer counts, and `audit`'s standing
+    // requirement that every elected compute op have a codegen row). A
+    // cuBLASLt marker — default since 2026-09-04 — is a host library
+    // call with no codegen row, so the chained-matmul fixture would
+    // leave the audit rather than pass it.
+    let mut rt =
+        CudaRuntime::load_with_registry(cx, luminal_cuda_lite::cuda_registry_without_cublaslt())
+            .expect("cuda load");
     let data: FxHashMap<NodeIndex, HostBuffer> = inputs.iter().cloned().collect();
     let outcome = rt
         .search(&data, &view_search_options())

--- a/docs/main-rejoin/ledger.md
+++ b/docs/main-rejoin/ledger.md
@@ -2510,6 +2510,14 @@ saturation, extraction and search all read the instance's list;
 `cuda_allow_list()` survive unchanged as the PRESETS' claim sets, for
 callers with no graph in hand.
 
+> **SUPERSEDED 2026-09-04 (cuBLASLt on by default).** The default-off
+> budget decision above is reversed: `cuda_registry()` is now the FULL
+> registry, markers included, and `load` is that call. The names
+> `cuda_registry_with_cublaslt`, `load_with_cublaslt` and
+> `allow_list_with_cublaslt` are deleted; the decomposed route is asked
+> for by name through the new `cuda_registry_without_cublaslt()`. The
+> paragraph above stands as the record of the Phase-2 state.
+
 **The configuration surface** (all outside-callable, no CL edit):
 `cuda_registry_filtered(|op| ...)` narrows the FULL registry (marker rows
 included, so a predicate can opt a row in as easily as out);


### PR DESCRIPTION
cuBLASLt stops being an explicit opt-in on the CUDA-lite runtime: the default registry carries the four marker contracts, the 32 MiB workspace is allocated once instead of per dispatch, and the tests that were leaning on the decomposed route being the default now ask for it by name. Approved by Austin 2026-09-04 as one PR.

## 1. Registry default

`cuda_registry()` is now the FULL registry — the kernel-bearing and plan-transparent rows PLUS the four fixed-arity cuBLASLt marker contracts — and `CudaRuntime::load` is `load_with_registry(cuda_registry())` over it. A default CL runtime therefore assembles the marker's egg snippets and may elect the host-call route.

Both reasons the markers sat behind a seam are settled: the `view-arity-lock` detonation was fixed by moving the check onto the `IndexMapLit`, and the 2x4-budget objection no longer decides the preset.

**API surface**

| Deleted | Replacement |
| --- | --- |
| `cuda_registry_with_cublaslt()` | `cuda_registry()` — it is that registry now |
| `cuda_matchers_with_cublaslt()` | `cuda_matchers()` — same, for the matcher column |
| `CudaRuntime::load_with_cublaslt(g)` | `CudaRuntime::load(g)` |
| `CudaRuntime::allow_list_with_cublaslt()` | `CudaRuntime::allow_list()` |

**Added:** `cuda_registry_without_cublaslt()` — the kernel-only set, for callers that want the DECOMPOSED route on purpose.

**Unchanged in name, changed in content:** `cuda_registry_filtered` and `cuda_matchers` now start from the full registry (which is what `cuda_registry_filtered` already documented). `allow_list()` derives from the full registry.

`cuda_matchers_with_cublaslt` was not named in the brief; it was defined in terms of the deleted `cuda_registry_with_cublaslt` and would have become an exact alias of `cuda_matchers()`, so it is deleted with the rest of the `_with_cublaslt` family. Its two call sites became `cuda_matchers()`.

Stale "opt-in" prose is corrected in `ops/mod.rs`, `runtime.rs`, `lib.rs` and the two tests that stated it. `docs/main-rejoin/ledger.md` keeps its Phase-2 history and gains one dated superseding line; the remaining `opt-in` in `lib.rs` is about CL-5 device profiling, not this.

## 2. Workspace: once-initialized, shared

`device_call.rs` allocated `WORKSPACE_BYTES` (32 MiB) with `stream.alloc_zeros` on EVERY dispatch. The search calls dispatch once per candidate genome per profiling round, so that allocation was charged to the marker on every measurement while the decomposed route it competes against pays nothing of the kind — the op gets ranked on its allocator cost rather than its matmul. This is the election bias main's FlashInfer host op records ("global workspaces (`static OnceLock`) are shared across all instances ... without this, the GA never selects FlashInfer because the first-run allocation cost dwarfs the kernel time"), and main's cuBLASLt handle cache `try_create_cublaslt` is the same shape.

`workspace_slab()` is now a `static OnceLock<Mutex<HashMap<usize, CudaSlice<u8>>>>`, reached exactly the way the existing `handle()` is.

**Keyed by CUDA context, not by stream** — the one place this departs from main. Main keys its handle cache by `stream.cu_stream()`; that cannot work here, because `CudaDevice::new` takes `ctx.default_stream()`, whose `cu_stream` is the NULL stream for every ordinal, so a stream key would hand a context-A allocation to a context-B dispatch. `cu_ctx` separates them. Within one context CL issues everything on that one NULL stream, so a shared slab is never touched by two overlapping matmuls. Each entry is held permanently and a `CudaSlice` owns its `Arc<CudaStream>` and thus its `Arc<CudaContext>`, so the address behind a key cannot be recycled by a different context. The cost is 32 MiB per context, never freed.

Zeroed only at creation: cuBLASLt treats the workspace as scratch and neither reads it before writing nor requires it clean between calls. The preference's `CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES` and the `cublasLtMatmul` workspace argument keep using the same constant. The arena and `CudaDevice::slab` are untouched — this is library-owned scratch, not plan memory.

## 3. Tests

| File | Test | What moved | How |
| --- | --- | --- | --- |
| `registry_selection.rs` | `the_presets_are_just_registries` | Inverted: the pin WAS the default | `load == load_with_registry(cuda_registry())` with the four markers CLAIMED; `cuda_registry_without_cublaslt()` claims none |
| `registry_selection.rs` | `a_row_registered_from_outside_joins_the_claim_set` | Base registry | Explicit `cuda_registry_without_cublaslt()` — pushing a marker row onto a registry that already ships all four is a duplicate, not an outside registration |
| `registry_selection.rs` | `a_non_base_cublaslt_row_without_base_is_refused_at_load` | Base registry | Same |
| `registry_selection.rs` | filter-arithmetic and label pins | Preset name only | `cuda_registry()` is the full registry those pins meant |
| `cublaslt_election.rs` | `cublaslt_contracts_are_registered_host_call_claims` | Inverted | DEFAULT claims all four; the decomposed preset claims none. Host-call derivation (no codegen row, not plan-transparent) untouched |
| `cublaslt_election.rs` | election table | Call-site rename only | `load_with_cublaslt` -> `load`; already marker-enabled |
| `codegen_identity.rs` | `codegen_strings_via_descriptors_match_the_buffer_table` | Was failing: `elected op CublasLt has no codegen row` | Explicit `cuda_registry_without_cublaslt()` — the pin compares two ways of deriving CUDA codegen geometry, so every elected node must HAVE a codegen row |
| `view_admission.rs` | `chained_matmul_folds_all_movement` (+3 sharing the helper) | Was failing: same reason | Explicit `cuda_registry_without_cublaslt()` in `plan_for` — the file audits the NVRTC plan shape and requires a codegen row per elected compute |
| `finalists_lattice.rs` | `a_device_budget_forces_the_lattice_to_a_slower_set` | Was failing: `no slower set is available` | Explicit `cuda_registry_without_cublaslt()` — the lattice's budget fallback needs a bucket whose finalists differ in slab size; under the marker vocabulary every finalist of that fixture elects the same host call and needs the same slab |
| `cublaslt_contracts.rs` | both tolerance comparisons (device) | The `plain` half | Explicit `cuda_registry_without_cublaslt()` — it used to get the decomposed route from the default; leaving it on `load` would have quietly degenerated marker-vs-decomposed into marker-vs-marker |
| `device_view_differentials.rs` | `run_differential` (device) | Not observable on CI | Explicit `cuda_registry_without_cublaslt()` — it asserts BYTE equality against the reference materialize route, which only the multiply/reduce kernels can hold |
| `cublaslt_bias_premise.rs`, `scc_sampler_marker.rs`, `input_producer_cleanup.rs` | — | Call-site renames only | Already marker-enabled; semantics identical |

Unaffected (no matmul in any fixture, so no marker can fire): `plan_smoke.rs`, `composed_read_families.rs`, `constant_extreme_literals.rs`, `example_smoke.rs`, `dim_buckets.rs`, `ladder_refusals.rs`, `device_profile.rs`, `device_fidelity.rs`, `cublaslt_contracts_cpu.rs`.

No test turned out to assert election merely as a proxy for "the frontend produced the decomposed form", so no e-graph-membership helper over `saturated_egraph()` was added — every mover needed the decomposed PLAN (a codegen row, a slab spread, byte equality), not the decomposed spelling. Nothing was weakened, deleted or `#[ignore]`d.

The example harness (`examples/support/mod.rs`) keeps `load` and therefore gets the markers, as intended.

## Soundness caveat

Recorded once, in the `ops/cublaslt/mod.rs` module doc. Electing a marker replaces a decomposed multiply/reduce chain with `cublasLtMatmul`, and the two are not bit-identical: cuBLASLt picks its own reduction order (split-k, tiling, the serialization of partial sums are per-algo and per-shape) and contracts multiply-add pairs into FMA where our NVRTC kernels need not. The matmul rewrites this estate mints are therefore equalities only up to float reassociation and contraction — sound for a real-arithmetic reading of the graph, conditionally sound for the machine one. The e-graph has no approximate-equality stratum, so nothing distinguishes the two today; building one (an explicit approximate-rewrite pass carrying its own tolerance account) is deferred by ruling 2026-09-04. Until it lands, the device-side check is the tolerance comparison in `tests/cublaslt_contracts.rs`, never a bit-for-bit one.

## Gate

```
cargo build -p luminal_cuda_lite --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.43s

cargo check -p luminal_cuda_lite --features device --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.66s

cargo test -p luminal_cuda_lite
    21 binaries, all `test result: ok`; 93 passed, 0 failed, 3 ignored

cargo clippy -p luminal_cuda_lite --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.35s

cargo clippy -p luminal_cuda_lite --all-targets --features device
    warning: very complex type used. Consider factoring parts into `type` definitions
      --> crates/luminal_cuda_lite/tests/device_profile.rs:46:29
    warning: `luminal_cuda_lite` (test "device_profile") generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.12s

cargo fmt --all -- --check
    (clean)
```

The one clippy warning is the pre-existing `type_complexity` at `device_profile.rs:46`.

Known failing DEVICE test, not runnable on this host and ignored by ruling: `cublaslt_contracts::marker_elected_bias_plan_matches_decomposed_route_tolerance_based` (seed-0 election pin).

**A100 device run and sizing pass pending.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
