### PR TITLE
egglog reaches every crate through luminal::prelude; one pin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ serde_json = "1.0.140"
 # The luminal-ai fork carries the atomic add_subsumed write the substitution
 # walk needs (proposed upstream alongside egglog-experimental #60), on branch
 # `luminal/subsumed-c2c0f151`. Bumping egglog = rebasing that branch, new rev.
+# Core is the ONLY crate that names egglog; every other crate uses
+# `luminal::prelude::{egglog, egglog_ast, egraph_serialize}`.
 egglog = { git = "https://github.com/luminal-ai/egglog", rev = "1bb30831e11121bd639caf93d84465d8d110e3f7" }
 egglog-ast = { git = "https://github.com/luminal-ai/egglog", rev = "1bb30831e11121bd639caf93d84465d8d110e3f7" }
 # egglog-reports: crate absorbed upstream; RunReport types re-export via egglog (pin bump 2026-08-11)
@@ -89,6 +91,11 @@ members = [
     "tests/scalar_refs",
     "tests/test_runtime",
 ]
+# Parked crates are not members. luminal_bench is excluded explicitly so it
+# still builds standalone (`cargo build --manifest-path
+# crates/luminal_bench/Cargo.toml`); it reaches egglog through the prelude,
+# so its lock cannot drift the rev above.
+exclude = ["crates/luminal_bench"]
 
 # Model examples are logical definitions only. Executable applications
 # belong to runtime crates, which bind and run these backend-neutral graphs.

--- a/crates/luminal_bench/Cargo.toml
+++ b/crates/luminal_bench/Cargo.toml
@@ -1,10 +1,16 @@
 [package]
 name = "luminal_bench"
 version = "0.1.0"
-edition.workspace = true
+edition = "2024"
 description = "Universal benchmark infrastructure for Luminal backends"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+
+# Not a member of the root workspace (a parked crate), and its own workspace
+# root so `cargo build --manifest-path crates/luminal_bench/Cargo.toml`
+# resolves standalone. egglog is deliberately absent: it arrives through
+# `luminal::prelude::{egglog, egglog_ast}`, so the root pin is the only one.
+[workspace]
 
 [dependencies]
 luminal = { path = "../.." }

--- a/crates/luminal_bench/Cargo.toml
+++ b/crates/luminal_bench/Cargo.toml
@@ -8,8 +8,9 @@ readme = "README.md"
 
 # Not a member of the root workspace (a parked crate), and its own workspace
 # root so `cargo build --manifest-path crates/luminal_bench/Cargo.toml`
-# resolves standalone. egglog is deliberately absent: it arrives through
-# `luminal::prelude::{egglog, egglog_ast}`, so the root pin is the only one.
+# resolves standalone. egglog and egraph-serialize are deliberately absent:
+# they arrive through `luminal::prelude::{egglog, egglog_ast,
+# egraph_serialize}`, so the root pins are the only ones.
 [workspace]
 
 [dependencies]
@@ -17,7 +18,6 @@ luminal = { path = "../.." }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"
-egraph-serialize = { version = "0.3.0", default-features = false }
 
 # Backend dependencies - optional, enabled via features
 luminal_metal = { path = "../luminal_metal", optional = true }

--- a/crates/luminal_bench/src/egglog_debug/analysis.rs
+++ b/crates/luminal_bench/src/egglog_debug/analysis.rs
@@ -4,13 +4,13 @@ use super::{
     DTypeChainAnalysis, DTypeStatus, DependencyGraph, FactStatus, FunctionChainAnalysis,
     FunctionTraceEntry,
 };
-use egraph_serialize::ClassId;
 use luminal::egglog_utils;
 use luminal::hlir::HLIROps;
 use luminal::op::{EgglogOp, IntoEgglogOp, Runtime};
 use luminal::prelude::egglog;
 use luminal::prelude::egglog::prelude::exprs;
 use luminal::prelude::egglog_ast::{RustSpan, Span};
+use luminal::prelude::egraph_serialize::ClassId;
 use luminal::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;

--- a/crates/luminal_cuda_lite/Cargo.toml
+++ b/crates/luminal_cuda_lite/Cargo.toml
@@ -23,11 +23,12 @@ luminal = { path = "../.." }
 anyhow = "1"
 rustc-hash = "2"
 # The runtime-owned extractor + search (Phase 1 of the #420/#422 rejoin).
-# Versions track luminal's exactly: the egraph-serialize/petgraph types
-# must UNIFY with luminal's, since this crate's extractor consumes
-# luminal's serialized e-graphs and produces luminal's ExtractedGraph.
+# The petgraph version tracks luminal's exactly: the types must UNIFY with
+# luminal's, since this crate's extractor consumes luminal's serialized
+# e-graphs and produces luminal's ExtractedGraph. egraph-serialize is NOT
+# pinned here — unification is guaranteed instead, by reaching it through
+# `luminal::prelude::egraph_serialize`.
 petgraph = "0.6.4"
-egraph-serialize = { version = "0.3.0", default-features = false, features = ["graphviz", "serde"]}
 rand = "0.9.2"
 colored = "2.0.4"
 cudarc = { version = "0.19.8", optional = true, features = ["cuda-version-from-build-system", "fallback-latest"] }

--- a/crates/luminal_reference/Cargo.toml
+++ b/crates/luminal_reference/Cargo.toml
@@ -21,8 +21,8 @@ petgraph = "0.6.4"
 rand = "0.9.2"
 colored = "2.0.4"
 float8 = { version = "0.7", features = ["bytemuck", "num-traits"] }
-# Pin tracks the workspace Cargo.toml exactly (luminal-ai egglog fork).
-egglog = { git = "https://github.com/luminal-ai/egglog", rev = "1bb30831e11121bd639caf93d84465d8d110e3f7" }
+# Pin tracks the workspace Cargo.toml exactly. egglog itself is NOT pinned
+# here: it reaches this crate through `luminal::prelude::egglog`.
 egraph-serialize = { version = "0.3.0", default-features = false, features = ["graphviz", "serde"]}
 
 [dev-dependencies]

--- a/crates/luminal_reference/Cargo.toml
+++ b/crates/luminal_reference/Cargo.toml
@@ -21,9 +21,9 @@ petgraph = "0.6.4"
 rand = "0.9.2"
 colored = "2.0.4"
 float8 = { version = "0.7", features = ["bytemuck", "num-traits"] }
-# Pin tracks the workspace Cargo.toml exactly. egglog itself is NOT pinned
-# here: it reaches this crate through `luminal::prelude::egglog`.
-egraph-serialize = { version = "0.3.0", default-features = false, features = ["graphviz", "serde"]}
+# Neither egglog nor egraph-serialize is pinned here: both reach this crate
+# through `luminal::prelude::{egglog, egraph_serialize}`, so the types UNIFY
+# with luminal's by construction (see the root Cargo.toml).
 
 [dev-dependencies]
 # The extractor copy's render-memo board hand-builds serialized e-nodes.

--- a/crates/luminal_reference/src/harness.rs
+++ b/crates/luminal_reference/src/harness.rs
@@ -70,7 +70,7 @@ pub fn producer_index_with_ops(
 /// Run `test_scripts/<script>` through egglog (with the full preamble) and
 /// hand back the serialized e-graph — the selection tooling's raw material.
 pub fn serialize_fixture(script: &str) -> egraph_serialize::EGraph {
-    use egglog::SerializeConfig;
+    use luminal::prelude::egglog::SerializeConfig;
 
     let preamble = crate::assembled_program();
     let source = fs::read_to_string(fixture_path(script))
@@ -187,7 +187,9 @@ pub fn plain_plan_exists(cx: &luminal::graph::Graph) -> anyhow::Result<()> {
         .map_err(|err| anyhow::anyhow!("saturation: {err}"))?;
     eprintln!("[plain-plan] saturation {:?}", start.elapsed());
     let start = std::time::Instant::now();
-    let serialized = egraph.serialize(egglog::SerializeConfig::default()).egraph;
+    let serialized = egraph
+        .serialize(luminal::prelude::egglog::SerializeConfig::default())
+        .egraph;
     eprintln!(
         "[plain-plan] serialize {:?} ({} nodes, {} classes)",
         start.elapsed(),

--- a/crates/luminal_reference/src/harness.rs
+++ b/crates/luminal_reference/src/harness.rs
@@ -10,6 +10,7 @@ use std::fs;
 
 use crate::extractor;
 use luminal::layout_ir::ExtractedGraph;
+use luminal::prelude::egraph_serialize;
 
 /// Fixture scripts live in the WORKSPACE-ROOT Egglog core tree; this crate
 /// runs two directories below it.

--- a/crates/luminal_reference/src/ops/index_map_apply_materialize/mod.rs
+++ b/crates/luminal_reference/src/ops/index_map_apply_materialize/mod.rs
@@ -6,6 +6,7 @@ use luminal::buffer_tensor_ir::{BufferTensorIrOp, OpSlotNames};
 use luminal::layout_ir::{
     AliasInfo, Bufferizable, ExtractionSite, LayoutIrOp, OpMatcher, Sharing, ToDps,
 };
+use luminal::prelude::egraph_serialize;
 
 /// `IndexMapApplyMaterialize(input) -> out`
 ///

--- a/crates/luminal_reference/src/runtime.rs
+++ b/crates/luminal_reference/src/runtime.rs
@@ -362,7 +362,9 @@ impl ReferenceRuntime {
         }
         let saturation_nanos = saturation_start.elapsed().as_nanos();
         let serialize_start = std::time::Instant::now();
-        let serialized = egraph.serialize(egglog::SerializeConfig::default()).egraph;
+        let serialized = egraph
+            .serialize(luminal::prelude::egglog::SerializeConfig::default())
+            .egraph;
         let serialize_nanos = serialize_start.elapsed().as_nanos();
         let mut outcome = crate::search::search_implementations_with_ops(
             &serialized,
@@ -1671,7 +1673,9 @@ mod tests {
         egraph
             .parse_and_run_program(None, &text)
             .expect("program runs");
-        let serialized = egraph.serialize(egglog::SerializeConfig::default()).egraph;
+        let serialized = egraph
+            .serialize(luminal::prelude::egglog::SerializeConfig::default())
+            .egraph;
         let allow = crate::reference_allow_list();
         let extracted = crate::extractor::extract_layout_ir_with_ops_and_matchers(
             &serialized,

--- a/crates/luminal_reference/src/search.rs
+++ b/crates/luminal_reference/src/search.rs
@@ -43,6 +43,7 @@ use crate::typed_buffer::TypedBuffer;
 use luminal::bufferize::BufferIrGraph;
 use luminal::graph::LogicalProgram;
 use luminal::layouts::DecodedLayout;
+use luminal::prelude::egraph_serialize;
 
 use crate::extractor::{self, Genome};
 use crate::runtime::{ReferenceRuntime, reference_allow_list};

--- a/crates/luminal_reference/src/search.rs
+++ b/crates/luminal_reference/src/search.rs
@@ -535,7 +535,9 @@ pub fn bucketed_search_implementations(
         egraph
             .parse_and_run_program(None, &text)
             .map_err(|err| anyhow!("bucket {ranges:?} representative render fails: {err}"))?;
-        let serialized = egraph.serialize(egglog::SerializeConfig::default()).egraph;
+        let serialized = egraph
+            .serialize(luminal::prelude::egglog::SerializeConfig::default())
+            .egraph;
         let data = input_data(&representative);
         let outcome = search_implementations_with_ops(
             &serialized,
@@ -695,7 +697,7 @@ pub fn search_implementations(
 
 #[cfg(test)]
 mod tests {
-    use egglog::SerializeConfig;
+    use luminal::prelude::egglog::SerializeConfig;
     use rustc_hash::FxHashMap;
 
     use luminal::dtype::DType;

--- a/tests/test_runtime/Cargo.toml
+++ b/tests/test_runtime/Cargo.toml
@@ -15,10 +15,10 @@ luminal = { path = "../.." }
 # would be asserting on a copy. This is a CPU-side dependency: CL
 # compiles fully without its `device` feature.
 luminal_cuda_lite = { path = "../../crates/luminal_cuda_lite" }
-# Versions track luminal's Cargo.toml exactly — the egglog/egraph-serialize/
+# Versions track luminal's Cargo.toml exactly — the egraph-serialize/
 # petgraph types must UNIFY with luminal's so the fixture runners can hand
-# this crate's egraphs to luminal's extractor and bufferizer.
-egglog = { git = "https://github.com/luminal-ai/egglog", rev = "1bb30831e11121bd639caf93d84465d8d110e3f7" }
+# this crate's egraphs to luminal's extractor and bufferizer. egglog itself
+# is NOT pinned here: it reaches this crate through `luminal::prelude::egglog`.
 egraph-serialize = { version = "0.3.0", default-features = false, features = ["graphviz", "serde"]}
 petgraph = "0.6.4"
 rustc-hash = "2.1.1"

--- a/tests/test_runtime/Cargo.toml
+++ b/tests/test_runtime/Cargo.toml
@@ -15,11 +15,11 @@ luminal = { path = "../.." }
 # would be asserting on a copy. This is a CPU-side dependency: CL
 # compiles fully without its `device` feature.
 luminal_cuda_lite = { path = "../../crates/luminal_cuda_lite" }
-# Versions track luminal's Cargo.toml exactly — the egraph-serialize/
-# petgraph types must UNIFY with luminal's so the fixture runners can hand
-# this crate's egraphs to luminal's extractor and bufferizer. egglog itself
-# is NOT pinned here: it reaches this crate through `luminal::prelude::egglog`.
-egraph-serialize = { version = "0.3.0", default-features = false, features = ["graphviz", "serde"]}
+# The petgraph version tracks luminal's Cargo.toml exactly — the types must
+# UNIFY with luminal's so the fixture runners can hand this crate's egraphs to
+# luminal's extractor and bufferizer. Neither egglog nor egraph-serialize is
+# pinned here: both reach this crate through
+# `luminal::prelude::{egglog, egraph_serialize}`.
 petgraph = "0.6.4"
 rustc-hash = "2.1.1"
 anyhow = "1.0"

--- a/tests/test_runtime/src/lib.rs
+++ b/tests/test_runtime/src/lib.rs
@@ -135,7 +135,7 @@ fn try_extract_text_with_ops(
 /// fixture script, run to saturation and serialized — the raw material
 /// for every extraction below. Panics on any failure: these are fixtures.
 pub fn serialize_fixture(script_text: &str) -> luminal::prelude::egraph_serialize::EGraph {
-    use egglog::SerializeConfig;
+    use luminal::prelude::egglog::SerializeConfig;
 
     let preamble = luminal::egglog_snippet::assembled_program_for(&matchers());
     let program = format!("{preamble}\n\n{script_text}");

--- a/tests/test_runtime/tests/cublaslt_bias_leftmajor_premise.rs
+++ b/tests/test_runtime/tests/cublaslt_bias_leftmajor_premise.rs
@@ -31,9 +31,9 @@
 
 use std::collections::BTreeSet;
 
-use egglog::SerializeConfig;
 use luminal::dtype::DType;
 use luminal::graph::Graph;
+use luminal::prelude::egglog::SerializeConfig;
 use luminal::prelude::egraph_serialize::{ClassId, EGraph, Node};
 
 fn count(s: &EGraph, op: &str) -> usize {

--- a/tests/test_runtime/tests/r11_collapse_revert_probe.rs
+++ b/tests/test_runtime/tests/r11_collapse_revert_probe.rs
@@ -79,7 +79,7 @@ fn bounded_program(iters: usize, with_collapse: bool) -> String {
 }
 
 fn node_count(program: &str) -> usize {
-    use egglog::SerializeConfig;
+    use luminal::prelude::egglog::SerializeConfig;
     let mut egraph = luminal::egglog_snippet::new_egraph();
     egraph
         .parse_and_run_program(None, program)


### PR DESCRIPTION
## The rule

**Core is the ONLY crate that names egglog.** Every other crate reaches it through
`luminal::prelude::{egglog, egglog_ast, egraph_serialize}`. Both forks are pinned in
exactly one place — the root `Cargo.toml` — and cannot drift between crates. The rule is
now written into the root manifest, directly above the pins it protects, so the next
person bumping the rev sees it.

Verification:

```
$ cargo tree -i egglog --depth 1 -e normal
egglog v2.0.0 (https://github.com/luminal-ai/egglog?rev=1bb30831e11121bd639caf93d84465d8d110e3f7#1bb30831)
└── luminal v0.2.0

$ cargo tree -i egraph-serialize --depth 1 -e normal
egraph-serialize v0.3.0
├── egglog v2.0.0 (https://github.com/luminal-ai/egglog?rev=1bb30831e11121bd639caf93d84465d8d110e3f7#1bb30831)
└── luminal v0.2.0
```

`luminal` is the only workspace crate on either edge. The `egglog → egraph-serialize` edge
is egglog's own upstream dependency, not one of ours.

Before this PR: three crates depended on egglog directly and four on egraph-serialize.

## Commit 1 — egglog

**Duplicate pins deleted.** Both crates carried the git URL and rev copy-pasted from the
root manifest, purely so they could spell `egglog::SerializeConfig`:

- `crates/luminal_reference/Cargo.toml`
- `tests/test_runtime/Cargo.toml`

**Nine call sites re-spelled** as `luminal::prelude::egglog::SerializeConfig`, matching the
idiom `luminal_cuda_lite` already uses (`src/runtime.rs:456`, `src/search.rs:934`):

- `crates/luminal_reference/src/{harness,runtime,search}.rs`
- `tests/test_runtime/src/lib.rs`
- `tests/test_runtime/tests/{cublaslt_bias_leftmajor_premise,r11_collapse_revert_probe}.rs`

**Root `Cargo.toml`** — the rule as a comment above the pins, plus
`exclude = ["crates/luminal_bench"]` (see below).

**`crates/luminal_bench/Cargo.toml`** — `[workspace]` table and a literal `edition = "2024"`.

No `^egglog` manifest line survives outside the root, and there is no `extern crate egglog`
anywhere. The non-root manifests that still contain the string `egglog` contain it only in
comments saying it is *not* pinned there.

## Commit 2 — egraph-serialize

Four more duplicate pins, each repeating "versions track luminal's exactly" in a comment
because nothing enforced it. Now nothing needs to: with one pin, the types UNIFY by
construction rather than by convention.

- `crates/luminal_cuda_lite/Cargo.toml` and `tests/test_runtime/Cargo.toml` were already
  fully prelude-routed in source. Their pins were dead weight — deleting them changed no
  Rust at all.
- `crates/luminal_reference/`'s three bare-`egraph_serialize::` files were resolving through
  the extern prelude that pin created. They now carry `use luminal::prelude::egraph_serialize;`
  — the same line CL has at `finalists.rs:58`, `search.rs:54` and
  `ops/index_map_apply_materialize/mod.rs:14`.
- `crates/luminal_bench/`'s single `use egraph_serialize::ClassId;` becomes the prelude path.

## luminal_bench's status

The premise that bench's egglog paths might be unresolved or hacked turned out to be wrong.
`src/egglog_debug/analysis.rs` already read:

```rust
use luminal::prelude::egglog;
use luminal::prelude::egglog::prelude::exprs;
use luminal::prelude::egglog_ast::{RustSpan, Span};
```

and its manifest never pinned egglog. **The egglog half of this crate was already correct.**

What was wrong is that bench could not be *resolved at all*. It is not a workspace member,
was not in `workspace.exclude`, and had no `[workspace]` table, so cargo refused before
compiling a single line:

```
error: current package believes it's in a workspace when it's not
```

This is the shared condition of every parked crate — `luminal_metal`,
`luminal_cuda_lite_hlir` and `luminal_python` all fail the same way today. Bench is now
excluded explicitly and made its own workspace root (`[workspace]` + literal
`edition = "2024"`, since an excluded package cannot inherit `edition.workspace = true`).
That gets it to the compiler.

It then fails on **stale pre-SSA core APIs**, which is a separate port and deliberately not
attempted here:

```
error[E0432]: unresolved import `luminal::hlir`
 --> src/egglog_debug/analysis.rs:9:14
9 | use luminal::hlir::HLIROps;
error[E0432]: unresolved import `luminal::op`
  --> src/egglog_debug/analysis.rs:10:14
10 | use luminal::op::{EgglogOp, IntoEgglogOp, Runtime};
error[E0432]: unresolved import `luminal::op`
  --> src/lib.rs:27:14
27 | use luminal::op::Runtime;
error[E0425]: cannot find function `full_egglog` in module `egglog_utils`
  --> src/egglog_debug/analysis.rs:97:30
```

`luminal::hlir` and `luminal::op` no longer exist; `luminal::egglog_utils` does but lost
`full_egglog`. Repairing this is not a rename — the `HLIROps` / `EgglogOp` / `IntoEgglogOp`
trait vocabulary was replaced wholesale by the matcher/instance split, and
`full_egglog(program, &ops, false)` is today's `egglog_snippet::assembled_program_for`.
Porting `egglog_debug` onto that vocabulary is its own change.

Its dependency resolution is nonetheless correct now: bench's standalone graph shows the
same single `luminal` edge on both crates.

## Gates

```
$ cargo build --workspace --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.10s

$ cargo test -p luminal_cuda_lite
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.24s
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.34s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.68s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 28.86s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.86s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.55s
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.22s
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 13.55s
test result: ok. 3 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 13.81s
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.10s
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.18s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.45s
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.24s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

$ cargo test -p luminal_reference
test result: ok. 44 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.84s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 1 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 1.81s
test result: ok. 7 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 7.97s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

$ cargo test -p test_runtime --test scc_sampler --test r10_debug
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.06s
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.79s

$ cargo clippy -p luminal_reference -p luminal_cuda_lite -p test_runtime --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.30s

$ cargo fmt --all -- --check
    (clean)

$ cargo build --manifest-path crates/luminal_bench/Cargo.toml
error: could not compile `luminal_bench` (lib) due to 4 previous errors; 1 warning emitted
    (stale pre-SSA APIs, unrelated to egglog — see above)
```

The one non-green line is bench, and it is not a regression: bench did not build before this
PR either. It failed one step earlier, at resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
