### PR TITLE
Retain prepared CUDA graph variants on a shared arena

### DIFF
--- a/crates/luminal_cuda_lite/src/host/cublaslt/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/cublaslt/mod.rs
@@ -777,6 +777,19 @@ impl PreparedCuBlasLtMatmul {
         self.workspace_ptr
     }
 
+    pub(crate) fn owned_scale_bytes(&self) -> usize {
+        [
+            &self._a_scale,
+            &self._b_scale,
+            &self._c_scale,
+            &self._d_scale,
+        ]
+        .into_iter()
+        .flatten()
+        .map(|scale| scale.len() * std::mem::size_of::<f32>())
+        .sum()
+    }
+
     fn update_descriptor_pointers(
         &self,
         stream: &Arc<CudaStream>,

--- a/crates/luminal_cuda_lite/src/kernel/to_host.rs
+++ b/crates/luminal_cuda_lite/src/kernel/to_host.rs
@@ -56,6 +56,10 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct CudaGraphDebugSummary {
+    /// Full graph builds since this compiled operation was created.
+    pub graph_builds: usize,
+    /// Resident executables, including the currently selected variant.
+    pub resident_variants: usize,
     pub n_kernels: usize,
     pub n_cublaslt: usize,
     pub n_flashinfer: usize,
@@ -759,6 +763,114 @@ struct CudaGraphOpState {
     timing_events: Vec<cudarc::driver::sys::CUevent>,
 }
 
+/// Shape-specific state only. Compiled functions, constants and topology stay
+/// in CudaGraphOpState; all variants address the same runtime-owned arena.
+/// Executables must be destroyed before their pointer-bearing resources.
+#[derive(Default)]
+struct ResidentGraphVariant {
+    cuda_graph_exec: Option<CudaGraphExecHandle>,
+    cuda_graph: Option<CudaGraphHandle>,
+    cublaslt_ops: Vec<CompiledCuBlasLt>,
+    flashinfer_ops: Vec<CompiledFlashInferDecode>,
+    captured_host_ops: Vec<CompiledCapturedHost>,
+    kernel_nodes: Vec<Option<CUgraphNode>>,
+    kernel_internal_bufs: Vec<Vec<CudaSlice<u8>>>,
+    kernel_params: Vec<UnifiedKernelParams>,
+    kernel_launches: Vec<KernelLaunchConfig>,
+    step_entry_nodes: Vec<CUgraphNode>,
+    step_output_nodes: Vec<CUgraphNode>,
+    cublaslt_prepare_cache: Vec<CachedCuBlasLtPrepare>,
+    cublaslt_workspace_pool: Vec<Arc<CudaSlice<u8>>>,
+    flashinfer_prepare_cache: Vec<CachedFlashInferPrepare>,
+    dyn_dims_buffer: Option<CudaSlice<i32>>,
+    last_dyn_values: DynMap,
+    last_buffer_ptrs: FxHashMap<NodeIndex, u64>,
+    last_buffers: FxHashMap<NodeIndex, DeviceBuffer>,
+    timing_events: Vec<cudarc::driver::sys::CUevent>,
+}
+
+impl ResidentGraphVariant {
+    fn empty(state: &CudaGraphOpState) -> Self {
+        let mut variant = Self::default();
+        variant.cublaslt_ops = state
+            .cublaslt_ops
+            .iter()
+            .map(|op| CompiledCuBlasLt::new(op.node, op.inputs.clone(), op.host_op.clone()))
+            .collect();
+        variant.flashinfer_ops = state
+            .flashinfer_ops
+            .iter()
+            .map(|op| CompiledFlashInferDecode::new(op.node, op.inputs.clone(), op.host_op.clone()))
+            .collect();
+        variant.captured_host_ops = state
+            .captured_host_ops
+            .iter()
+            .map(|op| CompiledCapturedHost {
+                node: op.node,
+                inputs: op.inputs.clone(),
+                host_op: op.host_op.clone(),
+                child_graph: None,
+                graph_node: None,
+            })
+            .collect();
+        variant.kernel_nodes = vec![None; state.kernels.len()];
+        variant.kernel_internal_bufs = (0..state.kernels.len()).map(|_| Vec::new()).collect();
+        variant.step_entry_nodes = vec![std::ptr::null_mut(); state.steps.len()];
+        variant.step_output_nodes = vec![std::ptr::null_mut(); state.steps.len()];
+        variant
+    }
+
+    fn swap(&mut self, state: &mut CudaGraphOpState) {
+        macro_rules! swap_fields {
+            ($($field:ident),* $(,)?) => {$(std::mem::swap(&mut self.$field, &mut state.$field);)*};
+        }
+        swap_fields!(
+            cuda_graph_exec,
+            cuda_graph,
+            cublaslt_ops,
+            flashinfer_ops,
+            captured_host_ops,
+            kernel_params,
+            kernel_launches,
+            step_entry_nodes,
+            step_output_nodes,
+            cublaslt_prepare_cache,
+            cublaslt_workspace_pool,
+            flashinfer_prepare_cache,
+            dyn_dims_buffer,
+            last_dyn_values,
+            last_buffer_ptrs,
+            last_buffers,
+            timing_events
+        );
+        for (index, kernel) in state.kernels.iter_mut().enumerate() {
+            std::mem::swap(&mut self.kernel_nodes[index], &mut kernel.graph_node);
+            std::mem::swap(
+                &mut self.kernel_internal_bufs[index],
+                &mut kernel.internal_bufs,
+            );
+        }
+    }
+}
+
+impl Drop for ResidentGraphVariant {
+    fn drop(&mut self) {
+        if let Some(exec) = &self.cuda_graph_exec {
+            for event in self.timing_events.drain(..) {
+                destroy_cuda_event(&exec.ctx, event);
+            }
+        }
+        drop(self.cuda_graph_exec.take());
+        drop(self.cuda_graph.take());
+    }
+}
+
+struct ResidentGraphVariants {
+    dims: Vec<Symbol>,
+    active_key: Option<Vec<usize>>,
+    inactive: FxHashMap<Vec<usize>, ResidentGraphVariant>,
+}
+
 impl CudaGraphOpState {
     fn new(
         kernels: Vec<CompiledKernel>,
@@ -843,6 +955,9 @@ pub struct CudaGraphOp {
     capture_stream: RefCell<Option<Arc<CudaStream>>>,
     /// Mutable state wrapped in RefCell for interior mutability
     state: RefCell<CudaGraphOpState>,
+    resident: RefCell<Option<ResidentGraphVariants>>,
+    residency_frozen: std::cell::Cell<bool>,
+    graph_builds: std::cell::Cell<usize>,
 }
 
 struct ArenaBufferOrderAccumulator {
@@ -1125,7 +1240,120 @@ impl CudaGraphOp {
             stream,
             capture_stream: RefCell::new(capture_stream),
             state: RefCell::new(state),
+            resident: RefCell::new(None),
+            residency_frozen: std::cell::Cell::new(false),
+            graph_builds: std::cell::Cell::new(0),
         }
+    }
+
+    pub(crate) fn enable_residency(&self, dims: &[Symbol]) {
+        assert!(
+            !self.residency_frozen.get(),
+            "CUDA graph residency is already frozen"
+        );
+        self.release_materialization();
+        let mut relevant: FxHashSet<_> = self
+            .cublaslt_users_by_dyn_dim
+            .keys()
+            .copied()
+            .chain(self.captured_host_dyn_dims.iter().copied())
+            .chain(self.internal_buffer_dyn_dims.iter().copied())
+            .collect();
+        assert!(
+            relevant.iter().all(|dim| dims.contains(dim)),
+            "capture-sensitive dimensions {relevant:?} must be declared in startup shape_dims"
+        );
+        if !self.state.borrow().flashinfer_ops.is_empty() {
+            relevant.extend(dims);
+        }
+        // Ordinary kernel launch dimensions are patchable and need no variant.
+        let mut dims: Vec<_> = relevant.into_iter().collect();
+        dims.sort_unstable();
+        *self.resident.borrow_mut() = Some(ResidentGraphVariants {
+            dims,
+            active_key: None,
+            inactive: FxHashMap::default(),
+        });
+    }
+
+    /// Select an already captured executable without modifying its topology.
+    /// During startup only, an unseen key gets an empty materialization slot.
+    pub(crate) fn select_resident_variant(&self, dyn_map: &DynMap) -> anyhow::Result<bool> {
+        let mut resident = self.resident.borrow_mut();
+        let Some(resident) = resident.as_mut() else {
+            return Ok(false);
+        };
+        let key = resident
+            .dims
+            .iter()
+            .map(|dim| {
+                dyn_map
+                    .get(dim)
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("missing resident CUDA graph dimension {dim:?}"))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        if resident.active_key.as_ref() == Some(&key) {
+            return Ok(false);
+        }
+        anyhow::ensure!(
+            !self.residency_frozen.get() || resident.inactive.contains_key(&key),
+            "CUDA graph shape was not prepared before serving: {:?}={key:?}",
+            resident.dims
+        );
+        let mut state = self.state.borrow_mut();
+        let mut next = resident
+            .inactive
+            .remove(&key)
+            .unwrap_or_else(|| ResidentGraphVariant::empty(&state));
+        next.swap(&mut state);
+        if let Some(previous_key) = resident.active_key.replace(key) {
+            resident.inactive.insert(previous_key, next);
+        }
+        Ok(true)
+    }
+
+    pub(crate) fn validate_residency(&self) -> anyhow::Result<()> {
+        let resident = self.resident.borrow();
+        let resident = resident
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("CUDA graph residency was not enabled"))?;
+        anyhow::ensure!(
+            resident.active_key.is_some() && self.is_materialized(),
+            "every CUDA graph bucket must be prepared before serving"
+        );
+        anyhow::ensure!(
+            resident
+                .inactive
+                .values()
+                .all(|variant| variant.cuda_graph_exec.is_some()),
+            "a resident CUDA graph variant was not fully prepared"
+        );
+        Ok(())
+    }
+
+    pub(crate) fn freeze_residency(&self) {
+        self.residency_frozen.set(true);
+    }
+
+    pub(crate) fn residency_stats(&self) -> (usize, usize) {
+        (
+            self.graph_builds.get(),
+            usize::from(self.is_materialized())
+                + self
+                    .resident
+                    .borrow()
+                    .as_ref()
+                    .map_or(0, |resident| resident.inactive.len()),
+        )
+    }
+
+    fn ensure_graph_mutation_allowed(&self, reason: &str) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !self.residency_frozen.get(),
+            "resident CUDA graph would rebuild after startup: {reason}"
+        );
+        Ok(())
     }
 
     fn capture_stream(&self) -> anyhow::Result<Arc<CudaStream>> {
@@ -1363,6 +1591,7 @@ impl CudaGraphOp {
         // workspace only when every user is dependency-ordered with the new
         // step. Unordered islands need distinct workspaces because they may
         // overlap in the captured graph.
+        let mut cublaslt_bytes = 0usize;
         let mut cublaslt_cache_plan: Vec<(CuBlasLtPrepareKey, Vec<usize>)> = Vec::new();
         for (idx, op) in state.cublaslt_ops.iter().enumerate() {
             let key = op
@@ -1381,7 +1610,7 @@ impl CudaGraphOp {
                     .ok_or(ResourceViolation::ArithmeticOverflow {
                         resource: "cached cuBLASLt prepared device memory",
                     })?;
-                persistent_bytes = persistent_bytes.checked_add(cached_bytes).ok_or(
+                cublaslt_bytes = cublaslt_bytes.checked_add(cached_bytes).ok_or(
                     ResourceViolation::ArithmeticOverflow {
                         resource: "cuBLASLt prepared device memory",
                     },
@@ -1452,8 +1681,54 @@ impl CudaGraphOp {
         shared_allocations.sort_unstable_by_key(|allocation| allocation.key);
         shared_allocations.dedup_by_key(|allocation| allocation.key);
 
+        let resident = self.resident.borrow();
+        let variants = resident.as_ref().map_or(1, |resident| {
+            (resident.inactive.len() + usize::from(resident.active_key.is_some())).max(1)
+        });
+        // Before capture, the preference limit is a conservative upper bound.
+        // Once every retained variant is materialized, count the allocations
+        // actually owned by its prepared plans. The selected cuBLAS algorithm
+        // often requires zero workspace despite a 32 MiB preference limit.
+        let cublaslt_bytes = if let Some(resident) = resident.as_ref().filter(|resident| {
+            resident.active_key.is_some()
+                && state.cuda_graph_exec.is_some()
+                && resident
+                    .inactive
+                    .values()
+                    .all(|variant| variant.cuda_graph_exec.is_some())
+        }) {
+            resident_cublaslt_device_bytes(
+                std::iter::once((
+                    state.cublaslt_ops.as_slice(),
+                    state.cublaslt_prepare_cache.as_slice(),
+                    state.cublaslt_workspace_pool.as_slice(),
+                ))
+                .chain(resident.inactive.values().map(|variant| {
+                    (
+                        variant.cublaslt_ops.as_slice(),
+                        variant.cublaslt_prepare_cache.as_slice(),
+                        variant.cublaslt_workspace_pool.as_slice(),
+                    )
+                })),
+            )?
+        } else {
+            cublaslt_bytes
+                .checked_mul(variants)
+                .ok_or(ResourceViolation::ArithmeticOverflow {
+                    resource: "resident cuBLASLt planned device memory",
+                })?
+        };
+
         Ok(HostDeviceMemoryPlan {
-            active_bucket_bytes: persistent_bytes,
+            // Every retained variant owns its captured library resources.
+            // The caller plans at bucket capacity, so charging that bound for
+            // each variant also covers smaller shapes conservatively.
+            active_bucket_bytes: persistent_bytes
+                .checked_mul(variants)
+                .and_then(|bytes| bytes.checked_add(cublaslt_bytes))
+                .ok_or(ResourceViolation::ArithmeticOverflow {
+                    resource: "resident CUDA graph variant memory",
+                })?,
             transient_peak_bytes,
             shared_allocations,
             ..Default::default()
@@ -1500,6 +1775,13 @@ impl CudaGraphOp {
             .unwrap_or_default();
 
         CudaGraphDebugSummary {
+            graph_builds: self.graph_builds.get(),
+            resident_variants: usize::from(state.cuda_graph_exec.is_some())
+                + self
+                    .resident
+                    .borrow()
+                    .as_ref()
+                    .map_or(0, |resident| resident.inactive.len()),
             n_kernels: state.kernels.len(),
             n_cublaslt: state.cublaslt_ops.len(),
             n_flashinfer: state.flashinfer_ops.len(),
@@ -1824,6 +2106,47 @@ fn steps_are_dependency_ordered(reachable: &[FixedBitSet], a: usize, b: usize) -
     a == b || reachable[a].contains(b) || reachable[b].contains(a)
 }
 
+type CuBlasLtResidentResources<'a> = (
+    &'a [CompiledCuBlasLt],
+    &'a [CachedCuBlasLtPrepare],
+    &'a [Arc<CudaSlice<u8>>],
+);
+
+fn resident_cublaslt_device_bytes<'a>(
+    variants: impl Iterator<Item = CuBlasLtResidentResources<'a>>,
+) -> Result<usize, ResourceViolation> {
+    let mut scales = FxHashMap::default();
+    let mut workspaces = FxHashMap::default();
+    for (ops, cache, pool) in variants {
+        for prepared in ops
+            .iter()
+            .flat_map(|op| {
+                op.prepared
+                    .iter()
+                    .chain(op.capture_cache.iter().map(|entry| &entry.prepared))
+            })
+            .chain(cache.iter().map(|entry| &entry.prepared))
+        {
+            scales.insert(Rc::as_ptr(prepared), prepared.owned_scale_bytes());
+            let workspace = prepared.workspace();
+            workspaces.insert(Arc::as_ptr(&workspace), workspace.len());
+        }
+        for workspace in pool {
+            workspaces.insert(Arc::as_ptr(workspace), workspace.len());
+        }
+    }
+    scales
+        .values()
+        .chain(workspaces.values())
+        .try_fold(0usize, |total, &bytes| {
+            total
+                .checked_add(bytes)
+                .ok_or(ResourceViolation::ArithmeticOverflow {
+                    resource: "resident cuBLASLt allocations",
+                })
+        })
+}
+
 fn prepare_cache_group_accepts<K: PartialEq>(
     candidate: &K,
     users: &[usize],
@@ -2122,6 +2445,9 @@ impl CudaGraphOp {
         state: &mut CudaGraphOpState,
         stream: &Arc<CudaStream>,
     ) -> anyhow::Result<()> {
+        self.ensure_graph_mutation_allowed(
+            "captured host shape, pointer, or internal allocation changed",
+        )?;
         Self::reset_materialization_state(state);
         self.trim_recapture_memory(stream)
     }
@@ -2129,6 +2455,14 @@ impl CudaGraphOp {
     /// Release driver-side graph resources while retaining the compiled op
     /// descriptions needed to materialize this bucket again later.
     pub(crate) fn release_materialization(&self) {
+        assert!(
+            !self.residency_frozen.get(),
+            "cannot evict a frozen CUDA graph"
+        );
+        if let Some(resident) = self.resident.borrow_mut().as_mut() {
+            resident.inactive.clear();
+            resident.active_key = None;
+        }
         let mut state = self.state.borrow_mut();
         Self::reset_materialization_state(&mut state);
     }
@@ -2853,6 +3187,7 @@ impl CudaGraphOp {
                     profile.cublaslt_resolve += timer.elapsed();
                     let signature = resolved.signature();
                     if state.cublaslt_ops[idx].signature != Some(signature) {
+                        self.ensure_graph_mutation_allowed("cuBLASLt shape or pointers changed")?;
                         let mut spec_changed = false;
                         if let Some(old_signature) = state.cublaslt_ops[idx].signature {
                             if old_signature.spec != signature.spec {
@@ -3031,6 +3366,7 @@ impl CudaGraphOp {
                     let needs_recapture = explicit_indptr
                         || state.flashinfer_ops[idx].signature != Some(signature.clone());
                     if needs_recapture {
+                        self.ensure_graph_mutation_allowed("FlashInfer capture signature changed")?;
                         let needs_prepare = state.flashinfer_ops[idx]
                             .signature
                             .as_ref()
@@ -3716,6 +4052,8 @@ impl CudaGraphOp {
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
         dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
+        self.ensure_graph_mutation_allowed("new graph construction")?;
+        self.graph_builds.set(self.graph_builds.get() + 1);
         let ctx = stream.context().clone();
         let mut graph = CudaGraphHandle::new(ctx.clone())?;
         let old_exec = state.cuda_graph_exec.take();
@@ -4096,6 +4434,9 @@ impl CudaGraphOp {
 
 impl Drop for CudaGraphOp {
     fn drop(&mut self) {
+        // Inactive executables also reference the compiled functions and
+        // constants in state. Retire them before Rust drops those modules.
+        drop(self.resident.get_mut().take());
         let mut state = self.state.borrow_mut();
 
         // Destroy timing events first

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -514,6 +514,7 @@ pub struct CudaRuntimeImpl<O> {
     /// kernels and the shared arena remain resident; only driver graph state
     /// is evicted and rebuilt when an older bucket is needed again.
     max_materialized_buckets: Option<usize>,
+    cuda_graphs_frozen: bool,
     materialized_bucket_lru: VecDeque<usize>,
     /// Bucket definitions per dimension (empty = single-bucket mode)
     dim_buckets: FxHashMap<Symbol, Vec<DimBucket>>,
@@ -666,6 +667,11 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
     /// `Some(0)` is invalid because the active bucket must remain usable.
     pub fn set_max_materialized_buckets(&mut self, max_buckets: Option<usize>) {
         assert!(
+            !self.cuda_graphs_frozen
+                || max_buckets.is_none_or(|cap| cap >= self.compiled_buckets.len()),
+            "cannot enable CUDA graph eviction after freezing residency"
+        );
+        assert!(
             max_buckets != Some(0),
             "materialized bucket capacity must be positive"
         );
@@ -677,6 +683,78 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
     pub fn with_max_materialized_buckets(mut self, max_buckets: usize) -> Self {
         self.set_max_materialized_buckets(Some(max_buckets));
         self
+    }
+
+    fn cuda_graphs(&self) -> impl Iterator<Item = &CudaGraphOp> {
+        self.compiled_buckets.iter().flat_map(|bucket| {
+            bucket
+                .exec_graph
+                .node_weights()
+                .filter_map(|op| op.internal.as_any().downcast_ref::<CudaGraphOp>())
+        })
+    }
+
+    /// Begin startup capture of finite shape variants sharing one arena.
+    /// Other dimensions remain patchable through the dynamic ABI.
+    pub fn begin_cuda_graph_preparation(&mut self, shape_dims: &[Symbol]) {
+        assert!(
+            !self.cuda_graphs_frozen,
+            "CUDA graph residency is already frozen"
+        );
+        self.cuda_stream.synchronize().unwrap();
+        self.set_max_materialized_buckets(None);
+        for graph in self.cuda_graphs() {
+            graph.enable_residency(shape_dims);
+        }
+        self.materialized_bucket_lru.clear();
+        self.release_pooled_memory();
+    }
+
+    /// Materialize one serving shape using the caller's current, valid input
+    /// descriptors. Does not launch the model or modify its KV state.
+    pub fn prepare_cuda_graphs(&mut self, dyn_map: &DynMap) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !self.cuda_graphs_frozen,
+            "CUDA graph preparation is already finished"
+        );
+        self.active_bucket = self.resolve_bucket(dyn_map);
+        self.compiled_buckets[self.active_bucket].hlir_synced = false;
+        self.prepare_bucket_buffers(self.active_bucket, dyn_map);
+        self.update_shared_dyn_dims(self.active_bucket, dyn_map);
+        self.apply_output_ptr_registrations();
+        self.materialize_bucket_cuda_graphs(self.active_bucket, dyn_map, false)?;
+        self.cuda_stream.synchronize()?;
+        Ok(())
+    }
+
+    /// Validate every retained bucket, then forbid recapture, eviction and arena growth.
+    pub fn finish_cuda_graph_preparation(&mut self) -> anyhow::Result<()> {
+        self.cuda_stream.synchronize()?;
+        // Include all retained library plans in the final capacity check.
+        self.validated_resource_signatures.clear();
+        let capacity = self.compiled_buckets[self.active_bucket]
+            .last_resource_validation_dyn_map
+            .clone();
+        self.validate_compiled_bucket_resources(self.active_bucket, &capacity)
+            .map_err(|error| {
+                anyhow::anyhow!("resident CUDA graph resources exceed capacity: {error}")
+            })?;
+        for graph in self.cuda_graphs() {
+            graph.validate_residency()?;
+        }
+        for graph in self.cuda_graphs() {
+            graph.freeze_residency();
+        }
+        self.cuda_graphs_frozen = true;
+        Ok(())
+    }
+
+    /// Total full graph builds and currently retained executables. Cheap
+    /// counters for asserting that serving never creates a new graph.
+    pub fn cuda_graph_residency_stats(&self) -> (usize, usize) {
+        self.cuda_graphs()
+            .map(CudaGraphOp::residency_stats)
+            .fold((0, 0), |a, b| (a.0 + b.0, a.1 + b.1))
     }
 
     /// Configure a hard per-kernel generated CUDA source limit. The runtime
@@ -921,6 +999,11 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         {
             return false;
         }
+
+        assert!(
+            !self.cuda_graphs_frozen,
+            "shared CUDA arena would grow after startup: required={required_bytes}"
+        );
 
         self.release_all_bucket_cuda_graphs();
         self.cuda_stream
@@ -1954,6 +2037,35 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         let len = buf.len();
         self.hlir_buffers.insert(id, CudaInput::Buffer { buf, len });
         self.changed_hlir.insert(id);
+    }
+
+    /// Commit recurrent state without changing its input address. Alias-proven
+    /// updates are free; copy-then-modify schedules copy into the existing
+    /// allocation instead of allocating a new input on every iteration.
+    pub fn copy_output_to_input(&mut self, output: impl ToId, input: impl ToId) {
+        let source = self.resolve_output_buffer(output);
+        let input = input.to_id();
+        let CudaInput::Buffer { buf, len } = self
+            .hlir_buffers
+            .get(&input)
+            .expect("missing recurrent input buffer")
+        else {
+            panic!("copy_output_to_input requires an owned input allocation");
+        };
+        assert_eq!(source.len(), *len, "recurrent state size must remain fixed");
+        let destination = buf.device_ptr(&self.cuda_stream).0;
+        if source.ptr() != destination {
+            unsafe {
+                result::memcpy_dtod_async(
+                    destination,
+                    source.ptr(),
+                    *len,
+                    self.cuda_stream.cu_stream(),
+                )
+                .expect("recurrent state copy failed");
+            }
+        }
+        self.hlir_host_mirrors.remove(&input);
     }
 
     pub fn get_bool(&self, id: impl ToId) -> Vec<bool> {
@@ -3065,7 +3177,9 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                 bucket.resource_validation_complete = false;
             }
         }
-        if !self.compiled_buckets[bucket_idx].resource_validation_complete {
+        let resource_validation_refreshed =
+            !self.compiled_buckets[bucket_idx].resource_validation_complete;
+        if resource_validation_refreshed {
             let resource_validation_signature =
                 self.resource_validation_signature(bucket_idx, &allocation_dyn_map);
             if !self
@@ -3151,14 +3265,19 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
 
         let timer = std::time::Instant::now();
         if stabilize_intermediate_pointers
-            && self.compiled_buckets[bucket_idx].last_dyn_map != *dyn_map
+            && (resource_validation_refreshed
+                || needs_binding
+                || !self.compiled_buckets[bucket_idx].hlir_synced
+                || self.compiled_buckets[bucket_idx].last_dyn_map != *dyn_map)
         {
             let bucket = &mut self.compiled_buckets[bucket_idx];
-            if bucket.hlir_synced {
+            if bucket.hlir_synced && !resource_validation_refreshed && !needs_binding {
                 Self::refresh_intermediate_buffer_lengths_for_changed_dims(bucket, dyn_map);
             } else {
-                // A cold bucket or relocated shared arena must rebuild every
-                // logical length before its cached views can be materialized.
+                // Capacity planning can replace last_dyn_map with the upper
+                // bound while existing views still have shorter logical
+                // lengths. Restore exact lengths after validation as well as
+                // on a cold bucket or relocated arena.
                 Self::refresh_intermediate_buffer_lengths(bucket, dyn_map);
             }
         }
@@ -3476,7 +3595,8 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             let Some(cuda_graph) = exec_op.internal.as_any().downcast_ref::<CudaGraphOp>() else {
                 continue;
             };
-            if !fully_dirty {
+            let variant_changed = cuda_graph.select_resident_variant(dyn_map)?;
+            if !fully_dirty && !variant_changed {
                 let mut changed_buffers = FxHashMap::default();
                 for node in dirty_nodes
                     .iter()
@@ -4985,6 +5105,7 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
             compiled_buckets: vec![CompiledBucket::new()],
             active_bucket: 0,
             max_materialized_buckets: None,
+            cuda_graphs_frozen: false,
             materialized_bucket_lru: VecDeque::new(),
             dim_buckets: FxHashMap::default(),
             output_ptr_registrations: FxHashMap::default(),
@@ -5484,6 +5605,24 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                     .map(CudaGraphOp::debug_summary)
             })
             .collect()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn debug_retained_host_memory_bytes(&self) -> usize {
+        let lengths = self.hlir_resource_buffer_lengths();
+        let plans = self
+            .compiled_buckets
+            .iter()
+            .map(|bucket| {
+                Self::compiled_host_device_memory_plans(
+                    bucket,
+                    &bucket.last_resource_validation_dyn_map,
+                    &Self::planned_resource_buffer_lengths(bucket, &lengths),
+                )
+                .unwrap()
+            })
+            .collect_vec();
+        Self::aggregate_host_device_memory(&plans, &[]).unwrap().0
     }
 
     #[cfg(test)]

--- a/crates/luminal_cuda_lite/src/tests/bucket_tests.rs
+++ b/crates/luminal_cuda_lite/src/tests/bucket_tests.rs
@@ -27,6 +27,44 @@ fn bucket_options(buckets: &[DimBucket]) -> CompileOptions {
 }
 
 #[test]
+fn resident_recurrent_output_preserves_input_allocation() {
+    let Some(stream) = get_cuda_stream() else {
+        return;
+    };
+    let mut cx = Graph::default();
+    let input = cx.tensor(('s', 4)).persist();
+    let output = (input + input).output();
+    cx.set_dim('s', 2);
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let mut rt = CudaRuntime::initialize(stream);
+    let initial = (1..=8).map(|value| value as f32).collect::<Vec<_>>();
+    rt.set_data(input, initial.clone());
+    let mut rng = SmallRng::seed_from_u64(19);
+    rt = cx.search_with_rng(
+        rt,
+        CompileOptions::default().search_graph_limit(5),
+        &mut rng,
+    );
+    rt.set_data(input, initial.clone());
+    rt.begin_cuda_graph_preparation(&[]);
+    rt.prepare_cuda_graphs(&cx.dyn_map).unwrap();
+    rt.finish_cuda_graph_preparation().unwrap();
+    let baseline = rt.cuda_graph_residency_stats();
+    for iteration in 1..=8 {
+        rt.execute(&cx.dyn_map);
+        assert_eq!(
+            rt.get_f32(output),
+            initial
+                .iter()
+                .map(|value| value * (1 << iteration) as f32)
+                .collect::<Vec<_>>()
+        );
+        rt.copy_output_to_input(output, input);
+        assert_eq!(rt.cuda_graph_residency_stats(), baseline);
+    }
+}
+
+#[test]
 fn test_bucket_dispatch_simple() {
     // Tests that bucketed compilation produces correct results for different dim values
     let Some(stream) = get_cuda_stream() else {

--- a/crates/luminal_cuda_lite/src/tests/cublaslt_rewrite_tests.rs
+++ b/crates/luminal_cuda_lite/src/tests/cublaslt_rewrite_tests.rs
@@ -1230,6 +1230,75 @@ fn bucket_range_and_singleton_cublaslt_buckets_are_captured() {
 }
 
 #[test]
+fn resident_cublaslt_variants_switch_without_recapture() {
+    let Some(stream) = get_cuda_stream() else {
+        return;
+    };
+    if !cublaslt_available_for_runtime(&stream)
+        || !crate::host::cublaslt::cublaslt_graph_capture_supported(&stream)
+    {
+        return;
+    }
+    let (k, n) = (5, 11);
+    let mut cx = Graph::new();
+    let a = cx.tensor(('s', k)).persist();
+    let b = cx.tensor((k, n)).persist();
+    let out = a.matmul(b).output();
+    cx.set_dim('s', 4);
+    let llir = extract_forced_cublaslt_llir_where(&mut cx, "resident cuBLASLt variants", |_| true);
+    let dim_buckets = [(
+        Symbol::from('s'),
+        vec![DimBucket::new(1, 1), DimBucket::new(2, 4)],
+    )]
+    .into_iter()
+    .collect();
+    let buckets = [(0, 1), (1, 4)].map(|(index, size)| {
+        (
+            [(Symbol::from('s'), index)].into_iter().collect(),
+            [(Symbol::from('s'), size)].into_iter().collect(),
+            llir.clone(),
+        )
+    });
+    let mut rt = CudaRuntime::initialize(stream);
+    rt.set_data_with_capacity(a, vec![0.0f32; 4 * k], 4 * k * 4);
+    let b_values = random_f32_vec(k * n, 17, -0.1, 0.1);
+    rt.set_data(b, b_values.clone());
+    rt.load_llir_buckets(&dim_buckets, &buckets);
+    rt.begin_cuda_graph_preparation(&['s'.into()]);
+    assert!(rt.debug_retained_host_memory_bytes() >= 2 * 32 * 1024 * 1024);
+    for s in [4, 2, 1] {
+        cx.set_dim('s', s);
+        rt.set_data(a, vec![0.0f32; s * k]);
+        rt.prepare_cuda_graphs(&cx.dyn_map).unwrap();
+    }
+    rt.finish_cuda_graph_preparation().unwrap();
+    // These tiny GEMMs do not need the 32 MiB workspace preference limit.
+    // Final residency validation must charge their actual allocations, even
+    // with several retained shapes, instead of multiplying that limit.
+    assert!(rt.debug_retained_host_memory_bytes() < 32 * 1024 * 1024);
+    let baseline = rt.cuda_graph_residency_stats();
+    let arena = rt.intermediate_buffer_bytes();
+    assert_eq!(baseline.1, 3);
+    for iteration in 0..24 {
+        let s = [1, 4, 2, 4, 1, 2][iteration % 6];
+        cx.set_dim('s', s);
+        let values = random_f32_vec(s * k, 123 + iteration as u64, -0.1, 0.1);
+        let expected = reference_matmul_2d(&values, &b_values, s, n, k);
+        rt.set_data(a, values);
+        rt.execute(&cx.dyn_map);
+        assert_close(&rt.get_f32(out), &expected, 1e-5, 1e-5);
+        assert_eq!(rt.cuda_graph_residency_stats(), baseline);
+        assert_eq!(rt.intermediate_buffer_bytes(), arena);
+    }
+    cx.set_dim('s', 3);
+    rt.set_data(a, vec![0.0f32; 3 * k]);
+    assert!(
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| rt.execute(&cx.dyn_map))).is_err()
+    );
+    assert_eq!(rt.cuda_graph_residency_stats(), baseline);
+}
+
+#[test]
 fn mixed_cuda_graph_cublaslt_recaptures_on_input_pointer_change() {
     let Some(stream) = get_cuda_stream() else {
         return;


### PR DESCRIPTION
Changing capture-sensitive dimensions currently rebuilds CUDA graphs and reallocates graph resources during execution. Add an explicit startup preparation phase that retains executable variants while sharing compiled kernels and one intermediate arena.

- Prepare finite shape variants, then freeze residency so serving rejects recapture, eviction, unseen capture shapes, and arena growth.
- Account for actual retained cuBLASLt workspaces and scale allocations, and destroy executables before the resources they reference.
- Keep recurrent input allocations stable when committing outputs, and restore exact logical buffer lengths after capacity validation and bucket rebinding.

Validation on an H200: 3 focused residency tests and 11 bucket tests passed, including numerical comparison across repeated cuBLASLt shape switches and stable recurrent input pointers. The combined server also passed a 256-request, one-layer GPT-OSS checkpoint test with constant graph counts and arena size. CUDA Lite Clippy with warnings denied and formatting checks passed.

Companion PRs: https://github.com/luminal-ai/luminal_cuda/pull/9 fixes attention scratch ownership across capture streams; https://github.com/luminal-ai/luminal-inference-server/pull/6 prepares all serving shapes at startup. Merge both library PRs before the server PR.
