### PR TITLE
cuBLASLt: a degenerate-extent D is both orders; bias forms take COL

### DIFF
--- a/crates/luminal_cuda_lite/src/ops/cublaslt/exec.rs
+++ b/crates/luminal_cuda_lite/src/ops/cublaslt/exec.rs
@@ -87,6 +87,16 @@
 //! call whose D is not COL is unreachable from the estate, and reaching
 //! it is a bug to bail on, never a case to handle.
 //!
+//! ONE EXCEPTION, and it is not a drift: at a DEGENERATE destination
+//! extent (`m == 1` or `n == 1`) the right-major and left-major
+//! contiguous index maps over `[m, n]` are the SAME FUNCTION, so both
+//! spellings live in one e-class and the decoder — RightMajor first by
+//! preference order — may hand this bridge the right-major one for a
+//! class whose left-major spelling the decorator matched. There is no
+//! disagreement about bytes to refuse, so [`bind_destination`] spells
+//! the coincidence COL on a bias-bearing call (whisper, A100
+//! 2026-09-04 — the arm carries the failure verbatim).
+//!
 //! THE DESTINATION FRAME IS THE PLAN'S, NOT A CONSTANT (regression fix,
 //! 2026-08-31 — see [`bind_destination`]). The paragraph above says
 //! "the executor materializes every result DENSE ROW-MAJOR in the
@@ -342,6 +352,50 @@ pub fn bind_destination(
         );
     }
     let desc = match &dest.mirror {
+        // THE DEGENERATE-EXTENT COINCIDENCE (whisper on the A100,
+        // 2026-09-04). At `n == 1` — symmetrically `m == 1` — the
+        // right-major and left-major contiguous index maps over the
+        // `[m, n]` frame are the SAME FUNCTION: `r*n + c` and `c*m + r`
+        // agree because the collapsed axis's coordinate can only be 0.
+        // The e-graph knows it (an extent-1 `CoordVar` welds to
+        // `(IntLit 0)` by the [n,n] pin collapse, so the right-major and
+        // left-major strided chains fold together and both contiguous
+        // spellings land in ONE class), and that is exactly the drift
+        // this bridge saw: the estate's bias decorators matched the
+        // `LeftMajorContiguousElementLayoutLit` spelling, while
+        // `decode_layout`, whose preference order tries RightMajor
+        // FIRST, handed the executor the right-major spelling out of
+        // that same class. Nothing had actually diverged — but building
+        // ROW here tripped [`assert_bias_destination_order`] and refused
+        // EVERY whisper candidate genome at device prepare:
+        //
+        //   cuBLASLt CublasLtAccumulateBias: unreachable: the bias
+        //   decorators require a LeftMajor D; a bias form
+        //   (LayoutTensorOpCublasLtAccumulateBias) reached the executor
+        //   with a Row-order D descriptor (384x1 ld 1). [...]
+        //
+        // (whisper tiny.en decodes ONE token: the recorder site is
+        // x[1, 384] @ w[384, 384] + b[384], so the sandwich sibling's
+        // call frame is m = 384, n = 1.) Search then died with "no
+        // candidate genome produced an executable plan".
+        //
+        // MEMORY IDENTITY, the whole argument: ROW `m x 1 / ld 1`
+        // addresses `r*1 + 0 = r` and COL `m x 1 / ld m` addresses
+        // `0*m + r = r`, for every `r` in `[0, m)`; ROW `1 x n / ld n`
+        // addresses `0*n + c = c` and COL `1 x n / ld 1` addresses
+        // `c*1 + 0 = c`. Same elements, same order, same reach. So on a
+        // bias-bearing call the coincidence is spelled the way the
+        // LIBRARY requires — BIAS/RELU_BIAS is CUBLAS_STATUS_NOT_SUPPORTED
+        // on a ROW-order D (measured on the A100 2026-08-28) — which is
+        // also the spelling the decorator's premise matched.
+        //
+        // NON-degenerate calls are untouched, and the tripwire below
+        // stays exactly as it is: with both extents > 1 the two orders
+        // denote DIFFERENT byte orders, and a bias form arriving with a
+        // ROW D there is a real drift to bail on.
+        M::RightMajor(_) if call.bias_operand.is_some() && (call.m == 1 || call.n == 1) => {
+            LtDesc::col(call.m, call.n, call.m.max(1))
+        }
         M::RightMajor(_) => LtDesc::row(call.m, call.n, call.n.max(1)),
         M::LeftMajor(_) => LtDesc::col(call.m, call.n, call.m.max(1)),
         other => bail!(
@@ -373,7 +427,12 @@ pub fn bind_destination(
 /// LeftMajor election to `CUBLASLT_ORDER_COL`. A bias-bearing call whose
 /// D descriptor is not COL is therefore UNREACHABLE from a planned
 /// dispatch — it can only mean the estate premise and this bridge have
-/// drifted apart (or a hand-built call). Bail, never dispatch: the
+/// drifted apart (or a hand-built call). The one way that used to be
+/// reachable WITHOUT a drift — a degenerate `m == 1` / `n == 1`
+/// destination, where the two orders are the same function and the
+/// decoder's RightMajor-first preference picks the other spelling out
+/// of the shared class — is resolved in [`bind_destination`] BEFORE
+/// this runs, so it never reaches here. Bail, never dispatch: the
 /// library refuses BIAS/RELU_BIAS on a ROW-order D
 /// (CUBLAS_STATUS_NOT_SUPPORTED, measured on the A100 2026-08-28), and
 /// this check names the finding BEFORE any descriptor is built.

--- a/crates/luminal_cuda_lite/tests/cublaslt_bias_premise.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_bias_premise.rs
@@ -334,6 +334,195 @@ fn search_elects_the_bias_form_and_binds_a_col_d() {
 }
 
 // ---------------------------------------------------------------------------
+// THE DEGENERATE-EXTENT COINCIDENCE (whisper on the A100, 2026-09-04) —
+// the CPU reproduction of the live defect and its cure.
+//
+// whisper tiny.en decodes ONE token, so its q/v projections are
+// `x[1, 384] @ w[384, 384] + b[384]`: the recorder's m is 1, and the
+// sandwich sibling's call frame is therefore `m = 384, n = 1`. At a
+// degenerate extent the right-major and left-major contiguous index maps
+// over `[m, n]` are the SAME FUNCTION, so BOTH spellings live in one
+// e-class: the estate's bias decorator matched the LeftMajor one, and
+// `decode_layout` (RightMajor first by preference order) handed the
+// executor the right-major one out of that same class. `bind_destination`
+// built a ROW D, `assert_bias_destination_order` fired, and EVERY
+// candidate genome was refused at device prepare:
+//
+//   cuBLASLt CublasLtAccumulateBias: unreachable: the bias decorators
+//   require a LeftMajor D; a bias form
+//   (LayoutTensorOpCublasLtAccumulateBias) reached the executor with a
+//   Row-order D descriptor (384x1 ld 1). [...] refused BEFORE dispatch
+//
+// -> "no candidate genome produced an executable plan".
+//
+// This pin is the same geometry at pin scale (`x[1, K] @ w[K, N] + b[N]`,
+// so the sibling frame is `[N, 1]`), and it is CPU-decidable end to end:
+// saturation mints the form, the seeded search elects it, and
+// `bind_destination` must resolve its D to COL rather than refusing.
+// ---------------------------------------------------------------------------
+
+/// The whisper shape at pin scale: a SINGLE batch row, so the sibling
+/// call frame's n collapses to 1.
+fn degenerate_linear_with_bias() -> (Graph, NodeIndex, NodeIndex, NodeIndex, NodeIndex) {
+    let mut cx = Graph::new();
+    let weight = cx.named_tensor("fc.weight", (K, N), DType::F32);
+    let bias = cx.named_tensor("fc.bias", N, DType::F32);
+    let x = cx.tensor((1usize, K), DType::F32);
+    let out = luminal_nn::linear(x, weight, Some(bias)).output();
+    (cx, x.id, weight.id, bias.id, out.id)
+}
+
+#[test]
+fn a_degenerate_extent_d_holds_both_contiguous_spellings_in_one_class() {
+    let (cx, _x, _w, _b, _out) = degenerate_linear_with_bias();
+    let rt = CudaRuntime::load(&cx).expect("load");
+    let egraph = rt.saturated_egraph().expect("saturation");
+    let (_base, bias, _acc, _acc_bias) = report_forms(&egraph, "linear(1xK . KxN)+b[N]");
+    assert!(
+        bias > 0,
+        "the bias form still mints at a degenerate extent (the LeftMajor \
+         premise is satisfied — the coincidence puts that spelling in the class)"
+    );
+    let mut classes: BTreeSet<ClassId> = BTreeSet::new();
+    for node in egraph
+        .nodes
+        .values()
+        .filter(|n| n.op == "LayoutTensorOpCublasLtBias")
+    {
+        classes.insert(d_layout_class(&egraph, node));
+    }
+    for class in &classes {
+        let ops = class_ops(&egraph, class);
+        let mirror = luminal::layouts::decode_layout_for(&egraph, class, "degenerate-D pin")
+            .expect("the D layout class decodes");
+        println!("DEGENERATE-D bias D class {class:?}: ops={ops:?}");
+        println!("DEGENERATE-D   decoded (most-structured spelling): {mirror:?}");
+        assert!(
+            ops.contains("LeftMajorContiguousElementLayoutLit"),
+            "the decorator's premise spelling must be present: {ops:?}"
+        );
+        // THE COINCIDENCE ITSELF: the right-major spelling is in the SAME
+        // class, because at n == 1 the two index maps are one function.
+        // This is what makes the decoder's RightMajor-first preference
+        // hand the executor a "different" order for the same bytes.
+        assert!(
+            ops.contains("RightMajorContiguousElementLayoutLit"),
+            "at a degenerate extent BOTH contiguous spellings live in one \
+             class — that coincidence is the whole defect: {ops:?}"
+        );
+    }
+}
+
+#[test]
+fn a_degenerate_extent_bias_election_binds_col_and_is_not_refused() {
+    let (cx, x, w, b, _out) = degenerate_linear_with_bias();
+    let data: FxHashMap<NodeIndex, HostBuffer> = [
+        (x, HostBuffer::from(weights(K, 1))),
+        (w, HostBuffer::from(weights(K * N, 2))),
+        (b, HostBuffer::from(weights(N, 3))),
+    ]
+    .into_iter()
+    .collect();
+
+    let mut elected = None;
+    for seed in 0..6u64 {
+        let options = luminal_cuda_lite::CompileOptions {
+            generations: 12,
+            generation_size: 16,
+            mutations: 4,
+            trials: 1,
+            seed,
+            search_log: false,
+            ..Default::default()
+        };
+        let mut rt = CudaRuntime::load(&cx).expect("load");
+        let outcome = match rt.search(&data, &options) {
+            Ok(outcome) => outcome,
+            Err(e) => {
+                // BEFORE THE FIX this is where whisper died: every genome
+                // carrying the bias form was refused at prepare, so the
+                // search itself reported "no candidate genome produced an
+                // executable plan".
+                panic!("DEGENERATE-D seed {seed}: SEARCH DIED: {e:#}");
+            }
+        };
+        let plan = rt.plan().expect("plan");
+        let labels: Vec<String> = plan
+            .dag
+            .node_weights()
+            .filter_map(|n| match n {
+                BufferNode::Compute { op, .. } => {
+                    let l = op.label().to_string();
+                    (l != "BufferAlloc" && l != "BufferFree").then_some(l)
+                }
+                _ => None,
+            })
+            .collect();
+        println!(
+            "DEGENERATE-D seed {seed}: computes={labels:?} refusals=[{}]",
+            outcome.refusal_breakdown.summary()
+        );
+        if labels
+            .iter()
+            .any(|l| l.starts_with("CublasLt") && l.contains("Bias"))
+        {
+            elected.get_or_insert((seed, rt));
+        }
+    }
+    let (seed, rt) = elected.expect(
+        "some seed in 0..6 must elect a cuBLASLt bias form on the degenerate \
+         [1, K] @ [K, N] + b[N] shape (this is the whisper site at pin scale)",
+    );
+    println!("DEGENERATE-D: asserting on the plan elected at seed {seed}");
+
+    let plan = rt.plan().expect("plan");
+    let mut checked = 0usize;
+    for node in plan.dag.node_weights() {
+        let BufferNode::Compute {
+            op, result_info, ..
+        } = node
+        else {
+            continue;
+        };
+        if !(op.label().starts_with("CublasLt") && op.label().contains("Bias")) {
+            continue;
+        }
+        let functional: &CublasLt = match op.as_any().downcast_ref::<CublasLtDps>() {
+            Some(dps) => &dps.op,
+            None => op
+                .as_any()
+                .downcast_ref::<CublasLt>()
+                .expect("a CublasLt*Bias compute node is a CublasLt(Dps) instance"),
+        };
+        let mut call = plan_call(functional).expect("plan_call on the elected bias spec");
+        let dest = &result_info
+            .first()
+            .expect("single-destination contract")
+            .layout;
+        println!(
+            "DEGENERATE-D elected: m={} n={} k={} dest={:?}",
+            call.m, call.n, call.k, dest.mirror
+        );
+        assert_eq!(call.n, 1, "the degenerate sibling frame has n == 1");
+        // THE REGRESSION: this call is the one that bailed. It must bind.
+        bind_destination(&mut call, dest, "degenerate-D pin").expect(
+            "a degenerate-extent bias form must BIND, not trip the fence: the \
+             right-major and left-major elections are the same function here",
+        );
+        assert_eq!(
+            call.d.order,
+            LtOrder::Col,
+            "the coincidence is spelled COL — the order the library accepts \
+             for BIAS/RELU_BIAS"
+        );
+        assert_eq!(call.d.ld, call.m, "COL ld = m");
+        assert_eq!(call.c, call.d, "C rides D's frame");
+        checked += 1;
+    }
+    assert!(checked >= 1, "at least one bias node was checked");
+}
+
+// ---------------------------------------------------------------------------
 // LOGICAL NEGATIVE: a bias broadcast along the WRONG axis (per row of the
 // recorder's [4, 3]) is not a per-feature bias; no bias form may mint.
 // ---------------------------------------------------------------------------

--- a/crates/luminal_cuda_lite/tests/cublaslt_contracts.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_contracts.rs
@@ -439,6 +439,125 @@ fn marker_elected_bias_plan_matches_decomposed_route_tolerance_based() {
     assert_close(&want, &got, "marker(bias) vs decomposed 4x8x3 + b[3]");
 }
 
+/// THE DEGENERATE-EXTENT COINCIDENCE ON DEVICE (whisper, A100
+/// 2026-09-04 — NEEDS A100 RUN). whisper tiny.en decodes ONE token, so
+/// its q/v projections are `x[1, 384] @ w[384, 384] + b[384]` and the
+/// sandwich sibling's call frame is `m = 384, n = 1`. At that degenerate
+/// extent the right-major and left-major contiguous index maps over
+/// `[m, n]` are the SAME FUNCTION, so both spellings live in ONE e-class:
+/// the estate's bias decorator matched the LeftMajor spelling while the
+/// decoder (RightMajor first by preference order) handed the executor the
+/// right-major one, `bind_destination` built a ROW D, and the tripwire
+/// refused EVERY candidate genome at prepare —
+///
+///   cuBLASLt CublasLtAccumulateBias: unreachable: the bias decorators
+///   require a LeftMajor D; a bias form
+///   (LayoutTensorOpCublasLtAccumulateBias) reached the executor with a
+///   Row-order D descriptor (384x1 ld 1). [...] refused BEFORE dispatch
+///
+/// — so the search died with "no candidate genome produced an executable
+/// plan". `bind_destination` now spells the coincidence COL on a
+/// bias-bearing call, and this is the DEVICE half: the whisper dims,
+/// searched, executed through the host-call arm with the BIAS epilogue
+/// under a COL `384x1 ld 384` D, against the decomposed route,
+/// tolerance-based.
+///
+/// The CPU halves (the class really holds both spellings; the elected
+/// call binds COL instead of bailing) are in
+/// `tests/cublaslt_bias_premise.rs`, and the descriptor arithmetic is in
+/// `tests/cublaslt_contracts_cpu.rs`.
+#[test]
+fn degenerate_extent_bias_plan_matches_decomposed_route_tolerance_based() {
+    // whisper tiny.en's `state` (examples/whisper/src/model.rs), and its
+    // decode step's single token row.
+    const STATE: usize = 384;
+    let build = || {
+        let mut cx = luminal::graph::Graph::new();
+        let weight = cx.named_tensor("q_proj.weight", (STATE, STATE), DType::F32);
+        let bias = cx.named_tensor("q_proj.bias", STATE, DType::F32);
+        let x = cx.tensor((1usize, STATE), DType::F32);
+        let out = luminal_nn::linear(x, weight, Some(bias)).output();
+        (cx, x.id, weight.id, bias.id, out.id)
+    };
+    let data_for = |x: NodeIndex, w: NodeIndex, b: NodeIndex| -> FxHashMap<NodeIndex, HostBuffer> {
+        [
+            (x, HostBuffer::from(weights(STATE, 1))),
+            (w, HostBuffer::from(weights(STATE * STATE, 2))),
+            (b, HostBuffer::from(weights(STATE, 3))),
+        ]
+        .into_iter()
+        .collect()
+    };
+
+    // Sweep the seeds the CPU pin sweeps: the assertion below needs a
+    // plan that actually carries a bias form, and which seed delivers one
+    // is an election fact, not a contract (see
+    // `tests/cublaslt_bias_premise.rs`, which sweeps 0..6 the same way).
+    let mut fused = None;
+    for seed in 0..6u64 {
+        let options = luminal_cuda_lite::CompileOptions {
+            generations: 12,
+            generation_size: 16,
+            mutations: 4,
+            trials: 1,
+            seed,
+            search_log: false,
+            ..Default::default()
+        };
+        let (cx, x, w, b, out) = build();
+        let mut rt = CudaRuntime::load(&cx).expect("load fused");
+        // BEFORE THE FIX this call is where whisper died: every genome
+        // carrying the bias form was refused at prepare, so the search
+        // reported "no candidate genome produced an executable plan".
+        rt.search(&data_for(x, w, b), &options)
+            .unwrap_or_else(|e| panic!("DEGENERATE-D seed {seed}: fused search: {e:#}"));
+        let elected_bias = rt.plan().expect("plan").dag.node_weights().any(|n| {
+            matches!(n, BufferNode::Compute { op, .. }
+                if op.label().starts_with("CublasLt") && op.label().contains("Bias"))
+        });
+        println!("DEGENERATE-D seed {seed}: bias form elected = {elected_bias}");
+        if elected_bias {
+            fused = Some((seed, rt, x, w, b, out));
+            break;
+        }
+    }
+    let (seed, mut fused, x, w, b, out) = fused.expect(
+        "some seed in 0..6 at the 12x16/mut-4 pin budget must elect a cuBLASLt \
+         bias form on the whisper decode shape (the CPU pin \
+         tests/cublaslt_bias_premise.rs sweeps the same seeds; re-sweep it if \
+         this moves) — without one this test is not exercising the degenerate-D \
+         binding at all",
+    );
+    println!("DEGENERATE-D: executing the plan searched at seed {seed}");
+    fused.set_data(x, weights(STATE, 1));
+    fused.set_data(w, weights(STATE * STATE, 2));
+    fused.set_data(b, weights(STATE, 3));
+    fused
+        .execute()
+        .expect("fused execute (bias epilogue under a degenerate COL D)");
+    let got = walked_dense(&fused, out);
+
+    // THE DECOMPOSED ROUTE ON PURPOSE (the default registry carries the
+    // marker since 2026-09-04, so this side asks for the plain one).
+    let (cx, x, w, b, out) = build();
+    let mut plain =
+        CudaRuntime::load_with_registry(&cx, luminal_cuda_lite::cuda_registry_without_cublaslt())
+            .expect("load plain");
+    plain
+        .search(
+            &data_for(x, w, b),
+            &luminal_cuda_lite::harness_search_options(),
+        )
+        .expect("plain search");
+    plain.set_data(x, weights(STATE, 1));
+    plain.set_data(w, weights(STATE * STATE, 2));
+    plain.set_data(b, weights(STATE, 3));
+    plain.execute().expect("plain execute");
+    let want = walked_dense(&plain, out);
+
+    assert_close(&want, &got, "marker(bias) vs decomposed 1x384x384 + b[384]");
+}
+
 /// Item 4 END TO END: the marker-elected plan (searched with the
 /// marker vocabulary, executed through the host-call arm) against the
 /// decomposed route (`cuda_registry_without_cublaslt`, NVRTC kernels),

--- a/crates/luminal_cuda_lite/tests/cublaslt_contracts_cpu.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_contracts_cpu.rs
@@ -485,6 +485,135 @@ fn dest_frame_refuses_layouts_this_backend_cannot_write() {
     );
 }
 
+/// `bias_spec` at an arbitrary frame, with the spec's COL readings kept
+/// CONSISTENT with it (`base_spec`'s convention: lda = m, ldb = k,
+/// ldc = ldd = m) so `validate_against` exercises real geometry.
+fn bias_spec_at(form: CublasLtForm, m: i64, n: i64, k: i64) -> LtMatmulSpec {
+    let mut spec = bias_spec(form);
+    spec.m = CuDim::Literal(m);
+    spec.n = CuDim::Literal(n);
+    spec.k = CuDim::Literal(k);
+    spec.lda = CuDim::Literal(m);
+    spec.ldb = CuDim::Literal(k);
+    spec.ldc = CuDim::Literal(m);
+    spec.ldd = CuDim::Literal(m);
+    spec
+}
+
+/// THE DEGENERATE-EXTENT COINCIDENCE (whisper on the A100, 2026-09-04).
+/// At `n == 1` the right-major and left-major contiguous index maps over
+/// `[m, n]` are the SAME function — `r*n + c` and `c*m + r` both address
+/// `r` when the collapsed axis's coordinate can only be 0 — so both
+/// spellings live in ONE e-class and `decode_layout`, RightMajor-first by
+/// preference order, may hand the bridge the right-major spelling of the
+/// very class whose LeftMajor spelling the estate's bias decorator
+/// matched. That is not a drift, and refusing it killed every whisper
+/// genome at device prepare:
+///
+///   a bias form (LayoutTensorOpCublasLtAccumulateBias) reached the
+///   executor with a Row-order D descriptor (384x1 ld 1)
+///
+/// (whisper tiny.en decodes ONE token, so the recorder site is
+/// `x[1, 384] @ w[384, 384] + b[384]` and the sandwich sibling's call
+/// frame is `m = 384`, `n = 1`.) A bias-bearing call at a degenerate
+/// extent therefore takes the COL spelling of the coincidence — the one
+/// the library accepts.
+#[test]
+fn degenerate_extent_binds_a_bias_form_col_in_both_orientations() {
+    // n == 1, THE WHISPER SHAPE: the sibling frame is [m, n] = [384, 1].
+    // ROW would be 384x1 ld 1; COL is 384x1 ld 384; both address exactly
+    // the elements 0..384 of the destination, in the same order.
+    for form in [CublasLtForm::Bias, CublasLtForm::AccumulateBias] {
+        let spec = bias_spec_at(form, 384, 1, 384);
+        let mut call = plan_call_from_spec(&spec).expect("plan");
+        assert_eq!(
+            call.d,
+            LtDesc::row(384, 1, 1),
+            "{form:?}: the spec-only default is still ROW (ld = n)"
+        );
+        bind_destination(&mut call, &right_major(&[384, 1]), "pin").expect(
+            "a degenerate-extent RightMajor election IS the LeftMajor election; \
+             the bias form must bind, not trip the fence",
+        );
+        assert_eq!(call.d, LtDesc::col(384, 1, 384), "{form:?}: COL D, ld = m");
+        assert_eq!(call.c, call.d, "{form:?}: C rides D's frame");
+        // Same 384 elements either way: COL reach = ld*(cols-1) + rows
+        // = 384*0 + 384 = 384, exactly the ROW reach 1*383 + 1.
+        // A holds m*k, B holds k*n, C (fold forms) holds m*n, bias m.
+        let mut elems = vec![384 * 384usize, 384];
+        if form.has_c() {
+            elems.push(384);
+        }
+        elems.push(384);
+        call.validate_against(&elems, 384)
+            .expect("the bound frame fits the 384-element destination");
+    }
+
+    // m == 1, the symmetric degeneracy: [1, 384]. ROW would be
+    // 1x384 ld 384; COL is 1x384 ld 1; same elements again.
+    for form in [CublasLtForm::Bias, CublasLtForm::AccumulateBias] {
+        let spec = bias_spec_at(form, 1, 384, 384);
+        let mut call = plan_call_from_spec(&spec).expect("plan");
+        assert_eq!(call.d, LtDesc::row(1, 384, 384), "the ROW default");
+        bind_destination(&mut call, &right_major(&[1, 384]), "pin")
+            .expect("the m == 1 coincidence binds too");
+        assert_eq!(
+            call.d,
+            LtDesc::col(1, 384, 1),
+            "{form:?}: COL D, ld = m = 1"
+        );
+        assert_eq!(call.c, call.d);
+        // A holds m*k = 384, B holds k*n, C (fold forms) holds m*n = 384,
+        // bias m = 1.
+        let mut elems = vec![384usize, 384 * 384];
+        if form.has_c() {
+            elems.push(384);
+        }
+        elems.push(1);
+        call.validate_against(&elems, 384)
+            .expect("the bound frame fits the 384-element destination");
+    }
+}
+
+/// THE FENCE IS INTACT. The coincidence arm is gated on the degeneracy:
+/// with BOTH extents > 1 the two orders denote different byte orders, so
+/// a bias form arriving with a RightMajor election is still the real
+/// drift `assert_bias_destination_order` exists to catch — and it still
+/// bails with the same message. (The broader default-form and
+/// bias-vs-ROW coverage lives in
+/// `bias_epilogue_forms_with_a_row_d_trip_the_unreachable_fence`; this
+/// pin exists so the degenerate carve-out can never be widened by
+/// accident.)
+#[test]
+fn a_non_degenerate_right_major_d_still_trips_the_bias_fence() {
+    for form in [CublasLtForm::Bias, CublasLtForm::AccumulateBias] {
+        // 384x2: n == 2, one step off the whisper shape, and the orders
+        // genuinely differ (ROW ld 2 vs COL ld 384 address differently).
+        let spec = bias_spec_at(form, 384, 2, 384);
+        let mut call = plan_call_from_spec(&spec).expect("plan");
+        let err = bind_destination(&mut call, &right_major(&[384, 2]), "pin")
+            .expect_err("a NON-degenerate ROW-order D under a bias form must be refused");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("unreachable"), "{form:?}: {msg}");
+        assert!(
+            msg.contains("bias decorators require a LeftMajor D"),
+            "{form:?}: {msg}"
+        );
+        assert!(msg.contains("Row-order D descriptor"), "{form:?}: {msg}");
+        assert!(msg.contains("refused BEFORE dispatch"), "{form:?}: {msg}");
+    }
+    // And the carve-out is BIAS-ONLY: a degenerate destination with NO
+    // bias operand keeps its right-major election as ROW.
+    let mut call = plan_call_from_spec(&base_spec(384, 1, 384)).expect("plan");
+    bind_destination(&mut call, &right_major(&[384, 1]), "pin").expect("no bias, no carve-out");
+    assert_eq!(
+        call.d,
+        LtDesc::row(384, 1, 1),
+        "a bias-free degenerate D stays ROW: the carve-out exists only \
+         because the LIBRARY refuses BIAS on a ROW D"
+    );
+}
+
 #[test]
 fn dest_frame_refuses_symbolic_extents() {
     let symbolic = DecodedLayout {


### PR DESCRIPTION
## The failure (A100, whisper example, 2026-09-04)

With markers on by default, every candidate genome was refused at device prepare:

```
cuBLASLt CublasLtAccumulateBias: unreachable: the bias decorators require a LeftMajor D; a bias form (LayoutTensorOpCublasLtAccumulateBias) reached the executor with a Row-order D descriptor (384x1 ld 1). The library refuses BIAS/RELU_BIAS on a ROW-order D (CUBLAS_STATUS_NOT_SUPPORTED, measured on the A100 2026-08-28) — refused BEFORE dispatch, no bytes move
```

(the same for `CublasLtBias`). Search then failed with "no candidate genome produced an executable plan".

## The coincidence argument

Whisper tiny.en decodes **one** token, so its q/v projections are `x[1, 384] @ w[384, 384] + b[384]` (`Linear::new(d.state, d.state, true, ...)`, `state = 384`). The marker's transpose sandwich dispatches the **sibling**, whose call frame is therefore `m = 384, n = 1` — exactly the `384x1 ld 1` in the refusal.

At a degenerate extent the two dense orders are **the same function**. Over the `[m, n]` frame, right-major addresses `r*n + c` and left-major addresses `c*m + r`; when the collapsed axis's coordinate can only be `0` these agree pointwise:

* `n == 1`: ROW `m x 1 / ld 1` reaches `r*1 + 0 = r`; COL `m x 1 / ld m` reaches `0*m + r = r`.
* `m == 1`: ROW `1 x n / ld n` reaches `0*n + c = c`; COL `1 x n / ld 1` reaches `c*1 + 0 = c`.

Same elements, same order, same reach (`384` either way).

**The e-graph knows this**, which is where the mismatch comes from. A `CoordVar` on an extent-1 axis has bounds `[0, 0]`, so the `[n,n]` pin collapse unions it with `(IntLit 0)`; the right-major and left-major strided chains then fold together, and both `RightMajorContiguousElementLayoutLit` and `LeftMajorContiguousElementLayoutLit` land in **one class** via the two `StridedElementLayoutLit` union rules in `egglog_preamble.egg`. (A new test asserts exactly this on the live e-graph.)

So the estate's bias decorator matched the `LeftMajorContiguousElementLayoutLit` spelling and minted the bias form correctly, while `luminal::layouts::decode_layout` — whose decoding *preference* order tries `RightMajorContiguousElementLayoutLit` first and returns the first spelling that parses — handed `bind_destination` the right-major spelling **out of that same class**. `bind_destination` built `LtDesc::row(...)`, and `assert_bias_destination_order` fired. The tripwire is right to fire on a real drift; here there was no drift, only two names for one function.

## The fix

One guarded arm in `bind_destination` (`crates/luminal_cuda_lite/src/ops/cublaslt/exec.rs`):

```rust
M::RightMajor(_) if call.bias_operand.is_some() && (call.m == 1 || call.n == 1) => {
    LtDesc::col(call.m, call.n, call.m.max(1))
}
```

The coincidence is spelled the way the **library** requires (BIAS/RELU_BIAS is `CUBLAS_STATUS_NOT_SUPPORTED` on a ROW-order D, measured on the A100 2026-08-28), which is also the spelling the decorator's premise matched. The arm carries the whisper failure verbatim as its comment.

What is deliberately **not** changed:

* the non-degenerate path — with both extents `> 1` the orders denote different byte orders;
* a bias-free degenerate destination — it keeps ROW, since the carve-out exists only because of the library restriction;
* `assert_bias_destination_order` — unchanged, still the coherence fence for a real drift;
* the estate's decorators (`egg/cublaslt_marker_decorate.egg`) — untouched;
* the A and B operand descriptors — see the note below.

The plan's disclosed destination layout stays right-major, and the readback walking it is still correct: at a degenerate extent it is the same byte order.

## Tests

`crates/luminal_cuda_lite/tests/cublaslt_contracts_cpu.rs` (host, no device):

* `degenerate_extent_binds_a_bias_form_col_in_both_orientations` — `Bias` and `AccumulateBias` at `m=384, n=1` (the whisper frame) bind `LtDesc::col(384, 1, 384)`, and at `m=1, n=384` bind `LtDesc::col(1, 384, 1)`; C rides D and `validate_against` passes on the 384-element destination.
* `a_non_degenerate_right_major_d_still_trips_the_bias_fence` — one step off the degeneracy (`384x2`) both bias forms still bail with the existing message; and a bias-free `384x1` keeps ROW.

`crates/luminal_cuda_lite/tests/cublaslt_bias_premise.rs` (host, end-to-end — the actual reproduction):

* `a_degenerate_extent_d_holds_both_contiguous_spellings_in_one_class` — on the saturated e-graph for `x[1, K] @ w[K, N] + b[N]`, the bias form's D class holds **both** contiguous spellings. This is the coincidence, measured rather than argued.
* `a_degenerate_extent_bias_election_binds_col_and_is_not_refused` — the seeded search elects a bias form on that shape and `bind_destination` resolves its D to COL with `ld = m`. **Verified to fail without the fix**, with the identical refusal at pin scale: `a bias form (LayoutTensorOpCublasLtBias) reached the executor with a Row-order D descriptor (3x1 ld 1)`.

`crates/luminal_cuda_lite/tests/cublaslt_contracts.rs` (`#![cfg(feature = "device")]`, type-checked here, not run):

* `degenerate_extent_bias_plan_matches_decomposed_route_tolerance_based` — whisper's real dims (`x[1, 384] @ w[384, 384] + b[384]`), searched over seeds `0..6` for a bias election, executed through the host-call arm, compared tolerance-based against `cuda_registry_without_cublaslt` per the reduction-order contract.

## Note (no change in this PR)

The A and B descriptors are **not** exposed to this coincidence: `plan_call_from_spec` derives them from the spec's own numerics (`lda`/`ldb`, `trans_a`/`trans_b`) by the ROW re-expression identity, and nothing reads a `MirrorLayout` spelling for them. The re-expression holds at any extent, degenerate included, and the vacuous-ld case is already covered by `validate_ld_bounds`. No A/B change is needed for correctness.

## Gate

```
cargo build -p luminal_cuda_lite --all-targets           Finished `dev` profile
cargo check -p luminal_cuda_lite --features device --all-targets   Finished `dev` profile
cargo test -p luminal_cuda_lite                          all 21 targets ok, 0 failed
cargo clippy -p luminal_cuda_lite --all-targets --features device   1 pre-existing warning (type_complexity, device_profile.rs:46)
cargo fmt --all -- --check                               clean
```

**A100 device run + whisper rerun pending.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
