### PR TITLE
Search timing: every second attributed, saturation broken down by rule

### DIFF
--- a/crates/luminal_cuda_lite/examples/support/mod.rs
+++ b/crates/luminal_cuda_lite/examples/support/mod.rs
@@ -169,6 +169,14 @@ pub mod device {
             outcome.plans_profiled,
             outcome.timings.summary()
         );
+        // WHERE SATURATION WENT, behind the same flag the progress
+        // lines use: per-ruleset totals and the slowest rules, from
+        // egglog's own run report.
+        if options.search_log_enabled()
+            && let Some(report) = &outcome.saturation
+        {
+            println!("{name}: {}", report.summary());
+        }
         println!(
             "{name}: winner {:.3} ms measured on device (heuristic cost {} bytes moved)",
             outcome.best_nanos as f64 / 1e6,

--- a/crates/luminal_cuda_lite/examples/support/mod.rs
+++ b/crates/luminal_cuda_lite/examples/support/mod.rs
@@ -169,13 +169,15 @@ pub mod device {
             outcome.plans_profiled,
             outcome.timings.summary()
         );
-        // WHERE SATURATION WENT, behind the same flag the progress
-        // lines use: per-ruleset totals and the slowest rules, from
-        // egglog's own run report.
-        if options.search_log_enabled()
-            && let Some(report) = &outcome.saturation
-        {
-            println!("{name}: {}", report.summary());
+        // THE FULL ATTRIBUTION, behind the same flag the progress lines
+        // use: every bucket with its sub-buckets, then where saturation
+        // went (per-ruleset totals and the slowest rules, from egglog's
+        // own run report).
+        if options.search_log_enabled() {
+            println!("{name}: timing breakdown{}", outcome.timings.breakdown());
+            if let Some(report) = &outcome.saturation {
+                println!("{name}: {}", report.summary());
+            }
         }
         println!(
             "{name}: winner {:.3} ms measured on device (heuristic cost {} bytes moved)",

--- a/crates/luminal_cuda_lite/src/device.rs
+++ b/crates/luminal_cuda_lite/src/device.rs
@@ -113,6 +113,16 @@ fn bytes_to_typed(bytes: &[u8], dtype: PlanDtype) -> Result<HostBuffer> {
 struct KernelCache {
     ctx: Arc<CudaContext>,
     modules: HashMap<u64, (Arc<CudaModule>, CudaFunction)>,
+    /// COMPILATION ACCOUNTING (2026-09-05). NVRTC time is paid once per
+    /// distinct kernel source for the whole life of the device, so it
+    /// belongs to no single candidate — but it is real search time, and
+    /// the only place that can see it is the miss path itself. The
+    /// counters are read by [`crate::profile::profile_candidate`] as
+    /// deltas, which is how the search attributes compilation inside
+    /// the prepare phase without restructuring `execute_plan`.
+    hits: u64,
+    misses: u64,
+    compile_nanos: u128,
 }
 
 impl KernelCache {
@@ -122,12 +132,16 @@ impl KernelCache {
         source.hash(&mut hasher);
         let key = hasher.finish();
         if let Some((_, func)) = self.modules.get(&key) {
+            self.hits += 1;
             return Ok(func.clone());
         }
+        self.misses += 1;
+        let compile_start = std::time::Instant::now();
         let ptx =
             compile_ptx(source).map_err(|e| anyhow!("NVRTC failed: {e:?}\nsource:\n{source}"))?;
         let module = self.ctx.load_module(ptx).context("module load")?;
         let func = module.load_function("k").context("entry `k` missing")?;
+        self.compile_nanos += compile_start.elapsed().as_nanos();
         self.modules.insert(key, (module, func.clone()));
         Ok(func)
     }
@@ -165,6 +179,9 @@ impl CudaDevice {
             cache: KernelCache {
                 ctx: ctx.clone(),
                 modules: HashMap::new(),
+                hits: 0,
+                misses: 0,
+                compile_nanos: 0,
             },
             ctx,
             stream,
@@ -185,6 +202,24 @@ impl CudaDevice {
                 .with_context(|| format!("arena slab alloc, {bytes} bytes"))?,
         );
         Ok(())
+    }
+
+    /// KERNEL-CACHE LOOKUPS that found a compiled module, over this
+    /// device's whole life.
+    pub fn kernel_cache_hits(&self) -> u64 {
+        self.cache.hits
+    }
+
+    /// KERNEL-CACHE MISSES — distinct kernel sources this device has
+    /// compiled through NVRTC.
+    pub fn kernel_cache_misses(&self) -> u64 {
+        self.cache.misses
+    }
+
+    /// Nanoseconds spent on the miss path: NVRTC compilation, module
+    /// load and entry lookup, over this device's whole life.
+    pub fn kernel_compile_nanos(&self) -> u128 {
+        self.cache.compile_nanos
     }
 
     /// The slab's current size in bytes (0 before the first plan needs

--- a/crates/luminal_cuda_lite/src/profile.rs
+++ b/crates/luminal_cuda_lite/src/profile.rs
@@ -72,6 +72,32 @@ pub enum Measurement {
     },
 }
 
+/// WHERE ONE CANDIDATE's profiling time went (2026-09-05), accumulated
+/// across candidates by the search.
+///
+/// WHAT IS AND IS NOT SEPARABLE. `execute_plan` is ONE call that
+/// compiles, allocates, stages, launches, synchronizes and reads back,
+/// so STAGE and WARM cannot be split from each other without
+/// restructuring the executor — and that restructuring is exactly the
+/// stage-once/run-many surgery this module's header defers. What CAN be
+/// split out is COMPILATION, because the device's kernel cache times
+/// its own miss path: `prepare_compile_nanos` is the NVRTC + module-load
+/// share of `prepare_nanos`, and the remainder is stage + warm.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ProfileTimings {
+    /// The untimed first `execute_plan`: compile + stage + one run.
+    pub prepare_nanos: u128,
+    /// The compilation inside it (device kernel-cache miss path).
+    pub prepare_compile_nanos: u128,
+    /// The timed trials, from the first one to the last.
+    pub trials_nanos: u128,
+    /// Kernel-cache lookups that hit, over the whole profiling call
+    /// (the trials re-look-up the same kernels, and those hits count).
+    pub kernel_cache_hits: u64,
+    /// Kernel-cache misses — kernel sources NVRTC compiled here.
+    pub kernel_cache_misses: u64,
+}
+
 /// Why a candidate produced no measurement — classified, because the
 /// search accounts the two differently (D10: *"runtimes can choose how
 /// to handle failures at different points"*).
@@ -141,48 +167,77 @@ pub fn profile_candidate(
     trials: usize,
     best_so_far: Option<u128>,
     candidate_timeout: Option<Duration>,
+    stats: &mut ProfileTimings,
 ) -> Result<Measurement, ProfileFailure> {
     // 1. PREPARE: compile + stage + one untimed run (warmup + validity).
-    execute_plan(device, plan, staged).map_err(ProfileFailure::Prepare)?;
+    // The compile share is read as a DELTA on the device's own kernel
+    // cache, which is the one place that can see NVRTC time.
+    let compile_before = device.kernel_compile_nanos();
+    let hits_before = device.kernel_cache_hits();
+    let misses_before = device.kernel_cache_misses();
+    let prepare_start = Instant::now();
+    let prepared = execute_plan(device, plan, staged);
+    stats.prepare_nanos += prepare_start.elapsed().as_nanos();
+    // Stamped even when prepare FAILED: a candidate NVRTC refuses still
+    // spent the compile attempt, and dropping it would hide exactly the
+    // time a refusing candidate costs.
+    stats.prepare_compile_nanos += device.kernel_compile_nanos().saturating_sub(compile_before);
+    let count_lookups = |device: &CudaDevice, stats: &mut ProfileTimings| {
+        stats.kernel_cache_hits += device.kernel_cache_hits().saturating_sub(hits_before);
+        stats.kernel_cache_misses += device.kernel_cache_misses().saturating_sub(misses_before);
+    };
+    if let Err(err) = prepared {
+        count_lookups(device, stats);
+        return Err(ProfileFailure::Prepare(err));
+    }
 
     // 2. THE TIMED RUN. The budget's clock starts HERE.
     let total = trials.max(1);
     let run_start = Instant::now();
     let mut sum = 0u128;
-    for trial in 0..total {
-        let start = Instant::now();
-        execute_plan(device, plan, staged).map_err(ProfileFailure::Execute)?;
-        sum += start.elapsed().as_nanos();
-        let completed = trial + 1;
-        if completed == total {
-            break;
+    // The trial loop is a closure ONLY so its several early returns (the
+    // timeout, the early stop) all pass through one place that stamps
+    // `trials_nanos`. Nothing about the measurement changes.
+    let mut timed = || -> Result<Measurement, ProfileFailure> {
+        for trial in 0..total {
+            let start = Instant::now();
+            execute_plan(device, plan, staged).map_err(ProfileFailure::Execute)?;
+            sum += start.elapsed().as_nanos();
+            let completed = trial + 1;
+            if completed == total {
+                break;
+            }
+            // TIMEOUT, checked between trials.
+            if candidate_timeout.is_some_and(|budget| run_start.elapsed() > budget) {
+                return Ok(Measurement::TimedOut {
+                    elapsed_nanos: run_start.elapsed().as_nanos(),
+                    completed_trials: completed,
+                });
+            }
+            // 3. EARLY STOP (#386), on the lower bound of the final mean.
+            if best_so_far.is_some_and(|best| early_stop_exceeded(sum / total as u128, best, 1.0)) {
+                return Ok(Measurement::Timed {
+                    mean_nanos: sum / completed as u128,
+                    completed_trials: completed,
+                });
+            }
         }
-        // TIMEOUT, checked between trials.
+        // A single trial that ran longer than the whole budget is a timeout
+        // too — the between-trials check cannot see it, and reporting it as
+        // a measurement would rank a plan the caller asked not to wait for.
         if candidate_timeout.is_some_and(|budget| run_start.elapsed() > budget) {
             return Ok(Measurement::TimedOut {
                 elapsed_nanos: run_start.elapsed().as_nanos(),
-                completed_trials: completed,
+                completed_trials: total,
             });
         }
-        // 3. EARLY STOP (#386), on the lower bound of the final mean.
-        if best_so_far.is_some_and(|best| early_stop_exceeded(sum / total as u128, best, 1.0)) {
-            return Ok(Measurement::Timed {
-                mean_nanos: sum / completed as u128,
-                completed_trials: completed,
-            });
-        }
-    }
-    // A single trial that ran longer than the whole budget is a timeout
-    // too — the between-trials check cannot see it, and reporting it as
-    // a measurement would rank a plan the caller asked not to wait for.
-    if candidate_timeout.is_some_and(|budget| run_start.elapsed() > budget) {
-        return Ok(Measurement::TimedOut {
-            elapsed_nanos: run_start.elapsed().as_nanos(),
+        Ok(Measurement::Timed {
+            mean_nanos: sum / total as u128,
             completed_trials: total,
-        });
-    }
-    Ok(Measurement::Timed {
-        mean_nanos: sum / total as u128,
-        completed_trials: total,
-    })
+        })
+    };
+    let measured = timed();
+    stats.trials_nanos += run_start.elapsed().as_nanos();
+    count_lookups(device, stats);
+    measured
 }

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -101,6 +101,20 @@ pub struct CudaRuntime {
     device: Option<crate::device::CudaDevice>,
 }
 
+/// What [`CudaRuntime::assemble_and_saturate`] produced, WITH the wall
+/// clock of the two halves that produced it (2026-09-05). The timings
+/// travel in the return value rather than in a global or an out-param
+/// because there are two callers and one of them
+/// ([`CudaRuntime::saturated_egraph`]) wants only the e-graph.
+struct SaturatedProgram {
+    serialized: luminal::prelude::egraph_serialize::EGraph,
+    program: graph::LogicalProgram,
+    /// egglog parse + run of the assembled program, to fixpoint.
+    saturation_nanos: u128,
+    /// `EGraph::serialize` of the saturated database.
+    serialize_nanos: u128,
+}
+
 impl CudaRuntime {
     /// Record the graph's native program under the DEFAULT op registry
     /// ([`crate::ops::cuda_registry`]) — which since the 2026-09-04
@@ -392,8 +406,7 @@ impl CudaRuntime {
     /// (which constructors were minted, which spellings a layout class
     /// holds) rather than on an election that depends on the budget.
     pub fn saturated_egraph(&self) -> Result<luminal::prelude::egraph_serialize::EGraph> {
-        let (serialized, _program) = self.assemble_and_saturate()?;
-        Ok(serialized)
+        Ok(self.assemble_and_saturate()?.serialized)
     }
 
     /// Assemble the program under this runtime's bindings and matcher
@@ -402,12 +415,7 @@ impl CudaRuntime {
     /// the two can never see different programs. On saturation failure
     /// the labeled post-checks are re-run in isolation to name the door,
     /// mirroring the reference runtime.
-    fn assemble_and_saturate(
-        &self,
-    ) -> Result<(
-        luminal::prelude::egraph_serialize::EGraph,
-        graph::LogicalProgram,
-    )> {
+    fn assemble_and_saturate(&self) -> Result<SaturatedProgram> {
         let native = self
             .native
             .as_ref()
@@ -429,6 +437,12 @@ impl CudaRuntime {
             program.text
         );
         let mut egraph = luminal::egglog_snippet::new_egraph();
+        // THE SATURATION CLOCK (2026-09-05). It runs from here to the
+        // end of `parse_and_run_program` and NOTHING else: the failure
+        // path's door-naming re-saturation is a diagnostic that only a
+        // failed search pays, and charging it to the bucket would price
+        // a green search by a red one's work.
+        let saturation_start = std::time::Instant::now();
         if let Err(err) = egraph.parse_and_run_program(None, &full) {
             // Name the door: re-saturate without checks, then probe each
             // labeled check alone.
@@ -453,8 +467,16 @@ impl CudaRuntime {
             }
             bail!("shape contracts failed:\n  - {}", doors.join("\n  - "));
         }
+        let saturation_nanos = saturation_start.elapsed().as_nanos();
+        let serialize_start = std::time::Instant::now();
         let serialized = egraph.serialize(luminal::prelude::egglog::SerializeConfig::default());
-        Ok((serialized.egraph, program))
+        let serialize_nanos = serialize_start.elapsed().as_nanos();
+        Ok(SaturatedProgram {
+            serialized: serialized.egraph,
+            program,
+            saturation_nanos,
+            serialize_nanos,
+        })
     }
 
     /// Assemble, saturate, and search — with THIS backend's allow list.
@@ -469,6 +491,13 @@ impl CudaRuntime {
         input_data: &FxHashMap<NodeIndex, HostBuffer>,
         options: &CompileOptions,
     ) -> Result<SearchOutcome> {
+        // THE WALL CLOCK, started once around the WHOLE body (2026-09-05)
+        // and stamped onto the outcome at the end. Everything the search
+        // does — saturation, serialization, the genetic loop, the
+        // finalist lattice, the install — is inside it, which is what
+        // makes `unattributed` a claim about missing buckets rather than
+        // about where the caller happened to put its own timer.
+        let search_start = std::time::Instant::now();
         let native = self
             .native
             .as_ref()
@@ -580,8 +609,13 @@ impl CudaRuntime {
         // plan is whichever FINALIST the bucket lattice selected under the
         // aggregate device budget. With no budget set they coincide,
         // which is why every existing caller sees the trajectory it had.
-        let (outcome, unbucketed_plan, searched_buckets) = if let Some((serialized, program)) = base
-        {
+        let (mut outcome, unbucketed_plan, searched_buckets) = if let Some(base) = base {
+            let SaturatedProgram {
+                serialized,
+                program,
+                saturation_nanos,
+                serialize_nanos,
+            } = base;
             let mut outcome = crate::search::search_implementations(
                 &serialized,
                 &program,
@@ -590,6 +624,13 @@ impl CudaRuntime {
                 matchers,
                 evaluator.reborrow(),
             )?;
+            // THE TWO BUCKETS THE GENETIC LOOP CANNOT FILL: they were
+            // spent before it started, in `assemble_and_saturate`. The
+            // reference runtime has stamped them since Phase 8; this
+            // backend never did, which is where a qwen3 search's missing
+            // 65 minutes were (2026-09-05).
+            outcome.timings.saturation_nanos = saturation_nanos;
+            outcome.timings.serialize_nanos = serialize_nanos;
             // THE UNBUCKETED LATTICE (Phase 5) — a lattice over ONE
             // bucket, so unbucketed and bucketed installs run the same
             // code. Main's "one designed difference" from its pre-#420
@@ -673,6 +714,7 @@ impl CudaRuntime {
             // eagerly only if the runtime already sits at a covered pin.
             let _ = self.select_bucket_plan();
         }
+        outcome.timings.total_nanos = search_start.elapsed().as_nanos();
         Ok(outcome)
     }
 

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -113,6 +113,9 @@ struct SaturatedProgram {
     saturation_nanos: u128,
     /// `EGraph::serialize` of the saturated database.
     serialize_nanos: u128,
+    /// egglog's OWN account of where the saturation went: per-ruleset
+    /// totals and the slowest rules with their match counts.
+    report: luminal::search_support::SaturationReport,
 }
 
 impl CudaRuntime {
@@ -468,6 +471,10 @@ impl CudaRuntime {
             bail!("shape contracts failed:\n  - {}", doors.join("\n  - "));
         }
         let saturation_nanos = saturation_start.elapsed().as_nanos();
+        // TAKEN BEFORE SERIALIZATION, off the e-graph that just ran:
+        // the report borrows from the `EGraph`, so it is copied into
+        // owned data here rather than kept as a borrow.
+        let report = luminal::search_support::SaturationReport::from_egraph(&egraph);
         let serialize_start = std::time::Instant::now();
         let serialized = egraph.serialize(luminal::prelude::egglog::SerializeConfig::default());
         let serialize_nanos = serialize_start.elapsed().as_nanos();
@@ -476,6 +483,7 @@ impl CudaRuntime {
             program,
             saturation_nanos,
             serialize_nanos,
+            report,
         })
     }
 
@@ -615,6 +623,7 @@ impl CudaRuntime {
                 program,
                 saturation_nanos,
                 serialize_nanos,
+                report,
             } = base;
             let mut outcome = crate::search::search_implementations(
                 &serialized,
@@ -631,6 +640,7 @@ impl CudaRuntime {
             // 65 minutes were (2026-09-05).
             outcome.timings.saturation_nanos = saturation_nanos;
             outcome.timings.serialize_nanos = serialize_nanos;
+            outcome.saturation = Some(report);
             // THE UNBUCKETED LATTICE (Phase 5) — a lattice over ONE
             // bucket, so unbucketed and bucketed installs run the same
             // code. Main's "one designed difference" from its pre-#420

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -656,8 +656,13 @@ impl CudaRuntime {
                 outcome.ranked.clone(),
                 Some(outcome.best_plan.clone()),
             )];
+            let finalist_start = std::time::Instant::now();
             let (selected, rejections) =
                 crate::search::select_finalist_set(finalists, options, &mut evaluator)?;
+            // THE LATTICE IS NOT FREE on a device build: it warms up
+            // every finalist it considers. Its own bucket, so it can
+            // never sit in the residual.
+            outcome.timings.finalist_nanos = finalist_start.elapsed().as_nanos();
             outcome.lattice_rejections = rejections;
             let (_, finalist) = selected
                 .into_iter()

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -927,13 +927,21 @@ pub fn bucketed_search_implementations(
     for (ranges, representative, program) in bucket_renders(assembly, dim_buckets)? {
         let text = format!("{}\n\n{}", assembly.assembled_program, program.text);
         let mut egraph = luminal::egglog_snippet::new_egraph();
+        // THE PER-BUCKET SATURATION CLOCK (2026-09-05): a bucketed
+        // search saturates ONCE PER COMBINATION, so each bucket's
+        // outcome carries ITS OWN saturation and serialization, never a
+        // sum over the lattice.
+        let saturation_start = std::time::Instant::now();
         egraph
             .parse_and_run_program(None, &text)
             .map_err(|err| anyhow!("bucket {ranges:?} representative render fails: {err}"))?;
+        let saturation_nanos = saturation_start.elapsed().as_nanos();
+        let serialize_start = std::time::Instant::now();
         let serialized = egraph
             .serialize(luminal::prelude::egglog::SerializeConfig::default())
             .egraph;
-        let outcome = search_implementations(
+        let serialize_nanos = serialize_start.elapsed().as_nanos();
+        let mut outcome = search_implementations(
             &serialized,
             &program,
             options,
@@ -944,6 +952,8 @@ pub fn bucketed_search_implementations(
             // combinations, so the evaluator is lent, not rebuilt.
             evaluator.reborrow(),
         )?;
+        outcome.timings.saturation_nanos = saturation_nanos;
+        outcome.timings.serialize_nanos = serialize_nanos;
         egraphs.push(serialized);
         searched.push((ranges, representative, program, outcome));
     }

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -353,6 +353,11 @@ pub fn search_implementations(
         }
     );
     let mut timings = SearchTimings::default();
+    // THE LOOP'S OWN WALL (2026-09-05): everything in this body is
+    // either a named bucket or `other_nanos`, computed at the end as
+    // this wall minus the named ones. Nothing between here and the
+    // return can hide.
+    let body_start = Instant::now();
     let analysis_start = Instant::now();
     // The allow list narrows the caller's matcher set; None = the whole set.
     let allow = allow_override;
@@ -379,7 +384,9 @@ pub fn search_implementations(
     // when it closes no cycle (see [`mutate_genome`]). Everything
     // outside a component is sampled freely: its edges leave the
     // component and the condensation is a DAG.
+    let space_start = Instant::now();
     let space = session.sampling_space(&index);
+    timings.space_nanos = space_start.elapsed().as_nanos();
 
     let random_genome = |rng: &mut StdRng| sample_genome(&index, &space, rng);
     let mutate = |parent: &Genome, rng: &mut StdRng, count: usize| {
@@ -396,6 +403,13 @@ pub fn search_implementations(
     // layout class per candidate. `egraph` is fixed for this loop, which
     // is what makes the `ClassId` keys comparable across candidates.
     let mut layout_cache = luminal::layouts::LayoutDecodeCache::new();
+    // The device evaluator's own sub-clocks (prepare / compile / trials
+    // and the kernel-cache lookup counts), accumulated across
+    // candidates and folded into `timings` after the loop. Declared
+    // unconditionally so the fold below reads the same on every build;
+    // a device-free search leaves it at zero.
+    #[cfg(feature = "device")]
+    let mut profile_stats = crate::profile::ProfileTimings::default();
     let mut plans_profiled = 0usize;
     let mut fingerprint_hits = 0usize;
     // Refusal accounting, minimal form (Step 5 down-payment): keep the
@@ -419,6 +433,7 @@ pub fn search_implementations(
 
     for generation in 0..options.generations {
         let mut candidates: Vec<Genome> = Vec::with_capacity(options.generation_size);
+        let sample_start = Instant::now();
         match &best {
             None => {
                 for _ in 0..options.generation_size {
@@ -432,6 +447,7 @@ pub fn search_implementations(
                 }
             }
         }
+        timings.sample_nanos += sample_start.elapsed().as_nanos();
 
         for genome in candidates {
             // Extraction failure = invalid genome (cycle, contract breach):
@@ -488,7 +504,9 @@ pub fn search_implementations(
                     continue;
                 }
             };
+            let fingerprint_start = Instant::now();
             let fingerprint = extractor::plan_fingerprint(&graph);
+            timings.fingerprint_nanos += fingerprint_start.elapsed().as_nanos();
             let nanos = match cache.get(&fingerprint) {
                 Some(nanos) => {
                     fingerprint_hits += 1;
@@ -506,14 +524,21 @@ pub fn search_implementations(
                     // values. They clone their tied result's layout class
                     // AND dtype fact, so every poison is a decoder-cache
                     // HIT: value-keying costs no extra decoder calls.
+                    let dps_start = Instant::now();
                     let dps = luminal::dps::dps_rewrite(&graph);
-                    let built = luminal::layouts::decode_layout_table(
+                    timings.dps_rewrite_nanos += dps_start.elapsed().as_nanos();
+                    let decode_start = Instant::now();
+                    let decoded = luminal::layouts::decode_layout_table(
                         egraph,
                         &dps,
                         "implementation search",
                         &mut layout_cache,
-                    )
-                    .and_then(|table| luminal::bufferize::bufferize(&dps, &table));
+                    );
+                    timings.decode_nanos += decode_start.elapsed().as_nanos();
+                    let bufferize_start = Instant::now();
+                    let built =
+                        decoded.and_then(|table| luminal::bufferize::bufferize(&dps, &table));
+                    timings.bufferize_nanos += bufferize_start.elapsed().as_nanos();
                     timings.plan_build_nanos += build_start.elapsed().as_nanos();
                     let plan = match built {
                         Ok(plan) => plan,
@@ -533,7 +558,9 @@ pub fn search_implementations(
                     // — it is what the outcome reports beside a measured
                     // winner — but under device profiling it is never
                     // ranked on.
+                    let heuristic_start = Instant::now();
                     let heuristic = crate::heuristic::heuristic_cost_of(&graph);
+                    timings.heuristic_nanos += heuristic_start.elapsed().as_nanos();
                     let profile_start = Instant::now();
                     let priced = if options.profile_on_device {
                         // ON-DEVICE MEASUREMENT (Phase 4). Compile +
@@ -559,6 +586,7 @@ pub fn search_implementations(
                                 options.trials,
                                 best.as_ref().map(|incumbent| incumbent.nanos),
                                 options.candidate_timeout,
+                                &mut profile_stats,
                             );
                             device.release_slab();
                             match measured {
@@ -660,14 +688,20 @@ pub fn search_implementations(
                 .is_none_or(|incumbent| nanos < incumbent.nanos)
             {
                 let build_start = Instant::now();
+                let dps_start = Instant::now();
                 let dps = luminal::dps::dps_rewrite(&graph);
-                let built = luminal::layouts::decode_layout_table(
+                timings.dps_rewrite_nanos += dps_start.elapsed().as_nanos();
+                let decode_start = Instant::now();
+                let decoded = luminal::layouts::decode_layout_table(
                     egraph,
                     &dps,
                     "implementation search",
                     &mut layout_cache,
-                )
-                .and_then(|table| luminal::bufferize::bufferize(&dps, &table));
+                );
+                timings.decode_nanos += decode_start.elapsed().as_nanos();
+                let bufferize_start = Instant::now();
+                let built = decoded.and_then(|table| luminal::bufferize::bufferize(&dps, &table));
+                timings.bufferize_nanos += bufferize_start.elapsed().as_nanos();
                 timings.plan_build_nanos += build_start.elapsed().as_nanos();
                 let plan = match built {
                     Ok(plan) => plan,
@@ -677,9 +711,12 @@ pub fn search_implementations(
                     }
                 };
                 rank_insert(&mut ranked, nanos, &genome, options.keep_finalists);
+                let heuristic_start = Instant::now();
+                let heuristic = crate::heuristic::heuristic_cost_of(&graph);
+                timings.heuristic_nanos += heuristic_start.elapsed().as_nanos();
                 best = Some(Best {
                     nanos,
-                    heuristic: crate::heuristic::heuristic_cost_of(&graph),
+                    heuristic,
                     genome: genome.clone(),
                     plan,
                 });
@@ -694,6 +731,32 @@ pub fn search_implementations(
     if let Some(progress) = progress.as_mut() {
         progress.finish();
     }
+    // THE SUB-BUCKETS, folded once. Extraction's phase clocks are
+    // cumulative on the session (it extracted every genome), and the
+    // device evaluator's are cumulative on the loop's own accumulator.
+    timings.absorb_extract(session.extract_timings());
+    #[cfg(feature = "device")]
+    {
+        timings.prepare_nanos = profile_stats.prepare_nanos;
+        timings.prepare_compile_nanos = profile_stats.prepare_compile_nanos;
+        timings.trials_nanos = profile_stats.trials_nanos;
+        timings.kernel_cache_hits = profile_stats.kernel_cache_hits;
+        timings.kernel_cache_misses = profile_stats.kernel_cache_misses;
+    }
+    // THE LOOP RESIDUAL, computed LAST so it is literally "the wall this
+    // body did not name": genome clones, cache lookups, `rank_insert`,
+    // refusal bookkeeping, progress printing — and anything a later
+    // change forgets to time.
+    timings.other_nanos = body_start.elapsed().as_nanos().saturating_sub(
+        timings.analysis_nanos
+            + timings.space_nanos
+            + timings.extract_nanos
+            + timings.plan_build_nanos
+            + timings.profile_nanos
+            + timings.sample_nanos
+            + timings.fingerprint_nanos
+            + timings.heuristic_nanos,
+    );
     let best = best.ok_or_else(|| {
         anyhow!("no candidate genome produced an executable plan; refusals: {refusals:#?}")
     })?;
@@ -972,6 +1035,7 @@ pub fn bucketed_search_implementations(
 
     // PHASE 5: the buckets' ranked genomes become finalists, and the
     // lattice picks one SET of them under the aggregate budget.
+    let finalist_start = Instant::now();
     let (selected, rejections) = {
         let buckets: Vec<crate::finalists::Finalists<'_>> = searched
             .iter()
@@ -990,6 +1054,11 @@ pub fn bucketed_search_implementations(
             .collect();
         select_finalist_set(buckets, options, &mut evaluator)?
     };
+    // ONE lattice runs over ALL the buckets, so its cost is charged to
+    // the FIRST bucket's outcome (the one `CudaRuntime::search` returns
+    // as the report) rather than duplicated onto every bucket, where a
+    // reader summing the buckets would count it once per combination.
+    let finalist_nanos = finalist_start.elapsed().as_nanos();
 
     let mut installed: BTreeMap<usize, crate::finalists::PendingFinalist> =
         selected.into_iter().collect();
@@ -1000,6 +1069,9 @@ pub fn bucketed_search_implementations(
             .remove(&index)
             .ok_or_else(|| anyhow!("the lattice selected no plan for bucket {index}"))?;
         outcome.lattice_rejections = rejections;
+        if index == 0 {
+            outcome.timings.finalist_nanos = finalist_nanos;
+        }
         plans.push(BucketPlan {
             ranges,
             representative,

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -59,10 +59,10 @@ use luminal::prelude::egraph_serialize;
 // `profile.rs`'s, and the tests read `RefusalBreakdown` off the
 // outcome).
 pub use luminal::search_support::{
-    CaptureAwareStderr, ProducerIndex, RefusalBreakdown, SearchProgress, SearchTimings,
-    bufferize_cycle_tripwire, early_stop_exceeded, log_channel_enabled, mutate_genome,
-    mutate_genome_reporting, mutate_genome_with_seed, sample_genome, sample_genome_reporting,
-    sample_genome_with_seed,
+    CaptureAwareStderr, ProducerIndex, RefusalBreakdown, RuleTiming, RulesetTiming,
+    SaturationReport, SearchProgress, SearchTimings, bufferize_cycle_tripwire, early_stop_exceeded,
+    log_channel_enabled, mutate_genome, mutate_genome_reporting, mutate_genome_with_seed,
+    sample_genome, sample_genome_reporting, sample_genome_with_seed,
 };
 
 #[derive(Debug, Clone)]
@@ -151,7 +151,7 @@ impl CompileOptions {
         self
     }
 
-    fn search_log_enabled(&self) -> bool {
+    pub fn search_log_enabled(&self) -> bool {
         log_channel_enabled(self.search_log, "SEARCH_LOG")
     }
 }
@@ -177,6 +177,13 @@ pub struct SearchOutcome {
     /// programmatic answer to "what is the search time actually spent
     /// on" (no env vars; read it from the outcome).
     pub timings: SearchTimings,
+    /// WHAT SATURATION SPENT ITS TIME ON (2026-09-05), read off
+    /// egglog's own run report: per-ruleset totals and the slowest
+    /// rules with their match counts. `None` when the caller saturated
+    /// somewhere this search cannot see — the genetic loop itself never
+    /// saturates, so it always leaves this `None` and the runtime
+    /// stamps it.
+    pub saturation: Option<SaturationReport>,
     /// What rejected genomes were rejected FOR (diagnosis ruling
     /// 2026-08-07: understand the breakdown, no auto-repair).
     pub refusal_breakdown: RefusalBreakdown,
@@ -699,6 +706,9 @@ pub fn search_implementations(
         plans_profiled,
         fingerprint_hits,
         timings,
+        // Stamped by whoever saturated (the runtime, or the bucketed
+        // driver below); the loop never does.
+        saturation: None,
         refusal_breakdown: breakdown,
         ranked,
         // The lattice has not run yet; the runtime stamps this once it
@@ -936,6 +946,7 @@ pub fn bucketed_search_implementations(
             .parse_and_run_program(None, &text)
             .map_err(|err| anyhow!("bucket {ranges:?} representative render fails: {err}"))?;
         let saturation_nanos = saturation_start.elapsed().as_nanos();
+        let saturation_report = SaturationReport::from_egraph(&egraph);
         let serialize_start = std::time::Instant::now();
         let serialized = egraph
             .serialize(luminal::prelude::egglog::SerializeConfig::default())
@@ -954,6 +965,7 @@ pub fn bucketed_search_implementations(
         )?;
         outcome.timings.saturation_nanos = saturation_nanos;
         outcome.timings.serialize_nanos = serialize_nanos;
+        outcome.saturation = Some(saturation_report);
         egraphs.push(serialized);
         searched.push((ranges, representative, program, outcome));
     }

--- a/crates/luminal_cuda_lite/tests/example_smoke.rs
+++ b/crates/luminal_cuda_lite/tests/example_smoke.rs
@@ -40,7 +40,37 @@ fn conv_example_graph_searches_with_zero_refusals() {
     let outcome = rt
         .search(&data, &luminal_cuda_lite::harness_search_options())
         .expect("cuda search");
+    // THE ATTRIBUTION, visible on a host run (`-- --nocapture`): the
+    // one-line summary with its residual, the per-bucket breakdown, and
+    // egglog's account of where saturation went.
+    println!("conv example: [{}]", outcome.timings.summary());
+    println!(
+        "conv example: timing breakdown{}",
+        outcome.timings.breakdown()
+    );
+    println!(
+        "conv example: {}",
+        outcome
+            .saturation
+            .as_ref()
+            .expect("the runtime stamps the saturation report")
+            .summary()
+    );
     assert!(outcome.plans_profiled > 0, "no plans profiled");
+    // EVERY SECOND ATTRIBUTED: the residual is what no bucket claimed.
+    // A host search is seconds long, so this is a real check that the
+    // buckets add up, not a formality — it is deliberately loose (10%
+    // of the wall) because the timers themselves are not free.
+    let timings = &outcome.timings;
+    assert!(
+        timings.total_nanos > 0,
+        "the runtime never stamped the wall"
+    );
+    assert!(
+        timings.unattributed_nanos() * 10 < timings.total_nanos,
+        "more than 10% of the search is in no bucket: [{}]",
+        timings.summary()
+    );
     let b = &outcome.refusal_breakdown;
     assert_eq!(
         (

--- a/src/extraction.rs
+++ b/src/extraction.rs
@@ -101,6 +101,12 @@ struct Extractor<'a> {
     /// sampled stacks inside `is_better`). The rendered form of an enode
     /// never changes within a session, so one cache serves every genome.
     stable_key_cache: std::cell::RefCell<HashMap<NodeId, std::rc::Rc<str>>>,
+    /// PHASE CLOCKS, cumulative over every genome this extractor
+    /// extracted (2026-09-05) — discovery, the relaxation fixpoint, and
+    /// the assembly that reads the settled memo. Never cleared by
+    /// `extract_with_genome`: the search wants the session's total, and
+    /// [`ExtractionSession::extract_timings`] is how it reads it.
+    timings: crate::search_support::ExtractTimings,
 }
 
 #[derive(Debug, Clone)]
@@ -490,6 +496,16 @@ impl<'a> ExtractionSession<'a> {
             out.push_str("no cyclic SCCs recorded");
         }
         out
+    }
+
+    /// THE SESSION's cumulative extraction phase clocks — discovery,
+    /// relaxation (with its pass count) and assembly, summed over every
+    /// genome extracted through it (2026-09-05). Read it after the
+    /// selection loop; the search folds it into
+    /// [`crate::search_support::SearchTimings`]'s `extract_*`
+    /// sub-buckets.
+    pub fn extract_timings(&self) -> crate::search_support::ExtractTimings {
+        self.extractor.timings
     }
 
     pub fn extract_with_genome(&mut self, genome: &Genome) -> Result<Option<ExtractedGraph>> {
@@ -985,6 +1001,7 @@ impl<'a> Extractor<'a> {
             tensor_bytes_cache: Default::default(),
             dtype_index: Default::default(),
             stable_key_cache: Default::default(),
+            timings: Default::default(),
         }
     }
 
@@ -1062,6 +1079,11 @@ impl<'a> Extractor<'a> {
         }
 
         self.relax_to_fixpoint(&roots);
+        // ASSEMBLE: everything after the fixpoint — the per-root
+        // settled-memo check (which on a refusal walks the output spine
+        // to name WHICH outputs have no plan) and the graph build that
+        // reads the memo.
+        let assemble_start = std::time::Instant::now();
         for root in &roots {
             if self.memo.get(root).cloned().flatten().is_none() {
                 // Refusal accounting: the output list is ONE class — walk
@@ -1110,6 +1132,7 @@ impl<'a> Extractor<'a> {
                             .and_then(|c| self.egraph.nodes.get(c).map(|n| n.eclass.clone()));
                     }
                 }
+                self.timings.assemble_nanos += assemble_start.elapsed().as_nanos();
                 bail!(
                     "failed to extract LayoutIR graph from BufferOutputLit eclass {root}; \
                      outputs with no plan (binding order): {failing:?}"
@@ -1117,7 +1140,9 @@ impl<'a> Extractor<'a> {
             }
         }
 
-        Ok(Some(self.build_extracted_graph(&roots)?))
+        let built = self.build_extracted_graph(&roots);
+        self.timings.assemble_nanos += assemble_start.elapsed().as_nanos();
+        Ok(Some(built?))
     }
 
     /// The candidate set for one class under the current genome (or the
@@ -1232,6 +1257,7 @@ impl<'a> Extractor<'a> {
             candidate_lists.push(candidates);
         }
         let total_candidates: usize = candidate_lists.iter().map(Vec::len).sum();
+        self.timings.discovery_nanos += discovery_start.elapsed().as_nanos();
         if discovery_start.elapsed().as_secs() >= 2 {
             eprintln!(
                 "[extract] discovery {:?}: {} classes, {} candidates",
@@ -1346,6 +1372,12 @@ impl<'a> Extractor<'a> {
                 .collect();
             self.blocked.insert(class.clone(), blockers);
         }
+        // THE RELAX CLOCK covers the pass loop, the settle that records
+        // the definitive `None`s, and the blockage record: all three are
+        // the fixpoint's own work, and a boundary drawn between them
+        // would leave a gap no bucket owns.
+        self.timings.relax_nanos += relax_start.elapsed().as_nanos();
+        self.timings.relax_passes += passes as u64;
     }
 
     fn candidate_for_node(&self, node_id: &NodeId, node: &Node) -> Option<Candidate> {

--- a/src/search_support.rs
+++ b/src/search_support.rs
@@ -303,6 +303,15 @@ impl RefusalBreakdown {
 /// Stage wall-clock totals for one search, in nanoseconds. Saturation
 /// and serialization happen in the runtime's `search` wrapper and are
 /// stamped there; the rest accumulate inside the selection loop.
+///
+/// THE ACCOUNTING CONTRACT (2026-09-05, "we need to instrument the
+/// search process better"): the TOP-LEVEL buckets below are disjoint
+/// and [`SearchTimings::attributed_nanos`] is their sum, so
+/// `total_nanos - attributed_nanos` is the wall time no bucket claims.
+/// A number that grows there is a MISSING BUCKET, not noise — which is
+/// exactly how the pre-instrumentation hour hid (a qwen3 search spent
+/// 65 of its 83 minutes in `saturation`/`serialize`, both of which
+/// CUDA-lite never stamped).
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SearchTimings {
     /// egglog parse + saturation to fixpoint (one per search).
@@ -318,21 +327,51 @@ pub struct SearchTimings {
     /// All candidate executions: warmup + timed trials (cumulative) —
     /// the part that shrinks with a faster runtime.
     pub profile_nanos: u128,
+    /// THE WHOLE SEARCH's wall clock, measured ONCE around the
+    /// runtime's `search` body and stamped by it. 0 means the caller
+    /// never stamped it, and the residual line says `total unmeasured`
+    /// rather than inventing a denominator.
+    pub total_nanos: u128,
 }
 
 impl SearchTimings {
-    /// A compact human-readable ms breakdown for test logs.
+    /// The sum of the DISJOINT top-level buckets — what
+    /// [`Self::total_nanos`] is compared against.
+    pub fn attributed_nanos(&self) -> u128 {
+        self.saturation_nanos
+            + self.serialize_nanos
+            + self.analysis_nanos
+            + self.extract_nanos
+            + self.plan_build_nanos
+            + self.profile_nanos
+    }
+
+    /// Wall time NO bucket claims: `total - attributed`, saturating (a
+    /// caller that never stamped `total_nanos` reports 0, not a
+    /// wraparound).
+    pub fn unattributed_nanos(&self) -> u128 {
+        self.total_nanos.saturating_sub(self.attributed_nanos())
+    }
+
+    /// A compact human-readable ms breakdown for test logs, ending in
+    /// the RESIDUAL LINE — `total | attributed | unattributed` — so a
+    /// bucket that is missing shows up as a number instead of as
+    /// silence.
     pub fn summary(&self) -> String {
         let ms = |n: u128| n as f64 / 1e6;
         format!(
             "saturation {:.0}ms, serialize {:.0}ms, analysis {:.0}ms, extract {:.0}ms, \
-             plan-build {:.0}ms, profile-exec {:.0}ms",
+             plan-build {:.0}ms, profile-exec {:.0}ms | total {:.0}ms | attributed {:.0}ms \
+             | unattributed {:.0}ms",
             ms(self.saturation_nanos),
             ms(self.serialize_nanos),
             ms(self.analysis_nanos),
             ms(self.extract_nanos),
             ms(self.plan_build_nanos),
-            ms(self.profile_nanos)
+            ms(self.profile_nanos),
+            ms(self.total_nanos),
+            ms(self.attributed_nanos()),
+            ms(self.unattributed_nanos())
         )
     }
 }
@@ -374,6 +413,46 @@ mod early_stop_tests {
         // ...and NOT a tie: the incumbent keeps its seat, but a tied
         // candidate is still worth finishing (it is not yet losing).
         assert!(!early_stop_exceeded(5 * MS, best, 1.0));
+    }
+}
+
+#[cfg(test)]
+mod timing_tests {
+    use super::SearchTimings;
+
+    const MS: u128 = 1_000_000;
+
+    /// THE RESIDUAL IS THE POINT: an unstamped bucket surfaces as
+    /// `unattributed`, never as silence.
+    #[test]
+    fn unattributed_is_total_minus_the_disjoint_buckets() {
+        let timings = SearchTimings {
+            saturation_nanos: 10 * MS,
+            serialize_nanos: 5 * MS,
+            analysis_nanos: 4 * MS,
+            extract_nanos: 3 * MS,
+            plan_build_nanos: 2 * MS,
+            profile_nanos: 1 * MS,
+            total_nanos: 40 * MS,
+        };
+        assert_eq!(timings.attributed_nanos(), 25 * MS);
+        assert_eq!(timings.unattributed_nanos(), 15 * MS);
+        let summary = timings.summary();
+        assert!(
+            summary.ends_with("| total 40ms | attributed 25ms | unattributed 15ms"),
+            "summary must end with the residual line: {summary}"
+        );
+    }
+
+    /// A caller that never stamped the wall clock reports 0 rather than
+    /// wrapping around.
+    #[test]
+    fn unstamped_total_never_wraps() {
+        let timings = SearchTimings {
+            extract_nanos: 7 * MS,
+            ..SearchTimings::default()
+        };
+        assert_eq!(timings.unattributed_nanos(), 0);
     }
 }
 

--- a/src/search_support.rs
+++ b/src/search_support.rs
@@ -312,14 +312,23 @@ impl RefusalBreakdown {
 /// exactly how the pre-instrumentation hour hid (a qwen3 search spent
 /// 65 of its 83 minutes in `saturation`/`serialize`, both of which
 /// CUDA-lite never stamped).
+///
+/// THE SUB-BUCKETS are a partition of the big buckets and are NOT part
+/// of that sum. They answer the next question — WHERE inside extract,
+/// plan-build and profile the time went — and each one names the phase
+/// the code names.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SearchTimings {
+    // ---- top-level buckets, disjoint, summed by `attributed_nanos` ----
     /// egglog parse + saturation to fixpoint (one per search).
     pub saturation_nanos: u128,
     /// e-graph serialization (one per search).
     pub serialize_nanos: u128,
     /// ExtractionSession::new + producer index + viability fixpoint.
     pub analysis_nanos: u128,
+    /// The SAMPLING SPACE: the candidate graph's strongly connected
+    /// components, built once per search from the producer index.
+    pub space_nanos: u128,
     /// All genome extractions (extract_with_genome, cumulative).
     pub extract_nanos: u128,
     /// All DPS rewrites + bufferizations (cumulative).
@@ -327,23 +336,89 @@ pub struct SearchTimings {
     /// All candidate executions: warmup + timed trials (cumulative) —
     /// the part that shrinks with a faster runtime.
     pub profile_nanos: u128,
+    /// Drawing candidates: `sample_genome` in generation 0 and
+    /// `mutate_genome` in every generation after it (cumulative).
+    pub sample_nanos: u128,
+    /// `plan_fingerprint` over the extracted graphs (cumulative) — the
+    /// dedup cache's key, paid on every candidate including the hits.
+    pub fingerprint_nanos: u128,
+    /// `heuristic_cost_of` (cumulative). Always computed, even under
+    /// device profiling, because the outcome reports it beside the
+    /// measurement.
+    pub heuristic_nanos: u128,
+    /// The Phase 5 finalist lattice (`select_finalist_set`), which on a
+    /// device build warms up each finalist it considers.
+    pub finalist_nanos: u128,
+    /// THE LOOP RESIDUAL: the selection loop's wall minus everything
+    /// the loop timed. Genome clones, the fingerprint cache lookups,
+    /// `rank_insert`, refusal bookkeeping and progress printing live
+    /// here, and so does anything a later change forgets to time.
+    pub other_nanos: u128,
+
+    // ---- sub-buckets of `extract_nanos` (see `ExtractTimings`) ----
+    /// Discovery: the BFS that walks candidates from the roots to build
+    /// the class universe `relax_to_fixpoint` relaxes over.
+    pub extract_discovery_nanos: u128,
+    /// The relaxation fixpoint itself — the pass loop.
+    pub extract_relax_nanos: u128,
+    /// How many relaxation PASSES those nanoseconds bought, summed over
+    /// every genome extraction in the search.
+    pub extract_relax_passes: u64,
+    /// `build_extracted_graph` and the root checks around it: turning
+    /// the settled memo into the extracted graph.
+    pub extract_assemble_nanos: u128,
+
+    // ---- sub-buckets of `plan_build_nanos` ----
+    /// `dps_rewrite`.
+    pub dps_rewrite_nanos: u128,
+    /// `decode_layout_table` (cache misses do the work; hits are cheap).
+    pub decode_nanos: u128,
+    /// `bufferize`.
+    pub bufferize_nanos: u128,
+
+    // ---- sub-buckets of `profile_nanos` (device evaluator only) ----
+    /// PREPARE: the untimed first `execute_plan` — NVRTC compilation,
+    /// slab growth, staging and one run. It is one call, so stage and
+    /// warm are NOT separable from each other without restructuring the
+    /// executor; only compilation is, because the kernel cache times
+    /// itself.
+    pub prepare_nanos: u128,
+    /// The compilation INSIDE `prepare_nanos`, measured by the device's
+    /// kernel cache on its miss path (NVRTC + module load).
+    pub prepare_compile_nanos: u128,
+    /// The timed trials.
+    pub trials_nanos: u128,
+    /// Kernel-cache hits over the whole search — kernels a previous
+    /// candidate already compiled.
+    pub kernel_cache_hits: u64,
+    /// Kernel-cache misses: distinct kernel sources NVRTC compiled.
+    pub kernel_cache_misses: u64,
+
+    // ---- the wall ----
     /// THE WHOLE SEARCH's wall clock, measured ONCE around the
     /// runtime's `search` body and stamped by it. 0 means the caller
-    /// never stamped it, and the residual line says `total unmeasured`
+    /// never stamped it, and the residual line says 0 unattributed
     /// rather than inventing a denominator.
     pub total_nanos: u128,
 }
 
 impl SearchTimings {
     /// The sum of the DISJOINT top-level buckets — what
-    /// [`Self::total_nanos`] is compared against.
+    /// [`Self::total_nanos`] is compared against. Sub-buckets are
+    /// deliberately absent: they partition their parents.
     pub fn attributed_nanos(&self) -> u128 {
         self.saturation_nanos
             + self.serialize_nanos
             + self.analysis_nanos
+            + self.space_nanos
             + self.extract_nanos
             + self.plan_build_nanos
             + self.profile_nanos
+            + self.sample_nanos
+            + self.fingerprint_nanos
+            + self.heuristic_nanos
+            + self.finalist_nanos
+            + self.other_nanos
     }
 
     /// Wall time NO bucket claims: `total - attributed`, saturating (a
@@ -353,26 +428,153 @@ impl SearchTimings {
         self.total_nanos.saturating_sub(self.attributed_nanos())
     }
 
-    /// A compact human-readable ms breakdown for test logs, ending in
-    /// the RESIDUAL LINE — `total | attributed | unattributed` — so a
-    /// bucket that is missing shows up as a number instead of as
-    /// silence.
+    /// Fold one extraction session's cumulative phase timings into the
+    /// `extract_*` sub-buckets.
+    pub fn absorb_extract(&mut self, extract: ExtractTimings) {
+        self.extract_discovery_nanos += extract.discovery_nanos;
+        self.extract_relax_nanos += extract.relax_nanos;
+        self.extract_relax_passes += extract.relax_passes;
+        self.extract_assemble_nanos += extract.assemble_nanos;
+    }
+
+    /// A compact ONE-LINE ms breakdown for test logs, ending in the
+    /// RESIDUAL LINE — `total | attributed | unattributed` — so a bucket
+    /// that is missing shows up as a number instead of as silence.
     pub fn summary(&self) -> String {
         let ms = |n: u128| n as f64 / 1e6;
         format!(
-            "saturation {:.0}ms, serialize {:.0}ms, analysis {:.0}ms, extract {:.0}ms, \
-             plan-build {:.0}ms, profile-exec {:.0}ms | total {:.0}ms | attributed {:.0}ms \
-             | unattributed {:.0}ms",
+            "saturation {:.0}ms, serialize {:.0}ms, analysis {:.0}ms, space {:.0}ms, \
+             extract {:.0}ms, plan-build {:.0}ms, profile-exec {:.0}ms, sample {:.0}ms, \
+             fingerprint {:.0}ms, heuristic {:.0}ms, finalists {:.0}ms, other {:.0}ms \
+             | total {} | attributed {:.0}ms | unattributed {:.0}ms",
             ms(self.saturation_nanos),
             ms(self.serialize_nanos),
             ms(self.analysis_nanos),
+            ms(self.space_nanos),
             ms(self.extract_nanos),
             ms(self.plan_build_nanos),
             ms(self.profile_nanos),
-            ms(self.total_nanos),
+            ms(self.sample_nanos),
+            ms(self.fingerprint_nanos),
+            ms(self.heuristic_nanos),
+            ms(self.finalist_nanos),
+            ms(self.other_nanos),
+            self.wall(),
             ms(self.attributed_nanos()),
             ms(self.unattributed_nanos())
         )
+    }
+
+    /// The wall as the residual line spells it: `unmeasured` when no
+    /// caller stamped [`Self::total_nanos`], so a runtime that does not
+    /// measure its own `search` body says so instead of reporting a
+    /// zero-length search.
+    fn wall(&self) -> String {
+        if self.total_nanos == 0 {
+            "unmeasured".to_string()
+        } else {
+            format!("{:.0}ms", self.total_nanos as f64 / 1e6)
+        }
+    }
+
+    /// THE FULL BREAKDOWN, one bucket per line with its sub-buckets
+    /// beside it, ending in the same residual line. This is the form to
+    /// print when a search took long enough that someone is reading.
+    pub fn breakdown(&self) -> String {
+        use std::fmt::Write;
+        let ms = |n: u128| n as f64 / 1e6;
+        let mut out = String::new();
+        let mut row = |label: &str, nanos: u128, note: String| {
+            let share = if self.total_nanos == 0 {
+                String::new()
+            } else {
+                format!(" {:>5.1}%", nanos as f64 * 100.0 / self.total_nanos as f64)
+            };
+            let _ = write!(out, "\n  {label:<14}{:>11.0}ms{share}", ms(nanos));
+            if !note.is_empty() {
+                let _ = write!(out, "   {note}");
+            }
+        };
+        row("saturation", self.saturation_nanos, String::new());
+        row("serialize", self.serialize_nanos, String::new());
+        row("analysis", self.analysis_nanos, String::new());
+        row("space", self.space_nanos, String::new());
+        row(
+            "extract",
+            self.extract_nanos,
+            format!(
+                "discovery {:.0}ms, relax {:.0}ms over {} pass(es), assemble {:.0}ms",
+                ms(self.extract_discovery_nanos),
+                ms(self.extract_relax_nanos),
+                self.extract_relax_passes,
+                ms(self.extract_assemble_nanos)
+            ),
+        );
+        row(
+            "plan-build",
+            self.plan_build_nanos,
+            format!(
+                "dps {:.0}ms, decode {:.0}ms, bufferize {:.0}ms",
+                ms(self.dps_rewrite_nanos),
+                ms(self.decode_nanos),
+                ms(self.bufferize_nanos)
+            ),
+        );
+        row(
+            "profile-exec",
+            self.profile_nanos,
+            format!(
+                "prepare {:.0}ms (compile {:.0}ms, {} kernel miss(es) / {} hit(s)), \
+                 trials {:.0}ms",
+                ms(self.prepare_nanos),
+                ms(self.prepare_compile_nanos),
+                self.kernel_cache_misses,
+                self.kernel_cache_hits,
+                ms(self.trials_nanos)
+            ),
+        );
+        row("sample", self.sample_nanos, String::new());
+        row("fingerprint", self.fingerprint_nanos, String::new());
+        row("heuristic", self.heuristic_nanos, String::new());
+        row("finalists", self.finalist_nanos, String::new());
+        row("other", self.other_nanos, "loop residual".to_string());
+        let _ = write!(
+            out,
+            "\n  total {} | attributed {:.0}ms | unattributed {:.0}ms",
+            self.wall(),
+            ms(self.attributed_nanos()),
+            ms(self.unattributed_nanos())
+        );
+        out
+    }
+}
+
+/// ONE EXTRACTION SESSION's phase clocks, cumulative over every genome
+/// it extracted (2026-09-05). The phases are the ones
+/// `Extractor::extract` and `Extractor::relax_to_fixpoint` already name
+/// in their own comments — discovery, the relaxation fixpoint, and the
+/// graph assembly that reads the settled memo.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ExtractTimings {
+    /// The candidate-walk BFS that builds the class universe.
+    pub discovery_nanos: u128,
+    /// The relaxation pass loop, plus the settle that records the
+    /// definitive `None`s.
+    pub relax_nanos: u128,
+    /// Passes the relaxation took, summed over extractions.
+    pub relax_passes: u64,
+    /// The root checks and `build_extracted_graph`.
+    pub assemble_nanos: u128,
+}
+
+/// A rule name on ONE LINE, at most `width` characters, cut on a char
+/// boundary. Runs of whitespace collapse to a single space so a rule
+/// body's indentation does not eat the budget.
+fn one_line(name: &str, width: usize) -> String {
+    let flat = name.split_whitespace().collect::<Vec<_>>().join(" ");
+    match flat.char_indices().nth(width) {
+        Some((cut, _)) => format!("{}...", &flat[..cut]),
+        None => flat,
     }
 }
 
@@ -431,6 +633,13 @@ pub struct SaturationReport {
 impl SaturationReport {
     /// How many rules [`Self::from_egraph`] keeps.
     pub const TOP_RULES: usize = 15;
+
+    /// How wide a rule name prints. MOST OF OUR RULES ARE ANONYMOUS, so
+    /// egglog names them by their SOURCE TEXT — a whole multi-line rule
+    /// body per name. [`Self::summary`] prints the head of that on one
+    /// line (egglog's own `Display` does the same at 80); the untruncated
+    /// name stays in [`RuleTiming::name`] for anything reading the data.
+    pub const NAME_WIDTH: usize = 110;
 
     /// Take the report off a saturated e-graph. Call it AFTER the run;
     /// on an e-graph that never ran it yields zeros, which is what a
@@ -511,10 +720,17 @@ impl SaturationReport {
             ms(self.rule_total_nanos)
         );
         for ruleset in &self.rulesets {
+            // egglog names the unnamed ruleset with the empty string —
+            // the rules that carry no `:ruleset`. Say so.
+            let name = if ruleset.name.is_empty() {
+                "(default)"
+            } else {
+                ruleset.name.as_str()
+            };
             let _ = write!(
                 out,
                 "\n  ruleset {:<28} search+apply {:>9.0}ms  merge {:>7.0}ms  rebuild {:>8.0}ms",
-                ruleset.name,
+                name,
                 ms(ruleset.search_and_apply_nanos),
                 ms(ruleset.merge_nanos),
                 ms(ruleset.rebuild_nanos)
@@ -527,7 +743,7 @@ impl SaturationReport {
                 rank + 1,
                 ms(rule.search_and_apply_nanos),
                 rule.matches,
-                rule.name
+                one_line(&rule.name, Self::NAME_WIDTH)
             );
         }
         if self.rulesets.is_empty() && self.top_rules.is_empty() {
@@ -593,8 +809,9 @@ mod timing_tests {
             analysis_nanos: 4 * MS,
             extract_nanos: 3 * MS,
             plan_build_nanos: 2 * MS,
-            profile_nanos: 1 * MS,
+            profile_nanos: MS,
             total_nanos: 40 * MS,
+            ..SearchTimings::default()
         };
         assert_eq!(timings.attributed_nanos(), 25 * MS);
         assert_eq!(timings.unattributed_nanos(), 15 * MS);
@@ -614,6 +831,11 @@ mod timing_tests {
             ..SearchTimings::default()
         };
         assert_eq!(timings.unattributed_nanos(), 0);
+        assert!(
+            timings.summary().contains("| total unmeasured |"),
+            "an unstamped wall must say so: {}",
+            timings.summary()
+        );
     }
 }
 

--- a/src/search_support.rs
+++ b/src/search_support.rs
@@ -376,6 +376,167 @@ impl SearchTimings {
     }
 }
 
+/// ONE RULESET's own totals, as egglog's `RunReport` keeps them.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RulesetTiming {
+    pub name: String,
+    pub search_and_apply_nanos: u128,
+    pub merge_nanos: u128,
+    pub rebuild_nanos: u128,
+}
+
+/// ONE RULE's search+apply cost and the number of matches it paid for.
+/// The pair is the point: a rule that is expensive AND matches nothing
+/// is a different problem from one that is expensive because it fires.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RuleTiming {
+    pub name: String,
+    pub search_and_apply_nanos: u128,
+    pub matches: usize,
+}
+
+/// WHAT SATURATION SPENT ITS TIME ON, read off egglog's own
+/// `RunReport` (2026-09-05) — the sub-breakdown of
+/// [`SearchTimings::saturation_nanos`].
+///
+/// Plain data, taken once after the run and owned from then on: the
+/// report borrows from the `EGraph`, and the e-graph does not outlive
+/// the search that produced it.
+///
+/// THE NUMBERS ARE EGGLOG'S, not ours. Per-rule search+apply time is
+/// collected at egglog's default `ReportLevel::TimeOnly`, so nothing
+/// has to be switched on and no rule is re-run to measure it. The
+/// ruleset totals and the per-rule totals are two different cuts of the
+/// same run and do not sum to each other; neither is expected to equal
+/// `saturation_nanos`, which also carries parse, scheduling and the
+/// time between rulesets.
+#[derive(Debug, Clone, Default)]
+pub struct SaturationReport {
+    /// Iterations the schedule ran.
+    pub iterations: usize,
+    /// Per ruleset: search+apply, merge, rebuild. Sorted by search+apply,
+    /// slowest first.
+    pub rulesets: Vec<RulesetTiming>,
+    /// The slowest rules by search+apply, at most
+    /// [`SaturationReport::TOP_RULES`] of them.
+    pub top_rules: Vec<RuleTiming>,
+    /// How many rules the report carried a time for (the `top_rules`
+    /// list is a prefix of this many).
+    pub rules_reported: usize,
+    /// Search+apply summed over EVERY rule, so the top-15 prefix can be
+    /// read as a fraction of the whole.
+    pub rule_total_nanos: u128,
+}
+
+impl SaturationReport {
+    /// How many rules [`Self::from_egraph`] keeps.
+    pub const TOP_RULES: usize = 15;
+
+    /// Take the report off a saturated e-graph. Call it AFTER the run;
+    /// on an e-graph that never ran it yields zeros, which is what a
+    /// search that failed before saturation should report.
+    pub fn from_egraph(egraph: &egglog::EGraph) -> Self {
+        Self::from_egraph_with_top(egraph, Self::TOP_RULES)
+    }
+
+    /// [`Self::from_egraph`] with an explicit rule cutoff.
+    pub fn from_egraph_with_top(egraph: &egglog::EGraph, top: usize) -> Self {
+        let report = egraph.get_overall_run_report();
+        let mut rulesets: BTreeMap<String, RulesetTiming> = BTreeMap::new();
+        fn slot<'a>(
+            rulesets: &'a mut BTreeMap<String, RulesetTiming>,
+            name: &str,
+        ) -> &'a mut RulesetTiming {
+            rulesets
+                .entry(name.to_string())
+                .or_insert_with(|| RulesetTiming {
+                    name: name.to_string(),
+                    ..RulesetTiming::default()
+                })
+        }
+        for (name, time) in &report.search_and_apply_time_per_ruleset {
+            slot(&mut rulesets, name).search_and_apply_nanos = time.as_nanos();
+        }
+        for (name, time) in &report.merge_time_per_ruleset {
+            slot(&mut rulesets, name).merge_nanos = time.as_nanos();
+        }
+        for (name, time) in &report.rebuild_time_per_ruleset {
+            slot(&mut rulesets, name).rebuild_nanos = time.as_nanos();
+        }
+        let mut rulesets: Vec<RulesetTiming> = rulesets.into_values().collect();
+        // Slowest first; the name breaks ties so the order is stable
+        // across runs (egglog's maps are hashed).
+        rulesets.sort_by(|a, b| {
+            b.search_and_apply_nanos
+                .cmp(&a.search_and_apply_nanos)
+                .then_with(|| a.name.cmp(&b.name))
+        });
+
+        let mut rules: Vec<RuleTiming> = report
+            .search_and_apply_time_per_rule
+            .iter()
+            .map(|(name, time)| RuleTiming {
+                name: name.to_string(),
+                search_and_apply_nanos: time.as_nanos(),
+                matches: report.num_matches_per_rule.get(name).copied().unwrap_or(0),
+            })
+            .collect();
+        rules.sort_by(|a, b| {
+            b.search_and_apply_nanos
+                .cmp(&a.search_and_apply_nanos)
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        let rules_reported = rules.len();
+        let rule_total_nanos = rules.iter().map(|rule| rule.search_and_apply_nanos).sum();
+        rules.truncate(top);
+
+        SaturationReport {
+            iterations: report.iterations.len(),
+            rulesets,
+            top_rules: rules,
+            rules_reported,
+            rule_total_nanos,
+        }
+    }
+
+    /// The human-readable cut: ruleset totals, then the top rules, one
+    /// per line, times in ms.
+    pub fn summary(&self) -> String {
+        use std::fmt::Write;
+        let ms = |n: u128| n as f64 / 1e6;
+        let mut out = format!(
+            "saturation: {} iteration(s), {} rule(s) timed, {:.0}ms summed over rules",
+            self.iterations,
+            self.rules_reported,
+            ms(self.rule_total_nanos)
+        );
+        for ruleset in &self.rulesets {
+            let _ = write!(
+                out,
+                "\n  ruleset {:<28} search+apply {:>9.0}ms  merge {:>7.0}ms  rebuild {:>8.0}ms",
+                ruleset.name,
+                ms(ruleset.search_and_apply_nanos),
+                ms(ruleset.merge_nanos),
+                ms(ruleset.rebuild_nanos)
+            );
+        }
+        for (rank, rule) in self.top_rules.iter().enumerate() {
+            let _ = write!(
+                out,
+                "\n  rule #{:<2} {:>9.0}ms  {:>10} matches  {}",
+                rank + 1,
+                ms(rule.search_and_apply_nanos),
+                rule.matches,
+                rule.name
+            );
+        }
+        if self.rulesets.is_empty() && self.top_rules.is_empty() {
+            out.push_str("\n  (egglog reported no per-rule timing)");
+        }
+        out
+    }
+}
+
 /// Main's `early_stop_exceeded` (its `src/op.rs`), retyped from
 /// `Duration` to this branch's u128 nanos: true once a candidate's mean
 /// trial cost exceeds `best * factor`, i.e. the candidate has already
@@ -453,6 +614,66 @@ mod timing_tests {
             ..SearchTimings::default()
         };
         assert_eq!(timings.unattributed_nanos(), 0);
+    }
+}
+
+#[cfg(test)]
+mod saturation_report_tests {
+    use super::SaturationReport;
+
+    /// EGGLOG REALLY DOES REPORT THIS. The per-rule and per-ruleset
+    /// timings come from egglog's default report level, so a saturated
+    /// e-graph carries them with nothing switched on — this pins that,
+    /// because the whole saturation breakdown rests on it.
+    #[test]
+    fn a_saturated_egraph_reports_its_rulesets_and_rules() {
+        let mut egraph = egglog::EGraph::default();
+        egraph
+            .parse_and_run_program(
+                None,
+                r#"
+                (datatype Math (Num i64) (Add Math Math))
+                (ruleset folding)
+                (rule ((= e (Add (Num a) (Num b))))
+                      ((union e (Num (+ a b))))
+                      :ruleset folding :name "fold-add")
+                (let start (Add (Num 1) (Num 2)))
+                (run-schedule (saturate folding))
+                "#,
+            )
+            .expect("the fixture program saturates");
+        let report = SaturationReport::from_egraph(&egraph);
+        assert!(report.iterations > 0, "no iterations reported");
+        assert!(
+            report
+                .rulesets
+                .iter()
+                .any(|ruleset| ruleset.name == "folding"),
+            "the `folding` ruleset is missing from {:?}",
+            report.rulesets
+        );
+        let rule = report
+            .top_rules
+            .iter()
+            .find(|rule| rule.name.contains("fold-add"))
+            .unwrap_or_else(|| panic!("`fold-add` is missing from {:?}", report.top_rules));
+        assert!(rule.matches > 0, "the rule fired but reports no matches");
+        assert!(report.rules_reported >= 1, "no rule was timed");
+        // The summary names both cuts, one line each.
+        let summary = report.summary();
+        assert!(summary.contains("ruleset folding"), "{summary}");
+        assert!(summary.contains("fold-add"), "{summary}");
+    }
+
+    /// An e-graph that never ran reports zeros rather than panicking —
+    /// what a search that failed before saturation should show.
+    #[test]
+    fn an_unrun_egraph_reports_nothing_rather_than_failing() {
+        let report = SaturationReport::from_egraph(&egglog::EGraph::default());
+        assert_eq!(report.iterations, 0);
+        assert!(report.rulesets.is_empty());
+        assert!(report.top_rules.is_empty());
+        assert!(report.summary().contains("no per-rule timing"));
     }
 }
 


### PR DESCRIPTION
## Why

Austin, 2026-09-05: *"those search times are way too long. We need to instrument the search process better."*

The CUDA-lite harness printed six buckets and never filled two of them. A qwen3 (4B) search on the A100:

```
search 4,968,027 ms | [saturation 0ms, serialize 0ms, analysis 10813ms,
                       extract 951261ms, plan-build 59337ms, profile-exec 18040ms]
```

About **65 of those 83 minutes were in no bucket at all**. gemma3: 5,488 s total, ~74 min unattributed. whisper: 365 s total, ~166 s unattributed.

The missing hour was `CudaRuntime::assemble_and_saturate` — egglog parse + saturation of the full model, then serialization, both run before the genetic loop and neither ever stamped. `SearchTimings::saturation_nanos` / `serialize_nanos` existed; only the reference runtime filled them.

## What this adds

**Every second attributed.** `SearchTimings` now carries disjoint top-level buckets whose sum is `attributed_nanos()`, and a wall (`total_nanos`) measured once around the whole `CudaRuntime::search` body. `summary()` ends with `total | attributed | unattributed`, so a bucket that goes missing shows up as a number instead of as silence.

Buckets: `saturation`, `serialize`, `analysis`, `space`, `extract`, `plan-build`, `profile-exec`, `sample`, `fingerprint`, `heuristic`, `finalists`, `other` (the loop's own residual).

Sub-buckets (a partition of their parent, not part of the sum):

- extract: `discovery` / `relax` (+ pass count) / `assemble`
- plan-build: `dps` / `decode` / `bufferize`
- profile: `prepare` (with the NVRTC `compile` share and kernel-cache hit/miss counts) / `trials`

**Saturation broken down by rule.** egglog's `RunReport` already carries per-ruleset (search+apply / merge / rebuild) and per-rule (search+apply, matches) timing at its DEFAULT report level — nothing to switch on, nothing re-run. `SaturationReport` takes it off the e-graph as owned plain data (no new dependency), rides on `SearchOutcome::saturation`, and prints ruleset totals plus the top 15 rules with their match counts.

**Timers only.** No behaviour, RNG consumption, election, or budget changed. The reference runtime is untouched.

## Sample (host run, conv example smoke test)

```
conv example: [saturation 685ms, serialize 10ms, analysis 22ms, space 1ms, extract 539ms,
 plan-build 249ms, profile-exec 0ms, sample 0ms, fingerprint 0ms, heuristic 0ms,
 finalists 0ms, other 1ms | total 1517ms | attributed 1508ms | unattributed 10ms]
conv example: timing breakdown
  saturation            685ms  45.1%
  serialize              10ms   0.6%
  analysis               22ms   1.4%
  space                   1ms   0.1%
  extract               539ms  35.5%   discovery 392ms, relax 52ms over 305 pass(es), assemble 94ms
  plan-build            249ms  16.4%   dps 1ms, decode 206ms, bufferize 42ms
  profile-exec            0ms   0.0%   prepare 0ms (compile 0ms, 0 kernel miss(es) / 0 hit(s)), trials 0ms
  sample                  0ms   0.0%
  fingerprint             0ms   0.0%
  heuristic               0ms   0.0%
  finalists               0ms   0.0%
  other                   1ms   0.1%   loop residual
  total 1517ms | attributed 1508ms | unattributed 10ms
conv example: saturation: 144 iteration(s), 290 rule(s) timed, 315ms summed over rules
  ruleset (default)                    search+apply       328ms  merge       2ms  rebuild        7ms
  ruleset subst-walk                   search+apply       121ms  merge       0ms  rebuild        1ms
  ruleset fixpoint-invariants          search+apply         1ms  merge       0ms  rebuild        0ms
  ruleset materializing-copy-mint      search+apply         0ms  merge       0ms  rebuild        0ms
  ruleset cleanup                      search+apply         0ms  merge       0ms  rebuild        0ms
  ruleset layout-tensor-op-metadata    search+apply         0ms  merge       0ms  rebuild        0ms
  rule #1         29ms           0 matches  (rule ((= ?out (LogicalReduceSum ?prod 0)) (= ?prod (LogicalMul ?a_bcast ?b_bcast)) ...
  rule #2         29ms           0 matches  (rule ((= ?out (LogicalReduceSum ?prod 0)) (= ?prod (LogicalMul ?a_bcast ?b_bcast)) ...
  rule #3         24ms           3 matches  (rule ((= ?out (LogicalReduceSum ?prod 0)) (= ?prod (LogicalMul ?a_bcast ?b_bcast)) ...
  ... (15 rules)
```

Two things this host run already says, on a 1.5-second search: saturation is 45% of it, and inside extraction **discovery** (392 ms) dwarfs the relaxation fixpoint (52 ms) — which is not where the `[extract] SLOW RELAX` lines pointed.

## Notes

- Stage and warm are NOT separated inside `profile`: they are one `execute_plan` call, and splitting them is the stage-once/run-many surgery `profile.rs` already defers. Compilation IS separated, because the device's kernel cache times its own miss path. `prepare - compile` is stage + warm.
- Most of our egglog rules are anonymous, so egglog names them by their source text; `summary()` prints the head on one line and the untruncated name stays in the data.
- **A100 measurement run pending** — the numbers that motivated this are from the A100; this PR was developed and gated on a host with no GPU (`--features device` type-checks only).

## Gate

```
cargo build -p luminal -p luminal_cuda_lite -p luminal_reference --all-targets   Finished
cargo check -p luminal_cuda_lite --features device --all-targets                 Finished
cargo test -p luminal_cuda_lite                                                  all suites ok, 0 failed
cargo test -p luminal --lib search_support                                        ok. 13 passed; 0 failed
cargo clippy -p luminal -p luminal_cuda_lite --all-targets                        Finished, 0 warnings
cargo fmt --all -- --check                                                        clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
