### PR TITLE
saturation_scaling: grow a model layer by layer and report egglog's own timers

### DIFF
--- a/crates/luminal_cuda_lite/examples/saturation_scaling.rs
+++ b/crates/luminal_cuda_lite/examples/saturation_scaling.rs
@@ -78,6 +78,13 @@ struct Options {
     cap_secs: f64,
     extract: bool,
     seed: u64,
+    /// How many characters of a rule's name print. MOST OF OUR RULES
+    /// ARE ANONYMOUS, so egglog names them by their whole source text,
+    /// and the arms of a rule FAMILY share a long common prefix — the
+    /// cuBLASLt marker rules agree for ~200 characters and differ only
+    /// in their `CoordVar` indices. 100 shows which family; naming the
+    /// exact arm needs several hundred.
+    rule_chars: usize,
 }
 
 impl Default for Options {
@@ -88,6 +95,7 @@ impl Default for Options {
             cap_secs: 300.0,
             extract: false,
             seed: 0,
+            rule_chars: 100,
         }
     }
 }
@@ -119,11 +127,12 @@ fn parse_args() -> Result<Options> {
             }
             "--cap-secs" => options.cap_secs = value()?.parse()?,
             "--seed" => options.seed = value()?.parse()?,
+            "--rule-chars" => options.rule_chars = value()?.parse()?,
             "--extract" => options.extract = true,
             "--help" | "-h" => {
                 println!(
                     "saturation_scaling [--model qwen3|gemma3] [--layers 1,2,3,4] \
-                     [--cap-secs 300] [--seed 0] [--extract]"
+                     [--cap-secs 300] [--seed 0] [--rule-chars 100] [--extract]"
                 );
                 std::process::exit(0);
             }
@@ -190,7 +199,7 @@ fn run() -> Result<()> {
         } else {
             None
         };
-        print_block(options.model, layers, build_ms, &stats);
+        print_block(options.model, layers, build_ms, &stats, options.rule_chars);
 
         let saturation_ms = stats.saturation_nanos as f64 / 1e6;
         rows.push(Row {
@@ -333,7 +342,13 @@ fn flatten(name: &str, width: usize) -> String {
     }
 }
 
-fn print_block(model: Model, layers: usize, build_ms: f64, stats: &SaturationStats) {
+fn print_block(
+    model: Model,
+    layers: usize,
+    build_ms: f64,
+    stats: &SaturationStats,
+    rule_chars: usize,
+) {
     let ms = |n: u128| n as f64 / 1e6;
     println!(
         "\n===== {} layers={layers} =====",
@@ -370,7 +385,7 @@ fn print_block(model: Model, layers: usize, build_ms: f64, stats: &SaturationSta
             rank + 1,
             ms(rule.search_and_apply_nanos),
             rule.matches,
-            flatten(&rule.name, 100)
+            flatten(&rule.name, rule_chars)
         );
     }
     for (rank, (op, count)) in stats.nodes_per_constructor.iter().take(15).enumerate() {

--- a/crates/luminal_cuda_lite/examples/saturation_scaling.rs
+++ b/crates/luminal_cuda_lite/examples/saturation_scaling.rs
@@ -1,0 +1,702 @@
+//! HOW SATURATION SCALES WITH MODEL SIZE — a script, not a test
+//! (2026-09-05).
+//!
+//! It grows a released model ONE TRANSFORMER LAYER AT A TIME, records
+//! the same graph the CUDA-lite application records, saturates it
+//! through [`luminal_cuda_lite::CudaRuntime::saturation_stats`], and
+//! prints what egglog itself says the run cost: iterations, per-ruleset
+//! search+apply/merge/rebuild, the slowest rules with their match
+//! counts, and three cuts of the e-graph's size. No search runs — the
+//! genetic loop, the extractor and the planner are all off the clock,
+//! so every number here belongs to saturation.
+//!
+//! THE POINT IS THE TREND, not any single N. The closing table fits the
+//! measured points three ways — a power law `a·N^b`, an exponential
+//! `a·e^(bN)`, and a line `c + m·N` — reports each fit's residual, and
+//! extrapolates all three to the full model's layer count, which is the
+//! question a scaling study is actually asked: does a 36-layer
+//! saturation cost 36 times a 1-layer one, or 2^36? THE RESIDUALS ARE
+//! THE ANSWER, not the extrapolations: three curves through four points
+//! agree on the points and disagree wildly at N=36, so the honest use
+//! of this table is to read which fit the measurements actually pick
+//! out — and, when the range is short, to say that they do not.
+//!
+//! HOST-ONLY. Nothing here touches a device; `--features device` is not
+//! needed and would change nothing.
+//!
+//! Run:
+//!   cargo run --release -p luminal_cuda_lite --example saturation_scaling \
+//!     -- --model qwen3 --layers 1,2,3,4 --cap-secs 300
+
+use anyhow::{Result, bail};
+use luminal::dtype::DType;
+use luminal::graph::Graph;
+use luminal_cuda_lite::{CudaRuntime, SaturationStats};
+
+/// The KV-cache slot count the applications record with
+/// (`crates/luminal_cuda_lite/examples/qwen3.rs`). Kept identical so
+/// this study's graph is the application's graph with a different layer
+/// count, and nothing else.
+const SLOTS: usize = 4;
+
+/// The full-size layer counts the trend extrapolates to.
+const QWEN3_4B_LAYERS: usize = 36;
+const GEMMA3_4B_LAYERS: usize = 34;
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("saturation_scaling: FAIL: {error:#}");
+        std::process::exit(1);
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Model {
+    Qwen3,
+    Gemma3,
+}
+
+impl Model {
+    fn name(self) -> &'static str {
+        match self {
+            Model::Qwen3 => "qwen3",
+            Model::Gemma3 => "gemma3",
+        }
+    }
+
+    fn full_layers(self) -> usize {
+        match self {
+            Model::Qwen3 => QWEN3_4B_LAYERS,
+            Model::Gemma3 => GEMMA3_4B_LAYERS,
+        }
+    }
+}
+
+struct Options {
+    model: Model,
+    layers: Vec<usize>,
+    cap_secs: f64,
+    extract: bool,
+    seed: u64,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            model: Model::Qwen3,
+            layers: vec![1, 2, 3, 4],
+            cap_secs: 300.0,
+            extract: false,
+            seed: 0,
+        }
+    }
+}
+
+fn parse_args() -> Result<Options> {
+    let mut options = Options::default();
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        let mut value = || {
+            args.next()
+                .ok_or_else(|| anyhow::anyhow!("{arg} needs a value"))
+        };
+        match arg.as_str() {
+            "--model" => {
+                options.model = match value()?.as_str() {
+                    "qwen3" => Model::Qwen3,
+                    "gemma3" => Model::Gemma3,
+                    other => bail!("unknown model '{other}' (qwen3 | gemma3)"),
+                }
+            }
+            "--layers" => {
+                options.layers = value()?
+                    .split(',')
+                    .map(|n| n.trim().parse::<usize>())
+                    .collect::<Result<Vec<_>, _>>()?;
+                if options.layers.contains(&0) {
+                    bail!("--layers must be positive");
+                }
+            }
+            "--cap-secs" => options.cap_secs = value()?.parse()?,
+            "--seed" => options.seed = value()?.parse()?,
+            "--extract" => options.extract = true,
+            "--help" | "-h" => {
+                println!(
+                    "saturation_scaling [--model qwen3|gemma3] [--layers 1,2,3,4] \
+                     [--cap-secs 300] [--seed 0] [--extract]"
+                );
+                std::process::exit(0);
+            }
+            other => bail!("unknown argument '{other}' (try --help)"),
+        }
+    }
+    if options.layers.is_empty() {
+        bail!("--layers listed nothing");
+    }
+    Ok(options)
+}
+
+/// ONE MEASURED POINT.
+struct Row {
+    layers: usize,
+    saturation_ms: f64,
+    serialize_ms: f64,
+    iterations: usize,
+    tuples: usize,
+    classes: usize,
+    nodes: usize,
+    top_ruleset: String,
+    top_rule: String,
+    extract_ms: Option<f64>,
+}
+
+fn run() -> Result<()> {
+    let options = parse_args()?;
+    println!(
+        "saturation_scaling: model {} | layers {:?} | cap {:.0}s | extract {}",
+        options.model.name(),
+        options.layers,
+        options.cap_secs,
+        options.extract
+    );
+    // THE SCHEDULE THE NUMBERS BELONG TO: printed once so a reader can
+    // map the per-ruleset rows below onto the strata that ran them.
+    println!(
+        "saturation_scaling: run-schedule {}",
+        luminal_cuda_lite::CudaBindings::SCHEDULE.trim()
+    );
+
+    let mut rows: Vec<Row> = Vec::new();
+    for layers in &options.layers {
+        let layers = *layers;
+        let build_start = std::time::Instant::now();
+        let cx = build_graph(options.model, layers)?;
+        let build_ms = build_start.elapsed().as_secs_f64() * 1e3;
+
+        let mut runtime = CudaRuntime::load(&cx)?;
+        // The applications' dyn discipline: pin every dynamic variable
+        // the recorder minted to the value the harness recorded it at.
+        let mut vars: Vec<_> = cx.dyn_map.iter().collect();
+        vars.sort();
+        for (var, value) in vars {
+            runtime.bind_dyn_range(*var, *value as u64, *value as u64)?;
+        }
+
+        let stats = runtime.saturation_stats()?;
+        let extract_ms = if options.extract {
+            let extraction = runtime.extraction_stats(&stats.serialized, options.seed)?;
+            print_extraction(layers, &extraction);
+            Some(extraction.extract_nanos as f64 / 1e6)
+        } else {
+            None
+        };
+        print_block(options.model, layers, build_ms, &stats);
+
+        let saturation_ms = stats.saturation_nanos as f64 / 1e6;
+        rows.push(Row {
+            layers,
+            saturation_ms,
+            serialize_ms: stats.serialize_nanos as f64 / 1e6,
+            iterations: stats.iterations,
+            tuples: stats.num_tuples,
+            classes: stats.classes,
+            nodes: stats.nodes,
+            top_ruleset: stats
+                .report
+                .rulesets
+                .first()
+                .map(|r| ruleset_name(&r.name).to_string())
+                .unwrap_or_else(|| "-".to_string()),
+            top_rule: stats
+                .report
+                .top_rules
+                .first()
+                .map(|r| flatten(&r.name, 48))
+                .unwrap_or_else(|| "-".to_string()),
+            extract_ms,
+        });
+
+        if saturation_ms / 1e3 > options.cap_secs {
+            println!(
+                "\nsaturation_scaling: STOP — layers={layers} saturation {:.1}s exceeded the \
+                 {:.0}s cap; not growing further.",
+                saturation_ms / 1e3,
+                options.cap_secs
+            );
+            break;
+        }
+    }
+
+    print_trend(options.model, &rows);
+    Ok(())
+}
+
+/// The application graph at `layers` transformer layers — the same
+/// recording sequence as `examples/{qwen3,gemma3}.rs`, minus the host
+/// tables and seeded payloads, which saturation never reads.
+fn build_graph(model: Model, layers: usize) -> Result<Graph> {
+    let mut cx = Graph::new();
+    match model {
+        Model::Qwen3 => {
+            use qwen3::{
+                Qwen, QwenDims,
+                model_support::{Namespace, named_kv_cache_pool},
+            };
+            let dims = QwenDims {
+                layers,
+                ..QwenDims::qwen3_4b()
+            };
+            let model = Qwen::init(&mut cx, &dims);
+            let token = cx.tensor(1, DType::Int);
+            let q_pos = cx.tensor(1, DType::Int);
+            let rope_cos = cx.tensor((1, dims.head_dim), DType::F32);
+            let rope_sin = cx.tensor((1, dims.head_dim), DType::F32);
+            let rope_rot = cx.tensor((dims.head_dim, dims.head_dim), DType::F32);
+            let gather_idx = cx.tensor(SLOTS, DType::Int);
+            let scatter_idx = cx.tensor(1, DType::Int);
+            let pool = named_kv_cache_pool(
+                &mut cx,
+                dims.layers,
+                SLOTS,
+                dims.kv_dim(),
+                DType::F32,
+                &Namespace::root().child("cache"),
+            );
+            let (logits, _) = model.forward(
+                token,
+                q_pos,
+                rope_cos,
+                rope_sin,
+                rope_rot,
+                &pool.layers,
+                gather_idx,
+                scatter_idx,
+            );
+            let _ = logits.output();
+        }
+        Model::Gemma3 => {
+            use gemma3::{
+                Gemma3, Gemma3Dims,
+                model_support::{Namespace, named_kv_cache_pool},
+            };
+            let dims = Gemma3Dims {
+                layers,
+                ..Gemma3Dims::gemma3_4b()
+            };
+            let model = Gemma3::init(&mut cx, &dims);
+            let token = cx.tensor(1, DType::Int);
+            let q_pos = cx.tensor(1, DType::Int);
+            let local_cos = cx.tensor((1, dims.head_dim), DType::F32);
+            let local_sin = cx.tensor((1, dims.head_dim), DType::F32);
+            let global_cos = cx.tensor((1, dims.head_dim), DType::F32);
+            let global_sin = cx.tensor((1, dims.head_dim), DType::F32);
+            let rope_rot = cx.tensor((dims.head_dim, dims.head_dim), DType::F32);
+            let gather_idx = cx.tensor(SLOTS, DType::Int);
+            let scatter_idx = cx.tensor(1, DType::Int);
+            let pool = named_kv_cache_pool(
+                &mut cx,
+                dims.layers,
+                SLOTS,
+                dims.kv_dim(),
+                DType::F32,
+                &Namespace::root().child("cache"),
+            );
+            let (logits, _) = model.forward(
+                token,
+                q_pos,
+                (local_cos, local_sin),
+                (global_cos, global_sin),
+                rope_rot,
+                &pool,
+                gather_idx,
+                scatter_idx,
+            );
+            let _ = logits.output();
+        }
+    }
+    Ok(cx)
+}
+
+/// egglog names the ruleset carrying no `:ruleset` with the empty
+/// string. Say so.
+fn ruleset_name(name: &str) -> &str {
+    if name.is_empty() { "(default)" } else { name }
+}
+
+/// A rule name on one line at most `width` chars. Most of our rules are
+/// ANONYMOUS, so egglog names them by their whole source text.
+fn flatten(name: &str, width: usize) -> String {
+    let flat = name.split_whitespace().collect::<Vec<_>>().join(" ");
+    match flat.char_indices().nth(width) {
+        Some((cut, _)) => format!("{}...", &flat[..cut]),
+        None => flat,
+    }
+}
+
+fn print_block(model: Model, layers: usize, build_ms: f64, stats: &SaturationStats) {
+    let ms = |n: u128| n as f64 / 1e6;
+    println!(
+        "\n===== {} layers={layers} =====",
+        model.name().to_uppercase()
+    );
+    println!(
+        "  record        {build_ms:>10.0}ms\n  \
+         saturation    {:>10.0}ms\n  \
+         serialize     {:>10.0}ms",
+        ms(stats.saturation_nanos),
+        ms(stats.serialize_nanos)
+    );
+    println!(
+        "  size          iterations {} | tuples {} | classes {} | nodes {}",
+        stats.iterations, stats.num_tuples, stats.classes, stats.nodes
+    );
+    println!(
+        "  rules         {} timed, {:.0}ms summed over rules",
+        stats.report.rules_reported,
+        ms(stats.report.rule_total_nanos)
+    );
+    for ruleset in &stats.report.rulesets {
+        println!(
+            "  ruleset {:<26} search+apply {:>9.0}ms  merge {:>7.0}ms  rebuild {:>8.0}ms",
+            ruleset_name(&ruleset.name),
+            ms(ruleset.search_and_apply_nanos),
+            ms(ruleset.merge_nanos),
+            ms(ruleset.rebuild_nanos)
+        );
+    }
+    for (rank, rule) in stats.report.top_rules.iter().enumerate() {
+        println!(
+            "  rule #{:<2} {:>9.0}ms {:>12} matches  {}",
+            rank + 1,
+            ms(rule.search_and_apply_nanos),
+            rule.matches,
+            flatten(&rule.name, 100)
+        );
+    }
+    for (rank, (op, count)) in stats.nodes_per_constructor.iter().take(15).enumerate() {
+        println!("  ctor #{:<2} {count:>10} nodes  {op}", rank + 1);
+    }
+    for (rank, (name, size)) in stats.function_sizes.iter().take(15).enumerate() {
+        println!("  func #{:<2} {size:>10} rows   {name}", rank + 1);
+    }
+}
+
+fn print_extraction(layers: usize, stats: &luminal_cuda_lite::ExtractionStats) {
+    let ms = |n: u128| n as f64 / 1e6;
+    println!(
+        "\n  extract layers={layers}: analysis {:.0}ms | space {:.0}ms | sample {:.0}ms | \
+         extract {:.0}ms (discovery {:.0}ms, relax {:.0}ms over {} pass(es), assemble {:.0}ms) | \
+         producer classes {} | extracted nodes {}",
+        ms(stats.analysis_nanos),
+        ms(stats.space_nanos),
+        ms(stats.sample_nanos),
+        ms(stats.extract_nanos),
+        ms(stats.sub.discovery_nanos),
+        ms(stats.sub.relax_nanos),
+        stats.sub.relax_passes,
+        ms(stats.sub.assemble_nanos),
+        stats.producer_classes,
+        stats
+            .extracted_nodes
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "refused".to_string())
+    );
+}
+
+/// A LEAST-SQUARES FIT of `y = a·exp(b·u)`, done on `ln y` (so it is a
+/// straight-line fit in the transformed space, not a nonlinear solve).
+/// With `u = ln N` this is the power law `a·N^b`; with `u = N` it is the
+/// exponential `a·e^(bN)`.
+///
+/// The residual reported is RMS in LOG SPACE, which is the honest one
+/// for a fit done there: a 10% miss costs the same whether it is on the
+/// smallest point or the largest. `max_rel` re-expresses the worst
+/// single point as a percentage, for readers who want a number in the
+/// units they measured.
+struct Fit {
+    a: f64,
+    b: f64,
+    rms_log: f64,
+    max_rel: f64,
+}
+
+impl Fit {
+    fn at(&self, u: f64) -> f64 {
+        self.a * (self.b * u).exp()
+    }
+}
+
+/// Fit `points` as `(u, y)`; `None` if fewer than two distinct `u` or any
+/// non-positive `y` (the log is undefined and a zero measurement is not
+/// a measurement).
+fn fit(points: &[(f64, f64)]) -> Option<Fit> {
+    if points.len() < 2 || points.iter().any(|(_, y)| *y <= 0.0) {
+        return None;
+    }
+    let n = points.len() as f64;
+    let mean_u = points.iter().map(|(u, _)| *u).sum::<f64>() / n;
+    let mean_ly = points.iter().map(|(_, y)| y.ln()).sum::<f64>() / n;
+    let mut cov = 0.0;
+    let mut var = 0.0;
+    for (u, y) in points {
+        cov += (u - mean_u) * (y.ln() - mean_ly);
+        var += (u - mean_u) * (u - mean_u);
+    }
+    if var == 0.0 {
+        return None;
+    }
+    let b = cov / var;
+    let a = (mean_ly - b * mean_u).exp();
+    let mut sq = 0.0;
+    let mut max_rel: f64 = 0.0;
+    for (u, y) in points {
+        let resid = y.ln() - (a.ln() + b * u);
+        sq += resid * resid;
+        max_rel = max_rel.max((resid.abs().exp() - 1.0) * 100.0);
+    }
+    Some(Fit {
+        a,
+        b,
+        rms_log: (sq / n).sqrt(),
+        max_rel,
+    })
+}
+
+/// AN ORDINARY LEAST-SQUARES LINE, `y = c + m·N`, fitted in LINEAR
+/// space (2026-09-05).
+///
+/// It is here as the THIRD null hypothesis, and specifically as the one
+/// the other two cannot express: a fixed cost plus a per-layer cost is
+/// what a schedule that parses a base program once and then does a
+/// layer's work per layer would look like, and neither a power law nor
+/// an exponential can represent a constant term. A power law fitted
+/// through `c + m·N` reads back a spuriously SUB-linear exponent,
+/// because the constant flattens the log-log slope. Printing all three
+/// residuals side by side is what makes the answer readable: the fit
+/// with the small residual over a wide N range is the shape, and over a
+/// narrow one near N=1 the line and the power law are not
+/// distinguishable.
+///
+/// Its residual is reported IN LOG SPACE like the other two, so the
+/// three numbers are comparable.
+struct Line {
+    c: f64,
+    m: f64,
+    rms_log: f64,
+    max_rel: f64,
+}
+
+impl Line {
+    fn at(&self, x: f64) -> f64 {
+        self.c + self.m * x
+    }
+}
+
+fn fit_line(points: &[(f64, f64)]) -> Option<Line> {
+    if points.len() < 2 {
+        return None;
+    }
+    let n = points.len() as f64;
+    let mean_x = points.iter().map(|(x, _)| *x).sum::<f64>() / n;
+    let mean_y = points.iter().map(|(_, y)| *y).sum::<f64>() / n;
+    let mut cov = 0.0;
+    let mut var = 0.0;
+    for (x, y) in points {
+        cov += (x - mean_x) * (y - mean_y);
+        var += (x - mean_x) * (x - mean_x);
+    }
+    if var == 0.0 {
+        return None;
+    }
+    let m = cov / var;
+    let c = mean_y - m * mean_x;
+    let mut sq = 0.0;
+    let mut max_rel: f64 = 0.0;
+    for (x, y) in points {
+        let predicted = c + m * x;
+        // A fitted line can dip non-positive on small x; a log residual
+        // is undefined there, so the fit reports no residual rather
+        // than a wrong one.
+        if predicted <= 0.0 || *y <= 0.0 {
+            return None;
+        }
+        let resid = y.ln() - predicted.ln();
+        sq += resid * resid;
+        max_rel = max_rel.max((resid.abs().exp() - 1.0) * 100.0);
+    }
+    Some(Line {
+        c,
+        m,
+        rms_log: (sq / n).sqrt(),
+        max_rel,
+    })
+}
+
+/// All three fits for one measured quantity, with the extrapolation to
+/// `target` layers.
+fn print_fits(label: &str, unit: &str, rows: &[Row], target: usize, value: impl Fn(&Row) -> f64) {
+    let power: Vec<(f64, f64)> = rows
+        .iter()
+        .map(|row| ((row.layers as f64).ln(), value(row)))
+        .collect();
+    let expo: Vec<(f64, f64)> = rows
+        .iter()
+        .map(|row| (row.layers as f64, value(row)))
+        .collect();
+    let t = target as f64;
+    match fit(&power) {
+        Some(f) => println!(
+            "  {label:<12} power law    {:>12.4} * N^{:<8.4}  rms(log) {:.4}  max err {:>6.1}%  \
+             → N={target}: {:.1} {unit}",
+            f.a,
+            f.b,
+            f.rms_log,
+            f.max_rel,
+            f.at(t.ln())
+        ),
+        None => println!("  {label:<12} power law    (not fittable)"),
+    }
+    match fit(&expo) {
+        Some(f) => println!(
+            "  {label:<12} exponential  {:>12.4} * e^({:.4}·N)  rms(log) {:.4}  max err {:>6.1}%  \
+             → N={target}: {:.1} {unit}",
+            f.a,
+            f.b,
+            f.rms_log,
+            f.max_rel,
+            f.at(t)
+        ),
+        None => println!("  {label:<12} exponential  (not fittable)"),
+    }
+    match fit_line(&expo) {
+        Some(f) => println!(
+            "  {label:<12} linear       {:>12.4} + {:.4}*N        rms(log) {:.4}  max err {:>6.1}%  \
+             \u{2192} N={target}: {:.1} {unit}",
+            f.c,
+            f.m,
+            f.rms_log,
+            f.max_rel,
+            f.at(t)
+        ),
+        None => println!("  {label:<12} linear       (not fittable)"),
+    }
+    // THE LOCAL SLOPE, from the last two points only. A global fit over
+    // a range that spans a fixed startup cost AND an asymptotic regime
+    // fits neither, and says so through a large residual; the log-log
+    // slope between the two LARGEST measured N is the exponent the
+    // curve is actually running at where it matters, and extrapolating
+    // from the largest measured point along it is the least
+    // unreasonable thing this data supports.
+    if let [.., prev, last] = rows {
+        let (n0, n1) = (prev.layers as f64, last.layers as f64);
+        let (y0, y1) = (value(prev), value(last));
+        if n1 > n0 && y0 > 0.0 && y1 > 0.0 {
+            let slope = (y1 / y0).ln() / (n1 / n0).ln();
+            println!(
+                "  {label:<12} local slope  N^{slope:<10.4} over N={}..{}                         \
+                 \u{2192} N={target}: {:.1} {unit}",
+                prev.layers,
+                last.layers,
+                y1 * (t / n1).powf(slope)
+            );
+        }
+    }
+}
+
+fn print_trend(model: Model, rows: &[Row]) {
+    println!("\n===== TREND: {} =====", model.name());
+    println!(
+        "{:>3} | {:>12} | {:>7} | {:>5} | {:>10} | {:>9} | {:>9} | {:>26} | top rule",
+        "N", "saturate ms", "ratio", "iters", "tuples", "classes", "nodes", "top ruleset"
+    );
+    for (index, row) in rows.iter().enumerate() {
+        let ratio = if index == 0 {
+            "-".to_string()
+        } else {
+            format!("{:.2}x", row.saturation_ms / rows[index - 1].saturation_ms)
+        };
+        println!(
+            "{:>3} | {:>12.0} | {:>7} | {:>5} | {:>10} | {:>9} | {:>9} | {:>26} | {}",
+            row.layers,
+            row.saturation_ms,
+            ratio,
+            row.iterations,
+            row.tuples,
+            row.classes,
+            row.nodes,
+            row.top_ruleset,
+            row.top_rule
+        );
+    }
+    if rows.iter().any(|row| row.extract_ms.is_some()) {
+        println!("\n  extraction (one sampled genome), ms per N:");
+        for row in rows {
+            if let Some(ms) = row.extract_ms {
+                println!("    N={:<3} {ms:>10.0}ms", row.layers);
+            }
+        }
+    }
+    println!("\n  serialize ms per N:");
+    for row in rows {
+        println!("    N={:<3} {:>10.0}ms", row.layers, row.serialize_ms);
+    }
+
+    let target = model.full_layers();
+    if rows.len() < 2 {
+        println!("\n  (fewer than two points — no fit)");
+        return;
+    }
+    println!(
+        "\n  FITS over N in {:?}, extrapolated to the full model (N={target}):",
+        rows.iter().map(|row| row.layers).collect::<Vec<_>>()
+    );
+    print_fits("saturate", "s", rows, target, |row| row.saturation_ms / 1e3);
+    print_fits("tuples", "tuples", rows, target, |row| row.tuples as f64);
+    print_fits("nodes", "nodes", rows, target, |row| row.nodes as f64);
+    println!(
+        "\n  (the three fits are least-squares over all {} points — the first two in log space, \
+         the line in linear space; the local slope uses only the last two. READ THE RESIDUALS: a \
+         fit with a large one is not describing this curve, and none of these are predictions \
+         with error bars.)",
+        rows.len()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{fit, fit_line};
+
+    /// The fit recovers a clean power law exactly: y = 3·N^2 sampled at
+    /// N = 1..4, fitted on (ln N, y), gives a = 3, b = 2, zero residual.
+    #[test]
+    fn power_law_fit_recovers_its_own_exponent() {
+        let points: Vec<(f64, f64)> = (1..=4)
+            .map(|n| ((n as f64).ln(), 3.0 * (n as f64).powi(2)))
+            .collect();
+        let f = fit(&points).expect("fittable");
+        assert!((f.a - 3.0).abs() < 1e-9, "a = {}", f.a);
+        assert!((f.b - 2.0).abs() < 1e-9, "b = {}", f.b);
+        assert!(f.rms_log < 1e-9, "residual = {}", f.rms_log);
+    }
+
+    /// The affine fit recovers a line exactly, and the power law
+    /// CANNOT — which is the reason the line is printed beside it: a
+    /// constant term reads back as a sub-linear exponent.
+    #[test]
+    fn line_fit_recovers_an_affine_law_the_power_law_misreads() {
+        let points: Vec<(f64, f64)> = (1..=4)
+            .map(|n| (n as f64, 100.0 + 7.0 * n as f64))
+            .collect();
+        let line = fit_line(&points).expect("fittable");
+        assert!((line.c - 100.0).abs() < 1e-9, "c = {}", line.c);
+        assert!((line.m - 7.0).abs() < 1e-9, "m = {}", line.m);
+        assert!(line.rms_log < 1e-12, "residual = {}", line.rms_log);
+        let power: Vec<(f64, f64)> = points.iter().map(|(x, y)| (x.ln(), *y)).collect();
+        let power = fit(&power).expect("fittable");
+        assert!(
+            power.b < 0.3,
+            "a constant-dominated line must read back as a badly sub-linear exponent, got {}",
+            power.b
+        );
+    }
+}

--- a/crates/luminal_cuda_lite/src/lib.rs
+++ b/crates/luminal_cuda_lite/src/lib.rs
@@ -93,7 +93,7 @@ pub use layouts::CudaPlan;
 pub use ops::{
     RegisteredOp, cuda_registry, cuda_registry_filtered, cuda_registry_without_cublaslt,
 };
-pub use runtime::CudaRuntime;
+pub use runtime::{CudaRuntime, ExtractionStats, SaturationStats};
 pub use search::{CompileOptions, Evaluator, SearchOutcome, harness_search_options};
 
 /// PLAN-TRANSPARENT (M4 Phase 5): claimable WITHOUT a kernel iff the

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -118,6 +118,87 @@ struct SaturatedProgram {
     report: luminal::search_support::SaturationReport,
 }
 
+/// The LIVE saturated e-graph, before serialization
+/// ([`CudaRuntime::saturate`], 2026-09-05). Serialization throws away
+/// the database — the function tables `num_tuples` and `print_size`
+/// read — so the callers that want to size the e-graph take it here.
+struct SaturatedEgraph {
+    egraph: luminal::prelude::egglog::EGraph,
+    program: graph::LogicalProgram,
+    /// egglog parse + run of the assembled program, to fixpoint.
+    saturation_nanos: u128,
+}
+
+/// HOW BIG SATURATION GOT AND WHAT IT COST, with no search after it
+/// ([`CudaRuntime::saturation_stats`], 2026-09-05).
+///
+/// The three size cuts are three different things and are all reported
+/// because they disagree in informative ways: `num_tuples` counts ROWS
+/// IN THE LIVE DATABASE (every function, including the ones that never
+/// serialize), while `classes`/`nodes` count the SERIALIZED e-graph the
+/// extractor actually walks. A schedule that inflates the database
+/// without minting new e-nodes moves the first and not the last.
+pub struct SaturationStats {
+    /// egglog parse + run of the assembled program, to fixpoint.
+    pub saturation_nanos: u128,
+    /// `EGraph::serialize` of the saturated database.
+    pub serialize_nanos: u128,
+    /// egglog's own run report: iterations, per-ruleset totals, slowest
+    /// rules with match counts.
+    pub report: luminal::search_support::SaturationReport,
+    /// `EGraph::num_tuples` — rows summed over every function table.
+    pub num_tuples: usize,
+    /// Iterations the schedule ran (the report's, repeated here so a
+    /// caller printing a size row need not reach through).
+    pub iterations: usize,
+    /// Distinct e-classes in the serialized e-graph.
+    pub classes: usize,
+    /// E-nodes in the serialized e-graph (subsumed ones included).
+    pub nodes: usize,
+    /// E-nodes per constructor (`Node::op`), biggest first, at most
+    /// [`SaturationStats::TOP`].
+    pub nodes_per_constructor: Vec<(String, usize)>,
+    /// Live function-table sizes from `EGraph::print_size(None)`,
+    /// biggest first, at most [`SaturationStats::TOP`]. Empty if egglog
+    /// refused the query.
+    pub function_sizes: Vec<(String, usize)>,
+    /// THE E-GRAPH THESE NUMBERS DESCRIBE. Carried so a caller that
+    /// also wants to measure EXTRACTION on top
+    /// ([`CudaRuntime::extraction_stats`]) does not have to saturate a
+    /// second time — on a full-size model that second run is the whole
+    /// cost of the measurement.
+    pub serialized: luminal::prelude::egraph_serialize::EGraph,
+}
+
+impl SaturationStats {
+    /// How many constructors / functions the two `Vec`s keep.
+    pub const TOP: usize = 25;
+}
+
+/// WHAT EXTRACTION COSTS ON TOP OF SATURATION
+/// ([`CudaRuntime::extraction_stats`], 2026-09-05): the one-time
+/// session analysis, the sampling space, and ONE sampled genome's
+/// extraction with the phase clocks the session already keeps.
+///
+/// One genome, not a search: this measures the SHAPE of the cost, not
+/// an election.
+pub struct ExtractionStats {
+    /// `ExtractionSession::new_with_matcher_set` + `producer_index`.
+    pub analysis_nanos: u128,
+    /// `ExtractionSession::sampling_space`.
+    pub space_nanos: u128,
+    /// Drawing the one genome.
+    pub sample_nanos: u128,
+    /// Extracting it.
+    pub extract_nanos: u128,
+    /// Producer classes the genome ranges over.
+    pub producer_classes: usize,
+    /// Nodes in the extracted graph, or `None` if the genome was refused.
+    pub extracted_nodes: Option<usize>,
+    /// The session's own discovery / relax / assemble clocks.
+    pub sub: luminal::search_support::ExtractTimings,
+}
+
 impl CudaRuntime {
     /// Record the graph's native program under the DEFAULT op registry
     /// ([`crate::ops::cuda_registry`]) — which since the 2026-09-04
@@ -412,13 +493,160 @@ impl CudaRuntime {
         Ok(self.assemble_and_saturate()?.serialized)
     }
 
+    /// SATURATE AND MEASURE, with no search after it (2026-09-05).
+    ///
+    /// Exactly the assembly [`CudaRuntime::search`] performs — this
+    /// backend's matcher vocabulary, the bound program, the same
+    /// schedule — run once, then sized three ways and priced by
+    /// egglog's own run report. The genetic loop, the extractor and the
+    /// planner never run, so every nanosecond reported here is
+    /// saturation's.
+    pub fn saturation_stats(&self) -> Result<SaturationStats> {
+        let SaturatedEgraph {
+            egraph,
+            saturation_nanos,
+            ..
+        } = self.saturate()?;
+        let report = luminal::search_support::SaturationReport::from_egraph(&egraph);
+        let iterations = report.iterations;
+        let num_tuples = egraph.num_tuples();
+        // `print_size(None)` returns every non-hidden function's row
+        // count. It is a query, not a print: the `CommandOutput` carries
+        // the pairs. A refusal is not fatal here — the sizes are a
+        // diagnostic, and the run report is the measurement.
+        let mut function_sizes = match egraph.print_size(None) {
+            Ok(luminal::prelude::egglog::CommandOutput::PrintAllFunctionsSize(sizes)) => sizes,
+            _ => Vec::new(),
+        };
+        function_sizes.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        function_sizes.truncate(SaturationStats::TOP);
+
+        let serialize_start = std::time::Instant::now();
+        let serialized = egraph
+            .serialize(luminal::prelude::egglog::SerializeConfig::default())
+            .egraph;
+        let serialize_nanos = serialize_start.elapsed().as_nanos();
+
+        let nodes = serialized.nodes.len();
+        let classes = serialized.classes().len();
+        let mut per_constructor: std::collections::BTreeMap<&str, usize> =
+            std::collections::BTreeMap::new();
+        for node in serialized.nodes.values() {
+            *per_constructor.entry(node.op.as_str()).or_default() += 1;
+        }
+        let mut nodes_per_constructor: Vec<(String, usize)> = per_constructor
+            .into_iter()
+            .map(|(op, count)| (op.to_string(), count))
+            .collect();
+        nodes_per_constructor.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        nodes_per_constructor.truncate(SaturationStats::TOP);
+
+        Ok(SaturationStats {
+            saturation_nanos,
+            serialize_nanos,
+            report,
+            num_tuples,
+            iterations,
+            classes,
+            nodes,
+            nodes_per_constructor,
+            function_sizes,
+            serialized,
+        })
+    }
+
+    /// ONE GENOME's extraction over an already-saturated e-graph
+    /// (2026-09-05) — the session analysis, the sampling space, and a
+    /// single sampled extraction, so a scaling study can see whether
+    /// extraction grows like saturation does.
+    ///
+    /// Takes the e-graph rather than saturating its own, because the
+    /// caller measuring both already has one
+    /// ([`SaturationStats::serialized`]) and saturating twice would
+    /// double the study's wall clock.
+    pub fn extraction_stats(
+        &self,
+        egraph: &luminal::prelude::egraph_serialize::EGraph,
+        seed: u64,
+    ) -> Result<ExtractionStats> {
+        use rand::SeedableRng;
+        let allow: Vec<&'static str> = self.active_allow_list().to_vec();
+        let analysis_start = std::time::Instant::now();
+        let mut session = luminal::extraction::ExtractionSession::new_with_matcher_set(
+            egraph,
+            Some(&allow),
+            self.matchers(),
+        );
+        let index = session.producer_index();
+        let analysis_nanos = analysis_start.elapsed().as_nanos();
+        let producer_classes = index.len();
+
+        let space_start = std::time::Instant::now();
+        let space = session.sampling_space(&index);
+        let space_nanos = space_start.elapsed().as_nanos();
+
+        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+        let sample_start = std::time::Instant::now();
+        let genome = luminal::search_support::sample_genome(&index, &space, &mut rng);
+        let sample_nanos = sample_start.elapsed().as_nanos();
+
+        let extract_start = std::time::Instant::now();
+        let extracted = session.extract_with_genome(&genome);
+        let extract_nanos = extract_start.elapsed().as_nanos();
+        let extracted_nodes = match extracted {
+            Ok(Some(graph)) => Some(graph.dag.node_count()),
+            // A refused genome is DATA here, not a failure: the study
+            // wants the clock either way, and one draw is not a search.
+            Ok(None) | Err(_) => None,
+        };
+
+        Ok(ExtractionStats {
+            analysis_nanos,
+            space_nanos,
+            sample_nanos,
+            extract_nanos,
+            producer_classes,
+            extracted_nodes,
+            sub: session.extract_timings(),
+        })
+    }
+
     /// Assemble the program under this runtime's bindings and matcher
     /// vocabulary, run it to saturation, and serialize. Shared by
     /// [`CudaRuntime::search`] and [`CudaRuntime::saturated_egraph`] so
-    /// the two can never see different programs. On saturation failure
-    /// the labeled post-checks are re-run in isolation to name the door,
-    /// mirroring the reference runtime.
+    /// the two can never see different programs.
     fn assemble_and_saturate(&self) -> Result<SaturatedProgram> {
+        let SaturatedEgraph {
+            egraph,
+            program,
+            saturation_nanos,
+        } = self.saturate()?;
+        // TAKEN BEFORE SERIALIZATION, off the e-graph that just ran:
+        // the report borrows from the `EGraph`, so it is copied into
+        // owned data here rather than kept as a borrow.
+        let report = luminal::search_support::SaturationReport::from_egraph(&egraph);
+        let serialize_start = std::time::Instant::now();
+        let serialized = egraph.serialize(luminal::prelude::egglog::SerializeConfig::default());
+        let serialize_nanos = serialize_start.elapsed().as_nanos();
+        Ok(SaturatedProgram {
+            serialized: serialized.egraph,
+            program,
+            saturation_nanos,
+            serialize_nanos,
+            report,
+        })
+    }
+
+    /// SATURATION AND NOTHING AFTER IT: assemble, parse, run the
+    /// schedule to fixpoint, and hand back the LIVE e-graph (2026-09-05).
+    ///
+    /// Split out of [`CudaRuntime::assemble_and_saturate`] because two
+    /// callers want two different things from the same run: the search
+    /// wants it serialized, and [`CudaRuntime::saturation_stats`] wants
+    /// the live database (`num_tuples`, `print_size`) that serialization
+    /// leaves behind. The saturation clock and the door-naming failure
+    /// path are here, so both callers get them identically.
+    fn saturate(&self) -> Result<SaturatedEgraph> {
         let native = self
             .native
             .as_ref()
@@ -471,19 +699,10 @@ impl CudaRuntime {
             bail!("shape contracts failed:\n  - {}", doors.join("\n  - "));
         }
         let saturation_nanos = saturation_start.elapsed().as_nanos();
-        // TAKEN BEFORE SERIALIZATION, off the e-graph that just ran:
-        // the report borrows from the `EGraph`, so it is copied into
-        // owned data here rather than kept as a borrow.
-        let report = luminal::search_support::SaturationReport::from_egraph(&egraph);
-        let serialize_start = std::time::Instant::now();
-        let serialized = egraph.serialize(luminal::prelude::egglog::SerializeConfig::default());
-        let serialize_nanos = serialize_start.elapsed().as_nanos();
-        Ok(SaturatedProgram {
-            serialized: serialized.egraph,
+        Ok(SaturatedEgraph {
+            egraph,
             program,
             saturation_nanos,
-            serialize_nanos,
-            report,
         })
     }
 


### PR DESCRIPTION
Stacked on #509 (`feat/search-timing-breakdown`), whose `SaturationReport` and
`SearchTimings` buckets this reads.

Austin, 2026-09-05: *"egglog has some built in timers and run reports that give
reports about how long certain rules take, how many nodes get created ... We can
make scripts (not tests) that take the full models and build them up layer by
layer and look at the scaling information for saturation."*

## What it prints

`crates/luminal_cuda_lite/examples/saturation_scaling.rs` records the released
qwen3 (or gemma3) graph at N transformer layers — the CUDA-lite application's own
recording sequence, minus the host RoPE tables and seeded payloads that
saturation never reads — and saturates it with **no search after it**. Per N:

* the saturation and serialize clocks, and the record clock;
* `iterations`, and three size cuts that disagree informatively: `num_tuples`
  (rows in the LIVE database, every function) versus `classes`/`nodes` (the
  SERIALIZED e-graph the extractor walks);
* every ruleset's search+apply / merge / rebuild, straight off egglog's
  `RunReport`;
* the 15 slowest rules with their match counts (an expensive rule that matches
  nothing is a different problem from one that is expensive because it fires);
* the 15 biggest constructors by node count and the 15 biggest function tables.

The `run-schedule` string is printed once, so a reader can map rulesets onto
strata. Then a TREND TABLE, and four fits per quantity.

## Running it

```
cargo run --release -p luminal_cuda_lite --example saturation_scaling \
  -- --model qwen3 --layers 1,2,3,4 --cap-secs 300
```

Host-only: no `--features device`, nothing touches a GPU. `--cap-secs` stops
growing once a step exceeds it (it fired at N=24 on a 300 s cap, which is how
the deep sweep below was capped by hand instead). `--rule-chars` widens rule names (see below); `--extract` additionally times
one sampled genome's extraction with #509's sub-timers; off by default.

## Two runtime entries (commit 1)

`assemble_and_saturate` did two things at once, and serialization THROWS AWAY the
database that `num_tuples`/`print_size` read. Split out `CudaRuntime::saturate`
(hands back the live e-graph); `assemble_and_saturate` is now its serializing
wrapper — same program, same schedule, same saturation clock, same door-naming
failure path, so `search` sees exactly what it saw before. On top:
`saturation_stats` and `extraction_stats`. `SaturationStats` carries the
serialized e-graph it measured, so `--extract` does not saturate a second time.

## Measured: qwen3 on this Mac (release, host-only)

The brief's run, N in 1..4:

```
  N |  saturate ms |   ratio | iters |     tuples |   classes |     nodes
  1 |         2012 |       - |   258 |      40574 |     23404 |     40607
  2 |         3255 |   1.62x |   350 |      51499 |     26397 |     51308
  3 |         5292 |   1.63x |   441 |      62420 |     29387 |     62006
  4 |         7041 |   1.33x |   533 |      73345 |     32381 |     72708
```

That window says "linear" and it is WRONG. Growing further:

```
  N |  saturate ms |   ratio | iters |     tuples |   classes |     nodes
  1 |         2024 |       - |   258 |      40574 |     23404 |     40607
  2 |         3281 |   1.62x |   350 |      51499 |     26397 |     51308
  4 |         7084 |   2.16x |   533 |      73345 |     32381 |     72708
  8 |        20690 |   2.92x |   901 |     117045 |     44356 |    115515
 16 |       143328 |   6.93x |  1637 |     204445 |     68307 |    201130
 24 |       428689 |   2.99x |  2373 |     291845 |     92259 |    286746
```

**The e-graph grows exactly linearly; the time does not.** `tuples = 29648 +
10925·N` fits with a residual of ZERO (max error 0.0%) across the whole 1..24
range, and so does `nodes`. Saturation time runs at **N^2.70 between N=16 and
N=24** — i.e. roughly the CUBE of the e-graph size (size grows 1.43x from N=16
to N=24 while time grows 2.99x: ln 2.99 / ln 1.43 = 3.05).

Fits over N in 1..24, extrapolated to the full model (N=36):

```
  saturate     power law          1.1330 * N^1.6971    rms(log) 0.4693  max err   86.7%  -> N=36: 496.0 s
  saturate     exponential        2.3510 * e^(0.2323*N)  rms(log) 0.3122  max err   48.2%  -> N=36: 10078.8 s
  saturate     linear       (not fittable)
  saturate     local slope  N^2.7021     over N=16..24                     -> N=36: 1282.2 s
  tuples       linear         29647.6952 + 10924.8514*N   rms(log) 0.0000  max err  0.0%  -> N=36: 422942.3 tuples
  nodes        linear         29903.1461 + 10701.7295*N   rms(log) 0.0000  max err  0.0%  -> N=36: 415165.4 nodes
```

Read the RESIDUALS, not the extrapolations. Over 1..24 the power law misses by
87% and the exponential by 48%: neither describes this curve, because it spans a
startup-dominated regime and an asymptotic one. The line is the exact fit for
SIZE and not fittable for TIME. The local slope is the only honest extrapolation
for time, and it says **~1280 s ≈ 21 minutes** of saturation for 36-layer qwen3
on this Mac.

## Against the A100 reference point

The full 36-layer qwen3 search on the A100 measured **~83 min total, of which
~65 min is believed to be saturation** (the instrumented run to confirm that is
in flight).

| source | 36-layer saturation |
|---|---|
| this Mac, N=1..4 trend extrapolated | 50-62 s |
| this Mac, N=16..24 local slope | ~1282 s (~21 min) |
| A100 box, believed | ~65 min |

**The 1-4 trend alone is NOT consistent with the A100 number** — it is off by a
factor of ~60, because at N<=4 the superlinear regime has not started. The
1..24 trend IS consistent: 21 min here versus ~65 min there is a 3.0x host-CPU
factor, which is the ordinary gap between an M-series Mac and an A100 box's
server CPU on single-threaded scalar work. **Which fit matches: none of the
global ones — the curve is a fixed cost plus a term growing near the cube of
e-graph size, and only the local slope reads that.** So the ~65 min belief looks
right, and the instrumented run should confirm it rather than overturn it.

## Where it goes: two rules are 92% of the cost

At N=24 the two slowest rules cost **198.4 s + 197.9 s of the 428.7 s total**
for 346 matches each. `--rule-chars 420` names them (at the default 100 they are
indistinguishable — our rules are anonymous, so egglog names them by their whole
source text and the arms of a family share a long prefix):

* `crates/luminal_cuda_lite/src/ops/cublaslt/egg/cublaslt_marker_site.egg:32`
* `crates/luminal_cuda_lite/src/ops/cublaslt/egg/cublaslt_marker_rewrite.egg:54`

Both carry the SAME fourteen-premise conjunction — the canonical matmul
spelling, `?a_map = (c2 c0)` and `?b_map = (c0 c1)` — and each pays the full
e-matching search for it separately. A third arm,
`cublaslt_marker_canonicalize.egg:98` (`?a_map = (c0 c2)`), spends 7.3 s at N=24
for **zero** matches. That is where a saturation-cost fix would go, and it is
the reason the pair (time, matches) is printed rather than time alone.

The rest is small by comparison: at every N>=2 the top ruleset is the UNNAMED one (at N=4, 6131 ms
of 7041 ms; `subst-walk` is 233 ms and every other ruleset is under 10 ms) and
the top rules are the matmul-recognition family
(`(= ?out (LogicalReduceSum ?prod 0)) (= ?prod (LogicalMul ?a_bcast ?b_bcast))`,
1323 ms + 1287 ms for 66 matches each) followed by five cuBLASLt-site rules at
~390 ms each. The biggest constructors are `layout-tensor-list-nth-from-end`
(6498), `int-subst-closed-demand` (5780), and the `LayoutTensorOpLit` /
`input-layout-tensor-list-of` / `output-layout-tensor-list-of` triple (4951 each).

## Gate

```
cargo build -p luminal_cuda_lite --all-targets                                    Finished
cargo check -p luminal_cuda_lite --features device --all-targets                  Finished
cargo test -p luminal_cuda_lite --test registry_selection --test example_smoke    6 passed
cargo clippy -p luminal_cuda_lite --all-targets                                   clean
cargo fmt --all -- --check                                                        clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
