### PR TITLE
EClass decoding: every call site names its constructor; core keeps no preference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,10 @@
 name = "luminal"
 version = "0.2.0"
 edition.workspace = true
-rust-version = "1.85"
+# MSRV: let-chains need 1.88 and trait upcasting (the eclass decoder's
+# `dyn Facts` -> `dyn Any` door) needs 1.86; 1.91 is the oldest toolchain
+# we actually run (this Mac 1.91.1, the A100 box 1.95).
+rust-version = "1.91"
 description = "Deep learning at the speed of light."
 license = "MIT OR Apache-2.0"
 

--- a/crates/luminal_cuda_lite/examples/eclass_decoder_demo.rs
+++ b/crates/luminal_cuda_lite/examples/eclass_decoder_demo.rs
@@ -1,0 +1,272 @@
+//! WHAT THE CALL SITE LOOKS LIKE NOW, and the whisper bug it fixes.
+//!
+//! Not a test — a printed demonstration (Austin: *"show me what the call
+//! site looks like and demonstrate (don't make a test, just show) that
+//! it fixes the bug we previously saw"*). Run it:
+//!
+//! ```text
+//! cargo run -p luminal_cuda_lite --example eclass_decoder_demo
+//! ```
+//!
+//! THE BUG. Whisper tiny.en decodes ONE token, so its q/v projections
+//! are `x[1, 384] @ w[384, 384] + b[384]` and the cuBLASLt transpose
+//! sandwich's sibling call frame is `[m, n] = [384, 1]`. At a degenerate
+//! extent the right-major and left-major contiguous index maps over
+//! `[m, n]` are the SAME FUNCTION — `r*n + c` and `c*m + r` agree when
+//! the collapsed axis's coordinate can only be 0 — and the e-graph knows
+//! it: both literals land in ONE class. The estate's bias decorators
+//! mint a bias form only on the LeftMajor spelling; the retired decoder,
+//! asked for "the" layout of that class, answered RightMajor by a fixed
+//! preference order; `bind_destination` built a ROW descriptor; the
+//! order fence refused every candidate genome and the search died with
+//! "no candidate genome produced an executable plan".
+//!
+//! THE FIX IS THAT THE QUESTION CHANGED. A call site names the
+//! constructor it needs — here `require::<LeftMajorContiguousElementLayout>`,
+//! which is literally the decorator's premise — and the class answers
+//! for THAT constructor. A class holding both spellings says yes. There
+//! is no degenerate-extent arm anywhere in the executor.
+//!
+//! SCALE. Whisper's real frame is `m = 384, n = 1`; this runs the same
+//! geometry at pin scale, `x[1, 8] @ w[8, 3] + b[3]`, so the sibling
+//! frame is `m = 3, n = 1`. Same coincidence, same class, seconds
+//! instead of minutes.
+
+use luminal::bufferize::BufferNode;
+use luminal::dtype::PlanDtype;
+use luminal::egglog_utils::eclass::EGraphView;
+use luminal::graph::Graph;
+use luminal::layouts::{
+    BitWidthTerm, DecodedLayout, IntExprTerm, Layout, LeftMajorContiguousElementLayout,
+    RightMajorContiguousElementLayout, ShapeTerm,
+};
+use luminal::prelude::egraph_serialize::{ClassId, EGraph, Node};
+use luminal::prelude::{DType, FxHashMap, NodeIndex};
+use luminal_cuda_lite::CudaRuntime;
+use luminal_cuda_lite::HostBuffer;
+use luminal_cuda_lite::ops::cublaslt::exec::{bind_destination, plan_call};
+use luminal_cuda_lite::ops::cublaslt::{CublasLt, CublasLtDps};
+
+const K: usize = 8;
+const N: usize = 3; // features — the sibling call's m
+
+/// THE RETIRED PREFERENCE ORDER, re-enacted over the class's own
+/// constructor names so the contrast can be shown without keeping the
+/// deleted code alive. This list was baked into core's decoder; it is
+/// now nobody's business but a call site's.
+const RETIRED_PREFERENCE_ORDER: [&str; 5] = [
+    "RightMajorContiguousElementLayoutLit",
+    "LeftMajorContiguousElementLayoutLit",
+    "StridedElementLayoutLit",
+    "ElementOffsetExpressionLayoutLit",
+    "BitOffsetExpressionLayoutLit",
+];
+
+fn weights(n: usize, seed: usize) -> Vec<f32> {
+    (0..n)
+        .map(|i| (((i * 37 + seed * 101 + 13) % 121) as f32 / 100.0) - 0.6)
+        .collect()
+}
+
+/// The whisper shape at pin scale: a SINGLE batch row, so the sibling
+/// call frame's n collapses to 1.
+fn degenerate_linear_with_bias() -> (Graph, NodeIndex, NodeIndex, NodeIndex) {
+    let mut cx = Graph::new();
+    let weight = cx.named_tensor("fc.weight", (K, N), DType::F32);
+    let bias = cx.named_tensor("fc.bias", N, DType::F32);
+    let x = cx.tensor((1usize, K), DType::F32);
+    let _out = luminal_nn::linear(x, weight, Some(bias)).output();
+    (cx, x.id, weight.id, bias.id)
+}
+
+fn child_class(egraph: &EGraph, node: &Node, index: usize) -> ClassId {
+    let id = node
+        .children
+        .get(index)
+        .unwrap_or_else(|| panic!("{} has no child {index}", node.op));
+    egraph.nodes[id].eclass.clone()
+}
+
+fn node_in_class<'a>(egraph: &'a EGraph, class: &ClassId, op: &str) -> Option<&'a Node> {
+    egraph
+        .nodes
+        .values()
+        .find(|n| &n.eclass == class && n.op == op)
+}
+
+/// The D descriptor of a `LayoutTensorOpCublasLt*` enode sits at slot 3
+/// on every form; its layout tensor is the descriptor's child 1; the
+/// LAYOUT class is that layout tensor's `LayoutTensorLit` child 1.
+fn d_layout_class(egraph: &EGraph, op_node: &Node) -> ClassId {
+    let d_desc_class = child_class(egraph, op_node, 3);
+    let desc = node_in_class(egraph, &d_desc_class, "CublasLtOutputDDescriptor")
+        .expect("slot 3 holds the D descriptor");
+    let lt_class = child_class(egraph, desc, 1);
+    let lt = node_in_class(egraph, &lt_class, "LayoutTensorLit")
+        .expect("the D descriptor names a layout tensor");
+    child_class(egraph, lt, 1)
+}
+
+fn main() -> anyhow::Result<()> {
+    println!(
+        "DEMO the whisper site at pin scale: x[1, {K}] @ w[{K}, {N}] + b[{N}] \
+         (whisper's real frame is m=384, n=1)"
+    );
+
+    // ---------------------------------------------------------------
+    // 1. ONE CLASS, BOTH SPELLINGS — asked constructor by constructor.
+    // ---------------------------------------------------------------
+    let (cx, _x, _w, _b) = degenerate_linear_with_bias();
+    let rt = CudaRuntime::load(&cx)?;
+    let egraph = rt.saturated_egraph()?;
+    let view = EGraphView::new(&egraph, rt.decoders());
+
+    let mut classes: Vec<ClassId> = Vec::new();
+    for node in egraph
+        .nodes
+        .values()
+        .filter(|n| n.op == "LayoutTensorOpCublasLtBias")
+    {
+        let class = d_layout_class(&egraph, node);
+        if !classes.contains(&class) {
+            classes.push(class);
+        }
+    }
+    if classes.is_empty() {
+        println!("DEMO no CublasLtBias form was minted — nothing to demonstrate");
+        return Ok(());
+    }
+    for class in &classes {
+        let decoded = view.class(class);
+        let present = decoded.present::<Layout>();
+        println!("DEMO D layout class: present = {present:?}");
+        println!(
+            "DEMO first::<LeftMajorContiguousElementLayout>()  = {:?}",
+            decoded.first::<LeftMajorContiguousElementLayout>()
+        );
+        println!(
+            "DEMO first::<RightMajorContiguousElementLayout>() = {:?}",
+            decoded.first::<RightMajorContiguousElementLayout>()
+        );
+        let retired = RETIRED_PREFERENCE_ORDER
+            .iter()
+            .find(|name| present.contains(name));
+        println!("DEMO retired preference order would have answered: {retired:?}");
+    }
+
+    // ---------------------------------------------------------------
+    // 2. THE BINDING, through the fence the estate's premise names.
+    // ---------------------------------------------------------------
+    let mut elected = None;
+    for seed in 0..6u64 {
+        let options = luminal_cuda_lite::CompileOptions {
+            generations: 12,
+            generation_size: 16,
+            mutations: 4,
+            trials: 1,
+            seed,
+            search_log: false,
+            ..Default::default()
+        };
+        let (cx, x, w, b) = degenerate_linear_with_bias();
+        let data: FxHashMap<NodeIndex, HostBuffer> = [
+            (x, HostBuffer::from(weights(K, 1))),
+            (w, HostBuffer::from(weights(K * N, 2))),
+            (b, HostBuffer::from(weights(N, 3))),
+        ]
+        .into_iter()
+        .collect();
+        let mut rt = CudaRuntime::load(&cx)?;
+        // BEFORE THE FIX this is where whisper died: every genome
+        // carrying the bias form was refused, so the SEARCH reported
+        // "no candidate genome produced an executable plan".
+        rt.search(&data, &options)?;
+        let has_bias = rt.plan().is_some_and(|plan| {
+            plan.dag.node_weights().any(|n| {
+                matches!(n, BufferNode::Compute { op, .. }
+                    if op.label().starts_with("CublasLt") && op.label().contains("Bias"))
+            })
+        });
+        if has_bias {
+            println!("DEMO search seed {seed} elected a cuBLASLt bias form");
+            elected = Some(rt);
+            break;
+        }
+    }
+    let Some(rt) = elected else {
+        println!("DEMO no seed in 0..6 elected a bias form — nothing more to show");
+        return Ok(());
+    };
+
+    let plan = rt.plan().expect("a searched runtime has a plan");
+    for node in plan.dag.node_weights() {
+        let BufferNode::Compute {
+            op, result_info, ..
+        } = node
+        else {
+            continue;
+        };
+        if !(op.label().starts_with("CublasLt") && op.label().contains("Bias")) {
+            continue;
+        }
+        let functional: &CublasLt = match op.as_any().downcast_ref::<CublasLtDps>() {
+            Some(dps) => &dps.op,
+            None => op
+                .as_any()
+                .downcast_ref::<CublasLt>()
+                .expect("a CublasLt*Bias compute node is a CublasLt(Dps) instance"),
+        };
+        let dest = &result_info
+            .first()
+            .expect("single-destination contract")
+            .layout;
+        let mut call = plan_call(functional)?;
+        println!(
+            "DEMO call frame m={} n={} k={} ; destination present = {:?}",
+            call.m,
+            call.n,
+            call.k,
+            dest.present()
+        );
+        match bind_destination(&mut call, dest, "demo") {
+            Ok(()) => println!(
+                "DEMO bind_destination -> Ok ; d = {:?} ; c == d is {}",
+                call.d,
+                call.c == call.d
+            ),
+            Err(err) => println!("DEMO bind_destination -> Err({err:#})"),
+        }
+        println!(
+            "DEMO the fence, spelled at the call site: \
+             dest.require::<LeftMajorContiguousElementLayout>(\"demo\") = {:?}",
+            dest.require::<LeftMajorContiguousElementLayout>("demo")
+                .map(|_| "Ok(the LeftMajor spelling)")
+                .map_err(|e| format!("{e:#}"))
+        );
+
+        // -----------------------------------------------------------
+        // 3. THE NEGATIVE, for contrast: a destination class holding
+        //    ONLY the right-major spelling. Same degenerate frame — the
+        //    fix is the CLASS, never the extent.
+        // -----------------------------------------------------------
+        let dims = dest
+            .literal_extents()
+            .expect("the elected destination has literal extents");
+        let right_major_only = DecodedLayout::of(
+            RightMajorContiguousElementLayout {
+                shape: ShapeTerm(dims.iter().map(|&d| IntExprTerm::Lit(d as i64)).collect()),
+                width: BitWidthTerm(32),
+            },
+            Some(PlanDtype::F32),
+        );
+        let mut negative = plan_call(functional)?;
+        match bind_destination(&mut negative, &right_major_only, "demo") {
+            Ok(()) => println!("DEMO right_major({dims:?}) alone: unexpectedly Ok"),
+            Err(err) => {
+                println!("DEMO right_major({dims:?}) alone under the bias form: Err({err:#})")
+            }
+        }
+        break;
+    }
+    Ok(())
+}

--- a/crates/luminal_cuda_lite/src/arena.rs
+++ b/crates/luminal_cuda_lite/src/arena.rs
@@ -77,18 +77,14 @@ use std::collections::{BTreeMap, BinaryHeap};
 /// GPU). One rule, one place, so the two can never disagree about a
 /// buffer's size.
 pub fn buffer_bytes(buffer: &Buffer<luminal::layouts::DecodedLayout>) -> Result<usize> {
-    let numel = buffer
-        .layout
-        .mirror
-        .literal_span_elements()
-        .ok_or_else(|| {
-            anyhow!(
-                "buffer {:?} (backing {}) has no literal span — symbolic or \
+    let numel = buffer.layout.literal_span_elements().ok_or_else(|| {
+        anyhow!(
+            "buffer {:?} (backing {}) has no literal span — symbolic or \
                  undisclosed-reach layouts are not executable",
-                buffer.label,
-                buffer.backs
-            )
-        })?;
+            buffer.label,
+            buffer.backs
+        )
+    })?;
     let dtype = buffer.layout.dtype.ok_or_else(|| {
         anyhow!(
             "buffer {:?} (backing {}) carries no dtype fact",

--- a/crates/luminal_cuda_lite/src/finalists.rs
+++ b/crates/luminal_cuda_lite/src/finalists.rs
@@ -242,7 +242,16 @@ impl<'a> Finalists<'a> {
             Err(err) => return Err(format!("extract: {err:#}")),
         };
         let dps = luminal::dps::dps_rewrite(&graph);
-        luminal::layouts::decode_layout_table(self.egraph, &dps, "finalist", &mut self.layout_cache)
+        // The decoder registry for THIS matcher set. Built here rather
+        // than held as a field because building it can REFUSE (a
+        // duplicate `(sort, constructor)` registration) and a refusal in
+        // the search path is a `Result`, never a panic — and the five
+        // core decoders cost nothing next to the extraction this walk
+        // just paid for.
+        let decoders = luminal::egglog_snippet::decoder_registry_for(self.matchers)
+            .map_err(|err| format!("decoders: {err:#}"))?;
+        let view = luminal::egglog_utils::eclass::EGraphView::new(self.egraph, &decoders);
+        luminal::layouts::decode_layout_table(&view, &dps, "finalist", &mut self.layout_cache)
             .and_then(|table| luminal::bufferize::bufferize(&dps, &table))
             .map_err(|err| format!("bufferize: {err:#}"))
     }

--- a/crates/luminal_cuda_lite/src/kernels.rs
+++ b/crates/luminal_cuda_lite/src/kernels.rs
@@ -20,7 +20,11 @@ use luminal::buffer_tensor_ir::BufferTensorIrOp;
 use luminal::bufferize::SlotDescriptor;
 use luminal::dtype::PlanDtype;
 use luminal::index_expr::IotaExpr;
-use luminal::layouts::DecodedLayout;
+use luminal::layouts::{
+    BitOffsetExpressionLayout as BO, DecodedLayout, ElementOffsetExpressionLayout as EO,
+    LeftMajorContiguousElementLayout as LM, RightMajorContiguousElementLayout as RM,
+    StridedElementLayout as ST,
+};
 use std::any::TypeId;
 
 /// Geometry + typing for one compute node, in plan order: operands
@@ -61,7 +65,7 @@ impl CodegenCtx {
         result_info: &[SlotDescriptor<DecodedLayout>],
     ) -> Result<Self> {
         let dims_of = |slot: &SlotDescriptor<DecodedLayout>, role: &str| -> Result<Vec<usize>> {
-            slot.layout.mirror.literal_extents().ok_or_else(|| {
+            slot.layout.literal_extents().ok_or_else(|| {
                 anyhow::anyhow!("{label} {role} has symbolic layout extents (no numeric codegen)")
             })
         };
@@ -142,7 +146,8 @@ impl CodegenCtx {
 // PROTOTYPE (Option B): reading operands through their SLOT LAYOUTS.
 //
 // The slot's own elected layout (`SlotDescriptor::layout`, the runtime's
-// decoded `MirrorLayout`) is the ONE vocabulary for how a value
+// decoded `DecodedLayout` — every spelling of the elected class) is the
+// ONE vocabulary for how a value
 // addresses its residence — for a folded operand it is the view's
 // COMPOSED layout, which the e-graph already minted (preamble view
 // BitOffset composition / native strided chains). The elementwise family
@@ -357,33 +362,41 @@ fn affine_of_term(expr: &luminal::layouts::IntExprTerm, rank: usize) -> Option<A
 }
 
 /// The slot layout's READ FUNCTION, reduced to an affine form over the
-/// value's coordinates — one `Affine` per mirror spelling, never a
+/// value's coordinates — one `Affine` per spelling, never a
 /// classification of the spelling itself. The layout's own domain must
 /// be literal and equal `dims` (its domain IS the value's shape); a
 /// foreign domain is a planner/decoder incoherence and is refused
 /// downstream, so it yields `None` here rather than a read.
+///
+/// THE PREFERENCE IS THIS CALL SITE'S, and it is stated here: all
+/// spellings of a class denote one function, so the codegen asks first
+/// for the most structured one, which yields the simplest C. Nobody
+/// else's decoder chooses for it.
 fn read_affine(layout: &DecodedLayout, dims: &[usize]) -> Option<Affine> {
-    use luminal::layouts::MirrorLayout as M;
     let rank = dims.len();
-    if layout.mirror.literal_extents().as_deref() != Some(dims) {
+    if layout.literal_extents().as_deref() != Some(dims) {
         return None;
     }
-    match &layout.mirror {
-        // The packed ladder states its strides structurally.
-        M::RightMajor(_) => Affine::from_strides(&strides_of(dims)),
-        M::LeftMajor(_) => {
-            let mut strides = vec![1usize; rank];
-            for axis in 1..rank {
-                strides[axis] = strides[axis - 1] * dims[axis - 1];
-            }
-            Affine::from_strides(&strides)
+    // The packed ladder states its strides structurally.
+    if layout.has::<RM>() {
+        Affine::from_strides(&strides_of(dims))
+    } else if layout.has::<LM>() {
+        let mut strides = vec![1usize; rank];
+        for axis in 1..rank {
+            strides[axis] = strides[axis - 1] * dims[axis - 1];
         }
-        // The expression forms state it as a term.
-        M::Strided(st) => st.chain.iter().try_fold(Affine::zero(rank), |acc, s| {
+        Affine::from_strides(&strides)
+    // The expression forms state it as a term.
+    } else if let Some(st) = layout.first::<ST>() {
+        st.chain.iter().try_fold(Affine::zero(rank), |acc, s| {
             acc.add(affine_of_term(s, rank)?)
-        }),
-        M::ElementOffset(eo) => affine_of_term(&eo.offset, rank),
-        M::BitOffset(bo) => affine_of_term(&bo.offset, rank)?.exact_div(bo.width.0),
+        })
+    } else if let Some(eo) = layout.first::<EO>() {
+        affine_of_term(&eo.offset, rank)
+    } else if let Some(bo) = layout.first::<BO>() {
+        affine_of_term(&bo.offset, rank)?.exact_div(bo.width.0)
+    } else {
+        None
     }
 }
 
@@ -514,7 +527,6 @@ pub fn layout_read_index(
         }
     }
     let in_prefix = coords.prefix();
-    use luminal::layouts::MirrorLayout;
     let rank = slot_dims.len();
     let idx = format!("{operand}_idx");
     let check_domain = |shape: &luminal::layouts::ShapeTerm| -> Result<()> {
@@ -536,66 +548,70 @@ pub fn layout_read_index(
     };
     // The flat element offset expression. No bound travels with it: see
     // the NO RUNTIME BOUNDS TRAPS note above.
-    let offset: String = match &layout.mirror {
-        MirrorLayout::RightMajor(rm) => {
-            check_domain(&rm.shape)?;
-            let strides = strides_of(slot_dims);
-            if rank == 0 {
-                "0LL".to_string()
-            } else {
-                (0..rank)
-                    .map(|axis| format!("{in_prefix}{axis} * {}LL", strides[axis]))
-                    .collect::<Vec<_>>()
-                    .join(" + ")
-            }
+    // THE PREFERENCE IS THIS CALL SITE'S (same order as `read_affine`):
+    // every spelling of the class denotes one function, and this codegen
+    // asks for the one it emits the simplest C for. A class holding none
+    // of them is a capability refusal, not a guess.
+    let offset: String = if let Some(rm) = layout.first::<RM>() {
+        check_domain(&rm.shape)?;
+        let strides = strides_of(slot_dims);
+        if rank == 0 {
+            "0LL".to_string()
+        } else {
+            (0..rank)
+                .map(|axis| format!("{in_prefix}{axis} * {}LL", strides[axis]))
+                .collect::<Vec<_>>()
+                .join(" + ")
         }
-        MirrorLayout::LeftMajor(lm) => {
-            check_domain(&lm.shape)?;
-            let mut strides = vec![1usize; rank];
-            for axis in 1..rank {
-                strides[axis] = strides[axis - 1] * slot_dims[axis - 1];
-            }
-            if rank == 0 {
-                "0LL".to_string()
-            } else {
-                (0..rank)
-                    .map(|axis| format!("{in_prefix}{axis} * {}LL", strides[axis]))
-                    .collect::<Vec<_>>()
-                    .join(" + ")
-            }
+    } else if let Some(lm) = layout.first::<LM>() {
+        check_domain(&lm.shape)?;
+        let mut strides = vec![1usize; rank];
+        for axis in 1..rank {
+            strides[axis] = strides[axis - 1] * slot_dims[axis - 1];
         }
-        MirrorLayout::Strided(st) => {
-            check_domain(&st.shape)?;
-            let summands = st
-                .chain
-                .iter()
-                .map(|s| lower_layout_term(s, rank, in_prefix))
-                .collect::<Result<Vec<_>>>()?;
-            if summands.is_empty() {
-                "0LL".to_string()
-            } else {
-                summands.join(" + ")
-            }
+        if rank == 0 {
+            "0LL".to_string()
+        } else {
+            (0..rank)
+                .map(|axis| format!("{in_prefix}{axis} * {}LL", strides[axis]))
+                .collect::<Vec<_>>()
+                .join(" + ")
         }
-        MirrorLayout::ElementOffset(eo) => {
-            check_domain(&eo.shape)?;
-            lower_layout_term(&eo.offset, rank, in_prefix)?
+    } else if let Some(st) = layout.first::<ST>() {
+        check_domain(&st.shape)?;
+        let summands = st
+            .chain
+            .iter()
+            .map(|s| lower_layout_term(s, rank, in_prefix))
+            .collect::<Result<Vec<_>>>()?;
+        if summands.is_empty() {
+            "0LL".to_string()
+        } else {
+            summands.join(" + ")
         }
-        MirrorLayout::BitOffset(bo) => {
-            check_domain(&bo.shape)?;
-            let bits = lower_layout_term(&bo.offset, rank, in_prefix)?;
-            let width = bo.width.0;
-            // Bit form: element index = bit offset / width. The bit
-            // offset's divisibility by the element width is a COMPILER
-            // invariant (a mid-element bit offset has no element read) —
-            // it used to be re-derived at runtime in every thread; see
-            // the NO RUNTIME BOUNDS TRAPS note above for why it is not.
-            let bits_var = format!("{operand}_bits");
-            let code = format!(
-                "    long long {bits_var} = {bits};\n    long long {idx} = {bits_var} / {width}LL;\n"
-            );
-            return Ok((code, idx));
-        }
+    } else if let Some(eo) = layout.first::<EO>() {
+        check_domain(&eo.shape)?;
+        lower_layout_term(&eo.offset, rank, in_prefix)?
+    } else if let Some(bo) = layout.first::<BO>() {
+        check_domain(&bo.shape)?;
+        let bits = lower_layout_term(&bo.offset, rank, in_prefix)?;
+        let width = bo.width.0;
+        // Bit form: element index = bit offset / width. The bit
+        // offset's divisibility by the element width is a COMPILER
+        // invariant (a mid-element bit offset has no element read) —
+        // it used to be re-derived at runtime in every thread; see
+        // the NO RUNTIME BOUNDS TRAPS note above for why it is not.
+        let bits_var = format!("{operand}_bits");
+        let code = format!(
+            "    long long {bits_var} = {bits};\n    long long {idx} = {bits_var} / {width}LL;\n"
+        );
+        return Ok((code, idx));
+    } else {
+        bail!(
+            "operand {operand}: no lowerable layout spelling — the elected class \
+             holds {:?}",
+            layout.present()
+        );
     };
     Ok((format!("    long long {idx} = {offset};\n"), idx))
 }

--- a/crates/luminal_cuda_lite/src/layouts.rs
+++ b/crates/luminal_cuda_lite/src/layouts.rs
@@ -4,10 +4,14 @@
 //! There is no CUDA-flavored layout type and no CUDA-flavored decoder
 //! any more (ruling D9, 2026-09-03): core owns the decoder and publishes
 //! the struct it produces ([`luminal::layouts::DecodedLayout`] — the
-//! shared mirror vocabulary plus the value's `dtype-of` fact), and the
-//! runtimes import it directly. A backend that wants a layout core has
-//! never heard of is still free to bring its own type; this one does
-//! not.
+//! elected class's decoded spellings plus the value's `dtype-of` fact),
+//! and the runtimes import it directly. A backend that wants a layout
+//! core has never heard of is still free to bring its own type; this one
+//! does not.
+//!
+//! The read-back helpers below evaluate through
+//! [`luminal::layouts::LayoutFacts::element_index`] — the constructor's
+//! own read function, asked of the layout rather than matched on.
 
 use anyhow::Result;
 pub use luminal::layouts::DecodedLayout;
@@ -24,41 +28,13 @@ pub type CudaPlan = luminal::bufferize::BufferIrGraph<DecodedLayout>;
 // depends on CL), so the CL device suites and examples share this one.
 // ===========================================================================
 
-/// Evaluate a mirror term at concrete coordinates (front-indexed;
+/// Evaluate a layout term at concrete coordinates (front-indexed;
 /// `Coord{axis_from_end}` reads `coords[rank-1-axis_from_end]`).
-/// Symbolic vars and unsupported forms refuse loudly.
+/// Symbolic vars refuse loudly. Core owns the evaluator
+/// ([`luminal::layouts::IntExprTerm::eval_at`]); this keeps the name the
+/// CL device suites, `view_admission` and the examples already call.
 pub fn eval_term(expr: &luminal::layouts::IntExprTerm, coords: &[usize]) -> Result<i64> {
-    use luminal::layouts::IntExprTerm as T;
-    let rank = coords.len();
-    Ok(match expr {
-        T::Lit(v) => *v,
-        T::Var(name) => anyhow::bail!("layout read: symbolic dim `{name}` cannot evaluate"),
-        T::Coord { axis_from_end } => {
-            let axis = usize::try_from(*axis_from_end)
-                .ok()
-                .filter(|&a| a < rank)
-                .ok_or_else(|| {
-                    anyhow::anyhow!("coordinate axis {axis_from_end} out of rank {rank}")
-                })?;
-            coords[rank - 1 - axis] as i64
-        }
-        T::Add(a, b) => eval_term(a, coords)? + eval_term(b, coords)?,
-        T::Mul(a, b) => eval_term(a, coords)? * eval_term(b, coords)?,
-        T::TruncDiv(a, b) => {
-            let (a, b) = (eval_term(a, coords)?, eval_term(b, coords)?);
-            anyhow::ensure!(b != 0, "division by zero in a layout expression");
-            a / b
-        }
-        T::TruncRem(a, b) => {
-            let (a, b) = (eval_term(a, coords)?, eval_term(b, coords)?);
-            anyhow::ensure!(b != 0, "remainder by zero in a layout expression");
-            a % b
-        }
-        T::Min(a, b) => eval_term(a, coords)?.min(eval_term(b, coords)?),
-        T::Max(a, b) => eval_term(a, coords)?.max(eval_term(b, coords)?),
-        T::LessThanCast(a, b) => i64::from(eval_term(a, coords)? < eval_term(b, coords)?),
-        other => anyhow::bail!("layout read: {other:?} has no evaluation here (fail-closed)"),
-    })
+    expr.eval_at(coords)
 }
 
 /// Element `coords` of a value interpreted under `layout`, down to the
@@ -66,54 +42,7 @@ pub fn eval_term(expr: &luminal::layouts::IntExprTerm, coords: &[usize]) -> Resu
 /// extents, foreign-rank coordinates, out-of-domain coordinates, a
 /// mid-element bit offset, and a negative result.
 pub fn element_index(layout: &DecodedLayout, coords: &[usize]) -> Result<usize> {
-    use luminal::layouts::MirrorLayout as M;
-    let extents = layout
-        .mirror
-        .literal_extents()
-        .ok_or_else(|| anyhow::anyhow!("layout read: symbolic extents"))?;
-    anyhow::ensure!(
-        coords.len() == extents.len(),
-        "{} coordinates for a rank-{} layout",
-        coords.len(),
-        extents.len()
-    );
-    for (axis, (&c, &d)) in coords.iter().zip(&extents).enumerate() {
-        anyhow::ensure!(c < d, "coordinate {c} out of extent {d} (axis {axis})");
-    }
-    let flat = match &layout.mirror {
-        M::RightMajor(_) => coords
-            .iter()
-            .zip(&extents)
-            .fold(0usize, |acc, (&c, &d)| acc * d + c) as i64,
-        M::LeftMajor(_) => {
-            let mut stride = 1usize;
-            let mut acc = 0usize;
-            for (&c, &d) in coords.iter().zip(&extents) {
-                acc += c * stride;
-                stride *= d;
-            }
-            acc as i64
-        }
-        M::Strided(st) => {
-            let mut total = 0i64;
-            for summand in &st.chain {
-                total += eval_term(summand, coords)?;
-            }
-            total
-        }
-        M::ElementOffset(eo) => eval_term(&eo.offset, coords)?,
-        M::BitOffset(bo) => {
-            let bits = eval_term(&bo.offset, coords)?;
-            anyhow::ensure!(bo.width.0 > 0, "non-positive bit width {}", bo.width.0);
-            anyhow::ensure!(
-                bits % bo.width.0 == 0,
-                "bit offset {bits} is not element-aligned to width {}",
-                bo.width.0
-            );
-            bits / bo.width.0
-        }
-    };
-    usize::try_from(flat).map_err(|_| anyhow::anyhow!("negative element index {flat}"))
+    layout.element_index(coords)
 }
 
 /// Read every element of a value out of `backing` through `layout`, in
@@ -123,7 +52,6 @@ pub fn element_index(layout: &DecodedLayout, coords: &[usize]) -> Result<usize> 
 /// bounds-checked against it.
 pub fn dense_f32(backing: &[f32], layout: &DecodedLayout) -> Result<Vec<f32>> {
     let dims = layout
-        .mirror
         .literal_extents()
         .ok_or_else(|| anyhow::anyhow!("dense read: symbolic extents"))?;
     let numel: usize = dims.iter().product();

--- a/crates/luminal_cuda_lite/src/ops/cublaslt/exec.rs
+++ b/crates/luminal_cuda_lite/src/ops/cublaslt/exec.rs
@@ -81,11 +81,21 @@
 //! left-major contiguous over the sibling frame `[n, m]`, which is
 //! byte-identical to the recorder's row-major `[m, n]`, puts the
 //! per-feature vector on D's rows (the API's only bias axis), and is
-//! exactly what [`bind_destination`] resolves to `LtDesc::col`. The
-//! executor therefore no longer refuses the bias forms; it carries a
-//! TRIPWIRE instead ([`assert_bias_destination_order`]): a bias-bearing
-//! call whose D is not COL is unreachable from the estate, and reaching
-//! it is a bug to bail on, never a case to handle.
+//! exactly what [`bind_destination`] resolves to `LtDesc::col`.
+//!
+//! THE FENCE IS THE SAME QUESTION, ASKED OF THE CLASS.
+//! [`bind_destination`] binds a bias form's D by
+//! `dest.require::<LeftMajorContiguousElementLayout>(who)` — the
+//! decorator's premise, spelled at the call site. A destination class
+//! that holds the LeftMajor spelling binds COL; one that does not is
+//! unreachable from the estate and is refused before any descriptor
+//! exists. The degenerate-extent coincidence — at `m == 1` or `n == 1`
+//! the right-major and left-major contiguous index maps over `[m, n]`
+//! are the SAME function, so the e-graph puts BOTH literals in one
+//! class — is NOT a case here: the class carries both spellings and
+//! `require` reads the class, not one chosen spelling. (It was a case
+//! only while a preference-ordered decoder handed this bridge one
+//! spelling of that class and hid the other; that decoder is gone.)
 //!
 //! THE DESTINATION FRAME IS THE PLAN'S, NOT A CONSTANT (regression fix,
 //! 2026-08-31 — see [`bind_destination`]). The paragraph above says
@@ -109,7 +119,8 @@
 //! spec-only DEFAULT (ROW), and the executor calls [`bind_destination`]
 //! with the result slot's elected layout before dispatch.
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
+use luminal::layouts::{LeftMajorContiguousElementLayout, RightMajorContiguousElementLayout};
 
 use super::{CuDim, CuEpilogue, CublasLt, CublasLtForm, LtMatmulSpec};
 
@@ -321,8 +332,7 @@ pub fn bind_destination(
     dest: &luminal::layouts::DecodedLayout,
     who: &str,
 ) -> Result<()> {
-    use luminal::layouts::MirrorLayout as M;
-    let extents = dest.mirror.literal_extents().ok_or_else(|| {
+    let extents = dest.literal_extents().ok_or_else(|| {
         anyhow::anyhow!(
             "cuBLASLt {who}: the destination's elected layout has SYMBOLIC extents \
              — the call frame cannot be checked against it; refused before dispatch"
@@ -341,47 +351,70 @@ pub fn bind_destination(
             call.n
         );
     }
-    let desc = match &dest.mirror {
-        M::RightMajor(_) => LtDesc::row(call.m, call.n, call.n.max(1)),
-        M::LeftMajor(_) => LtDesc::col(call.m, call.n, call.m.max(1)),
-        other => bail!(
-            "cuBLASLt {who}: the plan elected a {} destination layout; this backend \
-             writes only the two dense orders cuBLASLt can express (RightMajor -> \
-             CUBLASLT_ORDER_ROW, LeftMajor -> CUBLASLT_ORDER_COL). Strided and \
-             offset-expression destinations are NOT lowered — a CAPABILITY refusal \
-             (the host-call mirror of the codegen path's identity-index write fence), \
-             never a guess. Layout: {other:?}",
-            match other {
-                M::Strided(_) => "STRIDED",
-                M::ElementOffset(_) => "ELEMENT-OFFSET-EXPRESSION",
-                M::BitOffset(_) => "BIT-OFFSET-EXPRESSION",
-                _ => unreachable!("the dense orders are matched above"),
-            }
-        ),
+    let desc = if call.bias_operand.is_some() {
+        // THE FENCE. The estate's two bias decorators mint a bias form
+        // ONLY when the claimed D class HOLDS the LeftMajor spelling
+        // (`egg/cublaslt_marker_decorate.egg`, premise
+        // `(= ?inner_L (LeftMajorContiguousElementLayoutLit ?ishape ?d_bits2))`).
+        // Ask the class the same question — not "which spelling does a
+        // decoder prefer", which is how a degenerate extent (`m == 1` or
+        // `n == 1`, where the two contiguous index maps are ONE function
+        // and both literals share the class) once looked like a drift
+        // and refused every whisper genome. A bias form whose class
+        // lacks the spelling is unreachable from the estate: a real
+        // drift, refused BEFORE any descriptor exists.
+        dest.require::<LeftMajorContiguousElementLayout>(who)
+            .with_context(|| {
+                format!(
+                    "cuBLASLt {who}: unreachable: the bias decorators require a LeftMajor \
+                     D; a bias form ({}) reached the executor whose destination class \
+                     holds {:?} and no LeftMajorContiguousElementLayoutLit — the library \
+                     refuses BIAS/RELU_BIAS on a ROW-order D \
+                     (CUBLAS_STATUS_NOT_SUPPORTED, measured on the A100 2026-08-28); \
+                     refused BEFORE dispatch, no bytes move",
+                    call.form.constructor_name(),
+                    dest.present()
+                )
+            })?;
+        LtDesc::col(call.m, call.n, call.m.max(1))
+    } else if dest.has::<LeftMajorContiguousElementLayout>() {
+        LtDesc::col(call.m, call.n, call.m.max(1))
+    } else if dest.has::<RightMajorContiguousElementLayout>() {
+        LtDesc::row(call.m, call.n, call.n.max(1))
+    } else {
+        bail!(
+            "cuBLASLt {who}: the plan elected a destination layout whose class holds \
+             {:?}; this backend writes only the two dense orders cuBLASLt can express \
+             (RightMajor -> CUBLASLT_ORDER_ROW, LeftMajor -> CUBLASLT_ORDER_COL). \
+             Strided and offset-expression destinations are NOT lowered — a CAPABILITY \
+             refusal (the host-call mirror of the codegen path's identity-index write \
+             fence), never a guess.",
+            dest.present()
+        )
     };
     call.d = desc;
     call.c = desc;
-    // The bias/order tripwire runs HERE — after the D order is known,
-    // never before (the spec-only default is ROW and would fire falsely).
-    assert_bias_destination_order(call, who)
+    Ok(())
 }
 
-/// THE BIAS/ORDER TRIPWIRE (ruling 2026-09-01). The estate's two bias
-/// decorators (`egg/cublaslt_marker_decorate.egg`) mint a bias form ONLY
-/// when the claimed D carries the `LeftMajorContiguousElementLayoutLit`
-/// spelling over the sibling frame, and [`bind_destination`] maps a
-/// LeftMajor election to `CUBLASLT_ORDER_COL`. A bias-bearing call whose
-/// D descriptor is not COL is therefore UNREACHABLE from a planned
-/// dispatch — it can only mean the estate premise and this bridge have
-/// drifted apart (or a hand-built call). Bail, never dispatch: the
-/// library refuses BIAS/RELU_BIAS on a ROW-order D
-/// (CUBLAS_STATUS_NOT_SUPPORTED, measured on the A100 2026-08-28), and
-/// this check names the finding BEFORE any descriptor is built.
+/// THE VENDOR PRECONDITION, checked at dispatch: cuBLASLt refuses
+/// BIAS/RELU_BIAS on a ROW-order D (`CUBLAS_STATUS_NOT_SUPPORTED`,
+/// measured on the A100 2026-08-28), and the library documents no such
+/// guarantee anywhere a caller can read it. This names the finding
+/// BEFORE the call goes out.
 ///
 /// Classification (see the CHECK TAXONOMY on [`bind_destination`]): a
-/// COHERENCE FENCE between the estate's premise vocabulary (the LeftMajor
-/// literal) and the call frame the executor builds (the D order) — not an
-/// e-graph re-check, and not disposable.
+/// VENDOR CHECK — category (2), and it STAYS. Its one caller is
+/// `device_call::dispatch`, which sees every `LtCall` however built,
+/// INCLUDING the hand-built ones the direct-dispatch contract tests
+/// construct without ever passing through [`bind_destination`]. That is
+/// a release path, so a `debug_assert!` would be wrong here.
+///
+/// It is NOT called from [`bind_destination`] any more. There it merely
+/// restated that function's own postcondition — the bias branch binds
+/// COL or refuses — which is category (1), "OUT". The estate-premise
+/// fence lives in `bind_destination` itself, as
+/// `require::<LeftMajorContiguousElementLayout>`.
 pub fn assert_bias_destination_order(call: &LtCall, who: &str) -> Result<()> {
     if call.bias_operand.is_some() && call.d.order != LtOrder::Col {
         bail!(

--- a/crates/luminal_cuda_lite/src/ops/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/mod.rs
@@ -90,6 +90,13 @@ impl RegisteredOp {
         Self { matcher, prototype }
     }
 
+    /// The constructor decoders this row's matcher contributes — the
+    /// other half of `snippets()`: a row that DECLARES a constructor of
+    /// a decoded sort brings the struct that reads it back.
+    pub fn decoders(&self) -> Vec<luminal::egglog_utils::eclass::ConstructorDecoder> {
+        self.matcher.decoders()
+    }
+
     /// This row's egglog constructor — the name the estate mints and the
     /// name the derived allow list carries.
     pub fn constructor(&self) -> &'static str {

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -473,6 +473,10 @@ impl CudaRuntime {
             }
             bail!("shape contracts failed:\n  - {}", doors.join("\n  - "));
         }
+        // THE ASSEMBLY TRIPWIRE: this program's every constructor of a
+        // decoded sort has exactly one decoder, checked against the LIVE
+        // schema before anything reads a serialized class.
+        self.decoders.check(&egraph)?;
         let serialized = egraph.serialize(luminal::prelude::egglog::SerializeConfig::default());
         Ok((serialized.egraph, program))
     }
@@ -648,6 +652,7 @@ impl CudaRuntime {
                 input_slots: &native.input_slots,
                 output_slots: &native.output_slots,
                 base_dims: &self.dims,
+                decoders: &self.decoders,
             };
             let plans = crate::search::bucketed_search_implementations(
                 &assembly,

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -62,6 +62,12 @@ pub struct CudaRuntime {
     /// The claim set derived from that same registry — see
     /// [`CudaRuntime::allow_list_over`] for the three classes.
     allow: Vec<&'static str>,
+    /// The `(sort, constructor)` DECODERS for that same matcher set:
+    /// core's built-ins plus whatever the instance's matchers declare.
+    /// Every layout decode in this runtime reads through these, and the
+    /// assembly tripwire checks each saturated program against them. A
+    /// `Default` runtime carries an empty registry, like `matchers`.
+    decoders: luminal::egglog_utils::eclass::ConstructorRegistry,
     plan: Option<BufferIrGraph<DecodedLayout>>,
     /// Host-staged input payloads by BufferLit id, H2D'd at execute.
     staged: FxHashMap<i64, HostBuffer>,
@@ -181,7 +187,12 @@ impl CudaRuntime {
         // Derive the claim set BEFORE the rows are consumed: the allow
         // list reads the prototypes, the search reads the matchers.
         let allow = Self::allow_list_over(&registry);
-        let matchers = registry.into_iter().map(|entry| entry.matcher).collect();
+        let matchers: Vec<Box<dyn luminal::layout_ir::OpMatcher>> =
+            registry.into_iter().map(|entry| entry.matcher).collect();
+        // The decoders for that same vocabulary. Refused here if two
+        // matchers claim one `(sort, constructor)` — a registration bug,
+        // named at load rather than at the first decode.
+        let decoders = luminal::egglog_snippet::decoder_registry_for(&matchers)?;
         Ok(Self {
             native: Some(NativeParts {
                 pre_schedule,
@@ -193,6 +204,7 @@ impl CudaRuntime {
             }),
             matchers,
             allow,
+            decoders,
             ..Self::default()
         })
     }
@@ -201,6 +213,14 @@ impl CudaRuntime {
     /// LENT, never rebuilt (see the field's note).
     fn matchers(&self) -> &[Box<dyn luminal::layout_ir::OpMatcher>] {
         &self.matchers
+    }
+
+    /// THIS INSTANCE'S CONSTRUCTOR DECODERS — what to build an
+    /// [`luminal::egglog_utils::eclass::EGraphView`] over
+    /// [`Self::saturated_egraph`] with, so a caller can ask a class
+    /// which spellings it holds.
+    pub fn decoders(&self) -> &luminal::egglog_utils::eclass::ConstructorRegistry {
+        &self.decoders
     }
 
     /// The claim set THIS instance searches under — the allow list

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -896,6 +896,10 @@ pub struct BucketAssembly<'a> {
     /// representative map so a plan records the full pin it was searched
     /// at.
     pub base_dims: &'a luminal::shape::DynMap,
+    /// The runtime's `(sort, constructor)` decoders — what every
+    /// bucket's saturated program is checked against by the assembly
+    /// tripwire, and what its layout decodes read through.
+    pub decoders: &'a luminal::egglog_utils::eclass::ConstructorRegistry,
 }
 
 /// Range-seeded bucketed search: one Cartesian combination of
@@ -936,6 +940,7 @@ pub fn bucketed_search_implementations(
         egraph
             .parse_and_run_program(None, &text)
             .map_err(|err| anyhow!("bucket {ranges:?} representative render fails: {err}"))?;
+        assembly.decoders.check(&egraph)?;
         let serialized = egraph
             .serialize(luminal::prelude::egglog::SerializeConfig::default())
             .egraph;

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -381,13 +381,19 @@ pub fn search_implementations(
 
     // fingerprint → measured nanos (the dedup cache).
     let mut cache: FxHashMap<u64, u128> = FxHashMap::default();
+    // THE VIEW the layout decoders read through: this e-graph plus this
+    // matcher set's `(sort, constructor)` decoders. Built once — the
+    // view indexes classes through the serialized graph's own
+    // `classes()` cache, so every later class lookup is a map hit.
+    let decoders = luminal::egglog_snippet::decoder_registry_for(matchers)?;
+    let view = luminal::egglog_utils::eclass::EGraphView::new(egraph, &decoders);
     // THE DECODED-LAYOUT CACHE, one per search and CALLER-OWNED
     // (`decode_layout_table` takes it by `&mut`). Decoding is a pure
-    // function of `(layout class, dtype)`, and every decode builds a
-    // fresh `Reader` over the whole serialized e-graph — so a cache that
-    // did not span candidates would pay that index once per distinct
-    // layout class per candidate. `egraph` is fixed for this loop, which
-    // is what makes the `ClassId` keys comparable across candidates.
+    // function of `(layout class, dtype)`, and the table is VALUE-keyed
+    // per candidate — so a cache that did not span candidates would
+    // re-decode every distinct layout class once per candidate.
+    // `egraph` is fixed for this loop, which is what makes the
+    // `ClassId` keys comparable across candidates.
     let mut layout_cache = luminal::layouts::LayoutDecodeCache::new();
     let mut plans_profiled = 0usize;
     let mut fingerprint_hits = 0usize;
@@ -501,7 +507,7 @@ pub fn search_implementations(
                     // HIT: value-keying costs no extra decoder calls.
                     let dps = luminal::dps::dps_rewrite(&graph);
                     let built = luminal::layouts::decode_layout_table(
-                        egraph,
+                        &view,
                         &dps,
                         "implementation search",
                         &mut layout_cache,
@@ -655,7 +661,7 @@ pub fn search_implementations(
                 let build_start = Instant::now();
                 let dps = luminal::dps::dps_rewrite(&graph);
                 let built = luminal::layouts::decode_layout_table(
-                    egraph,
+                    &view,
                     &dps,
                     "implementation search",
                     &mut layout_cache,

--- a/crates/luminal_cuda_lite/tests/codegen_identity.rs
+++ b/crates/luminal_cuda_lite/tests/codegen_identity.rs
@@ -269,9 +269,10 @@ mod strided {
     use luminal::dtype::PlanDtype;
     use luminal_cuda_lite::{kernels, ops};
 
+    use luminal::egglog_utils::eclass::EgglogConstructor;
     use luminal::layouts::DecodedLayout;
     use luminal::layouts::{
-        BitWidthTerm, ElementOffsetExpressionLayout, IntExprTerm, MirrorLayout,
+        BitWidthTerm, ElementOffsetExpressionLayout, IntExprTerm, Layout,
         RightMajorContiguousElementLayout, ShapeTerm, StridedElementLayout,
     };
 
@@ -290,33 +291,30 @@ mod strided {
     fn shape(dims: &[i64]) -> ShapeTerm {
         ShapeTerm(dims.iter().map(|&d| lit(d)).collect())
     }
-    fn typed(mirror: MirrorLayout) -> DecodedLayout {
-        DecodedLayout {
-            mirror,
-            dtype: Some(PlanDtype::F32),
-        }
+    fn typed<C: EgglogConstructor<Sort = Layout> + luminal::layouts::LayoutFacts>(
+        spelling: C,
+    ) -> DecodedLayout {
+        DecodedLayout::of(spelling, Some(PlanDtype::F32))
     }
     fn rm_layout(dims: &[i64]) -> DecodedLayout {
-        typed(MirrorLayout::RightMajor(
-            RightMajorContiguousElementLayout {
-                shape: shape(dims),
-                width: BitWidthTerm(32),
-            },
-        ))
+        typed(RightMajorContiguousElementLayout {
+            shape: shape(dims),
+            width: BitWidthTerm(32),
+        })
     }
     fn strided_layout(dims: &[i64], chain: Vec<IntExprTerm>) -> DecodedLayout {
-        typed(MirrorLayout::Strided(StridedElementLayout {
+        typed(StridedElementLayout {
             shape: shape(dims),
             chain,
             width: BitWidthTerm(32),
-        }))
+        })
     }
     fn offset_layout(dims: &[i64], offset: IntExprTerm) -> DecodedLayout {
-        typed(MirrorLayout::ElementOffset(ElementOffsetExpressionLayout {
+        typed(ElementOffsetExpressionLayout {
             offset,
             shape: shape(dims),
             width: BitWidthTerm(32),
-        }))
+        })
     }
 
     /// A slot whose layout is the dense row-major read over its dims.
@@ -558,11 +556,11 @@ mod strided {
     fn unlowerable_layouts_refuse_loudly() {
         let op = ops::materialize_layout_copy::MaterializeLayoutCopyDps;
         // Symbolic extent in the layout's own domain — refused at ctx build.
-        let layout = typed(MirrorLayout::Strided(StridedElementLayout {
+        let layout = typed(StridedElementLayout {
             shape: ShapeTerm(vec![IntExprTerm::Var("n".to_string()), lit(2)]),
             chain: vec![coord(0), mul(coord(1), lit(2))],
             width: BitWidthTerm(32),
-        }));
+        });
         let err = kernels::CodegenCtx::from_descriptors(
             "Copy",
             &[slot_l(layout), slot(vec![3, 2])],
@@ -724,11 +722,11 @@ mod strided {
             ),
             (
                 "bit-offset at width 32",
-                typed(MirrorLayout::BitOffset(BitOffsetExpressionLayout {
+                typed(BitOffsetExpressionLayout {
                     offset: mul(add(mul(coord(1), lit(3)), coord(0)), lit(32)),
                     shape: shape(&[2, 3]),
                     width: BitWidthTerm(32),
-                })),
+                }),
             ),
         ];
 
@@ -860,24 +858,20 @@ mod strided {
             (
                 "left-major rank 1",
                 vec![5],
-                typed(MirrorLayout::LeftMajor(
-                    luminal::layouts::LeftMajorContiguousElementLayout {
-                        shape: shape(&[5]),
-                        width: BitWidthTerm(32),
-                    },
-                )),
+                typed(luminal::layouts::LeftMajorContiguousElementLayout {
+                    shape: shape(&[5]),
+                    width: BitWidthTerm(32),
+                }),
                 true,
             ),
             // ...and diverge at rank 2, where left-major is a transpose.
             (
                 "left-major rank 2",
                 vec![2, 3],
-                typed(MirrorLayout::LeftMajor(
-                    luminal::layouts::LeftMajorContiguousElementLayout {
-                        shape: shape(&[2, 3]),
-                        width: BitWidthTerm(32),
-                    },
-                )),
+                typed(luminal::layouts::LeftMajorContiguousElementLayout {
+                    shape: shape(&[2, 3]),
+                    width: BitWidthTerm(32),
+                }),
                 false,
             ),
         ];
@@ -902,31 +896,26 @@ fn descriptor_ctx_bails_loudly_on_unusable_layouts() {
     use luminal::bufferize::SlotDescriptor;
     use luminal::layouts::DecodedLayout;
     use luminal::layouts::{
-        BitWidthTerm, IntExprTerm, MirrorLayout, RightMajorContiguousElementLayout, ShapeTerm,
+        BitWidthTerm, IntExprTerm, RightMajorContiguousElementLayout, ShapeTerm,
     };
-    let rm = |shape: ShapeTerm| {
-        MirrorLayout::RightMajor(RightMajorContiguousElementLayout {
-            shape,
-            width: BitWidthTerm(32),
-        })
+    let rm = |shape: ShapeTerm| RightMajorContiguousElementLayout {
+        shape,
+        width: BitWidthTerm(32),
     };
     let lit_shape = ShapeTerm(vec![IntExprTerm::Lit(2), IntExprTerm::Lit(3)]);
     let filled = SlotDescriptor {
         value: luminal::prelude::egraph_serialize::ClassId::from("val$x"),
         buffer: luminal::bufferize::BufferId::Allocated(0),
-        layout: DecodedLayout {
-            mirror: rm(lit_shape.clone()),
-            dtype: Some(PlanDtype::F32),
-        },
+        layout: DecodedLayout::of(rm(lit_shape.clone()), Some(PlanDtype::F32)),
     };
     let symbolic = SlotDescriptor {
-        layout: DecodedLayout {
-            mirror: rm(ShapeTerm(vec![
+        layout: DecodedLayout::of(
+            rm(ShapeTerm(vec![
                 IntExprTerm::Var("n".to_string()),
                 IntExprTerm::Lit(3),
             ])),
-            dtype: Some(PlanDtype::F32),
-        },
+            Some(PlanDtype::F32),
+        ),
         ..filled.clone()
     };
     let err = kernels::CodegenCtx::from_descriptors(
@@ -940,10 +929,7 @@ fn descriptor_ctx_bails_loudly_on_unusable_layouts() {
         "got: {err}"
     );
     let untyped = SlotDescriptor {
-        layout: DecodedLayout {
-            mirror: rm(lit_shape),
-            dtype: None,
-        },
+        layout: DecodedLayout::of(rm(lit_shape), None),
         ..filled.clone()
     };
     let err =

--- a/crates/luminal_cuda_lite/tests/codegen_identity.rs
+++ b/crates/luminal_cuda_lite/tests/codegen_identity.rs
@@ -64,7 +64,6 @@ fn sources_via_buffer_table(
         .map(|(id, buffer)| {
             let dims = buffer
                 .layout
-                .mirror
                 .literal_extents()
                 .expect("plan buffer's layout has literal extents");
             (
@@ -231,7 +230,6 @@ fn sources_via_descriptors(
         let folded = operand_info.iter().any(|slot| {
             let dims = slot
                 .layout
-                .mirror
                 .literal_extents()
                 .expect("elected slot layouts are literal in these fixtures");
             // Ask the PRODUCTION read path: an operand whose expression

--- a/crates/luminal_cuda_lite/tests/codegen_identity.rs
+++ b/crates/luminal_cuda_lite/tests/codegen_identity.rs
@@ -665,12 +665,13 @@ mod strided {
     // =======================================================================
     // THE TWO-SPELLING PROOF (ruling 2026-08-31).
     //
-    // The e-graph may hand the decoder ANY spelling of a layout class —
-    // all spellings of a class denote one function, and `decode_layout`
-    // only states a PREFERENCE among the ones it finds. So the read
-    // decision may not be made on a spelling. These tests state one dense
-    // function five ways and require the emitted CUDA source to be
-    // byte-identical every time.
+    // All spellings of a layout class denote ONE function, and a caller
+    // picks the spelling IT lowers — nobody's decoder picks for it. So
+    // the read decision may not be made on a spelling. These tests state
+    // one dense function five ways and require the emitted CUDA source
+    // to be byte-identical every time; the sixth case puts TWO of those
+    // spellings in one class, the way the e-graph really delivers them,
+    // and requires the same source again.
     // =======================================================================
 
     /// The dense row-major read of a [2,3] value — strides [3,1] — in
@@ -687,9 +688,10 @@ mod strided {
     ///      the same read
     ///
     /// Each is first checked to BE the same function by the runtime's
-    /// own independent evaluator (`layouts::element_index`, which walks
-    /// the mirror structs and knows nothing about codegen), then the
-    /// emitted source is compared. Two statements, one answer.
+    /// own independent evaluator (`layouts::element_index`, which asks
+    /// each constructor for its own read function and knows nothing
+    /// about codegen), then the emitted source is compared. Two
+    /// statements, one answer.
     #[test]
     fn dense_spellings_all_collapse_to_the_flat_read() {
         use luminal::layouts::BitOffsetExpressionLayout;
@@ -725,6 +727,28 @@ mod strided {
                     shape: shape(&[2, 3]),
                     width: BitWidthTerm(32),
                 }),
+            ),
+            // 6. THE CLASS AS THE E-GRAPH DELIVERS IT: two of those
+            //    spellings in ONE class. Nothing chooses between them for
+            //    the codegen — it asks for the one it lowers.
+            (
+                "right-major AND the dense strided chain, one class",
+                DecodedLayout::of_spellings(
+                    vec![
+                        RightMajorContiguousElementLayout {
+                            shape: shape(&[2, 3]),
+                            width: BitWidthTerm(32),
+                        }
+                        .erase(),
+                        StridedElementLayout {
+                            shape: shape(&[2, 3]),
+                            chain: vec![coord(0), mul(coord(1), lit(3))],
+                            width: BitWidthTerm(32),
+                        }
+                        .erase(),
+                    ],
+                    Some(PlanDtype::F32),
+                ),
             ),
         ];
 

--- a/crates/luminal_cuda_lite/tests/composed_read_families.rs
+++ b/crates/luminal_cuda_lite/tests/composed_read_families.rs
@@ -520,9 +520,7 @@ fn materialize_lowers_a_folded_input_operand() {
     // permute's COMPOSED view layout over the parent domain (3,2),
     // operand 1 the DPS dest, entries = the slice's map.
     let sources: Vec<String> = {
-        use luminal::layouts::{
-            BitWidthTerm, IntExprTerm, MirrorLayout, ShapeTerm, StridedElementLayout,
-        };
+        use luminal::layouts::{BitWidthTerm, IntExprTerm, ShapeTerm, StridedElementLayout};
         use luminal_cuda_lite::layouts::DecodedLayout;
 
         let dims =
@@ -531,8 +529,8 @@ fn materialize_lowers_a_folded_input_operand() {
         // x^T seen at the parent VALUE's coordinates (3,2): x is (2,3)
         // row-major, so x^T[a][b] = x flat b*3 + a — the chain
         // [c_last, c_first*3] over domain (3,2).
-        let composed = DecodedLayout {
-            mirror: MirrorLayout::Strided(StridedElementLayout {
+        let composed = DecodedLayout::of(
+            StridedElementLayout {
                 shape: dims(&[3, 2]),
                 // Coord counts FROM THE END: p0 (first axis) is
                 // coord(1) at rank 2. x^T[p0][p1] = x flat p0*1 + p1*3.
@@ -541,15 +539,17 @@ fn materialize_lowers_a_folded_input_operand() {
                     IntExprTerm::Mul(Box::new(coord(0)), Box::new(IntExprTerm::Lit(3))),
                 ],
                 width: BitWidthTerm(32),
-            }),
-            dtype: Some(luminal::dtype::PlanDtype::F32),
-        };
-        let rm = |extents: &[i64]| DecodedLayout {
-            mirror: MirrorLayout::RightMajor(luminal::layouts::RightMajorContiguousElementLayout {
-                shape: dims(extents),
-                width: BitWidthTerm(32),
-            }),
-            dtype: Some(luminal::dtype::PlanDtype::F32),
+            },
+            Some(luminal::dtype::PlanDtype::F32),
+        );
+        let rm = |extents: &[i64]| {
+            DecodedLayout::of(
+                luminal::layouts::RightMajorContiguousElementLayout {
+                    shape: dims(extents),
+                    width: BitWidthTerm(32),
+                },
+                Some(luminal::dtype::PlanDtype::F32),
+            )
         };
         let slot = |layout: DecodedLayout| luminal::bufferize::SlotDescriptor {
             value: luminal::prelude::egraph_serialize::ClassId::from("probe"),

--- a/crates/luminal_cuda_lite/tests/cublaslt_bias_premise.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_bias_premise.rs
@@ -31,7 +31,11 @@
 use std::collections::BTreeSet;
 
 use luminal::bufferize::BufferNode;
+use luminal::egglog_utils::eclass::EGraphView;
 use luminal::graph::Graph;
+use luminal::layouts::{
+    Layout, LeftMajorContiguousElementLayout, RightMajorContiguousElementLayout,
+};
 use luminal::prelude::egraph_serialize::{ClassId, EGraph, Node};
 use luminal::prelude::{DType, FxHashMap, NodeIndex};
 use luminal_cuda_lite::CudaRuntime;
@@ -146,12 +150,15 @@ fn linear_with_bias_mints_the_bias_form_on_a_left_major_d() {
     {
         d_classes.insert(d_layout_class(&egraph, node));
     }
+    let view = EGraphView::new(&egraph, rt.decoders());
     for class in &d_classes {
         let ops = class_ops(&egraph, class);
-        let mirror = luminal::layouts::decode_layout_for(&egraph, class, "bias-premise pin")
-            .expect("the D layout class decodes");
+        let decoded = view.class(class);
         println!("BIAS-PREMISE CublasLtBias D layout class {class:?}: ops={ops:?}");
-        println!("BIAS-PREMISE   decoded (most-structured spelling): {mirror:?}");
+        println!(
+            "BIAS-PREMISE   registered Layout spellings present: {:?}",
+            decoded.present::<Layout>()
+        );
         assert!(
             ops.contains("LeftMajorContiguousElementLayoutLit"),
             "the bias form's D class must hold the LeftMajor spelling: {ops:?}"
@@ -169,10 +176,20 @@ fn linear_with_bias_mints_the_bias_form_on_a_left_major_d() {
             ops.contains("StridedElementLayoutLit"),
             "the native-chain-composition rung 3a reads: {ops:?}"
         );
+        // THE PREMISE, ASKED OF THE CLASS: the LeftMajor spelling is
+        // there and the RightMajor one is NOT — as it must be, since a
+        // [3,4] left-major over the bytes of a [4,3] right-major is not
+        // right-major. No preference order is consulted to learn this.
         assert!(
-            matches!(mirror, luminal::layouts::MirrorLayout::LeftMajor(_)),
-            "the decoder's most-structured spelling is LeftMajor (RightMajor is absent, \
-             as it must be: a [3,4] left-major over the bytes of a [4,3] right-major): {mirror:?}"
+            decoded.has::<LeftMajorContiguousElementLayout>(),
+            "the class holds a decodable LeftMajor spelling: {:?}",
+            decoded.present::<Layout>()
+        );
+        assert!(
+            !decoded.has::<RightMajorContiguousElementLayout>(),
+            "a [3,4] left-major over the bytes of a [4,3] right-major is not \
+             right-major: {:?}",
+            decoded.present::<Layout>()
         );
     }
 
@@ -314,7 +331,10 @@ fn search_elects_the_bias_form_and_binds_a_col_d() {
             .first()
             .expect("single-destination contract")
             .layout;
-        println!("BIAS-PREMISE elected destination layout: {:?}", dest.mirror);
+        println!(
+            "BIAS-PREMISE elected destination layout: spellings {:?}",
+            dest.present()
+        );
         bind_destination(&mut call, dest, "bias-premise pin")
             .expect("a bias form binds its destination (LeftMajor -> COL)");
         println!("BIAS-PREMISE LtCall: {call:#?}");

--- a/crates/luminal_cuda_lite/tests/cublaslt_bias_premise.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_bias_premise.rs
@@ -354,6 +354,205 @@ fn search_elects_the_bias_form_and_binds_a_col_d() {
 }
 
 // ---------------------------------------------------------------------------
+// THE DEGENERATE-EXTENT COINCIDENCE (whisper on the A100, 2026-09-04) —
+// the CPU reproduction of the live defect and its cure.
+//
+// whisper tiny.en decodes ONE token, so its q/v projections are
+// `x[1, 384] @ w[384, 384] + b[384]`: the recorder's m is 1, and the
+// sandwich sibling's call frame is therefore `m = 384, n = 1`. At a
+// degenerate extent the right-major and left-major contiguous index maps
+// over `[m, n]` are the SAME FUNCTION, so BOTH spellings live in one
+// e-class: the estate's bias decorator matched the LeftMajor one, and
+// the retired preference-ordered decoder (RightMajor first) handed the
+// executor the right-major one out of that same class. `bind_destination`
+// built a ROW D, the order fence fired, and EVERY candidate genome was
+// refused at device prepare:
+//
+//   cuBLASLt CublasLtAccumulateBias: unreachable: the bias decorators
+//   require a LeftMajor D; a bias form
+//   (LayoutTensorOpCublasLtAccumulateBias) reached the executor with a
+//   Row-order D descriptor (384x1 ld 1). [...] refused BEFORE dispatch
+//
+// -> "no candidate genome produced an executable plan".
+//
+// This pin is the same geometry at pin scale (`x[1, K] @ w[K, N] + b[N]`,
+// so the sibling frame is `[N, 1]`), and it is CPU-decidable end to end:
+// saturation mints the form, the seeded search elects it, and
+// `bind_destination` must resolve its D to COL rather than refusing —
+// because the class it asks HOLDS the LeftMajor spelling, not because
+// anything tests an extent.
+// ---------------------------------------------------------------------------
+
+/// The whisper shape at pin scale: a SINGLE batch row, so the sibling
+/// call frame's n collapses to 1.
+fn degenerate_linear_with_bias() -> (Graph, NodeIndex, NodeIndex, NodeIndex, NodeIndex) {
+    let mut cx = Graph::new();
+    let weight = cx.named_tensor("fc.weight", (K, N), DType::F32);
+    let bias = cx.named_tensor("fc.bias", N, DType::F32);
+    let x = cx.tensor((1usize, K), DType::F32);
+    let out = luminal_nn::linear(x, weight, Some(bias)).output();
+    (cx, x.id, weight.id, bias.id, out.id)
+}
+
+#[test]
+fn a_degenerate_extent_d_holds_both_contiguous_spellings_in_one_class() {
+    let (cx, _x, _w, _b, _out) = degenerate_linear_with_bias();
+    let rt = CudaRuntime::load(&cx).expect("load");
+    let egraph = rt.saturated_egraph().expect("saturation");
+    let (_base, bias, _acc, _acc_bias) = report_forms(&egraph, "linear(1xK . KxN)+b[N]");
+    assert!(
+        bias > 0,
+        "the bias form still mints at a degenerate extent (the LeftMajor \
+         premise is satisfied — the coincidence puts that spelling in the class)"
+    );
+    let mut classes: BTreeSet<ClassId> = BTreeSet::new();
+    for node in egraph
+        .nodes
+        .values()
+        .filter(|n| n.op == "LayoutTensorOpCublasLtBias")
+    {
+        classes.insert(d_layout_class(&egraph, node));
+    }
+    let view = EGraphView::new(&egraph, rt.decoders());
+    for class in &classes {
+        let ops = class_ops(&egraph, class);
+        let decoded = view.class(class);
+        println!("DEGENERATE-D bias D class {class:?}: ops={ops:?}");
+        println!(
+            "DEGENERATE-D   registered Layout spellings present: {:?}",
+            decoded.present::<Layout>()
+        );
+        assert!(
+            decoded.has::<LeftMajorContiguousElementLayout>(),
+            "the decorator's premise spelling must be present and decodable: {:?}",
+            decoded.present::<Layout>()
+        );
+        // THE COINCIDENCE ITSELF: the right-major spelling is in the SAME
+        // class, because at n == 1 the two index maps are one function.
+        // Asking the class for one constructor gets a straight answer for
+        // EACH of them; the retired decoder could only report one.
+        assert!(
+            decoded.has::<RightMajorContiguousElementLayout>(),
+            "at a degenerate extent BOTH contiguous spellings live in one \
+             class — that coincidence is the whole defect: {:?}",
+            decoded.present::<Layout>()
+        );
+    }
+}
+
+#[test]
+fn a_degenerate_extent_bias_election_binds_col_and_is_not_refused() {
+    let (cx, x, w, b, _out) = degenerate_linear_with_bias();
+    let data: FxHashMap<NodeIndex, HostBuffer> = [
+        (x, HostBuffer::from(weights(K, 1))),
+        (w, HostBuffer::from(weights(K * N, 2))),
+        (b, HostBuffer::from(weights(N, 3))),
+    ]
+    .into_iter()
+    .collect();
+
+    let mut elected = None;
+    for seed in 0..6u64 {
+        let options = luminal_cuda_lite::CompileOptions {
+            generations: 12,
+            generation_size: 16,
+            mutations: 4,
+            trials: 1,
+            seed,
+            search_log: false,
+            ..Default::default()
+        };
+        let mut rt = CudaRuntime::load(&cx).expect("load");
+        let outcome = match rt.search(&data, &options) {
+            Ok(outcome) => outcome,
+            Err(e) => {
+                // BEFORE THE FIX this is where whisper died: every genome
+                // carrying the bias form was refused at prepare, so the
+                // search itself reported "no candidate genome produced an
+                // executable plan".
+                panic!("DEGENERATE-D seed {seed}: SEARCH DIED: {e:#}");
+            }
+        };
+        let plan = rt.plan().expect("plan");
+        let labels: Vec<String> = plan
+            .dag
+            .node_weights()
+            .filter_map(|n| match n {
+                BufferNode::Compute { op, .. } => {
+                    let l = op.label().to_string();
+                    (l != "BufferAlloc" && l != "BufferFree").then_some(l)
+                }
+                _ => None,
+            })
+            .collect();
+        println!(
+            "DEGENERATE-D seed {seed}: computes={labels:?} refusals=[{}]",
+            outcome.refusal_breakdown.summary()
+        );
+        if labels
+            .iter()
+            .any(|l| l.starts_with("CublasLt") && l.contains("Bias"))
+        {
+            elected.get_or_insert((seed, rt));
+        }
+    }
+    let (seed, rt) = elected.expect(
+        "some seed in 0..6 must elect a cuBLASLt bias form on the degenerate \
+         [1, K] @ [K, N] + b[N] shape (this is the whisper site at pin scale)",
+    );
+    println!("DEGENERATE-D: asserting on the plan elected at seed {seed}");
+
+    let plan = rt.plan().expect("plan");
+    let mut checked = 0usize;
+    for node in plan.dag.node_weights() {
+        let BufferNode::Compute {
+            op, result_info, ..
+        } = node
+        else {
+            continue;
+        };
+        if !(op.label().starts_with("CublasLt") && op.label().contains("Bias")) {
+            continue;
+        }
+        let functional: &CublasLt = match op.as_any().downcast_ref::<CublasLtDps>() {
+            Some(dps) => &dps.op,
+            None => op
+                .as_any()
+                .downcast_ref::<CublasLt>()
+                .expect("a CublasLt*Bias compute node is a CublasLt(Dps) instance"),
+        };
+        let mut call = plan_call(functional).expect("plan_call on the elected bias spec");
+        let dest = &result_info
+            .first()
+            .expect("single-destination contract")
+            .layout;
+        println!(
+            "DEGENERATE-D elected: m={} n={} k={} dest spellings={:?}",
+            call.m,
+            call.n,
+            call.k,
+            dest.present()
+        );
+        assert_eq!(call.n, 1, "the degenerate sibling frame has n == 1");
+        // THE REGRESSION: this call is the one that bailed. It must bind.
+        bind_destination(&mut call, dest, "degenerate-D pin").expect(
+            "the destination class holds the LeftMajor spelling the decorators \
+             require, so the bias form BINDS instead of tripping the fence",
+        );
+        assert_eq!(
+            call.d.order,
+            LtOrder::Col,
+            "the class's LeftMajor spelling is spelled COL — the order the \
+             library accepts for BIAS/RELU_BIAS"
+        );
+        assert_eq!(call.d.ld, call.m, "COL ld = m");
+        assert_eq!(call.c, call.d, "C rides D's frame");
+        checked += 1;
+    }
+    assert!(checked >= 1, "at least one bias node was checked");
+}
+
+// ---------------------------------------------------------------------------
 // LOGICAL NEGATIVE: a bias broadcast along the WRONG axis (per row of the
 // recorder's [4, 3]) is not a per-feature bias; no bias form may mint.
 // ---------------------------------------------------------------------------

--- a/crates/luminal_cuda_lite/tests/cublaslt_contracts.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_contracts.rs
@@ -439,6 +439,125 @@ fn marker_elected_bias_plan_matches_decomposed_route_tolerance_based() {
     assert_close(&want, &got, "marker(bias) vs decomposed 4x8x3 + b[3]");
 }
 
+/// THE DEGENERATE-EXTENT COINCIDENCE ON DEVICE (whisper, A100
+/// 2026-09-04 — NEEDS A100 RUN). whisper tiny.en decodes ONE token, so
+/// its q/v projections are `x[1, 384] @ w[384, 384] + b[384]` and the
+/// sandwich sibling's call frame is `m = 384, n = 1`. At that degenerate
+/// extent the right-major and left-major contiguous index maps over
+/// `[m, n]` are the SAME FUNCTION, so both spellings live in ONE e-class:
+/// the estate's bias decorator matched the LeftMajor spelling while the
+/// decoder (RightMajor first by preference order) handed the executor the
+/// right-major one, `bind_destination` built a ROW D, and the tripwire
+/// refused EVERY candidate genome at prepare —
+///
+///   cuBLASLt CublasLtAccumulateBias: unreachable: the bias decorators
+///   require a LeftMajor D; a bias form
+///   (LayoutTensorOpCublasLtAccumulateBias) reached the executor with a
+///   Row-order D descriptor (384x1 ld 1). [...] refused BEFORE dispatch
+///
+/// — so the search died with "no candidate genome produced an executable
+/// plan". `bind_destination` now spells the coincidence COL on a
+/// bias-bearing call, and this is the DEVICE half: the whisper dims,
+/// searched, executed through the host-call arm with the BIAS epilogue
+/// under a COL `384x1 ld 384` D, against the decomposed route,
+/// tolerance-based.
+///
+/// The CPU halves (the class really holds both spellings; the elected
+/// call binds COL instead of bailing) are in
+/// `tests/cublaslt_bias_premise.rs`, and the descriptor arithmetic is in
+/// `tests/cublaslt_contracts_cpu.rs`.
+#[test]
+fn degenerate_extent_bias_plan_matches_decomposed_route_tolerance_based() {
+    // whisper tiny.en's `state` (examples/whisper/src/model.rs), and its
+    // decode step's single token row.
+    const STATE: usize = 384;
+    let build = || {
+        let mut cx = luminal::graph::Graph::new();
+        let weight = cx.named_tensor("q_proj.weight", (STATE, STATE), DType::F32);
+        let bias = cx.named_tensor("q_proj.bias", STATE, DType::F32);
+        let x = cx.tensor((1usize, STATE), DType::F32);
+        let out = luminal_nn::linear(x, weight, Some(bias)).output();
+        (cx, x.id, weight.id, bias.id, out.id)
+    };
+    let data_for = |x: NodeIndex, w: NodeIndex, b: NodeIndex| -> FxHashMap<NodeIndex, HostBuffer> {
+        [
+            (x, HostBuffer::from(weights(STATE, 1))),
+            (w, HostBuffer::from(weights(STATE * STATE, 2))),
+            (b, HostBuffer::from(weights(STATE, 3))),
+        ]
+        .into_iter()
+        .collect()
+    };
+
+    // Sweep the seeds the CPU pin sweeps: the assertion below needs a
+    // plan that actually carries a bias form, and which seed delivers one
+    // is an election fact, not a contract (see
+    // `tests/cublaslt_bias_premise.rs`, which sweeps 0..6 the same way).
+    let mut fused = None;
+    for seed in 0..6u64 {
+        let options = luminal_cuda_lite::CompileOptions {
+            generations: 12,
+            generation_size: 16,
+            mutations: 4,
+            trials: 1,
+            seed,
+            search_log: false,
+            ..Default::default()
+        };
+        let (cx, x, w, b, out) = build();
+        let mut rt = CudaRuntime::load(&cx).expect("load fused");
+        // BEFORE THE FIX this call is where whisper died: every genome
+        // carrying the bias form was refused at prepare, so the search
+        // reported "no candidate genome produced an executable plan".
+        rt.search(&data_for(x, w, b), &options)
+            .unwrap_or_else(|e| panic!("DEGENERATE-D seed {seed}: fused search: {e:#}"));
+        let elected_bias = rt.plan().expect("plan").dag.node_weights().any(|n| {
+            matches!(n, BufferNode::Compute { op, .. }
+                if op.label().starts_with("CublasLt") && op.label().contains("Bias"))
+        });
+        println!("DEGENERATE-D seed {seed}: bias form elected = {elected_bias}");
+        if elected_bias {
+            fused = Some((seed, rt, x, w, b, out));
+            break;
+        }
+    }
+    let (seed, mut fused, x, w, b, out) = fused.expect(
+        "some seed in 0..6 at the 12x16/mut-4 pin budget must elect a cuBLASLt \
+         bias form on the whisper decode shape (the CPU pin \
+         tests/cublaslt_bias_premise.rs sweeps the same seeds; re-sweep it if \
+         this moves) — without one this test is not exercising the degenerate-D \
+         binding at all",
+    );
+    println!("DEGENERATE-D: executing the plan searched at seed {seed}");
+    fused.set_data(x, weights(STATE, 1));
+    fused.set_data(w, weights(STATE * STATE, 2));
+    fused.set_data(b, weights(STATE, 3));
+    fused
+        .execute()
+        .expect("fused execute (bias epilogue under a degenerate COL D)");
+    let got = walked_dense(&fused, out);
+
+    // THE DECOMPOSED ROUTE ON PURPOSE (the default registry carries the
+    // marker since 2026-09-04, so this side asks for the plain one).
+    let (cx, x, w, b, out) = build();
+    let mut plain =
+        CudaRuntime::load_with_registry(&cx, luminal_cuda_lite::cuda_registry_without_cublaslt())
+            .expect("load plain");
+    plain
+        .search(
+            &data_for(x, w, b),
+            &luminal_cuda_lite::harness_search_options(),
+        )
+        .expect("plain search");
+    plain.set_data(x, weights(STATE, 1));
+    plain.set_data(w, weights(STATE * STATE, 2));
+    plain.set_data(b, weights(STATE, 3));
+    plain.execute().expect("plain execute");
+    let want = walked_dense(&plain, out);
+
+    assert_close(&want, &got, "marker(bias) vs decomposed 1x384x384 + b[384]");
+}
+
 /// Item 4 END TO END: the marker-elected plan (searched with the
 /// marker vocabulary, executed through the host-call arm) against the
 /// decomposed route (`cuda_registry_without_cublaslt`, NVRTC kernels),

--- a/crates/luminal_cuda_lite/tests/cublaslt_contracts_cpu.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_contracts_cpu.rs
@@ -3,6 +3,7 @@
 //! required. The device-gated halves live in `tests/cublaslt_contracts.rs`.
 
 use luminal::dtype::PlanDtype;
+use luminal::egglog_utils::eclass::EgglogConstructor;
 use luminal::layouts::{
     BitWidthTerm, ElementOffsetExpressionLayout, IntExprTerm, LeftMajorContiguousElementLayout,
     RightMajorContiguousElementLayout, ShapeTerm, StridedElementLayout,
@@ -228,12 +229,12 @@ fn bias_epilogue_forms_with_a_row_d_trip_the_unreachable_fence() {
             "{form:?}: the refusal must name the estate premise: {msg}"
         );
         assert!(
-            msg.contains("Row-order D descriptor"),
-            "{form:?}: the refusal must print the order it saw: {msg}"
+            msg.contains("RightMajorContiguousElementLayoutLit"),
+            "{form:?}: the refusal must print what the class DOES hold: {msg}"
         );
         assert!(msg.contains("refused BEFORE dispatch"), "{form:?}: {msg}");
     }
-    // The default forms are untouched by the tripwire: a ROW D binds.
+    // The default forms are untouched by the fence: a ROW D binds.
     for form in [CublasLtForm::Base, CublasLtForm::Accumulate] {
         let mut spec = base_spec(4, 3, 5);
         spec.form = form;
@@ -375,6 +376,28 @@ fn left_major(dims: &[i64]) -> DecodedLayout {
     )
 }
 
+/// THE DEGENERATE-EXTENT CLASS as the e-graph really has it: at
+/// `m == 1` or `n == 1` the two contiguous index maps over `[m, n]` are
+/// the SAME function, so BOTH literals land in one class and the decoded
+/// layout carries both spellings.
+fn both_orders(dims: &[i64]) -> DecodedLayout {
+    DecodedLayout::of_spellings(
+        vec![
+            RightMajorContiguousElementLayout {
+                shape: shape(dims),
+                width: BitWidthTerm(32),
+            }
+            .erase(),
+            LeftMajorContiguousElementLayout {
+                shape: shape(dims),
+                width: BitWidthTerm(32),
+            }
+            .erase(),
+        ],
+        Some(PlanDtype::F32),
+    )
+}
+
 #[test]
 fn dest_frame_binds_a_right_major_election_as_row_order() {
     // The ordinary case: the elected destination is dense row-major over
@@ -463,7 +486,7 @@ fn dest_frame_refuses_layouts_this_backend_cannot_write() {
     let mut call = plan_call_from_spec(&base_spec(4, 3, 5)).expect("plan");
     let err = bind_destination(&mut call, &strided, "pin").expect_err("strided dest");
     let msg = format!("{err:#}");
-    assert!(msg.contains("STRIDED"), "{msg}");
+    assert!(msg.contains("StridedElementLayoutLit"), "{msg}");
     assert!(
         msg.contains("CAPABILITY refusal"),
         "the refusal must classify itself: {msg}"
@@ -480,8 +503,164 @@ fn dest_frame_refuses_layouts_this_backend_cannot_write() {
     let mut call = plan_call_from_spec(&base_spec(4, 3, 5)).expect("plan");
     let err = bind_destination(&mut call, &offset, "pin").expect_err("offset dest");
     assert!(
-        format!("{err:#}").contains("ELEMENT-OFFSET-EXPRESSION"),
+        format!("{err:#}").contains("ElementOffsetExpressionLayoutLit"),
         "{err:#}"
+    );
+}
+
+/// `bias_spec` at an arbitrary frame, with the spec's COL readings kept
+/// CONSISTENT with it (`base_spec`'s convention: lda = m, ldb = k,
+/// ldc = ldd = m) so `validate_against` exercises real geometry.
+fn bias_spec_at(form: CublasLtForm, m: i64, n: i64, k: i64) -> LtMatmulSpec {
+    let mut spec = bias_spec(form);
+    spec.m = CuDim::Literal(m);
+    spec.n = CuDim::Literal(n);
+    spec.k = CuDim::Literal(k);
+    spec.lda = CuDim::Literal(m);
+    spec.ldb = CuDim::Literal(k);
+    spec.ldc = CuDim::Literal(m);
+    spec.ldd = CuDim::Literal(m);
+    spec
+}
+
+/// THE DEGENERATE-EXTENT COINCIDENCE (whisper on the A100, 2026-09-04).
+/// At `n == 1` the right-major and left-major contiguous index maps over
+/// `[m, n]` are the SAME function — `r*n + c` and `c*m + r` both address
+/// `r` when the collapsed axis's coordinate can only be 0 — so the
+/// e-graph puts BOTH spellings in ONE class. A preference-ordered
+/// decoder handed the bridge the right-major spelling of the very class
+/// whose LeftMajor spelling the estate's bias decorator matched, the
+/// fence read that one spelling, and refusing it killed every whisper
+/// genome at device prepare:
+///
+///   a bias form (LayoutTensorOpCublasLtAccumulateBias) reached the
+///   executor with a Row-order D descriptor (384x1 ld 1)
+///
+/// (whisper tiny.en decodes ONE token, so the recorder site is
+/// `x[1, 384] @ w[384, 384] + b[384]` and the sandwich sibling's call
+/// frame is `m = 384`, `n = 1`.) THE FIX IS THE CLASS, NOT THE EXTENT:
+/// `bind_destination` asks the destination class for the LeftMajor
+/// spelling, and a class that carries both answers yes. The destination
+/// below is that class — the two spellings the e-graph really holds —
+/// and there is no degenerate-extent arm anywhere.
+#[test]
+fn degenerate_extent_binds_a_bias_form_col_in_both_orientations() {
+    // n == 1, THE WHISPER SHAPE: the sibling frame is [m, n] = [384, 1].
+    // ROW would be 384x1 ld 1; COL is 384x1 ld 384; both address exactly
+    // the elements 0..384 of the destination, in the same order.
+    for form in [CublasLtForm::Bias, CublasLtForm::AccumulateBias] {
+        let spec = bias_spec_at(form, 384, 1, 384);
+        let mut call = plan_call_from_spec(&spec).expect("plan");
+        assert_eq!(
+            call.d,
+            LtDesc::row(384, 1, 1),
+            "{form:?}: the spec-only default is still ROW (ld = n)"
+        );
+        bind_destination(&mut call, &both_orders(&[384, 1]), "pin").expect(
+            "the destination class holds the LeftMajor spelling the decorators \
+             require, so the bias form binds — no extent test involved",
+        );
+        assert_eq!(call.d, LtDesc::col(384, 1, 384), "{form:?}: COL D, ld = m");
+        assert_eq!(call.c, call.d, "{form:?}: C rides D's frame");
+        // Same 384 elements either way: COL reach = ld*(cols-1) + rows
+        // = 384*0 + 384 = 384, exactly the ROW reach 1*383 + 1.
+        // A holds m*k, B holds k*n, C (fold forms) holds m*n, bias m.
+        let mut elems = vec![384 * 384usize, 384];
+        if form.has_c() {
+            elems.push(384);
+        }
+        elems.push(384);
+        call.validate_against(&elems, 384)
+            .expect("the bound frame fits the 384-element destination");
+    }
+
+    // m == 1, the symmetric degeneracy: [1, 384]. ROW would be
+    // 1x384 ld 384; COL is 1x384 ld 1; same elements again.
+    for form in [CublasLtForm::Bias, CublasLtForm::AccumulateBias] {
+        let spec = bias_spec_at(form, 1, 384, 384);
+        let mut call = plan_call_from_spec(&spec).expect("plan");
+        assert_eq!(call.d, LtDesc::row(1, 384, 384), "the ROW default");
+        bind_destination(&mut call, &both_orders(&[1, 384]), "pin")
+            .expect("the m == 1 coincidence binds too");
+        assert_eq!(
+            call.d,
+            LtDesc::col(1, 384, 1),
+            "{form:?}: COL D, ld = m = 1"
+        );
+        assert_eq!(call.c, call.d);
+        // A holds m*k = 384, B holds k*n, C (fold forms) holds m*n = 384,
+        // bias m = 1.
+        let mut elems = vec![384usize, 384 * 384];
+        if form.has_c() {
+            elems.push(384);
+        }
+        elems.push(1);
+        call.validate_against(&elems, 384)
+            .expect("the bound frame fits the 384-element destination");
+    }
+}
+
+/// THE FENCE IS INTACT, AND IT IS ABOUT THE CLASS, NOT THE EXTENT. Two
+/// destinations, same degenerate `[384, 1]` frame:
+///
+///  * a class holding ONLY the right-major spelling is REFUSED under a
+///    bias form — the decorators' premise is not satisfied, whatever the
+///    extents are;
+///  * a class holding BOTH (the test above) binds COL.
+///
+/// So the fix cannot be widened by accident into "degenerate extents are
+/// special": there is no extent test to widen.
+#[test]
+fn a_right_major_only_d_trips_the_bias_fence_at_any_extent() {
+    for form in [CublasLtForm::Bias, CublasLtForm::AccumulateBias] {
+        for (label, dims, m, n) in [
+            // 384x2: one step off the whisper shape.
+            ("non-degenerate", [384i64, 2], 384i64, 2i64),
+            // THE NEGATIVE THE DESIGN MAKES TRUE: the degenerate frame
+            // itself, but with a class that holds only the right-major
+            // spelling. The fix is the class carrying both, never the
+            // extent.
+            ("degenerate, right-major only", [384, 1], 384, 1),
+        ] {
+            let spec = bias_spec_at(form, m, n, 384);
+            let mut call = plan_call_from_spec(&spec).expect("plan");
+            let err = bind_destination(&mut call, &right_major(&dims), "pin")
+                .expect_err("a D class with no LeftMajor spelling must be refused");
+            let msg = format!("{err:#}");
+            assert!(msg.contains("unreachable"), "{form:?}/{label}: {msg}");
+            assert!(
+                msg.contains("bias decorators require a LeftMajor D"),
+                "{form:?}/{label}: {msg}"
+            );
+            assert!(
+                msg.contains("RightMajorContiguousElementLayoutLit"),
+                "{form:?}/{label}: the refusal names what the class holds: {msg}"
+            );
+            assert!(
+                msg.contains("refused BEFORE dispatch"),
+                "{form:?}/{label}: {msg}"
+            );
+        }
+    }
+    // BIAS-FREE, and now the call site's own preference decides: a class
+    // holding only the right-major spelling stays ROW...
+    let mut call = plan_call_from_spec(&base_spec(384, 1, 384)).expect("plan");
+    bind_destination(&mut call, &right_major(&[384, 1]), "pin").expect("no bias, no fence");
+    assert_eq!(
+        call.d,
+        LtDesc::row(384, 1, 1),
+        "a right-major-only D binds ROW whether or not an extent is 1"
+    );
+    // ...and a class holding BOTH binds COL, because this call site asks
+    // for LeftMajor first. Same elements, same order, same reach — COL
+    // 384x1 ld 384 reaches 0*384 + r, ROW 384x1 ld 1 reaches r*1 + 0
+    // (behaviour change flagged in the design, §8.9).
+    let mut call = plan_call_from_spec(&base_spec(384, 1, 384)).expect("plan");
+    bind_destination(&mut call, &both_orders(&[384, 1]), "pin").expect("no bias, no fence");
+    assert_eq!(
+        call.d,
+        LtDesc::col(384, 1, 384),
+        "both spellings present: this call site prefers LeftMajor -> COL"
     );
 }
 

--- a/crates/luminal_cuda_lite/tests/cublaslt_contracts_cpu.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_contracts_cpu.rs
@@ -5,7 +5,7 @@
 use luminal::dtype::PlanDtype;
 use luminal::layouts::{
     BitWidthTerm, ElementOffsetExpressionLayout, IntExprTerm, LeftMajorContiguousElementLayout,
-    MirrorLayout, RightMajorContiguousElementLayout, ShapeTerm, StridedElementLayout,
+    RightMajorContiguousElementLayout, ShapeTerm, StridedElementLayout,
 };
 use luminal::prelude::egraph_serialize::ClassId;
 use luminal_cuda_lite::layouts::DecodedLayout;
@@ -356,23 +356,23 @@ fn shape(dims: &[i64]) -> ShapeTerm {
 }
 
 fn right_major(dims: &[i64]) -> DecodedLayout {
-    DecodedLayout {
-        mirror: MirrorLayout::RightMajor(RightMajorContiguousElementLayout {
+    DecodedLayout::of(
+        RightMajorContiguousElementLayout {
             shape: shape(dims),
             width: BitWidthTerm(32),
-        }),
-        dtype: Some(PlanDtype::F32),
-    }
+        },
+        Some(PlanDtype::F32),
+    )
 }
 
 fn left_major(dims: &[i64]) -> DecodedLayout {
-    DecodedLayout {
-        mirror: MirrorLayout::LeftMajor(LeftMajorContiguousElementLayout {
+    DecodedLayout::of(
+        LeftMajorContiguousElementLayout {
             shape: shape(dims),
             width: BitWidthTerm(32),
-        }),
-        dtype: Some(PlanDtype::F32),
-    }
+        },
+        Some(PlanDtype::F32),
+    )
 }
 
 #[test]
@@ -449,17 +449,17 @@ fn dest_frame_refuses_layouts_this_backend_cannot_write() {
     // destination refusal: cuBLASLt has exactly two matrix orders,
     // so a strided or offset-expression destination is not writable by
     // this route. Loud, never wrong bytes.
-    let strided = DecodedLayout {
-        mirror: MirrorLayout::Strided(StridedElementLayout {
+    let strided = DecodedLayout::of(
+        StridedElementLayout {
             shape: shape(&[4, 3]),
             chain: vec![
                 IntExprTerm::Coord { axis_from_end: 1 },
                 IntExprTerm::Coord { axis_from_end: 0 },
             ],
             width: BitWidthTerm(32),
-        }),
-        dtype: Some(PlanDtype::F32),
-    };
+        },
+        Some(PlanDtype::F32),
+    );
     let mut call = plan_call_from_spec(&base_spec(4, 3, 5)).expect("plan");
     let err = bind_destination(&mut call, &strided, "pin").expect_err("strided dest");
     let msg = format!("{err:#}");
@@ -469,14 +469,14 @@ fn dest_frame_refuses_layouts_this_backend_cannot_write() {
         "the refusal must classify itself: {msg}"
     );
 
-    let offset = DecodedLayout {
-        mirror: MirrorLayout::ElementOffset(ElementOffsetExpressionLayout {
+    let offset = DecodedLayout::of(
+        ElementOffsetExpressionLayout {
             offset: IntExprTerm::Coord { axis_from_end: 0 },
             shape: shape(&[4, 3]),
             width: BitWidthTerm(32),
-        }),
-        dtype: Some(PlanDtype::F32),
-    };
+        },
+        Some(PlanDtype::F32),
+    );
     let mut call = plan_call_from_spec(&base_spec(4, 3, 5)).expect("plan");
     let err = bind_destination(&mut call, &offset, "pin").expect_err("offset dest");
     assert!(
@@ -487,13 +487,13 @@ fn dest_frame_refuses_layouts_this_backend_cannot_write() {
 
 #[test]
 fn dest_frame_refuses_symbolic_extents() {
-    let symbolic = DecodedLayout {
-        mirror: MirrorLayout::RightMajor(RightMajorContiguousElementLayout {
+    let symbolic = DecodedLayout::of(
+        RightMajorContiguousElementLayout {
             shape: ShapeTerm(vec![IntExprTerm::Var("s".into()), IntExprTerm::Lit(3)]),
             width: BitWidthTerm(32),
-        }),
-        dtype: Some(PlanDtype::F32),
-    };
+        },
+        Some(PlanDtype::F32),
+    );
     let mut call = plan_call_from_spec(&base_spec(4, 3, 5)).expect("plan");
     let err = bind_destination(&mut call, &symbolic, "pin").expect_err("symbolic dest");
     assert!(format!("{err:#}").contains("SYMBOLIC"), "{err:#}");

--- a/crates/luminal_cuda_lite/tests/plan_smoke.rs
+++ b/crates/luminal_cuda_lite/tests/plan_smoke.rs
@@ -75,16 +75,16 @@ fn codegen_emits_wellformed_sources() {
     // Add over (2,3) f32 and eyeball the load-bearing pieces.
     use luminal::dtype::PlanDtype;
     use luminal::layouts::{
-        BitWidthTerm, IntExprTerm, MirrorLayout, RightMajorContiguousElementLayout, ShapeTerm,
+        BitWidthTerm, IntExprTerm, RightMajorContiguousElementLayout, ShapeTerm,
     };
     fn rm_layout(dims: &[i64]) -> luminal_cuda_lite::layouts::DecodedLayout {
-        luminal_cuda_lite::layouts::DecodedLayout {
-            mirror: MirrorLayout::RightMajor(RightMajorContiguousElementLayout {
+        luminal_cuda_lite::layouts::DecodedLayout::of(
+            RightMajorContiguousElementLayout {
                 shape: ShapeTerm(dims.iter().map(|&d| IntExprTerm::Lit(d)).collect()),
                 width: BitWidthTerm(32),
-            }),
-            dtype: Some(PlanDtype::F32),
-        }
+            },
+            Some(PlanDtype::F32),
+        )
     }
     let ctx = kernels::CodegenCtx {
         operand_dims: vec![vec![2, 3], vec![2, 3], vec![2, 3]],

--- a/crates/luminal_cuda_lite/tests/registry_selection.rs
+++ b/crates/luminal_cuda_lite/tests/registry_selection.rs
@@ -273,3 +273,31 @@ fn a_non_base_cublaslt_row_without_base_is_refused_at_load() {
     ));
     CudaRuntime::load_with_registry(&cx, base_only).expect("Base alone loads");
 }
+
+/// THE ASSEMBLY TRIPWIRE, over the CUDA-lite registry's own assembled
+/// program: every constructor of a decoded sort that the marker estate's
+/// snippets add to core's preamble has exactly one registered decoder,
+/// and every registered decoder names a constructor the program really
+/// declares under that sort.
+///
+/// The estate declares no `Layout` constructor today (its datatypes are
+/// `CublasLt*` and its four `LayoutTensorOp*` rows), so the check passes
+/// on core's five. The point of the pin is that it is CHECKED, not
+/// assumed: the day a matcher declares one, `OpMatcher::decoders` must
+/// carry the struct that reads it back or this fails by name.
+#[test]
+fn the_cuda_registry_declares_no_constructor_it_cannot_decode() {
+    let (cx, _a, _b) = add_graph();
+    let rt = CudaRuntime::load(&cx).expect("load with the default registry");
+    // `saturated_egraph` runs the tripwire internally; this asserts on
+    // the registry directly too, so the failure names the constructor.
+    rt.saturated_egraph()
+        .expect("the assembled program saturates and every constructor decodes");
+    let decoders = rt.decoders();
+    assert!(
+        decoders
+            .constructors_of("Layout")
+            .any(|name| name == "LeftMajorContiguousElementLayoutLit"),
+        "the Layout sort is decoded by this registry"
+    );
+}

--- a/crates/luminal_cuda_lite/tests/view_admission.rs
+++ b/crates/luminal_cuda_lite/tests/view_admission.rs
@@ -130,7 +130,6 @@ fn audit(
                 for (slot, info) in operand_info.iter().enumerate() {
                     let dims = info
                         .layout
-                        .mirror
                         .literal_extents()
                         .expect("elected slot layouts are literal in these fixtures");
                     // Ask the PRODUCTION read path what it emits: a read
@@ -151,7 +150,6 @@ fn audit(
                 for info in result_info {
                     let dims = info
                         .layout
-                        .mirror
                         .literal_extents()
                         .expect("elected slot layouts are literal in these fixtures");
                     // THE WRITE-CAPABILITY CONSTRAINT'S REGRESSION
@@ -185,27 +183,6 @@ fn audit(
     (computes, copies, plan.buffers.len(), composed)
 }
 
-/// Evaluate a mirror term at concrete coordinates (front-indexed;
-/// `Coord{axis_from_end}` reads `coords[rank-1-axis_from_end]`). The
-/// fixtures' layouts use only the affine subset.
-fn eval_term(expr: &luminal::layouts::IntExprTerm, coords: &[usize]) -> i64 {
-    use luminal::layouts::IntExprTerm as T;
-    let rank = coords.len();
-    match expr {
-        T::Lit(v) => *v,
-        T::Coord { axis_from_end } => {
-            let axis = usize::try_from(*axis_from_end).expect("non-negative axis");
-            assert!(axis < rank, "coordinate axis {axis} out of rank {rank}");
-            coords[rank - 1 - axis] as i64
-        }
-        T::Add(a, b) => eval_term(a, coords) + eval_term(b, coords),
-        T::Mul(a, b) => eval_term(a, coords) * eval_term(b, coords),
-        T::TruncDiv(a, b) => eval_term(a, coords) / eval_term(b, coords),
-        T::TruncRem(a, b) => eval_term(a, coords) % eval_term(b, coords),
-        other => panic!("fixture layouts use no {other:?}"),
-    }
-}
-
 /// THE READ PATH, evaluated: the slot's own carried layout at one
 /// out-coordinate, down to the FLAT ELEMENT INDEX into the residence's
 /// bytes. This replaces the hop-chain walk — there are no intermediate
@@ -214,40 +191,9 @@ fn eval_term(expr: &luminal::layouts::IntExprTerm, coords: &[usize]) -> i64 {
 /// gone, the only bounds fence is the final index against the layout's
 /// span where the constructor discloses one.)
 fn flat_index(layout: &luminal::layouts::DecodedLayout, out_coord: &[usize]) -> i64 {
-    use luminal::layouts::MirrorLayout as M;
-    let flat = match &layout.mirror {
-        M::RightMajor(rm) => {
-            let extents = rm.shape.0.iter().map(|e| eval_term(e, &[]) as usize);
-            out_coord
-                .iter()
-                .zip(extents)
-                .fold(0usize, |acc, (&c, d)| acc * d + c) as i64
-        }
-        M::LeftMajor(lm) => {
-            let extents: Vec<usize> = lm
-                .shape
-                .0
-                .iter()
-                .map(|e| eval_term(e, &[]) as usize)
-                .collect();
-            let mut stride = 1usize;
-            let mut acc = 0usize;
-            for (&c, &d) in out_coord.iter().zip(&extents) {
-                acc += c * stride;
-                stride *= d;
-            }
-            acc as i64
-        }
-        M::Strided(st) => st.chain.iter().map(|s| eval_term(s, out_coord)).sum(),
-        M::ElementOffset(eo) => eval_term(&eo.offset, out_coord),
-        M::BitOffset(bo) => {
-            let bits = eval_term(&bo.offset, out_coord);
-            assert_eq!(bits % bo.width.0, 0, "bit offset is element-aligned");
-            bits / bo.width.0
-        }
-    };
-    assert!(flat >= 0, "negative element index {flat}");
-    flat
+    layout
+        .element_index(out_coord)
+        .expect("the elected layout reads at this coordinate") as i64
 }
 
 /// TRANSPOSE CONSUMER: x(2,3) permuted then multiplied. The searched
@@ -280,7 +226,7 @@ fn transpose_consumer_folds_and_carries_the_swap_map() {
     assert_eq!(label, "MulFunctionalGeneric");
     // The layout's DOMAIN is the view's shape (3,2) — the value's own
     // extents, which is exactly why no `dims` field is needed.
-    assert_eq!(layout.mirror.literal_extents(), Some(vec![3, 2]));
+    assert_eq!(layout.literal_extents(), Some(vec![3, 2]));
     for i in 0..3usize {
         for j in 0..2usize {
             // Parent x is (2,3) row-major; the transpose's (i,j) is
@@ -320,7 +266,7 @@ fn slice_consumer_folds_and_carries_the_offset_map() {
         plan.summary()
     );
     let (_, _, layout) = &composed[0];
-    assert_eq!(layout.mirror.literal_extents(), Some(vec![2, 6]));
+    assert_eq!(layout.literal_extents(), Some(vec![2, 6]));
     for i in 0..2usize {
         for j in 0..6usize {
             // Parent x is (4,6) row-major; rows 1..3, so out (i,j) is
@@ -361,7 +307,7 @@ fn broadcast_consumer_folds_and_carries_the_stride0_map() {
         plan.summary()
     );
     let (_, _, layout) = &composed[0];
-    assert_eq!(layout.mirror.literal_extents(), Some(vec![2, 3]));
+    assert_eq!(layout.literal_extents(), Some(vec![2, 3]));
     for i in 0..2usize {
         for j in 0..3usize {
             // Parent x is (3,) — the broadcast axis is stride-0, so every

--- a/crates/luminal_reference/src/harness.rs
+++ b/crates/luminal_reference/src/harness.rs
@@ -209,8 +209,10 @@ pub fn plain_plan_exists(cx: &luminal::graph::Graph) -> anyhow::Result<()> {
     let start = std::time::Instant::now();
     // VALUE-keyed table: decode over the POST-DPS graph bufferize sees.
     let dps = luminal::dps::dps_rewrite(&extracted);
+    let view =
+        luminal::egglog_utils::eclass::EGraphView::new(&serialized, crate::decoder_registry());
     let layouts = luminal::layouts::decode_layout_table(
-        &serialized,
+        &view,
         &dps,
         "plain plan",
         &mut luminal::layouts::LayoutDecodeCache::new(),

--- a/crates/luminal_reference/src/layouts.rs
+++ b/crates/luminal_reference/src/layouts.rs
@@ -8,8 +8,9 @@
 //!
 //! Core's bufferizer stays generic over an opaque layout type it only
 //! clones and transports; THIS runtime instantiates it with core's
-//! [`luminal::layouts::DecodedLayout`] — the shared mirror vocabulary
-//! plus the value's `dtype-of` fact. The dtype is what makes plans
+//! [`luminal::layouts::DecodedLayout`] — the elected class's decoded
+//! spellings plus the value's `dtype-of` fact. The dtype is what makes
+//! plans
 //! self-contained for `load_plan` callers: staging, allocation, and
 //! readback all read the carried layout instead of a table an external
 //! caller never had.

--- a/crates/luminal_reference/src/lib.rs
+++ b/crates/luminal_reference/src/lib.rs
@@ -45,3 +45,16 @@ pub fn assembled_program() -> &'static str {
     PROGRAM
         .get_or_init(|| luminal::egglog_snippet::assembled_program_for(&ops::built_in_matchers()))
 }
+
+/// The reference registry's CONSTRUCTOR DECODERS (core's built-ins plus
+/// this crate's matcher contributions), memoized — what every reference
+/// [`luminal::egglog_utils::eclass::EGraphView`] is built with, and what
+/// the assembly tripwire checks the saturated program against.
+pub fn decoder_registry() -> &'static luminal::egglog_utils::eclass::ConstructorRegistry {
+    use std::sync::OnceLock;
+    static REGISTRY: OnceLock<luminal::egglog_utils::eclass::ConstructorRegistry> = OnceLock::new();
+    REGISTRY.get_or_init(|| {
+        luminal::egglog_snippet::decoder_registry_for(&ops::built_in_matchers())
+            .expect("the built-in reference registry has no duplicate decoders")
+    })
+}

--- a/crates/luminal_reference/src/runtime.rs
+++ b/crates/luminal_reference/src/runtime.rs
@@ -1685,8 +1685,10 @@ mod tests {
         .expect("extracts")
         .expect("plan");
         let dps = luminal::dps::dps_rewrite(&extracted);
+        let view =
+            luminal::egglog_utils::eclass::EGraphView::new(&serialized, crate::decoder_registry());
         let layouts = luminal::layouts::decode_layout_table(
-            &serialized,
+            &view,
             &dps,
             "test",
             &mut luminal::layouts::LayoutDecodeCache::new(),

--- a/crates/luminal_reference/src/runtime.rs
+++ b/crates/luminal_reference/src/runtime.rs
@@ -550,18 +550,14 @@ impl ReferenceRuntime {
         // variant is a loud refusal, never a conversion.
         let mut storage: FxHashMap<BufferId, TypedBuffer> = FxHashMap::default();
         for (id, buffer) in &plan.buffers {
-            let numel = buffer
-                .layout
-                .mirror
-                .literal_span_elements()
-                .ok_or_else(|| {
-                    anyhow!(
-                        "buffer {} (backing {}) has no literal span — symbolic \
+            let numel = buffer.layout.literal_span_elements().ok_or_else(|| {
+                anyhow!(
+                    "buffer {} (backing {}) has no literal span — symbolic \
                      or undisclosed-reach layouts are not executable",
-                        buffer.label,
-                        buffer.backs
-                    )
-                })?;
+                    buffer.label,
+                    buffer.backs
+                )
+            })?;
             let dtype = buffer.layout.dtype.ok_or_else(|| {
                 anyhow!(
                     "buffer {} (backing {}) carries no dtype fact — cannot \
@@ -777,7 +773,7 @@ impl ReferenceRuntime {
                                 plan.buffers[id].label,
                             );
                         }
-                        let dims = slot.layout.mirror.literal_extents().ok_or_else(|| {
+                        let dims = slot.layout.literal_extents().ok_or_else(|| {
                             anyhow!("{} operand {k} has symbolic extents", op.label())
                         })?;
                         operand_dims.push(dims);

--- a/crates/luminal_reference/src/runtime.rs
+++ b/crates/luminal_reference/src/runtime.rs
@@ -360,6 +360,10 @@ impl ReferenceRuntime {
             }
             return Err(anyhow!("native saturation failed: {err}"));
         }
+        // THE ASSEMBLY TRIPWIRE: every constructor of a decoded sort in
+        // this program has exactly one decoder, checked against the LIVE
+        // schema before anything reads a serialized class.
+        crate::decoder_registry().check(&egraph)?;
         let saturation_nanos = saturation_start.elapsed().as_nanos();
         let serialize_start = std::time::Instant::now();
         let serialized = egraph

--- a/crates/luminal_reference/src/search.rs
+++ b/crates/luminal_reference/src/search.rs
@@ -541,6 +541,7 @@ pub fn bucketed_search_implementations(
         egraph
             .parse_and_run_program(None, &text)
             .map_err(|err| anyhow!("bucket {ranges:?} representative render fails: {err}"))?;
+        crate::decoder_registry().check(&egraph)?;
         let serialized = egraph
             .serialize(luminal::prelude::egglog::SerializeConfig::default())
             .egraph;

--- a/crates/luminal_reference/src/search.rs
+++ b/crates/luminal_reference/src/search.rs
@@ -240,13 +240,18 @@ pub fn search_implementations_with_ops(
 
     // fingerprint → measured nanos (the dedup cache).
     let mut cache: FxHashMap<u64, u128> = FxHashMap::default();
+    // THE VIEW the layout decoders read through: this e-graph plus the
+    // reference registry's `(sort, constructor)` decoders. Built once —
+    // the view indexes classes through the serialized graph's own
+    // `classes()` cache, so every later class lookup is a map hit.
+    let view = luminal::egglog_utils::eclass::EGraphView::new(egraph, crate::decoder_registry());
     // THE DECODED-LAYOUT CACHE, one per search and CALLER-OWNED
     // (`decode_layout_table` takes it by `&mut`). Decoding is a pure
-    // function of `(layout class, dtype)`, and every decode builds a
-    // fresh `Reader` over the whole serialized e-graph — so a cache that
-    // did not span candidates would pay that index once per distinct
-    // layout class per candidate. `egraph` is fixed for this loop, which
-    // is what makes the `ClassId` keys comparable across candidates.
+    // function of `(layout class, dtype)`, and the table is VALUE-keyed
+    // per candidate — so a cache that did not span candidates would
+    // re-decode every distinct layout class once per candidate.
+    // `egraph` is fixed for this loop, which is what makes the
+    // `ClassId` keys comparable across candidates.
     let mut layout_cache = luminal::layouts::LayoutDecodeCache::new();
     let mut plans_profiled = 0usize;
     let mut fingerprint_hits = 0usize;
@@ -354,7 +359,7 @@ pub fn search_implementations_with_ops(
                     // HIT: value-keying costs no extra decoder calls.
                     let dps = luminal::dps::dps_rewrite(&graph);
                     let built = luminal::layouts::decode_layout_table(
-                        egraph,
+                        &view,
                         &dps,
                         "implementation search",
                         &mut layout_cache,
@@ -425,7 +430,7 @@ pub fn search_implementations_with_ops(
                 let build_start = Instant::now();
                 let dps = luminal::dps::dps_rewrite(&graph);
                 let built = luminal::layouts::decode_layout_table(
-                    egraph,
+                    &view,
                     &dps,
                     "implementation search",
                     &mut layout_cache,

--- a/docs/design/eclass-decoder.md
+++ b/docs/design/eclass-decoder.md
@@ -1,0 +1,1126 @@
+# EClass decoding: an open, per-constructor API replacing the preference-ordered layout decoder
+
+Status: design approved by Austin 2026-09-05 (shape and names). This document is
+the refactor map and spec. It is written to be executed by an implementer without
+further design judgment; everything marked DECISION was decided here and the
+justification is beside it. Everything marked VERIFIED cites a file:line that was
+read on trunk `logical-ssa-project` at 1f101d62 (the mapped source files are
+byte-identical to c0ee79cd; only Cargo/vendor changed in between). Code blocks
+marked ILLUSTRATION show the intended shape; the implementer fills in the
+mechanics.
+
+Branch: `feat/eclass-decoder` (this worktree). Standalone PR into
+`logical-ssa-project`.
+
+---
+
+## 1. Summary, and the bug this fixes
+
+**Summary.** Core's `luminal::layouts::decode_layout` walks one `Layout` e-class of
+the serialized e-graph and returns *one* spelling as a `MirrorLayout` enum, chosen
+by a FIXED preference order baked into the decoder (RightMajor > LeftMajor >
+Strided > ElementOffset > BitOffset; VERIFIED `src/layouts.rs:427-535`). That
+decoder is replaced by a small, open API over the serialized e-graph —
+`EGraphView` / `EClass` / `ENode` — where every egglog constructor has a Rust
+struct implementing `EgglogConstructor` (decode one e-node of that constructor),
+and a caller asks a class for exactly the constructor(s) it cares about:
+`first::<C>()`, `has::<C>()`, `require::<C>(who)`, or, for generic code that needs
+a fact about a layout it did not author, the erased `spellings::<Layout>()` whose
+items expose `LayoutFacts` (shape, width, span, evaluation). Preferences move to
+the call sites, where they belong (Austin: "having a decoder that makes choices
+about which constructor to look for is too general to be useful. Each call site
+will have some preferences that need to be expressed somehow"). Decoders are
+registered per `(sort, constructor)` beside the egg snippet that declares the
+constructor, and a tripwire at assembly proves every constructor of a decoded sort
+has exactly one decoder. `MirrorLayout`, the preference list, and the legacy
+`decode_layout` are deleted.
+
+**The bug.** Whisper tiny.en decodes one token, so its projections are
+`x[1,384] @ w[384,384] + b[384]`; the cuBLASLt transpose-sandwich sibling's
+destination frame is `[m,n] = [384,1]`. At an extent-1 axis the right-major and
+left-major contiguous index maps are the same function (`r*1 + c` and `c*384 + r`
+with `c ≡ 0`), and the e-graph knows it: the `[n,n]` pin collapse welds the
+extent-1 `CoordVar` to `(IntLit 0)`, both stride tuples zip to the same affine
+chain class, and the two contiguous-discovery rules
+(VERIFIED `src/egglog_core/egglog_preamble.egg:3530-3560`, the `(3a)` arms that
+`union ?layout (RightMajorContiguousElementLayoutLit …)` and
+`… (LeftMajorContiguousElementLayoutLit …)`) put BOTH literals into ONE class. The
+estate's bias decorators mint a bias form only on the LeftMajor spelling
+(VERIFIED `crates/luminal_cuda_lite/src/ops/cublaslt/egg/cublaslt_marker_decorate.egg:182`,
+premise `(= ?inner_L (LeftMajorContiguousElementLayoutLit ?ishape ?d_bits2))`);
+the decoder, asked for "the" layout of that class, returned RightMajor by
+preference (`src/layouts.rs:432-444`); `bind_destination` built a ROW descriptor
+(`crates/luminal_cuda_lite/src/ops/cublaslt/exec.rs:344-346`); the coherence
+fence `assert_bias_destination_order` (`exec.rs:380-397`) refused every candidate
+genome, and the search died with "no candidate genome produced an executable
+plan". PR #507 (open, branch `fix/cublaslt-degenerate-d-order`, commit c3b4c428)
+added a guarded arm `M::RightMajor(_) if bias && (m == 1 || n == 1) => COL` to
+`bind_destination`. This design subsumes that arm: the binding asks the class
+`require::<LeftMajorContiguousElementLayout>()` and the class answers yes, because
+the spelling is there. No arm, no degenerate-extent special case.
+
+---
+
+## 2. The API, final
+
+### 2.1 Where things live (crate ownership)
+
+| Item | File | Crate |
+|---|---|---|
+| `EGraphView`, `EClass`, `ENode`, `Sort`, `DynFacts`, `EgglogConstructor`, `ConstructorDecoder`, `ConstructorRegistry`, `Spellings` | NEW `src/egglog_core/egglog_utils/eclass.rs`, declared `pub mod eclass;` in `src/egglog_core/egglog_utils/mod.rs` (reachable as `luminal::egglog_utils::eclass::*`; `egglog_utils` is `#[path]`-mounted at `src/lib.rs:7-8`, VERIFIED) | core |
+| `Layout` sort marker, `LayoutFacts`, the five constructor structs with their `EgglogConstructor` + `LayoutFacts` impls, the term decoders (`shape_term`, `bit_width`, `affine_chain`, `int_expr`), `layout_decoders()`, `DecodedLayout`, `LayoutDecodeCache`, `decode_layout_table` | `src/layouts.rs` | core |
+| `core_decoders()`, `decoder_registry_for(matchers)` (mirrors `assembled_program_for`) | `src/egglog_snippet.rs` | core |
+| `OpMatcher::decoders()` default method | `src/layout_ir/mod.rs` (trait at :518-547, VERIFIED) | core |
+| `RegisteredOp::decoders()` delegating to its matcher | `crates/luminal_cuda_lite/src/ops/mod.rs` (struct at :74-77) | CUDA-lite |
+| `luminal_reference::decoder_registry()` (`OnceLock`, like `assembled_program()` at `crates/luminal_reference/src/lib.rs:42-47`) | `crates/luminal_reference/src/lib.rs` | reference |
+| CUDA-lite-declared constructors of decoded sorts | none today (VERIFIED: `cublaslt_marker_constructors.egg` declares datatypes `CublasLt*` and four `LayoutTensorOp*` constructors, no `Layout` constructor; no other CL op egg declares a constructor) — the plumbing exists for when one appears | CUDA-lite |
+
+Doctrine kept throughout: no closed enum over constructors anywhere; diagnostics
+print constructor NAMES; refusals are `Result` in the search path and `expect`
+only after validation; tests locate by structure, never by class id; delete what
+is superseded.
+
+### 2.2 `eclass.rs` — the generic surface
+
+Facts this rests on (VERIFIED in `egraph-serialize-0.3.0/src/lib.rs`): `EGraph {
+nodes: IndexMap<NodeId, Node>, class_data: IndexMap<ClassId, ClassData>, .. }`
+(:65-74); `Node { op: String, children: Vec<NodeId>, eclass: ClassId, cost,
+subsumed: bool }` (:168-177); `ClassData { typ: Option<String>, extra }`
+(:197-203); `EGraph::classes(&self) -> &IndexMap<ClassId, Class { id, nodes:
+Vec<NodeId> }>` built once over ALL nodes (subsumed included) behind a `OnceCell`
+(:107-120); `ClassId(Arc<str>)` with `From<&str>` (used as
+`ClassId::from("val$synthetic")` in CL tests). Egglog's serializer (fork rev
+1bb30831, identical lines to c2c0f151): a constructor/function row becomes a node
+whose `op` is the function name (`src/serialize.rs:218`), whose `eclass` is the
+OUTPUT value's class, and whose `children[i]` is a node inside argument i's class
+(:204-215); every class touched gets `class_data[..].typ = Some(sort.name())`
+(:393); primitives are rendered with `{:?}` of the base value (:353-362), so i64
+literals are digit strings and strings are quoted — exactly what the old Reader
+parsed (`src/layouts.rs:395-418`).
+
+```rust
+// src/egglog_core/egglog_utils/eclass.rs                                — SPEC
+use std::any::Any;
+use std::sync::Arc;
+use anyhow::Result;
+use egraph_serialize::{ClassId, EGraph, Node, NodeId};
+
+/// Read-only view of one serialized e-graph plus the decoders that know its
+/// constructors. Two references; `Copy`.
+#[derive(Clone, Copy)]
+pub struct EGraphView<'g> { egraph: &'g EGraph, decoders: &'g ConstructorRegistry }
+impl<'g> EGraphView<'g> {
+    pub fn new(egraph: &'g EGraph, decoders: &'g ConstructorRegistry) -> Self;
+    /// Total: an id with no nodes yields a class whose `nodes()` is empty.
+    pub fn class(&self, id: &ClassId) -> EClass<'g>;
+    pub fn egraph(&self) -> &'g EGraph;
+    pub fn decoders(&self) -> &'g ConstructorRegistry;
+}
+
+/// One e-class of the view. Cheap to clone (the id is an `Arc<str>`).
+#[derive(Clone)]
+pub struct EClass<'g> { view: EGraphView<'g>, id: ClassId }
+impl<'g> EClass<'g> {
+    pub fn id(&self) -> &ClassId;
+    /// `class_data[id].typ` — the egglog sort name the serializer stamped.
+    pub fn sort_name(&self) -> Option<&'g str>;
+    /// Every e-node in the class: UNSUBSUMED FIRST, then by `NodeId` (the
+    /// order the old Reader used, `src/layouts.rs:359-364,388-398`).
+    pub fn nodes(&self) -> Vec<ENode<'g>>;
+    pub fn nodes_named(&self, op: &str) -> impl Iterator<Item = ENode<'g>> + '_;
+    /// Every distinct `op` in the class, in `nodes()` order (diagnostics).
+    pub fn ops(&self) -> Vec<String>;
+    /// Any node whose op parses as i64 / as a quoted string.
+    pub fn i64_literal(&self) -> Option<i64>;
+    pub fn string_literal(&self) -> Option<String>;
+
+    // ---- typed, registry-free: the call site names the constructor ----
+    /// Every node named `C::NAME` that decodes, in `nodes()` order.
+    pub fn all<C: EgglogConstructor>(&self) -> Vec<C>;
+    pub fn first<C: EgglogConstructor>(&self) -> Option<C>;
+    /// `first::<C>().is_some()` — a DECODABLE spelling is present.
+    pub fn has<C: EgglogConstructor>(&self) -> bool;
+    /// `first::<C>()` or a refusal naming who asked, the class, its sort,
+    /// `C::NAME`, and `present::<C::Sort>()`.
+    pub fn require<C: EgglogConstructor>(&self, who: &str) -> Result<C>;
+    /// Panics with `why` — only after validation.
+    pub fn expect<C: EgglogConstructor>(&self, why: &str) -> C;
+
+    // ---- erased, registry-driven: generic code over a sort ----
+    /// Registered constructor names of sort `S` that appear in the class
+    /// (≥1 node, decodable or not), in REGISTRY order.
+    pub fn present<S: Sort>(&self) -> Vec<&'static str>;
+    /// Every registered constructor of `S` present in the class, decoded.
+    pub fn spellings<S: Sort>(&self) -> Spellings<S>;
+    /// `spellings::<S>()` items, for the common "I just need a fact" shape.
+    pub fn facts<S: Sort>(&self) -> impl Iterator<Item = Arc<S::Facts>>;
+    /// Ops in the class with no decoder registered under sort `S` —
+    /// see §8.3 for what this contains and why it is diagnostics-only.
+    pub fn unknown<S: Sort>(&self) -> Vec<String>;
+}
+
+/// One e-node: op name + children as classes.
+#[derive(Clone, Copy)]
+pub struct ENode<'g> { view: EGraphView<'g>, id: &'g NodeId, node: &'g Node }
+impl<'g> ENode<'g> {
+    pub fn id(&self) -> &'g NodeId;
+    pub fn op(&self) -> &'g str;
+    pub fn class(&self) -> EClass<'g>;
+    pub fn is_subsumed(&self) -> bool;
+    pub fn arity(&self) -> usize;
+    /// `children[i]` → that node's `eclass` (serialize.rs:204-215 contract).
+    pub fn child(&self, index: usize) -> Option<EClass<'g>>;
+    pub fn children(&self) -> Vec<EClass<'g>>;
+}
+
+/// A decoded sort: its egglog name and the erased fact surface its
+/// constructors share (e.g. `Layout: Sort<Facts = dyn LayoutFacts>`).
+pub trait Sort: 'static {
+    const NAME: &'static str;
+    type Facts: ?Sized + DynFacts;
+}
+
+/// The sort-agnostic erased surface every decoded constructor exposes.
+/// Blanket-implemented for every `EgglogConstructor` that is
+/// `PartialEq + Debug + Send + Sync`, so constructor structs write NO
+/// boilerplate for it.
+pub trait DynFacts: Any + std::fmt::Debug + Send + Sync {
+    fn constructor(&self) -> &'static str;
+    fn as_any(&self) -> &dyn Any;
+    fn dyn_eq(&self, other: &dyn Any) -> bool;
+}
+impl<T: EgglogConstructor + PartialEq + std::fmt::Debug + Send + Sync> DynFacts for T {
+    fn constructor(&self) -> &'static str { T::NAME }
+    fn as_any(&self) -> &dyn Any { self }
+    fn dyn_eq(&self, other: &dyn Any) -> bool { other.downcast_ref::<T>() == Some(self) }
+}
+
+/// One egglog constructor mirrored as a Rust struct.
+pub trait EgglogConstructor: Sized + 'static {
+    const NAME: &'static str;
+    type Sort: Sort;
+    /// Decode ONE e-node of this constructor. `node.op() == Self::NAME` is
+    /// guaranteed by the callers; children are read by index. Failure =
+    /// this spelling does not parse (e.g. a foreign-shape coordinate under
+    /// the owner-shape guard) — the caller moves on to the next node.
+    fn decode(node: &ENode<'_>) -> Result<Self>;
+    /// Erase into the sort's shared fact object. One line per struct:
+    /// `Arc::new(self)` (the unsizing coercion is only expressible where
+    /// the concrete type is known — see §8.2).
+    fn erase(self) -> Arc<<Self::Sort as Sort>::Facts>;
+}
+
+/// A registered `(sort, constructor)` decoder. `decode` yields a
+/// `Box<dyn Any>` that HOLDS an `Arc<<S as Sort>::Facts>` — the
+/// convention `Spellings` downcasts back through.
+pub struct ConstructorDecoder {
+    pub sort: &'static str,
+    pub name: &'static str,
+    pub decode: fn(&ENode<'_>) -> Result<Box<dyn Any>>,
+}
+impl ConstructorDecoder {
+    pub fn of<C: EgglogConstructor>() -> Self {
+        Self {
+            sort: <C::Sort as Sort>::NAME,
+            name: C::NAME,
+            decode: |node| C::decode(node).map(|c| Box::new(c.erase()) as Box<dyn Any>),
+        }
+    }
+}
+
+/// Decoders keyed by `(sort, constructor)`, in insertion order (core
+/// built-ins first, then matcher contributions in registry order).
+pub struct ConstructorRegistry { entries: Vec<ConstructorDecoder> /* + index */ }
+impl ConstructorRegistry {
+    /// Refuses a duplicate `(sort, name)`: "exactly one decoder" is the
+    /// contract, and a duplicate is a registration bug, not a preference.
+    pub fn new(decoders: impl IntoIterator<Item = ConstructorDecoder>) -> Result<Self>;
+    pub fn get(&self, sort: &str, name: &str) -> Option<&ConstructorDecoder>;
+    pub fn sorts(&self) -> impl Iterator<Item = &'static str>;
+    pub fn constructors_of(&self, sort: &str) -> impl Iterator<Item = &'static str>;
+    /// THE TRIPWIRE — §3.3.
+    pub fn check(&self, egraph: &egglog::EGraph) -> Result<()>;
+}
+
+/// The decoded constructor instances of sort `S` found in one class.
+pub struct Spellings<S: Sort> {
+    decoded: Vec<Arc<S::Facts>>,            // registry order, then node order
+    present: Vec<&'static str>,             // names with ≥1 node in the class
+    failed: Vec<(&'static str, String)>,    // (name, reason) per undecodable node
+}
+impl<S: Sort> Spellings<S> {
+    pub fn first<C: EgglogConstructor<Sort = S>>(&self) -> Option<&C>;   // as_any().downcast_ref
+    pub fn all<C: EgglogConstructor<Sort = S>>(&self) -> Vec<&C>;
+    pub fn has<C: EgglogConstructor<Sort = S>>(&self) -> bool;
+    pub fn require<C: EgglogConstructor<Sort = S>>(&self, who: &str) -> Result<&C>;
+    pub fn present(&self) -> &[&'static str];
+    pub fn failed(&self) -> &[(&'static str, String)];
+    pub fn iter(&self) -> impl Iterator<Item = &S::Facts>;
+    pub fn any(&self) -> Option<&S::Facts>;   // first decoded, registry order
+    pub fn is_empty(&self) -> bool;
+}
+impl<S: Sort> Clone for Spellings<S> {}                 // Arc clones; hand-written (no S: Clone)
+impl<S: Sort> PartialEq for Spellings<S> {}             // same length, pairwise `dyn_eq`
+impl<S: Sort> Eq for Spellings<S> {}
+impl<S: Sort> std::fmt::Debug for Spellings<S> {}       // prints `present` and each item
+```
+
+Contracts, one line each:
+
+* `EClass::nodes()` is the ONLY place ordering is decided; everything above it
+  inherits "unsubsumed first, then `NodeId`". Subsumed nodes are kept because a
+  subsumed constructor is still a true member of its class (the slice_pad lesson,
+  `src/layouts.rs:380-384`).
+* `first::<C>()` is registry-free and generic: `nodes_named(C::NAME)` →
+  `C::decode` → first `Ok`. This is what the cuBLASLt fence uses.
+* `spellings::<S>()` iterates `decoders.constructors_of(S::NAME)` in registry
+  order; a `Box<dyn Any>` that does not downcast to `Arc<S::Facts>` is a registry
+  bug and panics with the offending `(sort, name)`.
+* Nothing in `eclass.rs` knows about layouts.
+
+### 2.3 `layouts.rs` — the `Layout` sort and its five constructors
+
+```rust
+// src/layouts.rs                                                          — SPEC
+pub struct Layout;
+impl Sort for Layout { const NAME: &'static str = "Layout"; type Facts = dyn LayoutFacts; }
+
+/// What every layout constructor discloses. Object-safe (no generics, all
+/// `&self`), so `dyn LayoutFacts` is the erased item type.
+pub trait LayoutFacts: DynFacts {
+    /// The DOMAIN (every constructor carries one).
+    fn shape(&self) -> &ShapeTerm;
+    fn width(&self) -> BitWidthTerm;
+    /// Storage reach in ELEMENTS as an expression, where the constructor
+    /// discloses one (the packed ladder: `SpanExpr`); `None` for the
+    /// offset-expression forms — nothing here guesses a reach.
+    fn span_elements(&self) -> Option<IntExprTerm>;
+    /// The constructor's read function evaluated at literal coordinates
+    /// (front-indexed), down to the flat ELEMENT index. Runtime
+    /// convenience, never planner machinery. Fail-closed on symbolic
+    /// extents, foreign rank, out-of-domain coordinates, a mid-element
+    /// bit offset, a negative result.
+    fn element_index(&self, coords: &[usize]) -> Result<usize>;
+}
+impl PartialEq for dyn LayoutFacts { fn eq(&self, o: &Self) -> bool { self.dyn_eq(o.as_any()) } }
+impl Eq for dyn LayoutFacts {}
+
+// The five structs (unchanged fields, `src/layouts.rs:129-167`) each get:
+impl EgglogConstructor for RightMajorContiguousElementLayout {
+    const NAME: &'static str = "RightMajorContiguousElementLayoutLit";
+    type Sort = Layout;
+    fn decode(node: &ENode<'_>) -> Result<Self> {
+        let shape = shape_term(&node.child(0).ok_or_else(..)?).ok_or_else(..)?;
+        let width = bit_width(&node.child(1).ok_or_else(..)?).ok_or_else(..)?;
+        Ok(Self { shape, width })
+    }
+    fn erase(self) -> Arc<dyn LayoutFacts> { Arc::new(self) }
+}
+impl LayoutFacts for RightMajorContiguousElementLayout { /* shape/width/span (numel)/element_index (row-major fold) */ }
+// LeftMajorContiguousElementLayout: children (0 shape, 1 width); span = numel; element_index = col-major fold.
+// StridedElementLayout:            children (0 shape, 1 chain, 2 width); chain via `affine_chain(child1, owner_shape = child0)`; span = SpanExpr; element_index = Σ eval(summand).
+// ElementOffsetExpressionLayout:   children (0 offset, 1 shape, 2 width); offset via `int_expr(child0, Some(child1))`; span None; element_index = eval(offset).
+// BitOffsetExpressionLayout:       children (0 offset, 1 shape, 2 width); span None; element_index = eval(offset)/width with the alignment check.
+
+/// The core preamble's Layout constructors, in this order (it is the
+/// `Spellings` iteration order and therefore what `present()` prints).
+pub fn layout_decoders() -> Vec<ConstructorDecoder> {
+    vec![
+        ConstructorDecoder::of::<RightMajorContiguousElementLayout>(),
+        ConstructorDecoder::of::<LeftMajorContiguousElementLayout>(),
+        ConstructorDecoder::of::<StridedElementLayout>(),
+        ConstructorDecoder::of::<ElementOffsetExpressionLayout>(),
+        ConstructorDecoder::of::<BitOffsetExpressionLayout>(),
+    ]
+}
+
+// Term decoders — the old Reader's `decode_shape` (:550-566), `decode_bit_width`
+// (:538-548), `decode_affine_chain` (:568-585), `decode_expr_list` (:587-620),
+// `parse_int_expr*` (:622-769, memo + cycle-taint rule) MOVED onto `EClass`
+// unchanged in logic:
+pub fn shape_term(class: &EClass<'_>) -> Option<ShapeTerm>;
+pub fn bit_width(class: &EClass<'_>) -> Option<BitWidthTerm>;
+pub fn affine_chain(class: &EClass<'_>, owner_shape: &EClass<'_>) -> Option<Vec<IntExprTerm>>;
+pub fn int_expr(class: &EClass<'_>, owner_shape: Option<&EClass<'_>>) -> Option<IntExprTerm>;
+// `IntExprTerm::eval_at(&self, coords: &[usize]) -> Result<i64>` — the
+// coordinate evaluator today duplicated as `eval_term` in
+// crates/luminal_cuda_lite/src/layouts.rs:29-64 and
+// tests/test_runtime/src/test_equality.rs:23-58; take test_equality's
+// (it has the CeilDiv arm), the CL copy becomes a one-line wrapper.
+```
+
+### 2.4 `DecodedLayout` — the plan layout both runtimes carry
+
+DECISION: the plan layout carries the decoded SPELLING SET, not just the class
+id. Refutation of the alternative (`{class, dtype}` only, facts looked up live):
+`arena::buffer_bytes` (`crates/luminal_cuda_lite/src/arena.rs:79-104`), the
+reference executor's storage sizing (`crates/luminal_reference/src/runtime.rs:549-570`),
+CL codegen (`kernels.rs:365-598`), readback (`layouts.rs:68-150`) and
+`bind_destination` all run at EXECUTE time, where `load_plan` callers and every
+hand-built test plan (`codegen_identity.rs`, `plan_smoke.rs`,
+`cublaslt_contracts_cpu.rs`, `composed_read_families.rs`, `src/test_support.rs:3829-3862`)
+have no e-graph; and the bug fix itself needs the WHOLE spelling set of the
+destination class (`has::<LeftMajor>()`), not one chosen spelling. So the plan
+carries every decoded spelling; the class id is kept for diagnostics and as the
+cache key; the dtype fact rides along as today.
+
+```rust
+// src/layouts.rs                                                          — SPEC
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedLayout {
+    /// The layout e-class this was decoded from (serialized id; diagnostics
+    /// and cache key only — never pinned by a test). Hand-built plans use
+    /// `ClassId::from("hand-built")`.
+    pub class: ClassId,
+    pub dtype: Option<crate::dtype::PlanDtype>,
+    /// Every registered Layout constructor present in the class, decoded.
+    pub spellings: Spellings<Layout>,
+}
+impl DecodedLayout {
+    /// The decoder: refuses a class with ZERO decoded spellings (message
+    /// lists `present` and `failed`) and a class whose decoded spellings
+    /// DISAGREE on `shape()` or `width()` (layout identity = domain ×
+    /// interpretation, preamble :217; a mixed-domain class is a false
+    /// union — see §8.5).
+    pub fn from_class(class: &EClass<'_>, dtype: Option<PlanDtype>) -> Result<Self>;
+    /// Hand-built, one spelling (test fixtures).
+    pub fn of(spelling: impl EgglogConstructor<Sort = Layout>, dtype: Option<PlanDtype>) -> Self;
+    /// Hand-built, several spellings of ONE function (the degenerate-extent
+    /// fixture: RightMajor[384,1] and LeftMajor[384,1]).
+    pub fn of_spellings(spellings: Vec<Arc<dyn LayoutFacts>>, dtype: Option<PlanDtype>) -> Self;
+
+    // Class-invariant facts (all spellings denote one function).
+    pub fn shape(&self) -> &ShapeTerm;                       // first spelling's
+    pub fn width_bits(&self) -> i64;
+    pub fn literal_extents(&self) -> Option<Vec<usize>>;     // was MirrorLayout::literal_extents
+    pub fn literal_span_elements(&self) -> Option<usize>;    // first spelling that discloses a span, evaluated
+    pub fn element_index(&self, coords: &[usize]) -> Result<usize>;   // first spelling's read function
+    // Call-site preferences, delegated to `spellings`.
+    pub fn first<C: EgglogConstructor<Sort = Layout>>(&self) -> Option<&C>;
+    pub fn has<C: EgglogConstructor<Sort = Layout>>(&self) -> bool;
+    pub fn require<C: EgglogConstructor<Sort = Layout>>(&self, who: &str) -> Result<&C>;
+    pub fn present(&self) -> &[&'static str];
+}
+
+pub type LayoutDecodeCache = HashMap<(ClassId, Option<PlanDtype>), DecodedLayout>;   // unchanged
+
+/// Signature change: the view replaces the bare e-graph. Body as today
+/// (`src/layouts.rs:830-873`) with `decode_layout(egraph, &class)` replaced by
+/// `DecodedLayout::from_class(&view.class(&value.layout.eclass), value.dtype_enum)`.
+pub fn decode_layout_table(
+    view: &EGraphView<'_>,
+    graph: &crate::layout_ir::ExtractedGraph,
+    who: &str,
+    cache: &mut LayoutDecodeCache,
+) -> Result<HashMap<ClassId, DecodedLayout>>;
+```
+
+`PlanLayout` requires only `Clone + Debug` (VERIFIED `src/bufferize.rs:99-100`);
+`PartialEq` is used by the reference executor's fold check
+(`crates/luminal_reference/src/runtime.rs:767`) and the transport pin
+(`src/test_support.rs:1497`) — both keep working: equal classes decode to equal
+spelling sets, and two different layout classes always differ in at least one
+decoded term (constructors are hash-consed, so equal spellings would have been
+one class).
+
+### 2.5 The downcast idiom
+
+Recovering a concrete struct from the erased path:
+
+```rust
+// (a) explicit as_any — WORKS ON THE DECLARED MSRV
+let lm = facts.as_any().downcast_ref::<LeftMajorContiguousElementLayout>();
+// (b) trait upcasting to dyn Any — requires Rust ≥ 1.86
+let lm = (facts as &dyn Any).downcast_ref::<LeftMajorContiguousElementLayout>();
+```
+
+DECISION: use (a). The workspace declares `rust-version = "1.85"` (VERIFIED
+`Cargo.toml:5`); trait upcasting stabilized in 1.86, so (b) does not compile
+under the declared floor even though the local toolchain is 1.91.1. (a) costs
+nothing because `DynFacts::as_any` is blanket-provided. `Spellings::first::<C>()`
+wraps it so call sites rarely spell either.
+
+---
+
+## 3. Registration, plumbing, and the tripwire
+
+### 3.1 Registration rides on the matchers
+
+DECISION: decoders travel on `OpMatcher`, not as a new field on `RegisteredOp`.
+`OpMatcher::snippets()` (`src/layout_ir/mod.rs:534-542`) is where a constructor's
+DECLARATION travels; the decoder for that constructor belongs beside it, and the
+matcher is the one type all three registries share (`RegisteredOp.matcher`,
+`ReferenceOp.matcher: fn() -> Box<dyn OpMatcher>` at
+`crates/luminal_reference/src/ops/mod.rs:144-150`, test_runtime's matcher list).
+A `RegisteredOp` field would leave the reference runtime with no path.
+
+```rust
+// src/layout_ir/mod.rs, in `pub trait OpMatcher` after `snippets()`      — SPEC
+/// Decoders for every constructor this matcher's snippets DECLARE for a
+/// decoded sort. Mirrors `snippets()`: the declaration and its decoder
+/// travel together. Default empty — no matcher declares one today.
+fn decoders(&self) -> Vec<crate::egglog_utils::eclass::ConstructorDecoder> { Vec::new() }
+
+// crates/luminal_cuda_lite/src/ops/mod.rs, impl RegisteredOp             — SPEC
+pub fn decoders(&self) -> Vec<ConstructorDecoder> { self.matcher.decoders() }
+
+// src/egglog_snippet.rs, beside `assembled_program_for`                   — SPEC
+/// What core's own preamble declares and decodes: the five Layout constructors.
+pub fn core_decoders() -> Vec<ConstructorDecoder> { crate::layouts::layout_decoders() }
+/// The registry for a runtime's matcher set — the same shape as
+/// `assembled_program_for(matchers)`: core built-ins, then each matcher's
+/// contribution in registry order. Errors on a duplicate `(sort, name)`.
+pub fn decoder_registry_for(matchers: &[Box<dyn OpMatcher>]) -> Result<ConstructorRegistry> {
+    ConstructorRegistry::new(core_decoders().into_iter().chain(matchers.iter().flat_map(|m| m.decoders())))
+}
+
+// crates/luminal_reference/src/lib.rs, beside `assembled_program()`       — SPEC
+pub fn decoder_registry() -> &'static ConstructorRegistry {
+    static R: OnceLock<ConstructorRegistry> = OnceLock::new();
+    R.get_or_init(|| luminal::egglog_snippet::decoder_registry_for(&ops::built_in_matchers())
+        .expect("the built-in reference registry has no duplicate decoders"))
+}
+```
+
+### 3.2 Every signature that changes, and every caller
+
+| Function | Today | New | Who constructs the view |
+|---|---|---|---|
+| `luminal::layouts::decode_layout_table` (`src/layouts.rs:830`) | `(egraph: &EGraph, graph, who, cache)` | `(view: &EGraphView<'_>, graph, who, cache)` | callers below |
+| `luminal::layouts::decode_layout` / `decode_layout_for` (:343, :773) | exist | DELETED | — |
+| `src/test_support.rs:1478` | `decode_layout_table(&egraph, &graph, "dtype row test", &mut LayoutDecodeCache::new())` | `let view = EGraphView::new(&egraph, luminal_reference::decoder_registry()); decode_layout_table(&view, …)` | core test (already depends on `luminal_reference`, :2431) |
+| `crates/luminal_reference/src/harness.rs:209` | `(&serialized, &dps, "plain plan", …)` | `EGraphView::new(&serialized, crate::decoder_registry())` | harness |
+| `crates/luminal_reference/src/runtime.rs:1684` | same shape | same as above | runtime test |
+| `crates/luminal_reference/src/search.rs:355, 426` (inside `search_implementations_with_ops`, :182) | `(egraph, &dps, "implementation search", &mut layout_cache)` | build once at :249 next to `layout_cache`: `let view = EGraphView::new(egraph, crate::decoder_registry());` then `&view` at both sites | search loop; NO change to `search_implementations_with_ops`'s signature |
+| `crates/luminal_cuda_lite/src/search.rs:503, 657` (inside `search_implementations`, :328) | same | at :391 next to `layout_cache`: `let decoders = luminal::egglog_snippet::decoder_registry_for(matchers)?; let view = EGraphView::new(egraph, &decoders);` | search loop; NO signature change (`matchers` is already a parameter) |
+| `crates/luminal_cuda_lite/src/finalists.rs:245` (`Finalists::build_plan`) | `decode_layout_table(self.egraph, &dps, "finalist", &mut self.layout_cache)` | `Finalists` gains a field `decoders: ConstructorRegistry` built in `new` (:131-155) from `matchers`; `build_plan` does `let view = EGraphView::new(self.egraph, &self.decoders);` | finalists; `Finalists::new` signature unchanged |
+
+That is all 8 callers. The search loops, `Finalists::new`, `CudaRuntime::search`,
+`bucketed_search_implementations` and the `BucketAssembly` struct keep their
+public signatures; the only new state is `Finalists.decoders` and
+`CudaRuntime.decoders` (§3.3).
+
+### 3.3 The tripwire — VERIFIED mechanism
+
+Runs against the LIVE `egglog::EGraph` right after a successful
+`parse_and_run_program` and before `serialize`, where every runtime already holds
+it. The live schema is reachable read-only — no `&mut`, no text scanning:
+
+* `egglog::EGraph::functions_iter(&self) -> impl Iterator<Item = (&String, &Function)>`
+  — fork `src/lib.rs:1236` (also `get_function(&self, name) -> Option<&Function>`,
+  :2318; `get_function_names`, :1230).
+* `Function::func_type(&self) -> &FuncType` — `src/lib.rs:342`;
+  `Function::name()` — :337.
+* `pub struct FuncType { pub name, pub subtype: FunctionSubtype, pub input:
+  Vec<ArcSort>, pub output: ArcSort }` — `src/typechecking.rs:115-120`;
+  re-exported as `egglog::FuncType` (`src/lib.rs:74`).
+* `pub enum FunctionSubtype { Constructor, Custom }` — `src/ast/mod.rs:1298-1302`
+  (`egglog::ast` is `pub mod`, `src/lib.rs:3`). `(datatype …)` variants and
+  `(constructor …)` are `Constructor`; `(function … :no-merge)` rows such as
+  `layout-of` (`egglog_preamble.egg:451`, output sort `Layout`) are `Custom` and
+  must be skipped — they are not spellings.
+* `egglog::sort::Sort::name(&self) -> &str` — `src/sort/mod.rs:52`; `ArcSort =
+  Arc<dyn Sort>`.
+* NOT usable: `EGraph::type_info(&mut self)` (`src/lib.rs:589`) takes `&mut`;
+  `TypeInfo::get_func_type`/`is_constructor` (`typechecking.rs:1146, 1157`) are
+  therefore reachable only mutably. The `functions_iter` route is the one to use.
+* Fallback (NOT chosen): regex over the assembled text for
+  `(constructor NAME (…) SORT`. Fragile (comments, `:cost`, multi-line forms) and
+  blind to `datatype` variants. The live schema is authoritative.
+
+```rust
+// eclass.rs                                                               — SPEC
+impl ConstructorRegistry {
+    pub fn check(&self, egraph: &egglog::EGraph) -> Result<()> {
+        use egglog::ast::FunctionSubtype;
+        let mut problems = Vec::new();
+        // (1) every declared constructor of a decoded sort has a decoder
+        for (name, func) in egraph.functions_iter() {
+            let ft = func.func_type();
+            if ft.subtype != FunctionSubtype::Constructor { continue; }
+            let sort = ft.output.name();
+            if !self.sorts().any(|s| s == sort) { continue; }
+            if self.get(sort, name).is_none() {
+                problems.push(format!("sort {sort}: constructor `{name}` is declared by the program but has no registered decoder"));
+            }
+        }
+        // (2) every decoder names a constructor the program declares, under the right sort
+        for d in &self.entries {
+            match egraph.get_function(d.name) {
+                None => problems.push(format!("sort {}: decoder for `{}` names a constructor the program does not declare", d.sort, d.name)),
+                Some(f) => {
+                    let ft = f.func_type();
+                    if ft.subtype != FunctionSubtype::Constructor || ft.output.name() != d.sort {
+                        problems.push(format!("sort {}: decoder for `{}` is registered under sort {} but the program declares it as {} with output sort {}",
+                            d.sort, d.name, d.sort, ft.subtype.label(), ft.output.name()));
+                    }
+                }
+            }
+        }
+        if problems.is_empty() { return Ok(()); }
+        anyhow::bail!(
+            "egglog constructor decoders are incomplete for the assembled program:\n  - {}\n\
+             Every constructor of a decoded sort needs exactly one decoder, registered beside the \
+             snippet that declares it (OpMatcher::decoders); see docs/design/eclass-decoder.md.",
+            problems.join("\n  - ")
+        )
+    }
+}
+```
+
+Duplicates are refused earlier, at `ConstructorRegistry::new`, with the same
+message family ("sort {sort}: two decoders registered for `{name}`").
+
+Where it is called (REQUIRED — the four places a runtime assembles for search;
+each has the live `EGraph` in a local right before `serialize`):
+
+1. CL `CudaRuntime::assemble_and_saturate`, `crates/luminal_cuda_lite/src/runtime.rs:432-456`:
+   after the `if let Err(err) = egraph.parse_and_run_program(…)` block, before
+   `let serialized = egraph.serialize(…)` at :456 — `self.decoders.check(&egraph)?;`.
+   `CudaRuntime` gains `decoders: ConstructorRegistry` built in
+   `load_with_registry` (:143-146) as
+   `luminal::egglog_snippet::decoder_registry_for(&matchers)?` (the matcher column
+   is already extracted there). `Default` gets an empty registry, like `matchers`.
+2. CL bucketed search, `crates/luminal_cuda_lite/src/search.rs:931-934`: `BucketAssembly`
+   gains `decoders: &'a ConstructorRegistry` (set from `&self.decoders` at
+   `runtime.rs:622`); call `assembly.decoders.check(&egraph)?` before :934.
+3. Reference `ReferenceRuntime::search`, `crates/luminal_reference/src/runtime.rs:332-365`:
+   after the error block, before :365 — `crate::decoder_registry().check(&egraph)?;`.
+4. Reference bucketed search, `crates/luminal_reference/src/search.rs:536-538`: same
+   call before :538.
+
+RECOMMENDED (cheap, keeps fixtures honest): `luminal_reference::harness::serialize_fixture`
+(`harness.rs:72-85`), `harness.rs:186-190`, `test_runtime/src/lib.rs:144-146`,
+`src/extraction.rs:4309-4311`. Not required for correctness — the fixtures use
+core's preamble, which core's own test below already checks.
+
+Core unit tests (in `eclass.rs` / `layouts.rs`):
+
+* `core_preamble_layout_constructors_all_have_decoders`: `new_egraph()` +
+  `assembled_program_for(&[])` + `ConstructorRegistry::new(core_decoders())?.check(&egraph)` is `Ok`.
+* `a_missing_decoder_is_named`: same program, registry = `core_decoders()` minus
+  `BitOffsetExpressionLayoutLit` → `Err` whose message contains
+  ``sort Layout: constructor `BitOffsetExpressionLayoutLit` is declared by the program but has no registered decoder``.
+* `a_stale_decoder_is_named`: registry with an extra
+  `ConstructorDecoder { sort: "Layout", name: "NoSuchLayoutLit", .. }` → `Err`
+  containing ``decoder for `NoSuchLayoutLit` names a constructor the program does not declare``.
+* `a_duplicate_registration_is_refused`: `ConstructorRegistry::new` on
+  `core_decoders()` twice → `Err`.
+* CL: `cuda_registry()`'s matchers → `decoder_registry_for(..)?.check(&saturated egraph)` is `Ok`
+  (belongs in `crates/luminal_cuda_lite/tests/registry_selection.rs`).
+
+Failure at a runtime site surfaces as the search's error
+(`context("cuda-lite saturation failed")` style is NOT wrapped around it — the
+message is self-describing).
+
+---
+
+## 4. Consumer-by-consumer refactor map
+
+Legend: SITE = file:line on trunk; NOW = current shape; NEW = replacement. Where
+a site is a match over the five `MirrorLayout` variants, "chain" means the
+call-site-preference chain of `first::<C>()` calls in the order RightMajor,
+LeftMajor, Strided, ElementOffset, BitOffset with a terminal `bail!` that prints
+`layout.present()`. That order is chosen HERE, by the codegen, because the most
+structured spelling yields the simplest C; it is no longer anyone else's business.
+
+### 4.1 `crates/luminal_cuda_lite/src/kernels.rs` (10 sites)
+
+| SITE | NOW | NEW |
+|---|---|---|
+| :23 `use luminal::layouts::DecodedLayout;` | — | unchanged (add `use luminal::layouts::{RightMajorContiguousElementLayout as RM, LeftMajorContiguousElementLayout as LM, StridedElementLayout as ST, ElementOffsetExpressionLayout as EO, BitOffsetExpressionLayout as BO};`) |
+| :64 `slot.layout.mirror.literal_extents()` in `from_descriptors` | via `.mirror` | `slot.layout.literal_extents()` — message unchanged (`"{label} {role} has symbolic layout extents (no numeric codegen)"`, pinned by `codegen_identity.rs:573,939`) |
+| :145 module comment "the runtime's decoded `MirrorLayout`" | text | "the runtime's decoded `DecodedLayout` (every spelling of the elected class)" |
+| :365-392 `read_affine` | `use MirrorLayout as M; if layout.mirror.literal_extents()…; match &layout.mirror { M::RightMajor(_) => strides; M::LeftMajor(_) => …; M::Strided(st) => …; M::ElementOffset(eo) => …; M::BitOffset(bo) => … }` | `layout.literal_extents()` for the domain check; then the chain: `if let Some(_) = layout.first::<RM>() { Affine::from_strides(..) } else if let Some(_) = layout.first::<LM>() { .. } else if let Some(st) = layout.first::<ST>() { .. } else if let Some(eo) = layout.first::<EO>() { .. } else if let Some(bo) = layout.first::<BO>() { .. } else { None }` — arm bodies verbatim |
+| :517 `use luminal::layouts::MirrorLayout;` | — | delete |
+| :539-598 `layout_read_index` offset emission | `match &layout.mirror { … five arms … }` | the same chain; arm bodies VERBATIM (the emitted strings are pinned bit-for-bit at `codegen_identity.rs:405,440,464,491,523`); terminal arm `bail!("operand {operand}: no lowerable layout spelling — present: {:?}", layout.present())` |
+
+Why not one uniform lowering (`LayoutFacts::offset_term()` → `lower_layout_term`)?
+It changes the emitted C (`c1 + (c0 * 8LL)` would gain outer parentheses and the
+RightMajor form would lose its stride spelling), breaking the five string pins.
+Recorded as a follow-up in §8.7; Austin decides whether to re-bless the pins.
+
+### 4.2 `crates/luminal_cuda_lite/src/ops/cublaslt/exec.rs` (5 sites + the #507 arm)
+
+| SITE | NOW | NEW |
+|---|---|---|
+| :73-88 module doc (bias forms paragraph) | describes the tripwire as the fence | rewrite: the fence is `require::<LeftMajorContiguousElementLayout>` on the destination class; the degenerate-extent coincidence is not a case because the class carries both spellings and `require` reads the class, not one chosen spelling |
+| :321 `dest: &luminal::layouts::DecodedLayout` | — | unchanged |
+| :324 `use luminal::layouts::MirrorLayout as M;` | — | delete; `use luminal::layouts::{LeftMajorContiguousElementLayout, RightMajorContiguousElementLayout};` |
+| :325 `dest.mirror.literal_extents()` | — | `dest.literal_extents()`; message unchanged (`"…SYMBOLIC extents…"`, pinned `cublaslt_contracts_cpu.rs:498`) |
+| :344-360 `let desc = match &dest.mirror { M::RightMajor(_) => row, M::LeftMajor(_) => col, other => bail!(…STRIDED/ELEMENT-OFFSET-EXPRESSION/BIT-OFFSET-EXPRESSION…) }` | preference-blind match | the binding below |
+| :363-366 `assert_bias_destination_order(call, who)` call | second fence | DELETE this call (the `require` IS the fence); the function itself stays for `device_call.rs:261` — see below |
+| #507 arm (branch only, `M::RightMajor(_) if call.bias_operand.is_some() && (call.m == 1 \|\| call.n == 1) => col`) | not on trunk | NEVER lands; see §5 |
+
+The binding, final:
+
+```rust
+// exec.rs, bind_destination, replacing :344-366                           — SPEC
+let desc = if call.bias_operand.is_some() {
+    // THE FENCE. The estate's two bias decorators mint a bias form only
+    // when the claimed D class HOLDS the LeftMajor spelling
+    // (egg/cublaslt_marker_decorate.egg, premise
+    // `(= ?inner_L (LeftMajorContiguousElementLayoutLit ?ishape ?d_bits2))`).
+    // Ask the class the same question. A degenerate extent, where the
+    // RightMajor spelling shares the class, is not a case: the answer is
+    // still yes. A bias form whose class lacks the spelling is unreachable
+    // from the estate — a real drift, refused before any descriptor exists.
+    dest.require::<LeftMajorContiguousElementLayout>(who).with_context(|| {
+        format!(
+            "cuBLASLt {who}: unreachable: the bias decorators require a LeftMajor D; a bias form \
+             ({}) reached the executor whose destination class holds {:?} and no \
+             LeftMajorContiguousElementLayoutLit — the library refuses BIAS/RELU_BIAS on a \
+             ROW-order D (CUBLAS_STATUS_NOT_SUPPORTED, measured on the A100 2026-08-28); \
+             refused BEFORE dispatch, no bytes move",
+            call.form.constructor_name(),
+            dest.present()
+        )
+    })?;
+    LtDesc::col(call.m, call.n, call.m.max(1))
+} else if dest.has::<LeftMajorContiguousElementLayout>() {
+    LtDesc::col(call.m, call.n, call.m.max(1))
+} else if dest.has::<RightMajorContiguousElementLayout>() {
+    LtDesc::row(call.m, call.n, call.n.max(1))
+} else {
+    bail!(
+        "cuBLASLt {who}: the plan elected a destination layout whose class holds {:?}; this \
+         backend writes only the two dense orders cuBLASLt can express (RightMajor -> \
+         CUBLASLT_ORDER_ROW, LeftMajor -> CUBLASLT_ORDER_COL). Strided and offset-expression \
+         destinations are NOT lowered — a CAPABILITY refusal (the host-call mirror of the \
+         codegen path's identity-index write fence), never a guess.",
+        dest.present()
+    )
+};
+call.d = desc;
+call.c = desc;
+Ok(())
+```
+
+Non-bias with BOTH contiguous spellings (degenerate extents only) now binds COL
+where it bound ROW; same bytes, same reach (#507's memory-identity argument,
+`validate_against` passes both). Flagged in §8.9 as a behaviour change Austin
+should see.
+
+Test message pins affected: `cublaslt_contracts_cpu.rs:225-234` asserts
+`"unreachable"`, `"bias decorators require a LeftMajor D"`, `"Row-order D descriptor"`,
+`"refused BEFORE dispatch"`. Keep the first, second and fourth; replace the third
+with `msg.contains("RightMajorContiguousElementLayoutLit")` (the class listing) and
+`!msg.contains("LeftMajorContiguousElementLayoutLit —")` is unnecessary — the
+message's "no LeftMajor…" clause is stable text. `cublaslt_contracts_cpu.rs:464-485`
+asserts `"STRIDED"`, `"CAPABILITY refusal"`, `"ELEMENT-OFFSET-EXPRESSION"`: the
+new capability message prints the class's constructor names instead of the
+shouted kind; retarget to `"StridedElementLayoutLit"` / `"CAPABILITY refusal"` /
+`"ElementOffsetExpressionLayoutLit"`.
+
+**`assert_bias_destination_order` (:380-397).** DECISION: keep the function, drop
+its call from `bind_destination`, and re-document it as what its remaining caller
+makes it — a VENDOR-PRECONDITION check at dispatch
+(`crates/luminal_cuda_lite/src/ops/cublaslt/device_call.rs:261`, called on every
+`LtCall` however built, including the hand-built direct-dispatch contract tests).
+Justification: inside `bind_destination` it restated the function's own
+postcondition (the bias branch sets COL or refuses) — category (1) of the module's
+own check taxonomy, "OUT". At `device_call.rs:261` it guards the library's
+documented refusal for a call that never passed through `bind_destination` —
+category (2), "STAYS". A `debug_assert!` would be wrong there: the hand-built path
+is a release path. Its doc comment (:368-379) must stop describing itself as the
+estate fence.
+
+### 4.3 `crates/luminal_cuda_lite/src/layouts.rs` (5 sites)
+
+| SITE | NOW | NEW |
+|---|---|---|
+| :1-11 module doc | "core owns the decoder and publishes `DecodedLayout`" | keep; add one sentence: the read-back helpers evaluate through `LayoutFacts::element_index` |
+| :29-64 `pub fn eval_term` | local evaluator (no CeilDiv arm) | `pub fn eval_term(expr, coords) -> Result<i64> { expr.eval_at(coords) }` (core's evaluator; keeps the pub name for `view_admission.rs`, `examples/support`, device tests) |
+| :68-120 `pub fn element_index(layout: &DecodedLayout, coords)` | `use M; layout.mirror.literal_extents()…; match &layout.mirror { five arms }` | `layout.element_index(coords)` — signature unchanged; the five arms move into core as each struct's `LayoutFacts::element_index` |
+| :124-150 `pub fn dense_f32` | `layout.mirror.literal_extents()` | `layout.literal_extents()`; rest unchanged |
+| :13 `pub use luminal::layouts::DecodedLayout;` | — | unchanged |
+
+### 4.4 Other CUDA-lite runtime readers
+
+| SITE | NOW | NEW |
+|---|---|---|
+| `arena.rs:79-104 buffer_bytes` | `buffer.layout.mirror.literal_span_elements()` | `buffer.layout.literal_span_elements()`; messages unchanged |
+| `device.rs:319` | `buffer.layout.dtype` | unchanged |
+| `device.rs:525-527` | `bind_destination(&mut call, &dest_slot.layout, label)` | unchanged |
+| `device_call.rs:261` | `assert_bias_destination_order(call, "dispatch")?` | unchanged (see 4.2) |
+| `heuristic.rs` | sums `op.heuristic_cost` | unchanged (reads no layout) |
+| `profile.rs:139`, `runtime.rs:65,72,795-816` | `BufferIrGraph<DecodedLayout>` types | unchanged |
+| `ops/cublaslt/mod.rs:389-470, 562-700` (`layout_class_of`, `stride_chain`, `leading_dimension`, the `BitOffsetExpressionLayoutLit` view walks at :649, :689) | per-enode SPEC readers over `ExtractionSite`, asking for ONE named constructor and needing its children as CLASSES (symbolic dims are parsed by class) | NOT migrated in this PR: they already have `first::<C>()` semantics (one constructor, no preference) and need class-level children the decoded term structs do not carry. Follow-up §8.8. |
+| `ops/cublaslt/election.rs` | genome election by constructor NAME preferences (`genome_preferring`) | reads no layout class; unchanged |
+
+### 4.5 Reference runtime
+
+| SITE | NOW | NEW |
+|---|---|---|
+| `crates/luminal_reference/src/runtime.rs:549-570` storage sizing | `buffer.layout.mirror.literal_span_elements()` | `buffer.layout.literal_span_elements()`; message unchanged |
+| `runtime.rs:767` fold check | `slot.layout != plan.buffers[id].layout` | unchanged (`PartialEq` preserved, §2.4) |
+| `runtime.rs:778` operand dims | `slot.layout.mirror.literal_extents()` | `slot.layout.literal_extents()` |
+| `runtime.rs:544` comment "own DecodedLayout — width alone cannot pick a variant" | text | keep ("variant" now means a typed-buffer variant, which is what it meant) |
+| `layouts.rs:11-18` | doc mentions "shared mirror vocabulary" | "core's `DecodedLayout` (the elected class's decoded spellings plus the dtype fact)" |
+| `kernels/**`, `ops/**` | read `operand_dims`/`dests` from `ReferenceKernelCtx`, never a layout (VERIFIED by grep) | unchanged |
+| `search.rs:243-249` comment + `layout_cache` | describes `decode_layout` building a fresh Reader per call | rewrite the comment: the view indexes classes once (`EGraph::classes()`); the cache still spans candidates because the table is value-keyed per candidate |
+
+### 4.6 Core
+
+| SITE | NOW | NEW |
+|---|---|---|
+| `src/layouts.rs:1-35` module doc | five mirror structs + `MirrorLayout` + preference decoder | rewrite per §2.3/§2.4 |
+| `src/layouts.rs:176-183 MirrorLayout`, :286-333 `impl MirrorLayout`, :339-345 `decode_layout`, :347-769 `Reader` (+ `ParseMemo`), :771-774 `decode_layout_for`, :999-1015 test `mirror_layout_equality_is_structural` | — | DELETE (term-decoding bodies move to the §2.3 free functions; the equality test becomes `decoded_layout_equality_is_structural` over `DecodedLayout::of`) |
+| `src/lib.rs:56-61` comment on `pub mod layouts` | "Convenience mirrors … + decode_layout" | "the `Layout` sort's constructor structs, `LayoutFacts`, `DecodedLayout` and the value-keyed table; THE BUFFERIZER NEVER CALLS ANY OF THIS" |
+| `src/lib.rs:25` comment | `layouts::decode_layout_table` | unchanged name |
+| `src/bufferize.rs:96, 1538, 1550` comments | reference `decode_layout_table` | unchanged |
+| `src/test_support.rs:1461-1469` doc | "`DecodedLayout { mirror, dtype }`" | "`DecodedLayout { class, dtype, spellings }`" |
+| `src/test_support.rs:1478-1483` | `decode_layout_table(&egraph, …)` | §3.2 |
+| `src/test_support.rs:3829-3862` `rm_layout`, `transpose_strided_layout` | `DecodedLayout { mirror: MirrorLayout::RightMajor(..), dtype }` literals | `DecodedLayout::of(RightMajorContiguousElementLayout { shape, width }, Some(F32))`, `DecodedLayout::of(StridedElementLayout { .. }, Some(F32))` |
+| `src/test_support.rs:3983-3986` | `binding.layout.mirror.literal_extents()`; `let MirrorLayout::Strided(strided) = &binding.layout.mirror else { panic!(..) }` | `binding.layout.literal_extents()`; `let strided = binding.layout.first::<StridedElementLayout>().expect("the disclosed layout is the composed strided form");` |
+| `src/extraction.rs:1756-1759` (`estimated_layout_dims`), :2375-2441 and :2458/:2480/:2507 (renderer summaries), :2846-2867 (`numeric_layout_dims/bits`), :2882-2904, :3609 (`metadata_preferred_op`), :4016-4018 (`RENDER_PREFERRED_OPS`) | spelling readers of class-INVARIANT facts (domain, width) or render-text preferences | NOT migrated: no preference-bug exposure (the domain is the same in every spelling), and the heuristic's dim estimate needs the dim CLASS for its bounds lookup (`extraction.rs:1786-1800`), which term structs do not carry. Follow-up §8.8. |
+
+### 4.7 `tests/test_runtime/src/test_equality.rs` (5 arms + 3 signatures)
+
+| SITE | NOW | NEW |
+|---|---|---|
+| :18 `use luminal::layouts::{IntExprTerm, MirrorLayout, ShapeTerm};` | — | `use luminal::layouts::{DecodedLayout, IntExprTerm};` |
+| :23-58 `eval_term` | local evaluator (the complete one) | body MOVES to core as `IntExprTerm::eval_at`; keep `pub fn eval_term` as a wrapper |
+| :81-143 `element_index(layout: &MirrorLayout, coords)` | five arms | `pub fn element_index(layout: &DecodedLayout, coords: &[usize]) -> Result<usize> { layout.element_index(coords) }` |
+| :146 `dense_f32(backing, layout: &MirrorLayout, value_dims)` | — | `&DecodedLayout` |
+| :173-174 comparison helper `(&[f32], &MirrorLayout)` | — | `(&[f32], &DecodedLayout)` |
+| :192-290 tests constructing `MirrorLayout::*` | — | `DecodedLayout::of(..)` |
+
+### 4.8 CUDA-lite tests (hand-built fixtures and readers)
+
+| File | Sites | NEW |
+|---|---|---|
+| `tests/codegen_identity.rs` | :35 `reads_flat(layout: &DecodedLayout, …)` (unchanged); :67 and :234 `.mirror.literal_extents()`; :272-320 `typed(mirror)`, `rm_layout`, `strided_layout`, `offset_layout`; :670-680 comment ("`decode_layout` only states a PREFERENCE"); :700-735 the five spellings incl. `MirrorLayout::BitOffset`; :860-880 `MirrorLayout::LeftMajor`; :903-950 `DecodedLayout { mirror: rm(..), dtype }` | `.literal_extents()`; `fn typed(s: impl EgglogConstructor<Sort = Layout>) -> DecodedLayout { DecodedLayout::of(s, Some(F32)) }`; the comment becomes "all spellings of a class denote one function and a caller picks the spelling IT lowers; these tests state one function five ways and require byte-identical CUDA" — the two-spelling proof gets STRONGER: add a sixth case `DecodedLayout::of_spellings(vec![rm, strided_dense], ..)` (both present) and require the same source |
+| `tests/cublaslt_contracts_cpu.rs` | :6-9 imports; :358-376 `right_major`, `left_major`; :452-495 strided/offset/symbolic literals; :219-249 fence-message pins (see 4.2) | `DecodedLayout::of(..)`; plus the #507 carry-over tests (§5) |
+| `tests/cublaslt_bias_premise.rs` | :151-176 `decode_layout_for(&egraph, class, ..)` + `matches!(mirror, MirrorLayout::LeftMajor(_))` (an assertion ON THE PREFERENCE ORDER: "the decoder's most-structured spelling is LeftMajor (RightMajor is absent…)"); :317 `println!(.. dest.mirror)` | `let view = EGraphView::new(&egraph, &decoders); let c = view.class(class); assert!(c.has::<LeftMajorContiguousElementLayout>()); assert!(!c.has::<RightMajorContiguousElementLayout>(), "a [3,4] left-major over the bytes of a [4,3] right-major is not right-major"); println!("{:?}", c.present::<Layout>())`; `println!("{:?}", dest.present())`. The registry here: `luminal::egglog_snippet::decoder_registry_for(&cuda_registry().into_iter().map(|r| r.matcher).collect::<Vec<_>>())` (`RegisteredOp.matcher` is pub; `CudaRuntime::matchers()` is private, `runtime.rs:202`) — or expose `CudaRuntime::decoders(&self) -> &ConstructorRegistry` (RECOMMENDED, one accessor) |
+| `tests/plan_smoke.rs:78-90` | `DecodedLayout { mirror: MirrorLayout::RightMajor(..) }` | `DecodedLayout::of(..)` |
+| `tests/composed_read_families.rs:524-552` | `composed`/`rm` literals | `DecodedLayout::of(..)` |
+| `tests/view_admission.rs` | :133, :154 `.mirror.literal_extents()`; :216-245 `flat_index(layout, out_coord)` five arms; :283/:323/:364 `layout.mirror.literal_extents()` | `.literal_extents()`; `flat_index` → `layout.element_index(out_coord).expect(..) as i64` (delete the local arms) |
+| `tests/finalists_lattice.rs:30,39` | `DecodedLayout` as a type only | unchanged |
+
+Tally of sites in this map: kernels.rs 10; exec.rs 5 (+1 branch-only arm); CL
+layouts.rs 5; arena/device/device_call 4; reference runtime/search 6; core
+layouts.rs deletions 6 blocks; core test_support 5; extraction/renderer 9 lines
+listed as deliberately untouched; test_equality 8; CL tests 7 files / 27 sites;
+decode_layout_table callers 8. Total touched: 84 sites across 21 files, plus
+the 9 recorded-untouched lines.
+
+---
+
+## 5. What is deleted
+
+* `MirrorLayout` (`src/layouts.rs:176-183`) and `impl MirrorLayout` (:286-333). Its
+  four facts (`shape`, `width_bits`, `literal_extents`, `literal_span_elements`)
+  become `DecodedLayout` methods (class-invariant, §2.4).
+* `DecodedLayout.mirror`: replaced by `spellings: Spellings<Layout>` plus
+  `class: ClassId`. Each runtime builds its plan-layout value in ONE place —
+  `decode_layout_table` → `DecodedLayout::from_class` — and hand-built plans use
+  `DecodedLayout::of`/`of_spellings`. Neither runtime has a runtime-flavored
+  layout type (ruling D9, 2026-09-03, unchanged): `CudaPlan` and `ReferencePlan`
+  stay `BufferIrGraph<luminal::layouts::DecodedLayout>`.
+* `decode_layout` (:343-345), `decode_layout_for` (:771-774), `Reader` and
+  `ParseMemo` (:347-769) — the term-decoding bodies move to the §2.3 functions;
+  the preference loop is gone.
+* The #507 arm and its rationale paragraphs (exec.rs module doc and the arm's
+  comment on the branch). DECISION on #507: this PR supersedes it. #507 must not
+  merge its `exec.rs` hunk. Its FOUR tests are carried into this PR, retargeted:
+  * `cublaslt_bias_premise.rs` `a_degenerate_extent_d_holds_both_contiguous_spellings_in_one_class`
+    — keep (it is the coincidence, measured); replace `decode_layout_for` +
+    `mirror` prints with `view.class(c).present::<Layout>()` and assert
+    `has::<LeftMajor>() && has::<RightMajor>()`. Structural; no class ids pinned.
+  * `cublaslt_bias_premise.rs` `a_degenerate_extent_bias_election_binds_col_and_is_not_refused`
+    — keep verbatim except the `dest.mirror` print → `dest.present()`.
+  * `cublaslt_contracts_cpu.rs` `degenerate_extent_binds_a_bias_form_col_in_both_orientations`
+    — the destination becomes
+    `DecodedLayout::of_spellings(vec![RightMajor[384,1].erase(), LeftMajor[384,1].erase()], Some(F32))`
+    (the class as the e-graph has it); expected COL/ld=m unchanged. ADD the
+    negative the design makes true: `right_major(&[384, 1])` ALONE under a bias
+    form is REFUSED (message contains "bias decorators require a LeftMajor D") —
+    the fix is the class carrying both spellings, not an extent test.
+  * `cublaslt_contracts_cpu.rs` `a_non_degenerate_right_major_d_still_trips_the_bias_fence`
+    — keep with the §4.2 message retarget; its last assertion ("a bias-free
+    degenerate D stays ROW") becomes: bias-free with `right_major(&[384,1])` alone
+    → ROW (unchanged), bias-free with both spellings → COL (§4.2 rule).
+  * `cublaslt_contracts.rs` (device) `degenerate_extent_bias_plan_matches_decomposed_route_tolerance_based`
+    — carry verbatim (touches no layout type).
+  If #507 merges first anyway, step S3 below additionally deletes the arm and
+  the "ONE EXCEPTION" doc paragraph; the test retargets are the same.
+* Any test asserting the preference order: `cublaslt_bias_premise.rs:170-176`
+  (`matches!(mirror, MirrorLayout::LeftMajor(_))` with "the decoder's
+  most-structured spelling") is the only one; it becomes the `has`/`!has` pair
+  above. `codegen_identity.rs:670-680` is a comment, not an assertion.
+* The `LeftMajorContiguousElementLayoutLit` premise on the bias decorators is
+  NOT touched (`cublaslt_marker_decorate.egg:155-215`). It is exactly what the
+  fence now asks the class.
+
+---
+
+## 6. Migration order (each step compile-green with its gate)
+
+Gate vocabulary (Austin 2026-09-03: minimal gate blocks; the full ~10-minute
+gate runs detached and its failures are follow-ups). Disk is tight: use
+`export CARGO_TARGET_DIR=/Users/austin/Developer/luminal-logical-ssa/.claude/worktrees/rejoin-p1/target`
+and check `df -h` before parallel builds.
+
+```
+G-build   cargo build -p luminal -p luminal_reference -p luminal_cuda_lite -p test_runtime --all-targets
+G-device  cargo check -p luminal_cuda_lite --features device --all-targets      (type-checks device.rs:525 and device_call.rs:261)
+G-fmt     cargo fmt --all -- --check
+G-clippy  cargo clippy -p luminal -p luminal_reference -p luminal_cuda_lite --lib
+G-core    cargo test -p luminal --lib layouts:: egglog_utils::eclass::
+G-cl      cargo test -p luminal_cuda_lite --test codegen_identity --test cublaslt_contracts_cpu --test cublaslt_bias_premise --test plan_smoke --test composed_read_families --test view_admission --test finalists_lattice --test registry_selection
+G-ref     cargo test -p luminal_reference --lib
+G-tr      cargo test -p test_runtime --lib
+G-pins    cargo test -p luminal_cuda_lite --test cublaslt_election -- --nocapture 2>&1 | grep -E 'ELECTION|elect|computes' > /tmp/after.txt   — diff against the same capture on trunk: rows must be identical (bit-identical elections); `canonical_2d_matmul_elects_the_marker` must pass
+```
+
+**S1 — core: `eclass.rs`.** Add the module and its unit tests over a
+hand-built `egraph_serialize::EGraph` (three nodes: a constructor row, its
+children) plus the four tripwire tests of §3.3 (these need only
+`assembled_program_for(&[])`; the `Layout` sort does not exist yet, so the
+tests register a throwaway `Sort`/`EgglogConstructor` pair for the hand-built
+graph and use `core_decoders()` = empty until S2a — or land S1 and S2a's
+`layout_decoders()` together; DECISION: land S1 with the hand-built-graph tests
+only, move the tripwire tests to S2a). Gate: G-build (core only), G-core, G-fmt.
+
+**S2a — core: the vocabulary, shimmed.** In `src/layouts.rs`: `Layout`,
+`LayoutFacts`, the five `EgglogConstructor`/`LayoutFacts` impls, the term
+decoders on `EClass`, `IntExprTerm::eval_at`, `layout_decoders()`;
+`DecodedLayout` gains `class` and `spellings` and KEEPS `mirror` for this step,
+populated by a private shim `fn mirror_of(spellings) -> MirrorLayout` that picks
+the first present spelling in the OLD order (behaviour identical); add
+`DecodedLayout::of/of_spellings/from_class` and the fact methods;
+`decode_layout_table(view, …)`; `egglog_snippet::{core_decoders, decoder_registry_for}`;
+`OpMatcher::decoders` default; `RegisteredOp::decoders`;
+`luminal_reference::decoder_registry()`; the 8 callers of §3.2; every
+`DecodedLayout { mirror, dtype }` literal in tests/fixtures → `DecodedLayout::of`
+(§4.6-4.8 literal rows only). Tripwire unit tests of §3.3 land here. Gate:
+G-build, G-core, G-cl, G-ref, G-tr, G-fmt.
+
+**S2b — consumers off `.mirror`.** kernels.rs (§4.1), CL layouts.rs (§4.3),
+arena.rs, reference runtime.rs, test_support.rs:3983-3986, test_equality.rs,
+view_admission.rs, codegen_identity.rs readers, bias_premise.rs:151-176 and :317
+(§4.8). Gate: G-build, G-cl, G-ref, G-tr, G-pins (first capture), G-fmt.
+
+**S2c — delete.** `mirror` field and the shim, `MirrorLayout`, `impl
+MirrorLayout`, `decode_layout`, `decode_layout_for`, `Reader`, `ParseMemo`, the
+`mirror_layout_equality_is_structural` test (replaced). `grep -rn MirrorLayout
+--include='*.rs' .` must return nothing. Gate: G-build, G-core, G-cl, G-ref,
+G-tr, G-clippy, G-fmt.
+
+**S3 — cuBLASLt binding.** exec.rs per §4.2 (binding, fence-call removal,
+module doc, `assert_bias_destination_order` re-documentation); the #507 test
+carry-over per §5 with the retargets; `cublaslt_contracts_cpu.rs` message pins
+retargeted. Gate: G-build, G-device, `cargo test -p luminal_cuda_lite --test
+cublaslt_contracts_cpu --test cublaslt_bias_premise`, G-pins (compare to trunk
+capture), G-fmt.
+
+**S4 — the tripwire at the four runtime sites** (§3.3), `CudaRuntime.decoders`
++ `CudaRuntime::decoders()` accessor, `BucketAssembly.decoders`,
+`Finalists.decoders`; the CL registry test in `registry_selection.rs`. Gate:
+G-build, G-device, G-cl, G-ref, `cargo test -p luminal_cuda_lite --test
+dim_buckets` (exercises `bucketed_search_implementations`), G-fmt.
+
+**S5 — the demonstration** (§7). Gate: `cargo run -p luminal_cuda_lite --example
+eclass_decoder_demo` prints the §7 lines.
+
+**S6 — sweep.** Doc comments listed in §4 (kernels.rs:145, exec.rs module doc,
+CL layouts.rs and lib.rs:21, reference layouts.rs, search.rs:243-249 both
+runtimes, src/lib.rs:56-61, test_support.rs:1461, codegen_identity.rs:670-680);
+`grep -rn "preference" src/layouts.rs` returns nothing; G-clippy, G-fmt; then
+the full gate detached (`cargo test --workspace`) — failures become follow-ups,
+not blockers, per the 2026-09-03 ruling.
+
+Commit per step; each commit message ends with
+`Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>` if written by an agent.
+
+---
+
+## 7. Demonstration plan
+
+Austin: "show me what the call site looks like and demonstrate (don't make a
+test, just show) that it fixes the bug we previously saw."
+
+New example `crates/luminal_cuda_lite/examples/eclass_decoder_demo.rs` (CL's
+examples already have `luminal_nn` and the model crates as dev-dependencies,
+`crates/luminal_cuda_lite/Cargo.toml:37-48`). It re-uses the fixture and helpers
+from `tests/cublaslt_bias_premise.rs` (`degenerate_linear_with_bias` on the #507
+branch: `x[1,K] @ w[K,N] + b[N]` with `K=8, N=3` through `luminal_nn::linear`;
+`d_layout_class`, `report_forms`, the seed sweep `0..6` at 12×16/mutations 4).
+Copy them into the example (examples cannot import test files).
+
+Steps and REQUIRED printed lines:
+
+1. `let (cx, x, w, b, _) = degenerate_linear_with_bias(); let rt = CudaRuntime::load(&cx)?; let egraph = rt.saturated_egraph()?;`
+   `let decoders = rt.decoders(); let view = EGraphView::new(&egraph, decoders);`
+2. For every `LayoutTensorOpCublasLtBias` node's D layout class `c = view.class(&d_layout_class(..))`, print:
+   ```
+   DEMO D layout class: present = ["RightMajorContiguousElementLayoutLit", "LeftMajorContiguousElementLayoutLit", "StridedElementLayoutLit", "BitOffsetExpressionLayoutLit"]   (order = registry order; the set must contain BOTH contiguous names)
+   DEMO first::<LeftMajorContiguousElementLayout>()  = Some(LeftMajorContiguousElementLayout { shape: ShapeTerm([Lit(3), Lit(1)]), width: BitWidthTerm(32) })
+   DEMO first::<RightMajorContiguousElementLayout>() = Some(RightMajorContiguousElementLayout { shape: ShapeTerm([Lit(3), Lit(1)]), width: BitWidthTerm(32) })
+   DEMO retired preference order would have answered: RightMajorContiguousElementLayoutLit
+   ```
+   The last line is computed by re-enacting the deleted list —
+   `["RightMajor…","LeftMajor…","Strided…","ElementOffset…","BitOffset…"].iter().find(|n| present.contains(n))`
+   — so the contrast is shown without keeping the old code alive.
+3. Run the seed sweep; on the first plan whose computes contain a
+   `CublasLt*Bias` node, `plan_call(functional)` then
+   `bind_destination(&mut call, dest, "demo")` and print:
+   ```
+   DEMO call frame m=3 n=1 k=8 ; destination present = [...]
+   DEMO bind_destination -> Ok ; d = LtDesc { rows: 3, cols: 1, ld: 3, order: Col } ; c == d
+   DEMO the fence, spelled at the call site: dest.require::<LeftMajorContiguousElementLayout>("demo") = Ok(..)
+   ```
+4. Print the negative for contrast, on a hand-built destination holding only
+   the right-major spelling:
+   ```
+   DEMO right_major([3,1]) alone under the bias form: Err(cuBLASLt demo: unreachable: the bias decorators require a LeftMajor D; a bias form (LayoutTensorOpCublasLtBias) reached the executor whose destination class holds ["RightMajorContiguousElementLayoutLit"] and no LeftMajorContiguousElementLayoutLit — …)
+   ```
+5. Exit 0. No assertions; the reader compares lines 2-4 against the whisper
+   refusal quoted in §1. Note in the example's header that whisper's real frame
+   is `m=384, n=1`; the pin-scale frame is `m=3, n=1` — same coincidence.
+
+---
+
+## 8. Risks and open questions, with recommendations
+
+**8.1 `Sort` collides with `egglog::sort::Sort`.** Austin fixed the name.
+`eclass.rs` refers to egglog's trait only through `ArcSort::name()` (a method call
+on `Arc<dyn Sort>`; no import needed), so the collision is a reading hazard, not a
+compile one. RECOMMEND: keep the name; in the two files that mention both
+(`eclass.rs`, `egglog_snippet.rs`) refer to egglog's as `egglog::sort::Sort` in
+comments and never `use` it.
+
+**8.2 Object safety and the erase step.** `LayoutFacts` is object-safe (all
+methods `&self`, no generics; the generic `first::<C>()` lives on
+`Spellings`/`EClass`). The one non-obvious constraint: converting a concrete `C`
+into `Arc<<C::Sort as Sort>::Facts>` is an unsizing coercion the compiler only
+performs where the concrete type AND the target `dyn` type are both known, so it
+cannot be written once generically over `S::Facts`; hence
+`EgglogConstructor::erase(self)` with a one-line `Arc::new(self)` per struct
+(five lines total). `DynFacts` is blanket-implemented, so `constructor()`,
+`as_any()`, `dyn_eq()` cost the structs nothing. `dyn-clone` is in `Cargo.lock`
+(line 506) but is not needed: `Arc` gives `Clone` for free, which is why the
+items are `Arc<S::Facts>` and not `Box`.
+
+**8.3 `unknown::<S>()` semantics.** A `Layout` class legitimately contains
+non-constructor nodes: rows of `Custom` functions whose output sort is `Layout`
+(`layout-of`, `egglog_preamble.egg:451`) and, after truncation, the serializer's
+`[...]` placeholder (`serialize.rs:331`). `unknown()` = ops in the class with no
+decoder registered under `S` — so it lists those rows too. RECOMMEND: keep it
+diagnostics-only (it is printed in `from_class`'s zero-spellings refusal and
+nowhere else). If a consumer ever needs "constructor I have no decoder for" as a
+hard signal, extend `check()` to record `Custom` function names per sort and
+subtract them — deferred; the tripwire already guarantees no undecodable
+constructor exists in a checked program.
+
+**8.4 Decode failures are skipped, recorded, and only fatal in aggregate.** A
+constructor node whose fields do not parse (foreign-shape `CoordVar` under the
+owner-shape guard, a cons spine with no parsing spelling, a cycle) is skipped
+exactly as the old Reader skipped it (`continue` at `src/layouts.rs:440,454,468-477`),
+but now lands in `Spellings::failed` with a reason. `from_class` refuses when
+NOTHING decoded, printing `present` and `failed`. `has::<C>()` means decodable;
+`present()` means named. The fence therefore refuses a class that holds an
+undecodable LeftMajor spelling — correct: a spelling we cannot read is not one we
+can bind on.
+
+**8.5 The cross-spelling domain check may fire on a benign class.** `from_class`
+refuses when decoded spellings disagree on `shape()` or `width()`. Argument that
+it cannot fire benignly: every spelling's shape is a `ShapeLit` e-class; decoded
+terms differ only if the classes differ; two different shape classes in one
+layout class is the false cross-rank/cross-domain union the preamble comment at
+:217 names as a bug. Counter-example attempted: a symbolic extent spelled two
+ways (`s` vs `s+0`) — these are unioned by the ring rewrites into one class, so
+`shape_term` reads the same class. Not refuted, but the argument rests on
+saturation reaching the union. RECOMMEND: implement as a `Result` refusal (a
+refusal rejects the genome; if every genome hits it, the search dies loudly with
+the class printed — the right outcome for a false union). If it fires on any of
+the seven minis in the detached full gate, downgrade to `eprintln!` and file the
+false union as its own bug.
+
+**8.6 Equality of `DecodedLayout` is now set equality.** Used by the reference
+executor's fold check (`runtime.rs:767`) and the transport pin
+(`test_support.rs:1497`). Same-class values decode to identical sets; different
+classes differ in at least one term (hash-consing). Refutation attempt: two
+right-major `[2,3] f32` values in different layout classes — impossible, the
+constructor node `(RightMajorContiguousElementLayoutLit (ShapeLit …) (BitWidthLit 32))`
+with equal children is one e-node. Not refuted. `class` participates in the
+derived `PartialEq`; hand-built fixtures all use the same sentinel, so fixtures
+compare as before.
+
+**8.7 Uniform lowering via `LayoutFacts::offset_term()` (follow-up).** Adding
+`fn offset_term(&self) -> IntExprTerm` (the element-offset function as a term;
+`BitOffset` yields `TruncDiv(offset, Lit(width))`) would let `read_affine` and
+`layout_read_index` lower ANY spelling with zero constructor dispatch — the
+literal form of "never depend on spelling". It changes the emitted C for the
+contiguous and strided forms (parenthesization, stride spelling), so the five
+string pins in `codegen_identity.rs` would need re-blessing. NOT in this PR
+(§4.1). Austin decides.
+
+**8.8 Spelling readers deliberately left in place.** (a) the extractor's
+heuristic and renderer (`extraction.rs`, §4.6) read the domain — class-invariant,
+so the preference bug cannot occur — and need dim CLASSES for the bounds-midpoint
+estimate; (b) `cublaslt/mod.rs`'s spec readers ask for one named constructor via
+`ExtractionSite` and need entry classes for symbolic dims. Both could move onto
+the new API once `EClass` grows a node-level typed query
+(`first_node::<C>() -> Option<ENode>`, so children stay classes) and once the
+registry records each constructor's INPUT sorts from `FuncType.input` at
+`check()` time (then "the Shape child" is the child whose declared sort is
+`Shape`, with no per-constructor index table). Both are follow-ups; neither is
+touched by the election pins.
+
+**8.9 Behaviour change to flag:** a bias-FREE cuBLASLt destination whose class
+holds both contiguous spellings (degenerate extents only) binds COL where it
+bound ROW. Same elements, same order, same reach (`validate_against` passes both
+per #507's arithmetic). Device-visible only as the descriptor's order attribute.
+Austin should see this line.
+
+**8.10 Class ids in the plan.** `DecodedLayout.class` is a serialized-graph id:
+random every run by ruling (2026-09-02). It is never compared in a test and never
+printed in a pin; it appears only in refusal messages and as the cache key it
+already was. Permutation-invariance is preserved.
+
+**8.11 Performance** is explicitly not a concern (Austin). For the record the new
+path is cheaper: the old `Reader::new` indexed every node of the serialized graph
+per decode (`src/layouts.rs:357-370`); `EGraphView` uses the graph's own
+`classes()` index, built once behind a `OnceCell`.
+
+**8.12 #507 sequencing.** Recommend closing #507 in favour of this PR (its
+e-graph test is the valuable part and is carried here). If it merges first, S3
+also deletes the arm; nothing else changes.
+
+---
+
+## Appendix A — Verified-facts ledger (file:line, trunk 1f101d62 unless noted)
+
+* Decoder preference loop: `src/layouts.rs:427-535`; class index per decode
+  :357-370; spelling order :380-398; literal parsing :395-418; `MirrorLayout`
+  :176-183 and :286-333; `DecodedLayout` :796-800; cache :806; table :830-873.
+* `MirrorLayout` uses outside `src/layouts.rs`: `src/test_support.rs` (3834-3855, 3983-3985),
+  `crates/luminal_cuda_lite/src/{layouts.rs:69, kernels.rs:145,366,517,540-584, ops/cublaslt/exec.rs:324}`,
+  CL tests (`view_admission.rs:217`, `plan_smoke.rs:78-82`, `codegen_identity.rs:274-315,561,727,863-908`,
+  `cublaslt_contracts_cpu.rs:8,360-491`, `composed_read_families.rs:524-548`, `cublaslt_bias_premise.rs:173`),
+  `tests/test_runtime/src/test_equality.rs:18,81-282`.
+* `decode_layout_table` callers: `src/test_support.rs:1478`,
+  `crates/luminal_reference/src/{harness.rs:209, runtime.rs:1684, search.rs:355,426}`,
+  `crates/luminal_cuda_lite/src/{finalists.rs:245, search.rs:503,657}`.
+* `.mirror` field reads: `arena.rs:82`, `kernels.rs:64,368,371,539`, CL `layouts.rs:71,83,126`,
+  `exec.rs:325,344`, reference `runtime.rs:553,778`, `test_support.rs:3984-3985`,
+  `codegen_identity.rs:67,234`, `view_admission.rs:133,154,218,283,323,364`, `cublaslt_bias_premise.rs:317`.
+* Bias decorator premise: `cublaslt_marker_decorate.egg:182` (and the second decorator's copy at :244).
+* Contiguous discovery unions: `egglog_preamble.egg:3530-3560`; `layout-of` function :451; Layout datatype :203-241.
+* `bind_destination` callers: `device.rs:525`, tests; `assert_bias_destination_order` callers: `exec.rs:366`, `device_call.rs:261`.
+* Saturation→serialize sites: CL `runtime.rs:432-456`, `search.rs:931-934`; reference `runtime.rs:332-365`,
+  `search.rs:536-538`, `harness.rs:82-84, 186-190`, `runtime.rs:1672-1674`, `search.rs:737-739`;
+  core `extraction.rs:4309-4311`; `test_runtime/src/lib.rs:144-146`.
+* `OpMatcher` trait: `src/layout_ir/mod.rs:518-547`; `RegisteredOp`: `crates/luminal_cuda_lite/src/ops/mod.rs:74-77`;
+  `ReferenceOp`: `crates/luminal_reference/src/ops/mod.rs:144-150`; `assembled_program_for`: `src/egglog_snippet.rs:142-152`.
+* `PlanLayout: Clone + Debug`: `src/bufferize.rs:99-100`. `rust-version = "1.85"`: `Cargo.toml:5`.
+* egglog fork rev 1bb30831 (`Cargo.toml:30-31`): `functions_iter` `src/lib.rs:1236`, `get_function` :2318,
+  `Function::func_type` :342, `type_info(&mut self)` :589, `pub use typechecking::FuncType` :74,
+  `FuncType` fields `src/typechecking.rs:115-120`, `FunctionSubtype` `src/ast/mod.rs:1298-1302`,
+  `Sort::name` `src/sort/mod.rs:52`, serializer op/children :204-224, `typ` :393, `[...]` :331,
+  `SerializeConfig::default` = no truncation :59-63.
+* egraph-serialize 0.3.0: `EGraph` :65-74, `classes()` :107-120, `Node` :168-177, `Class` :190-193, `ClassData` :197-203, `ClassId(Arc<str>)` :21.
+* Codegen string pins: `codegen_identity.rs:405,440,464,491,523`; message pins :573,603,939,953,1012; cuBLASLt message pins `cublaslt_contracts_cpu.rs:225-234,464-485,498`.
+* PR #507: branch `fix/cublaslt-degenerate-d-order` @ c3b4c428, files `exec.rs` (+61), `cublaslt_bias_premise.rs` (+189), `cublaslt_contracts.rs` (+119), `cublaslt_contracts_cpu.rs` (+129); OPEN, not merged.

--- a/docs/design/eclass-decoder.md
+++ b/docs/design/eclass-decoder.md
@@ -178,20 +178,22 @@ impl<'g> ENode<'g> {
 pub trait Sort: 'static {
     const NAME: &'static str;
     type Facts: ?Sized + DynFacts;
+    /// The downcast door, one line per sort (`{ facts }`): the trait
+    /// upcast `dyn XFacts` -> `dyn Any`. See §2.5.
+    fn upcast_any(facts: &Self::Facts) -> &dyn Any;
 }
 
 /// The sort-agnostic erased surface every decoded constructor exposes.
 /// Blanket-implemented for every `EgglogConstructor` that is
 /// `PartialEq + Debug + Send + Sync`, so constructor structs write NO
-/// boilerplate for it.
+/// boilerplate for it. `Any` is a supertrait, which is what makes a
+/// fact object upcastable (§2.5) — there is no `as_any()` here.
 pub trait DynFacts: Any + std::fmt::Debug + Send + Sync {
     fn constructor(&self) -> &'static str;
-    fn as_any(&self) -> &dyn Any;
     fn dyn_eq(&self, other: &dyn Any) -> bool;
 }
 impl<T: EgglogConstructor + PartialEq + std::fmt::Debug + Send + Sync> DynFacts for T {
     fn constructor(&self) -> &'static str { T::NAME }
-    fn as_any(&self) -> &dyn Any { self }
     fn dyn_eq(&self, other: &dyn Any) -> bool { other.downcast_ref::<T>() == Some(self) }
 }
 
@@ -249,7 +251,7 @@ pub struct Spellings<S: Sort> {
     failed: Vec<(&'static str, String)>,    // (name, reason) per undecodable node
 }
 impl<S: Sort> Spellings<S> {
-    pub fn first<C: EgglogConstructor<Sort = S>>(&self) -> Option<&C>;   // as_any().downcast_ref
+    pub fn first<C: EgglogConstructor<Sort = S>>(&self) -> Option<&C>;   // S::upcast_any().downcast_ref
     pub fn all<C: EgglogConstructor<Sort = S>>(&self) -> Vec<&C>;
     pub fn has<C: EgglogConstructor<Sort = S>>(&self) -> bool;
     pub fn require<C: EgglogConstructor<Sort = S>>(&self, who: &str) -> Result<&C>;
@@ -302,7 +304,7 @@ pub trait LayoutFacts: DynFacts {
     /// bit offset, a negative result.
     fn element_index(&self, coords: &[usize]) -> Result<usize>;
 }
-impl PartialEq for dyn LayoutFacts { fn eq(&self, o: &Self) -> bool { self.dyn_eq(o.as_any()) } }
+impl PartialEq for dyn LayoutFacts { fn eq(&self, o: &Self) -> bool { self.dyn_eq(o as &dyn Any) } }
 impl Eq for dyn LayoutFacts {}
 
 // The five structs (unchanged fields, `src/layouts.rs:129-167`) each get:
@@ -428,17 +430,44 @@ one class).
 Recovering a concrete struct from the erased path:
 
 ```rust
-// (a) explicit as_any — WORKS ON THE DECLARED MSRV
+// (a) explicit as_any — a hand-written door on the fact trait
 let lm = facts.as_any().downcast_ref::<LeftMajorContiguousElementLayout>();
 // (b) trait upcasting to dyn Any — requires Rust ≥ 1.86
 let lm = (facts as &dyn Any).downcast_ref::<LeftMajorContiguousElementLayout>();
 ```
 
-DECISION: use (a). The workspace declares `rust-version = "1.85"` (VERIFIED
-`Cargo.toml:5`); trait upcasting stabilized in 1.86, so (b) does not compile
-under the declared floor even though the local toolchain is 1.91.1. (a) costs
-nothing because `DynFacts::as_any` is blanket-provided. `Spellings::first::<C>()`
-wraps it so call sites rarely spell either.
+DECISION (2026-09-05, amended): use (b), trait upcasting. The original decision
+was (a), because the workspace declared `rust-version = "1.85"` and upcasting
+stabilized in 1.86. That floor was already false — the tree uses let-chains
+(stable 1.88) at 27 `&& let` sites — so the same follow-up raises it to
+`rust-version = "1.91"` (`Cargo.toml:5`), the oldest toolchain we run (this Mac
+1.91.1, the A100 box 1.95). `DynFacts::as_any` is therefore DELETED; `Any` stays a supertrait of
+`DynFacts`, which is exactly what makes a fact object upcastable.
+
+One nuance the type system forces, VERIFIED with rustc 1.91.1: an upcast is a
+coercion between two KNOWN types, so it cannot be written over the generic
+`S::Facts`, which is `?Sized` —
+
+```
+error[E0277]: the size for values of type `<S as Sort>::Facts` cannot be known
+              at compilation time
+   = note: required for the cast from `&<S as Sort>::Facts` to `&(dyn Any + 'static)`
+```
+
+— so the upcast is spelled once per SORT, as `Sort::upcast_any`:
+
+```rust
+impl Sort for Layout {
+    const NAME: &'static str = "Layout";
+    type Facts = dyn LayoutFacts;
+    fn upcast_any(facts: &Self::Facts) -> &dyn Any { facts }   // the upcast
+}
+```
+
+— the same shape, and for the same reason, as `EgglogConstructor::erase` (§8.2):
+one line where the concrete `dyn` type is known. Constructor structs still write
+no boilerplate, and `Spellings::first::<C>()` wraps the door so call sites spell
+neither. Concrete sites (`impl PartialEq for dyn LayoutFacts`) upcast directly.
 
 ---
 
@@ -998,8 +1027,10 @@ into `Arc<<C::Sort as Sort>::Facts>` is an unsizing coercion the compiler only
 performs where the concrete type AND the target `dyn` type are both known, so it
 cannot be written once generically over `S::Facts`; hence
 `EgglogConstructor::erase(self)` with a one-line `Arc::new(self)` per struct
-(five lines total). `DynFacts` is blanket-implemented, so `constructor()`,
-`as_any()`, `dyn_eq()` cost the structs nothing. `dyn-clone` is in `Cargo.lock`
+(five lines total). The same constraint applies to the `dyn Any` upcast in the
+other direction, hence `Sort::upcast_any` — one line per sort (§2.5). `DynFacts`
+is blanket-implemented, so `constructor()` and `dyn_eq()` cost the structs
+nothing. `dyn-clone` is in `Cargo.lock`
 (line 506) but is not needed: `Arc` gives `Clone` for free, which is why the
 items are `Arc<S::Facts>` and not `Box`.
 
@@ -1115,7 +1146,8 @@ also deletes the arm; nothing else changes.
   core `extraction.rs:4309-4311`; `test_runtime/src/lib.rs:144-146`.
 * `OpMatcher` trait: `src/layout_ir/mod.rs:518-547`; `RegisteredOp`: `crates/luminal_cuda_lite/src/ops/mod.rs:74-77`;
   `ReferenceOp`: `crates/luminal_reference/src/ops/mod.rs:144-150`; `assembled_program_for`: `src/egglog_snippet.rs:142-152`.
-* `PlanLayout: Clone + Debug`: `src/bufferize.rs:99-100`. `rust-version = "1.85"`: `Cargo.toml:5`.
+* `PlanLayout: Clone + Debug`: `src/bufferize.rs:99-100`. `rust-version = "1.91"`: `Cargo.toml:5`
+  (raised from "1.85" on 2026-09-05 with the §2.5 amendment; let-chains already needed 1.88).
 * egglog fork rev 1bb30831 (`Cargo.toml:30-31`): `functions_iter` `src/lib.rs:1236`, `get_function` :2318,
   `Function::func_type` :342, `type_info(&mut self)` :589, `pub use typechecking::FuncType` :74,
   `FuncType` fields `src/typechecking.rs:115-120`, `FunctionSubtype` `src/ast/mod.rs:1298-1302`,

--- a/src/bufferize.rs
+++ b/src/bufferize.rs
@@ -339,7 +339,7 @@ pub enum BufferNode<L: PlanLayout> {
 // something called 'test equality' or something in the testing crate").
 // Element readback through a returned layout is a TEST concern: the
 // testing crate's `test_equality` module evaluates the runtime's own
-// layout vocabulary ((buffer, layout) pairs, mirror-struct expressions),
+// layout vocabulary ((buffer, layout) pairs, constructor-struct expressions),
 // with no core involvement. Core transports layouts; it never reads
 // through them.
 

--- a/src/egglog_core/egglog_utils/eclass.rs
+++ b/src/egglog_core/egglog_utils/eclass.rs
@@ -10,8 +10,9 @@
 //!    `children[i]` is a node inside argument `i`'s class);
 //!  * [`EgglogConstructor`] — one egglog constructor mirrored as a Rust
 //!    struct that can decode ONE e-node of that constructor;
-//!  * [`Sort`] / [`DynFacts`] — a decoded sort's name and the erased
-//!    fact surface its constructors share;
+//!  * [`Sort`] / [`DynFacts`] — a decoded sort's name, the erased fact
+//!    surface its constructors share, and the one-line-per-sort upcast
+//!    to `dyn Any` that reopens a concrete spelling;
 //!  * [`ConstructorDecoder`] / [`ConstructorRegistry`] — the registered
 //!    `(sort, constructor)` decoders, and the assembly TRIPWIRE that
 //!    proves a program's every constructor of a decoded sort has exactly
@@ -377,20 +378,33 @@ impl<'g> ENode<'g> {
 pub trait Sort: 'static {
     const NAME: &'static str;
     type Facts: ?Sized + DynFacts;
+
+    /// The DOWNCAST DOOR, opened once per sort: a trait upcast from the
+    /// sort's fact object to `dyn Any` (`Any` is a supertrait of
+    /// [`DynFacts`]), so `Spellings::first::<C>()` can recover the
+    /// concrete constructor struct.
+    ///
+    /// One line per sort — `{ facts }` — because an upcast coercion is
+    /// only expressible where the concrete `dyn` type is known; over a
+    /// `?Sized` `Self::Facts` the compiler has no unsizing to perform.
+    /// Same reason [`EgglogConstructor::erase`] is written per struct.
+    /// Constructor structs still write NO boilerplate for it.
+    fn upcast_any(facts: &Self::Facts) -> &dyn Any;
 }
 
 /// The sort-agnostic erased surface every decoded constructor exposes.
 /// Blanket-implemented for every [`EgglogConstructor`] that is
 /// `PartialEq + Debug + Send + Sync`, so constructor structs write NO
 /// boilerplate for it.
+///
+/// `Any` is a SUPERTRAIT: a `dyn LayoutFacts` (or any other sort's fact
+/// object) upcasts to `dyn Any` on its own, which is why there is no
+/// `as_any()` here. [`Sort::upcast_any`] spells that upcast once per
+/// sort, where the concrete `dyn` type is known.
 pub trait DynFacts: Any + std::fmt::Debug + Send + Sync {
     /// The egglog constructor this value was decoded from — a NAME, for
     /// diagnostics. Nothing branches on it to change behaviour.
     fn constructor(&self) -> &'static str;
-    /// The downcast door (`as_any().downcast_ref::<C>()`), spelled
-    /// explicitly because trait upcasting needs Rust 1.86 and the
-    /// workspace floor is 1.85.
-    fn as_any(&self) -> &dyn Any;
     /// Structural equality against another erased value.
     fn dyn_eq(&self, other: &dyn Any) -> bool;
 }
@@ -398,9 +412,6 @@ pub trait DynFacts: Any + std::fmt::Debug + Send + Sync {
 impl<T: EgglogConstructor + PartialEq + std::fmt::Debug + Send + Sync> DynFacts for T {
     fn constructor(&self) -> &'static str {
         T::NAME
-    }
-    fn as_any(&self) -> &dyn Any {
-        self
     }
     fn dyn_eq(&self, other: &dyn Any) -> bool {
         other.downcast_ref::<T>() == Some(self)
@@ -630,13 +641,13 @@ impl<S: Sort> Spellings<S> {
     pub fn first<C: EgglogConstructor<Sort = S>>(&self) -> Option<&C> {
         self.decoded
             .iter()
-            .find_map(|item| item.as_any().downcast_ref::<C>())
+            .find_map(|item| S::upcast_any(&**item).downcast_ref::<C>())
     }
 
     pub fn all<C: EgglogConstructor<Sort = S>>(&self) -> Vec<&C> {
         self.decoded
             .iter()
-            .filter_map(|item| item.as_any().downcast_ref::<C>())
+            .filter_map(|item| S::upcast_any(&**item).downcast_ref::<C>())
             .collect()
     }
 
@@ -704,7 +715,7 @@ impl<S: Sort> PartialEq for Spellings<S> {
                 .decoded
                 .iter()
                 .zip(&other.decoded)
-                .all(|(a, b)| a.dyn_eq(b.as_any()))
+                .all(|(a, b)| a.dyn_eq(S::upcast_any(&**b)))
     }
 }
 
@@ -735,6 +746,9 @@ mod tests {
     impl Sort for Pair {
         const NAME: &'static str = "Pair";
         type Facts = dyn PairFacts;
+        fn upcast_any(facts: &Self::Facts) -> &dyn Any {
+            facts
+        }
     }
 
     pub trait PairFacts: DynFacts {

--- a/src/egglog_core/egglog_utils/eclass.rs
+++ b/src/egglog_core/egglog_utils/eclass.rs
@@ -1,0 +1,951 @@
+//! READING A SERIALIZED E-CLASS, one named constructor at a time.
+//!
+//! This module knows nothing about layouts, dtypes, or any particular
+//! egglog sort. It is the generic surface over a serialized e-graph:
+//!
+//!  * [`EGraphView`] — a serialized e-graph plus the decoders that know
+//!    its constructors;
+//!  * [`EClass`] / [`ENode`] — a class and its e-nodes, with children
+//!    resolved back to CLASSES (the serializer's contract: a node's
+//!    `children[i]` is a node inside argument `i`'s class);
+//!  * [`EgglogConstructor`] — one egglog constructor mirrored as a Rust
+//!    struct that can decode ONE e-node of that constructor;
+//!  * [`Sort`] / [`DynFacts`] — a decoded sort's name and the erased
+//!    fact surface its constructors share;
+//!  * [`ConstructorDecoder`] / [`ConstructorRegistry`] — the registered
+//!    `(sort, constructor)` decoders, and the assembly TRIPWIRE that
+//!    proves a program's every constructor of a decoded sort has exactly
+//!    one.
+//!
+//! THERE IS NO PREFERENCE ORDER HERE, and there is no closed enum of
+//! constructors. A caller that wants one spelling names it —
+//! `first::<C>()`, `has::<C>()`, `require::<C>(who)` — and a caller that
+//! wants "whatever facts this class discloses" asks the registry through
+//! `spellings::<S>()`. Which spelling a call site prefers is that call
+//! site's business; the reader never chooses for it.
+//!
+//! Ordering is decided in exactly one place, [`EClass::nodes`]:
+//! UNSUBSUMED nodes first, then by `NodeId`. Subsumed nodes are kept — a
+//! subsumed constructor is still a true member of its class, and
+//! saturation can subsume every constructor spelling of a class.
+//!
+//! NOTE ON THE NAME `Sort`: egglog has its own `egglog::sort::Sort`
+//! trait. This module never imports it (it reaches egglog's sorts only
+//! through `ArcSort::name()`), so the collision is a reading hazard and
+//! not a compile one.
+
+use anyhow::{Result, anyhow, bail};
+use egraph_serialize::{ClassId, EGraph, Node, NodeId};
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+// =============================================================================
+// The view, the class, the node
+// =============================================================================
+
+/// Read-only view of one serialized e-graph plus the decoders that know
+/// its constructors. Two references; `Copy`.
+#[derive(Clone, Copy)]
+pub struct EGraphView<'g> {
+    egraph: &'g EGraph,
+    decoders: &'g ConstructorRegistry,
+}
+
+impl<'g> EGraphView<'g> {
+    pub fn new(egraph: &'g EGraph, decoders: &'g ConstructorRegistry) -> Self {
+        Self { egraph, decoders }
+    }
+
+    /// TOTAL: an id with no nodes yields a class whose [`EClass::nodes`]
+    /// is empty (asking about an absent class is a question, not a bug).
+    pub fn class(&self, id: &ClassId) -> EClass<'g> {
+        EClass {
+            view: *self,
+            id: id.clone(),
+        }
+    }
+
+    pub fn egraph(&self) -> &'g EGraph {
+        self.egraph
+    }
+
+    pub fn decoders(&self) -> &'g ConstructorRegistry {
+        self.decoders
+    }
+}
+
+impl std::fmt::Debug for EGraphView<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EGraphView")
+            .field("nodes", &self.egraph.nodes.len())
+            .field("decoders", &self.decoders.len())
+            .finish()
+    }
+}
+
+/// One e-class of the view. Cheap to clone (the id is an `Arc<str>`).
+#[derive(Clone)]
+pub struct EClass<'g> {
+    view: EGraphView<'g>,
+    id: ClassId,
+}
+
+impl std::fmt::Debug for EClass<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EClass")
+            .field("id", &self.id)
+            .field("sort", &self.sort_name())
+            .field("ops", &self.ops())
+            .finish()
+    }
+}
+
+impl<'g> EClass<'g> {
+    pub fn id(&self) -> &ClassId {
+        &self.id
+    }
+
+    pub fn view(&self) -> EGraphView<'g> {
+        self.view
+    }
+
+    /// `class_data[id].typ` — the egglog sort name the serializer
+    /// stamped on this class.
+    pub fn sort_name(&self) -> Option<&'g str> {
+        self.view
+            .egraph
+            .class_data
+            .get(&self.id)
+            .and_then(|data| data.typ.as_deref())
+    }
+
+    /// Every e-node in the class: UNSUBSUMED FIRST, then by `NodeId`.
+    /// THE ONLY PLACE ORDER IS DECIDED.
+    pub fn nodes(&self) -> Vec<ENode<'g>> {
+        let Some(class) = self.view.egraph.classes().get(&self.id) else {
+            return Vec::new();
+        };
+        let mut ids: Vec<&'g NodeId> = class.nodes.iter().collect();
+        ids.sort();
+        let mut out: Vec<ENode<'g>> = Vec::with_capacity(ids.len());
+        for want_subsumed in [false, true] {
+            for id in &ids {
+                let Some(node) = self.view.egraph.nodes.get(*id) else {
+                    continue;
+                };
+                if node.subsumed == want_subsumed {
+                    out.push(ENode {
+                        view: self.view,
+                        id,
+                        node,
+                    });
+                }
+            }
+        }
+        out
+    }
+
+    /// The class's nodes whose op is exactly `op`, in [`EClass::nodes`]
+    /// order.
+    pub fn nodes_named(&self, op: &str) -> impl Iterator<Item = ENode<'g>> + '_ {
+        let op = op.to_string();
+        self.nodes().into_iter().filter(move |n| n.op() == op)
+    }
+
+    /// Every distinct `op` in the class, in [`EClass::nodes`] order —
+    /// diagnostics.
+    pub fn ops(&self) -> Vec<String> {
+        let mut seen: Vec<String> = Vec::new();
+        for node in self.nodes() {
+            if !seen.iter().any(|op| op == node.op()) {
+                seen.push(node.op().to_string());
+            }
+        }
+        seen
+    }
+
+    /// Any node in the class whose op parses as an i64 (the serializer
+    /// renders base values with `{:?}`, so an i64 literal is a digit
+    /// string).
+    pub fn i64_literal(&self) -> Option<i64> {
+        self.nodes()
+            .into_iter()
+            .find_map(|n| n.op().parse::<i64>().ok())
+    }
+
+    /// Any node in the class whose op is a quoted string literal.
+    pub fn string_literal(&self) -> Option<String> {
+        self.nodes().into_iter().find_map(|n| {
+            n.op()
+                .strip_prefix('"')?
+                .strip_suffix('"')
+                .map(str::to_string)
+        })
+    }
+
+    // ---- typed, registry-free: the call site names the constructor ----
+
+    /// Every node named `C::NAME` that DECODES, in [`EClass::nodes`]
+    /// order.
+    pub fn all<C: EgglogConstructor>(&self) -> Vec<C> {
+        self.nodes_named(C::NAME)
+            .filter_map(|node| C::decode(&node).ok())
+            .collect()
+    }
+
+    /// The first node named `C::NAME` that decodes.
+    pub fn first<C: EgglogConstructor>(&self) -> Option<C> {
+        self.nodes_named(C::NAME)
+            .find_map(|node| C::decode(&node).ok())
+    }
+
+    /// A DECODABLE `C` spelling is present in the class.
+    pub fn has<C: EgglogConstructor>(&self) -> bool {
+        self.first::<C>().is_some()
+    }
+
+    /// [`EClass::first`] or a refusal naming who asked, the class, its
+    /// sort, `C::NAME`, and what the class does hold.
+    pub fn require<C: EgglogConstructor>(&self, who: &str) -> Result<C> {
+        self.first::<C>().ok_or_else(|| {
+            anyhow!(
+                "{who}: e-class {} (sort {}) holds no decodable `{}` spelling — \
+                 registered {} constructors present: {:?}; every op in the class: {:?}",
+                self.id,
+                self.sort_name().unwrap_or("?"),
+                C::NAME,
+                <C::Sort as Sort>::NAME,
+                self.present::<C::Sort>(),
+                self.ops()
+            )
+        })
+    }
+
+    /// [`EClass::require`] as a panic — ONLY after validation.
+    pub fn expect<C: EgglogConstructor>(&self, why: &str) -> C {
+        match self.require::<C>(why) {
+            Ok(found) => found,
+            Err(err) => panic!("{err:#}"),
+        }
+    }
+
+    // ---- erased, registry-driven: generic code over a sort ----
+
+    /// Registered constructor names of sort `S` that APPEAR in the class
+    /// (at least one node, decodable or not), in REGISTRY order.
+    pub fn present<S: Sort>(&self) -> Vec<&'static str> {
+        let ops = self.ops();
+        self.view
+            .decoders
+            .constructors_of(S::NAME)
+            .filter(|name| ops.iter().any(|op| op == name))
+            .collect()
+    }
+
+    /// Every registered constructor of `S` present in the class,
+    /// decoded — registry order, then node order.
+    pub fn spellings<S: Sort>(&self) -> Spellings<S> {
+        let nodes = self.nodes();
+        let mut decoded: Vec<Arc<S::Facts>> = Vec::new();
+        let mut present: Vec<&'static str> = Vec::new();
+        let mut failed: Vec<(&'static str, String)> = Vec::new();
+        for name in self.view.decoders.constructors_of(S::NAME) {
+            let decoder = self
+                .view
+                .decoders
+                .get(S::NAME, name)
+                .expect("constructors_of only names registered decoders");
+            let mut seen = false;
+            for node in nodes.iter().filter(|n| n.op() == name) {
+                seen = true;
+                match (decoder.decode)(node) {
+                    Ok(erased) => match erased.downcast::<Arc<S::Facts>>() {
+                        Ok(facts) => decoded.push(*facts),
+                        Err(_) => panic!(
+                            "decoder ({}, {name}) produced a value that is not an \
+                             Arc of the sort's fact type — a registry bug",
+                            S::NAME
+                        ),
+                    },
+                    Err(err) => failed.push((name, format!("{err:#}"))),
+                }
+            }
+            if seen {
+                present.push(name);
+            }
+        }
+        Spellings {
+            decoded,
+            present,
+            failed,
+        }
+    }
+
+    /// [`EClass::spellings`] items, for the "I just need a fact" shape.
+    pub fn facts<S: Sort>(&self) -> std::vec::IntoIter<Arc<S::Facts>> {
+        self.spellings::<S>().decoded.into_iter()
+    }
+
+    /// Ops in the class with NO decoder registered under sort `S`. A
+    /// decoded sort's class legitimately holds such rows (`Custom`
+    /// function rows whose output sort is `S`, the serializer's `[...]`
+    /// truncation placeholder), so this is DIAGNOSTICS ONLY — the
+    /// tripwire, not this list, is what proves the constructors are
+    /// covered.
+    pub fn unknown<S: Sort>(&self) -> Vec<String> {
+        self.ops()
+            .into_iter()
+            .filter(|op| self.view.decoders.get(S::NAME, op).is_none())
+            .collect()
+    }
+}
+
+/// One e-node: its op name plus its children as CLASSES.
+#[derive(Clone, Copy)]
+pub struct ENode<'g> {
+    view: EGraphView<'g>,
+    id: &'g NodeId,
+    node: &'g Node,
+}
+
+impl std::fmt::Debug for ENode<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ENode")
+            .field("id", self.id)
+            .field("op", &self.node.op)
+            .field("arity", &self.node.children.len())
+            .finish()
+    }
+}
+
+impl<'g> ENode<'g> {
+    pub fn id(&self) -> &'g NodeId {
+        self.id
+    }
+
+    pub fn op(&self) -> &'g str {
+        &self.node.op
+    }
+
+    /// The class this node belongs to.
+    pub fn class(&self) -> EClass<'g> {
+        self.view.class(&self.node.eclass)
+    }
+
+    pub fn is_subsumed(&self) -> bool {
+        self.node.subsumed
+    }
+
+    pub fn arity(&self) -> usize {
+        self.node.children.len()
+    }
+
+    /// `children[i]` resolved to that child node's e-class — the
+    /// serializer's contract (an argument is rendered as SOME node
+    /// inside the argument's class).
+    pub fn child(&self, index: usize) -> Option<EClass<'g>> {
+        let child = self.node.children.get(index)?;
+        let class = &self.view.egraph.nodes.get(child)?.eclass;
+        Some(self.view.class(class))
+    }
+
+    /// [`ENode::child`] or a refusal naming the constructor and index —
+    /// an arity the decoder assumed and the program does not have.
+    pub fn child_or_bail(&self, index: usize) -> Result<EClass<'g>> {
+        self.child(index).ok_or_else(|| {
+            anyhow!(
+                "`{}` node {} has no child {index} (arity {})",
+                self.op(),
+                self.id,
+                self.arity()
+            )
+        })
+    }
+
+    pub fn children(&self) -> Vec<EClass<'g>> {
+        (0..self.arity()).filter_map(|i| self.child(i)).collect()
+    }
+}
+
+// =============================================================================
+// Sorts, constructors, erased facts
+// =============================================================================
+
+/// A DECODED SORT: its egglog name and the erased fact surface its
+/// constructors share (e.g. `Layout: Sort<Facts = dyn LayoutFacts>`).
+pub trait Sort: 'static {
+    const NAME: &'static str;
+    type Facts: ?Sized + DynFacts;
+}
+
+/// The sort-agnostic erased surface every decoded constructor exposes.
+/// Blanket-implemented for every [`EgglogConstructor`] that is
+/// `PartialEq + Debug + Send + Sync`, so constructor structs write NO
+/// boilerplate for it.
+pub trait DynFacts: Any + std::fmt::Debug + Send + Sync {
+    /// The egglog constructor this value was decoded from — a NAME, for
+    /// diagnostics. Nothing branches on it to change behaviour.
+    fn constructor(&self) -> &'static str;
+    /// The downcast door (`as_any().downcast_ref::<C>()`), spelled
+    /// explicitly because trait upcasting needs Rust 1.86 and the
+    /// workspace floor is 1.85.
+    fn as_any(&self) -> &dyn Any;
+    /// Structural equality against another erased value.
+    fn dyn_eq(&self, other: &dyn Any) -> bool;
+}
+
+impl<T: EgglogConstructor + PartialEq + std::fmt::Debug + Send + Sync> DynFacts for T {
+    fn constructor(&self) -> &'static str {
+        T::NAME
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn dyn_eq(&self, other: &dyn Any) -> bool {
+        other.downcast_ref::<T>() == Some(self)
+    }
+}
+
+/// ONE EGGLOG CONSTRUCTOR, mirrored as a Rust struct.
+pub trait EgglogConstructor: Sized + 'static {
+    /// The full egglog constructor name, e.g.
+    /// `"RightMajorContiguousElementLayoutLit"`.
+    const NAME: &'static str;
+    /// The sort this constructor produces.
+    type Sort: Sort;
+
+    /// Decode ONE e-node of this constructor. `node.op() == Self::NAME`
+    /// is guaranteed by the callers; children are read by index.
+    /// Failure means THIS SPELLING does not parse (a foreign-shape
+    /// coordinate under the owner-shape guard, a cons spine with no
+    /// parsing spelling, a cycle) — the caller moves on to the next
+    /// node, exactly as the spelling walk always has.
+    fn decode(node: &ENode<'_>) -> Result<Self>;
+
+    /// Erase into the sort's shared fact object. One line per struct
+    /// (`Arc::new(self)`): the unsizing coercion is only expressible
+    /// where the concrete type and the target `dyn` type are both known.
+    fn erase(self) -> Arc<<Self::Sort as Sort>::Facts>;
+}
+
+// =============================================================================
+// The registry and THE TRIPWIRE
+// =============================================================================
+
+/// A registered `(sort, constructor)` decoder. `decode` yields a
+/// `Box<dyn Any>` that HOLDS an `Arc<<S as Sort>::Facts>` — the
+/// convention [`Spellings`] downcasts back through.
+pub struct ConstructorDecoder {
+    pub sort: &'static str,
+    pub name: &'static str,
+    pub decode: fn(&ENode<'_>) -> Result<Box<dyn Any>>,
+}
+
+impl ConstructorDecoder {
+    pub fn of<C: EgglogConstructor>() -> Self {
+        Self {
+            sort: <C::Sort as Sort>::NAME,
+            name: C::NAME,
+            decode: |node| C::decode(node).map(|c| Box::new(c.erase()) as Box<dyn Any>),
+        }
+    }
+}
+
+impl std::fmt::Debug for ConstructorDecoder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConstructorDecoder")
+            .field("sort", &self.sort)
+            .field("name", &self.name)
+            .finish()
+    }
+}
+
+/// Decoders keyed by `(sort, constructor)`, in INSERTION ORDER (core
+/// built-ins first, then matcher contributions in registry order). That
+/// order is the only order [`Spellings`] and [`EClass::present`] speak
+/// in — it is a listing order, never a preference.
+#[derive(Debug, Default)]
+pub struct ConstructorRegistry {
+    entries: Vec<ConstructorDecoder>,
+    index: HashMap<(&'static str, &'static str), usize>,
+}
+
+impl ConstructorRegistry {
+    /// Build a registry. A duplicate `(sort, name)` is REFUSED: "exactly
+    /// one decoder" is the contract, and a duplicate is a registration
+    /// bug, never a preference to resolve.
+    pub fn new(decoders: impl IntoIterator<Item = ConstructorDecoder>) -> Result<Self> {
+        let mut registry = Self::default();
+        for decoder in decoders {
+            let key = (decoder.sort, decoder.name);
+            if registry.index.contains_key(&key) {
+                bail!(
+                    "sort {}: two decoders registered for `{}` — every constructor \
+                     of a decoded sort has exactly one decoder, registered beside \
+                     the snippet that declares it",
+                    decoder.sort,
+                    decoder.name
+                );
+            }
+            registry.index.insert(key, registry.entries.len());
+            registry.entries.push(decoder);
+        }
+        Ok(registry)
+    }
+
+    pub fn get(&self, sort: &str, name: &str) -> Option<&ConstructorDecoder> {
+        self.entries
+            .iter()
+            .find(|d| d.sort == sort && d.name == name)
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Every DECODED sort name, in registry order, once each.
+    pub fn sorts(&self) -> impl Iterator<Item = &'static str> + '_ {
+        let mut seen: Vec<&'static str> = Vec::new();
+        for entry in &self.entries {
+            if !seen.contains(&entry.sort) {
+                seen.push(entry.sort);
+            }
+        }
+        seen.into_iter()
+    }
+
+    /// The registered constructors of one sort, in registry order.
+    pub fn constructors_of<'a>(&'a self, sort: &'a str) -> impl Iterator<Item = &'static str> + 'a {
+        self.entries
+            .iter()
+            .filter(move |d| d.sort == sort)
+            .map(|d| d.name)
+    }
+
+    /// THE ASSEMBLY TRIPWIRE. Run against the LIVE e-graph right after
+    /// the assembled program parses and before it is serialized: every
+    /// `(constructor ...)` (and `(datatype ...)` variant) whose OUTPUT
+    /// sort is a sort this registry decodes must have a decoder, and
+    /// every decoder must name a constructor the program declares under
+    /// that sort.
+    ///
+    /// `Custom` function rows are SKIPPED — a `(function ... :no-merge)`
+    /// row such as `layout-of` has a `Layout` output but is not a
+    /// spelling of one.
+    pub fn check(&self, egraph: &egglog::EGraph) -> Result<()> {
+        use egglog::ast::FunctionSubtype;
+        let mut problems: Vec<String> = Vec::new();
+        // (1) every declared constructor of a decoded sort has a decoder.
+        for (name, func) in egraph.functions_iter() {
+            let func_type = func.func_type();
+            if func_type.subtype != FunctionSubtype::Constructor {
+                continue;
+            }
+            let sort = func_type.output.name();
+            if !self.sorts().any(|registered| registered == sort) {
+                continue;
+            }
+            if self.get(sort, name).is_none() {
+                problems.push(format!(
+                    "sort {sort}: constructor `{name}` is declared by the program but \
+                     has no registered decoder"
+                ));
+            }
+        }
+        // (2) every decoder names a constructor the program declares,
+        //     under the sort it was registered for.
+        for decoder in &self.entries {
+            match egraph.get_function(decoder.name) {
+                None => problems.push(format!(
+                    "sort {}: decoder for `{}` names a constructor the program does \
+                     not declare",
+                    decoder.sort, decoder.name
+                )),
+                Some(func) => {
+                    let func_type = func.func_type();
+                    if func_type.subtype != FunctionSubtype::Constructor
+                        || func_type.output.name() != decoder.sort
+                    {
+                        problems.push(format!(
+                            "sort {}: decoder for `{}` is registered under sort {} but \
+                             the program declares it as {} with output sort {}",
+                            decoder.sort,
+                            decoder.name,
+                            decoder.sort,
+                            func_type.subtype.label(),
+                            func_type.output.name()
+                        ));
+                    }
+                }
+            }
+        }
+        if problems.is_empty() {
+            return Ok(());
+        }
+        bail!(
+            "egglog constructor decoders are incomplete for the assembled program:\n  - {}\n\
+             Every constructor of a decoded sort needs exactly one decoder, registered \
+             beside the snippet that declares it (OpMatcher::decoders); see \
+             docs/design/eclass-decoder.md.",
+            problems.join("\n  - ")
+        )
+    }
+}
+
+// =============================================================================
+// The decoded spelling set of one class
+// =============================================================================
+
+/// The decoded constructor instances of sort `S` found in ONE class —
+/// every registered spelling the class holds, never a chosen one.
+pub struct Spellings<S: Sort> {
+    decoded: Vec<Arc<S::Facts>>,
+    present: Vec<&'static str>,
+    failed: Vec<(&'static str, String)>,
+}
+
+impl<S: Sort> Spellings<S> {
+    /// A hand-built spelling set (test fixtures and plan literals): the
+    /// listed facts, `present` derived from what they say they are.
+    pub fn from_decoded(decoded: Vec<Arc<S::Facts>>) -> Self {
+        let mut present: Vec<&'static str> = Vec::new();
+        for item in &decoded {
+            let name = item.constructor();
+            if !present.contains(&name) {
+                present.push(name);
+            }
+        }
+        Self {
+            decoded,
+            present,
+            failed: Vec::new(),
+        }
+    }
+
+    pub fn first<C: EgglogConstructor<Sort = S>>(&self) -> Option<&C> {
+        self.decoded
+            .iter()
+            .find_map(|item| item.as_any().downcast_ref::<C>())
+    }
+
+    pub fn all<C: EgglogConstructor<Sort = S>>(&self) -> Vec<&C> {
+        self.decoded
+            .iter()
+            .filter_map(|item| item.as_any().downcast_ref::<C>())
+            .collect()
+    }
+
+    pub fn has<C: EgglogConstructor<Sort = S>>(&self) -> bool {
+        self.first::<C>().is_some()
+    }
+
+    pub fn require<C: EgglogConstructor<Sort = S>>(&self, who: &str) -> Result<&C> {
+        self.first::<C>().ok_or_else(|| {
+            anyhow!(
+                "{who}: no decodable `{}` spelling — the {} spellings present are {:?}",
+                C::NAME,
+                S::NAME,
+                self.present
+            )
+        })
+    }
+
+    /// The constructor NAMES with at least one node in the class, in
+    /// registry order.
+    pub fn present(&self) -> &[&'static str] {
+        &self.present
+    }
+
+    /// `(constructor, reason)` for every node that named a registered
+    /// constructor and did not parse.
+    pub fn failed(&self) -> &[(&'static str, String)] {
+        &self.failed
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &S::Facts> {
+        self.decoded.iter().map(|item| &**item)
+    }
+
+    /// The first decoded spelling in registry order — for the
+    /// class-INVARIANT facts (the domain, the width), where every
+    /// spelling of a class must agree.
+    pub fn any(&self) -> Option<&S::Facts> {
+        self.decoded.first().map(|item| &**item)
+    }
+
+    pub fn len(&self) -> usize {
+        self.decoded.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.decoded.is_empty()
+    }
+}
+
+impl<S: Sort> Clone for Spellings<S> {
+    fn clone(&self) -> Self {
+        Self {
+            decoded: self.decoded.clone(),
+            present: self.present.clone(),
+            failed: self.failed.clone(),
+        }
+    }
+}
+
+impl<S: Sort> PartialEq for Spellings<S> {
+    fn eq(&self, other: &Self) -> bool {
+        self.decoded.len() == other.decoded.len()
+            && self
+                .decoded
+                .iter()
+                .zip(&other.decoded)
+                .all(|(a, b)| a.dyn_eq(b.as_any()))
+    }
+}
+
+impl<S: Sort> Eq for Spellings<S> {}
+
+impl<S: Sort> std::fmt::Debug for Spellings<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Spellings")
+            .field("sort", &S::NAME)
+            .field("present", &self.present)
+            .field("decoded", &self.decoded.iter().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+// =============================================================================
+// Tests — over a HAND-BUILT serialized e-graph, with a throwaway sort.
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A throwaway sort and two constructors of it, so the generic
+    // surface is tested with no layout vocabulary in sight.
+    #[derive(Debug)]
+    pub struct Pair;
+    impl Sort for Pair {
+        const NAME: &'static str = "Pair";
+        type Facts = dyn PairFacts;
+    }
+
+    pub trait PairFacts: DynFacts {
+        fn left(&self) -> i64;
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct Point {
+        x: i64,
+        y: i64,
+    }
+    impl EgglogConstructor for Point {
+        const NAME: &'static str = "PointLit";
+        type Sort = Pair;
+        fn decode(node: &ENode<'_>) -> Result<Self> {
+            let x = node
+                .child_or_bail(0)?
+                .i64_literal()
+                .ok_or_else(|| anyhow!("child 0 is not an i64 literal"))?;
+            let y = node
+                .child_or_bail(1)?
+                .i64_literal()
+                .ok_or_else(|| anyhow!("child 1 is not an i64 literal"))?;
+            Ok(Self { x, y })
+        }
+        fn erase(self) -> Arc<dyn PairFacts> {
+            Arc::new(self)
+        }
+    }
+    impl PairFacts for Point {
+        fn left(&self) -> i64 {
+            self.x
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct Named {
+        name: String,
+    }
+    impl EgglogConstructor for Named {
+        const NAME: &'static str = "NamedLit";
+        type Sort = Pair;
+        fn decode(node: &ENode<'_>) -> Result<Self> {
+            let name = node
+                .child_or_bail(0)?
+                .string_literal()
+                .ok_or_else(|| anyhow!("child 0 is not a string literal"))?;
+            Ok(Self { name })
+        }
+        fn erase(self) -> Arc<dyn PairFacts> {
+            Arc::new(self)
+        }
+    }
+    impl PairFacts for Named {
+        fn left(&self) -> i64 {
+            -1
+        }
+    }
+
+    fn node(op: &str, children: &[&str], eclass: &str, subsumed: bool) -> Node {
+        Node {
+            op: op.to_string(),
+            children: children.iter().map(|c| NodeId::from(*c)).collect(),
+            eclass: ClassId::from(eclass),
+            cost: egraph_serialize::Cost::new(1.0).unwrap(),
+            subsumed,
+        }
+    }
+
+    /// One class holding BOTH constructors plus their literal children.
+    fn two_spelling_graph() -> EGraph {
+        let mut egraph = EGraph::default();
+        egraph.add_node("n-x", node("2", &[], "c-x", false));
+        egraph.add_node("n-y", node("3", &[], "c-y", false));
+        egraph.add_node("n-s", node("\"hello\"", &[], "c-s", false));
+        egraph.add_node(
+            "n-point",
+            node("PointLit", &["n-x", "n-y"], "c-pair", false),
+        );
+        egraph.add_node("n-named", node("NamedLit", &["n-s"], "c-pair", false));
+        egraph
+    }
+
+    fn registry() -> ConstructorRegistry {
+        ConstructorRegistry::new([
+            ConstructorDecoder::of::<Point>(),
+            ConstructorDecoder::of::<Named>(),
+        ])
+        .expect("no duplicates")
+    }
+
+    #[test]
+    fn a_class_answers_for_each_constructor_it_is_asked_about() {
+        let egraph = two_spelling_graph();
+        let decoders = registry();
+        let view = EGraphView::new(&egraph, &decoders);
+        let class = view.class(&ClassId::from("c-pair"));
+        assert_eq!(class.first::<Point>(), Some(Point { x: 2, y: 3 }));
+        assert_eq!(
+            class.first::<Named>(),
+            Some(Named {
+                name: "hello".to_string()
+            })
+        );
+        assert!(class.has::<Point>() && class.has::<Named>());
+        assert_eq!(
+            class.present::<Pair>(),
+            vec!["PointLit", "NamedLit"],
+            "present() lists in REGISTRY order, not node order"
+        );
+        // The erased path finds the same two, and the fact surface works.
+        let spellings = class.spellings::<Pair>();
+        assert_eq!(spellings.len(), 2);
+        assert_eq!(spellings.first::<Point>().map(|p| p.x), Some(2));
+        assert_eq!(
+            spellings.iter().map(|f| f.left()).collect::<Vec<_>>(),
+            vec![2, -1]
+        );
+        assert!(spellings.failed().is_empty());
+    }
+
+    /// An absent class is a question, not a bug; and a class that does
+    /// not hold the asked-for constructor refuses by NAME.
+    #[test]
+    fn absent_classes_and_absent_constructors() {
+        let egraph = two_spelling_graph();
+        let decoders = registry();
+        let view = EGraphView::new(&egraph, &decoders);
+        let missing = view.class(&ClassId::from("c-nope"));
+        assert!(missing.nodes().is_empty());
+        assert!(missing.first::<Point>().is_none());
+        let x_class = view.class(&ClassId::from("c-x"));
+        let err = format!("{:#}", x_class.require::<Point>("a caller").unwrap_err());
+        assert!(err.contains("a caller"), "{err}");
+        assert!(err.contains("PointLit"), "{err}");
+        assert!(err.contains("Pair"), "{err}");
+    }
+
+    /// A node that does not parse is SKIPPED, recorded in `failed`, and
+    /// never fatal on its own.
+    #[test]
+    fn an_undecodable_spelling_is_recorded_not_fatal() {
+        let mut egraph = two_spelling_graph();
+        // A second PointLit whose second child is a string: it names the
+        // constructor and does not parse.
+        egraph.add_node("n-bad", node("PointLit", &["n-x", "n-s"], "c-pair2", false));
+        egraph.add_node("n-good", node("NamedLit", &["n-s"], "c-pair2", false));
+        let decoders = registry();
+        let view = EGraphView::new(&egraph, &decoders);
+        let class = view.class(&ClassId::from("c-pair2"));
+        assert!(class.first::<Point>().is_none());
+        assert_eq!(
+            class.present::<Pair>(),
+            vec!["PointLit", "NamedLit"],
+            "present() names it — the node is there; `has` says it does not decode"
+        );
+        let spellings = class.spellings::<Pair>();
+        assert_eq!(spellings.len(), 1);
+        assert_eq!(spellings.failed().len(), 1);
+        assert_eq!(spellings.failed()[0].0, "PointLit");
+    }
+
+    /// UNSUBSUMED FIRST, then by `NodeId` — the only ordering rule.
+    #[test]
+    fn nodes_are_unsubsumed_first_then_by_id() {
+        let mut egraph = EGraph::default();
+        egraph.add_node("n-a", node("2", &[], "c-lit", false));
+        egraph.add_node("n-b", node("5", &[], "c-lit", false));
+        // Insertion order deliberately puts the subsumed one first and
+        // the later id first.
+        egraph.add_node("z-sub", node("SubsumedOp", &[], "c-many", true));
+        egraph.add_node("m-two", node("SecondOp", &[], "c-many", false));
+        egraph.add_node("b-one", node("FirstOp", &[], "c-many", false));
+        let decoders = ConstructorRegistry::default();
+        let view = EGraphView::new(&egraph, &decoders);
+        let class = view.class(&ClassId::from("c-many"));
+        assert_eq!(class.ops(), vec!["FirstOp", "SecondOp", "SubsumedOp"]);
+        assert!(class.nodes()[2].is_subsumed());
+    }
+
+    #[test]
+    fn a_duplicate_registration_is_refused() {
+        let err = ConstructorRegistry::new([
+            ConstructorDecoder::of::<Point>(),
+            ConstructorDecoder::of::<Point>(),
+        ])
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("two decoders registered for `PointLit`"),
+            "{msg}"
+        );
+    }
+
+    /// Structural equality of a spelling SET, and the literal readers.
+    #[test]
+    fn spelling_sets_compare_structurally_and_literals_read() {
+        let egraph = two_spelling_graph();
+        let decoders = registry();
+        let view = EGraphView::new(&egraph, &decoders);
+        let class = view.class(&ClassId::from("c-pair"));
+        assert_eq!(class.spellings::<Pair>(), class.spellings::<Pair>());
+        let hand: Spellings<Pair> = Spellings::from_decoded(vec![Point { x: 2, y: 3 }.erase()]);
+        assert_ne!(hand, class.spellings::<Pair>());
+        assert_eq!(hand.present(), ["PointLit"]);
+        assert_eq!(view.class(&ClassId::from("c-x")).i64_literal(), Some(2));
+        assert_eq!(
+            view.class(&ClassId::from("c-s"))
+                .string_literal()
+                .as_deref(),
+            Some("hello")
+        );
+    }
+}

--- a/src/egglog_core/egglog_utils/mod.rs
+++ b/src/egglog_core/egglog_utils/mod.rs
@@ -9,6 +9,7 @@
 
 pub mod api;
 pub mod base;
+pub mod eclass;
 
 pub use egraph_serialize::{ClassId, NodeId};
 

--- a/src/egglog_snippet.rs
+++ b/src/egglog_snippet.rs
@@ -151,6 +151,29 @@ pub fn assembled_program_for(matchers: &[Box<dyn crate::layout_ir::OpMatcher>]) 
     assemble(core, &snippets)
 }
 
+/// WHAT CORE'S OWN PREAMBLE DECLARES AND DECODES: the five `Layout`
+/// constructors. The declaration and its decoder travel together — this
+/// is the `core` half of that pairing, the matcher's
+/// [`crate::layout_ir::OpMatcher::decoders`] is the other.
+pub fn core_decoders() -> Vec<crate::egglog_utils::eclass::ConstructorDecoder> {
+    crate::layouts::layout_decoders()
+}
+
+/// The decoder registry for a runtime's matcher set — the same shape as
+/// [`assembled_program_for`]: core's built-ins first, then each
+/// matcher's contribution in registry order. A duplicate
+/// `(sort, constructor)` is REFUSED (registering two decoders for one
+/// constructor is a bug, never a preference).
+pub fn decoder_registry_for(
+    matchers: &[Box<dyn crate::layout_ir::OpMatcher>],
+) -> anyhow::Result<crate::egglog_utils::eclass::ConstructorRegistry> {
+    crate::egglog_utils::eclass::ConstructorRegistry::new(
+        core_decoders()
+            .into_iter()
+            .chain(matchers.iter().flat_map(|matcher| matcher.decoders())),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/layout_ir/mod.rs
+++ b/src/layout_ir/mod.rs
@@ -541,6 +541,16 @@ pub trait OpMatcher: std::fmt::Debug {
         Vec::new()
     }
 
+    /// Decoders for every constructor this matcher's snippets DECLARE
+    /// for a decoded sort. Mirrors [`OpMatcher::snippets`]: a
+    /// constructor's declaration and the Rust struct that reads it back
+    /// travel together, so the assembly tripwire can prove the pair is
+    /// complete. Default empty — no matcher declares a `Layout`
+    /// constructor today.
+    fn decoders(&self) -> Vec<crate::egglog_utils::eclass::ConstructorDecoder> {
+        Vec::new()
+    }
+
     /// Build the concrete instance for a matched enode. Infallible by the
     /// validity contract above.
     fn extract(&self, site: &ExtractionSite<'_>) -> Box<dyn LayoutIrOp>;

--- a/src/layouts.rs
+++ b/src/layouts.rs
@@ -39,11 +39,10 @@
 //! guess.
 
 use crate::egglog_utils::eclass::{
-    ConstructorDecoder, ConstructorRegistry, DynFacts, EClass, EGraphView, ENode,
-    EgglogConstructor, Sort, Spellings,
+    ConstructorDecoder, DynFacts, EClass, EGraphView, ENode, EgglogConstructor, Sort, Spellings,
 };
 use anyhow::{Result, anyhow, bail, ensure};
-use egraph_serialize::{ClassId, EGraph};
+use egraph_serialize::ClassId;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -173,21 +172,6 @@ pub struct BitOffsetExpressionLayout {
     pub offset: IntExprTerm,
     pub shape: ShapeTerm,
     pub width: BitWidthTerm,
-}
-
-/// RETIRING (deleted in the next step of this refactor): the closed sum
-/// over the five constructors. It was flagged for review as "too
-/// enum-ish for a vocabulary that is deliberately open" and Austin ruled
-/// it out — a class holds a SET of spellings and every call site names
-/// the one it wants. Kept for exactly one step so consumers move off it
-/// one file at a time.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum MirrorLayout {
-    RightMajor(RightMajorContiguousElementLayout),
-    LeftMajor(LeftMajorContiguousElementLayout),
-    Strided(StridedElementLayout),
-    ElementOffset(ElementOffsetExpressionLayout),
-    BitOffset(BitOffsetExpressionLayout),
 }
 
 // =============================================================================
@@ -336,57 +320,6 @@ impl IntExprTerm {
         })
     }
 }
-
-impl MirrorLayout {
-    /// The layout's DOMAIN shape (every constructor carries one).
-    pub fn shape(&self) -> &ShapeTerm {
-        match self {
-            MirrorLayout::RightMajor(l) => &l.shape,
-            MirrorLayout::LeftMajor(l) => &l.shape,
-            MirrorLayout::Strided(l) => &l.shape,
-            MirrorLayout::ElementOffset(l) => &l.shape,
-            MirrorLayout::BitOffset(l) => &l.shape,
-        }
-    }
-
-    /// The element access width in bits.
-    pub fn width_bits(&self) -> i64 {
-        match self {
-            MirrorLayout::RightMajor(l) => l.width.0,
-            MirrorLayout::LeftMajor(l) => l.width.0,
-            MirrorLayout::Strided(l) => l.width.0,
-            MirrorLayout::ElementOffset(l) => l.width.0,
-            MirrorLayout::BitOffset(l) => l.width.0,
-        }
-    }
-
-    /// The domain extents as literals — `None` if any axis is symbolic.
-    pub fn literal_extents(&self) -> Option<Vec<usize>> {
-        self.shape()
-            .0
-            .iter()
-            .map(|e| e.eval_literal().and_then(|v| usize::try_from(v).ok()))
-            .collect()
-    }
-
-    /// The layout's storage reach in ELEMENTS, where the constructor
-    /// discloses one ([`SpanExpr`]: the packed ladder) and the terms are
-    /// literal. `None` for the offset-expression forms (undisclosed
-    /// reach) and for symbolic terms — allocation-sizing callers bail
-    /// loudly on `None`, never guess.
-    pub fn literal_span_elements(&self) -> Option<usize> {
-        let span = match self {
-            MirrorLayout::RightMajor(l) => l.span(),
-            MirrorLayout::LeftMajor(l) => l.span(),
-            MirrorLayout::Strided(l) => l.span(),
-            MirrorLayout::ElementOffset(_) | MirrorLayout::BitOffset(_) => return None,
-        };
-        span.eval_literal().and_then(|v| usize::try_from(v).ok())
-    }
-}
-
-// =============================================================================
-// The spelling decoder
 
 // =============================================================================
 // THE `Layout` SORT — its erased fact surface and its five constructors
@@ -965,35 +898,6 @@ pub struct DecodedLayout {
     /// Every registered `Layout` constructor present in the class,
     /// decoded, in registry order.
     pub spellings: Spellings<Layout>,
-    /// TRANSITIONAL (deleted in the next step): the first spelling in
-    /// registry order, re-spelled as the retiring [`MirrorLayout`] sum,
-    /// so consumers can move off it one file at a time.
-    pub mirror: MirrorLayout,
-}
-
-/// The first decoded spelling, re-spelled as the retiring
-/// [`MirrorLayout`] sum. Registry order IS the order the deleted
-/// preference list used, so this is bit-for-bit what the old decoder
-/// returned.
-fn mirror_of(spellings: &Spellings<Layout>) -> Option<MirrorLayout> {
-    let facts = spellings.any()?;
-    let any = facts.as_any();
-    if let Some(v) = any.downcast_ref::<RightMajorContiguousElementLayout>() {
-        return Some(MirrorLayout::RightMajor(v.clone()));
-    }
-    if let Some(v) = any.downcast_ref::<LeftMajorContiguousElementLayout>() {
-        return Some(MirrorLayout::LeftMajor(v.clone()));
-    }
-    if let Some(v) = any.downcast_ref::<StridedElementLayout>() {
-        return Some(MirrorLayout::Strided(v.clone()));
-    }
-    if let Some(v) = any.downcast_ref::<ElementOffsetExpressionLayout>() {
-        return Some(MirrorLayout::ElementOffset(v.clone()));
-    }
-    if let Some(v) = any.downcast_ref::<BitOffsetExpressionLayout>() {
-        return Some(MirrorLayout::BitOffset(v.clone()));
-    }
-    None
 }
 
 impl DecodedLayout {
@@ -1040,12 +944,10 @@ impl DecodedLayout {
                 );
             }
         }
-        let mirror = mirror_of(&spellings).expect("a decoded spelling is one of the five");
         Ok(Self {
             class: class.id().clone(),
             dtype,
             spellings,
-            mirror,
         })
     }
 
@@ -1074,14 +976,10 @@ impl DecodedLayout {
             !spellings.is_empty(),
             "a hand-built DecodedLayout states at least one spelling"
         );
-        let spellings = Spellings::from_decoded(spellings);
-        let mirror = mirror_of(&spellings)
-            .expect("a hand-built spelling is one of the five Layout constructors");
         Self {
             class: ClassId::from(HAND_BUILT_CLASS),
             dtype,
-            spellings,
-            mirror,
+            spellings: Spellings::from_decoded(spellings),
         }
     }
 
@@ -1229,27 +1127,10 @@ pub fn decode_layout_table(
     Ok(table)
 }
 
-// =============================================================================
-// TRANSITIONAL: the retiring `MirrorLayout` decoders, now one line over
-// the spelling set. Deleted in the next step with the type itself.
-// =============================================================================
-
-/// Decode one layout e-class into the retiring [`MirrorLayout`] sum: the
-/// first spelling in registry order.
-pub fn decode_layout(egraph: &EGraph, class: &ClassId) -> Result<MirrorLayout> {
-    let decoders = ConstructorRegistry::new(layout_decoders())?;
-    let view = EGraphView::new(egraph, &decoders);
-    Ok(DecodedLayout::from_class(&view.class(class), None)?.mirror)
-}
-
-/// [`decode_layout`] with the error contextualized by who was asking.
-pub fn decode_layout_for(egraph: &EGraph, class: &ClassId, who: &str) -> Result<MirrorLayout> {
-    decode_layout(egraph, class).map_err(|err| anyhow!("{who}: {err}"))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::egglog_utils::eclass::ConstructorRegistry;
 
     /// THE ASSEMBLY TRIPWIRE, over core's own preamble: every `Layout`
     /// constructor the program declares has exactly one decoder, and

--- a/src/layouts.rs
+++ b/src/layouts.rs
@@ -1,14 +1,11 @@
-//! Rust mirrors of the five egglog `Layout` constructors — the CONVENIENCE
-//! vocabulary runtimes may share (resident-geometry cleanup train; folded
-//! into core from the short-lived `luminal_layouts` crate by Austin's
-//! amendment: "don't make it separate crate, people can just pull these
-//! structs from core for now").
+//! THE `Layout` SORT, mirrored: its five constructors as Rust structs,
+//! the facts they disclose, and the decoded spelling set a plan carries.
 //!
 //! THE BUFFERIZER NEVER CALLS ANY OF THIS. Living in core does not make
 //! this a core vocabulary: the bufferizer stays generic over an opaque
 //! layout type it only clones and transports, and nothing in the planner
-//! imports this module. It exists so runtimes can pull the five mirror
-//! structs, the [`SpanExpr`] trait, and [`decode_layout`] from one place
+//! imports this module. It exists so runtimes can pull the constructor
+//! structs, the [`SpanExpr`] trait and [`DecodedLayout`] from one place
 //! instead of each respelling them; a backend that wants a different
 //! layout vocabulary brings its own type and ignores this module
 //! entirely — nothing here is a closed set the planner depends on.
@@ -16,26 +13,39 @@
 //! Contents:
 //!  * [`IntExprTerm`] / [`ShapeTerm`] / [`BitWidthTerm`] — the term
 //!    vocabulary the constructor fields are spelled in;
-//!  * the five mirror structs, field-for-field with the preamble's
-//!    constructors (`RightMajorContiguousElementLayoutLit(Shape, BitWidth)`
-//!    and friends), plus the [`MirrorLayout`] sum for decoders;
-//!  * [`SpanExpr`] — the span-as-EXPRESSION trait, implemented ONLY where
-//!    a span is honest (the packed element ladder: right-major,
+//!  * the five constructor structs, field-for-field with the preamble's
+//!    constructors (`RightMajorContiguousElementLayoutLit(Shape,
+//!    BitWidth)` and friends), each implementing
+//!    [`crate::egglog_utils::eclass::EgglogConstructor`] (decode ONE
+//!    e-node of that constructor) and [`LayoutFacts`] (what it
+//!    discloses);
+//!  * [`SpanExpr`] — the span-as-EXPRESSION trait, implemented ONLY
+//!    where a span is honest (the packed element ladder: right-major,
 //!    left-major, strided). The offset-expression forms deliberately do
 //!    NOT implement it: an offset function alone does not disclose its
-//!    reach, and nothing here guesses. NOTHING consumes `span()` yet.
-//!  * [`decode_layout`] — the spelling decoder: walk one layout e-class
-//!    of a serialized e-graph into a [`MirrorLayout`]. Any spelling
-//!    present in a class is correct (all spellings of a layout class
-//!    denote one function); the walk PREFERS the most-structured spelling
-//!    present (RightMajor > LeftMajor > Strided > ElementOffset >
-//!    BitOffset) as a decoding preference only. No normalization, no
-//!    analysis — a class none of whose spellings parse is a loud error,
-//!    never a guess.
+//!    reach, and nothing here guesses;
+//!  * [`layout_decoders`] — the five `(sort, constructor)` decoders core
+//!    registers, and [`shape_term`] / [`bit_width`] / [`affine_chain`] /
+//!    [`int_expr`], the term decoders they are written in terms of;
+//!  * [`DecodedLayout`] — one elected value's layout: EVERY registered
+//!    spelling its class holds, plus the value's dtype fact, plus the
+//!    class id for diagnostics.
+//!
+//! THERE IS NO PREFERENCE ORDER. A class holds every spelling the
+//! e-graph proved of it, all denoting one function; a caller asks for
+//! the spelling IT can lower (`first::<C>()`, `has::<C>()`,
+//! `require::<C>(who)`) and states its own preference at its own call
+//! site. A class none of whose spellings parse is a loud error, never a
+//! guess.
 
-use anyhow::{Result, anyhow, bail};
-use egraph_serialize::{ClassId, EGraph, Node, NodeId};
+use crate::egglog_utils::eclass::{
+    ConstructorDecoder, ConstructorRegistry, DynFacts, EClass, EGraphView, ENode,
+    EgglogConstructor, Sort, Spellings,
+};
+use anyhow::{Result, anyhow, bail, ensure};
+use egraph_serialize::{ClassId, EGraph};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 // =============================================================================
 // Term vocabulary
@@ -165,13 +175,12 @@ pub struct BitOffsetExpressionLayout {
     pub width: BitWidthTerm,
 }
 
-/// The convenience sum decoders produce — one value for "some spelling
-/// of this layout class". DECODER CONVENIENCE ONLY: the bufferizer is
-/// generic and never sees this type; a backend may decode into its own
-/// type instead. NOT a closed vocabulary — and FLAGGED for review
-/// (Austin): a sum over the five constructors may already be too
-/// enum-ish for a vocabulary that is deliberately open; kept for now as
-/// the shared decoders' return type.
+/// RETIRING (deleted in the next step of this refactor): the closed sum
+/// over the five constructors. It was flagged for review as "too
+/// enum-ish for a vocabulary that is deliberately open" and Austin ruled
+/// it out — a class holds a SET of spellings and every call site names
+/// the one it wants. Kept for exactly one step so consumers move off it
+/// one file at a time.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MirrorLayout {
     RightMajor(RightMajorContiguousElementLayout),
@@ -281,6 +290,51 @@ impl IntExprTerm {
             IntExprTerm::LessThanCast(a, b) => i64::from(go(a)? < go(b)?),
         })
     }
+
+    /// Evaluate at concrete coordinates (FRONT-indexed: `Coord {
+    /// axis_from_end }` reads `coords[rank - 1 - axis_from_end]`).
+    /// Symbolic vars, out-of-rank axes and zero divisors refuse loudly —
+    /// runtime-side convenience, never planner machinery.
+    pub fn eval_at(&self, coords: &[usize]) -> Result<i64> {
+        let rank = coords.len();
+        Ok(match self {
+            IntExprTerm::Lit(v) => *v,
+            IntExprTerm::Var(name) => {
+                bail!("layout read: symbolic dim `{name}` cannot evaluate")
+            }
+            IntExprTerm::Coord { axis_from_end } => {
+                let axis = usize::try_from(*axis_from_end)
+                    .ok()
+                    .filter(|&a| a < rank)
+                    .ok_or_else(|| anyhow!("coordinate axis {axis_from_end} out of rank {rank}"))?;
+                coords[rank - 1 - axis] as i64
+            }
+            IntExprTerm::Add(a, b) => a.eval_at(coords)? + b.eval_at(coords)?,
+            IntExprTerm::Mul(a, b) => a.eval_at(coords)? * b.eval_at(coords)?,
+            IntExprTerm::TruncDiv(a, b) => {
+                let (a, b) = (a.eval_at(coords)?, b.eval_at(coords)?);
+                ensure!(b != 0, "division by zero in a layout expression");
+                // Rust's `/` on i64 IS truncation toward zero.
+                a / b
+            }
+            IntExprTerm::TruncRem(a, b) => {
+                let (a, b) = (a.eval_at(coords)?, b.eval_at(coords)?);
+                ensure!(b != 0, "remainder by zero in a layout expression");
+                a % b
+            }
+            IntExprTerm::CeilDiv(a, b) => {
+                let (a, b) = (a.eval_at(coords)?, b.eval_at(coords)?);
+                ensure!(
+                    b > 0,
+                    "ceil-div by non-positive divisor in a layout expression"
+                );
+                a.div_euclid(b) + i64::from(a.rem_euclid(b) != 0)
+            }
+            IntExprTerm::Min(a, b) => a.eval_at(coords)?.min(b.eval_at(coords)?),
+            IntExprTerm::Max(a, b) => a.eval_at(coords)?.max(b.eval_at(coords)?),
+            IntExprTerm::LessThanCast(a, b) => i64::from(a.eval_at(coords)? < b.eval_at(coords)?),
+        })
+    }
 }
 
 impl MirrorLayout {
@@ -333,22 +387,313 @@ impl MirrorLayout {
 
 // =============================================================================
 // The spelling decoder
+
+// =============================================================================
+// THE `Layout` SORT — its erased fact surface and its five constructors
 // =============================================================================
 
-/// Decode one layout e-class of a serialized e-graph into a
-/// [`MirrorLayout`]. Builds a class index for the walk (one pass over the
-/// e-graph), so callers decoding many classes should memoize per class
-/// (all spellings of a class denote one function, so a class decodes the
-/// same every time). Errors are LOUD and name the class — never a guess.
-pub fn decode_layout(egraph: &EGraph, class: &ClassId) -> Result<MirrorLayout> {
-    Reader::new(egraph).decode_layout(class)
+/// The egglog `Layout` sort, as [`Sort`] names it. `Layout::Facts` is
+/// [`LayoutFacts`], so `spellings::<Layout>()` hands generic code the
+/// facts every layout constructor discloses without anyone naming a
+/// constructor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Layout;
+
+impl Sort for Layout {
+    const NAME: &'static str = "Layout";
+    type Facts = dyn LayoutFacts;
 }
 
-/// The decoder's walk state: the e-graph plus its by-class node index.
-struct Reader<'a> {
-    egraph: &'a EGraph,
-    class_nodes: HashMap<&'a ClassId, Vec<&'a NodeId>>,
+/// WHAT EVERY LAYOUT CONSTRUCTOR DISCLOSES. Object-safe (no generics,
+/// every method `&self`), so `dyn LayoutFacts` is the erased item type
+/// `Spellings<Layout>` carries.
+///
+/// This is a FACT surface, never a classification: nothing here says
+/// "which kind of layout is this". A caller that needs a particular
+/// spelling names it (`first::<C>()`); a caller that needs a fact about
+/// a layout it did not author asks here.
+pub trait LayoutFacts: DynFacts {
+    /// The DOMAIN (every constructor carries one).
+    fn shape(&self) -> &ShapeTerm;
+
+    /// The element access width in bits.
+    fn width(&self) -> BitWidthTerm;
+
+    /// Storage reach in ELEMENTS as an expression, where the constructor
+    /// DISCLOSES one (the packed ladder, [`SpanExpr`]). `None` for the
+    /// offset-expression forms — an offset function alone does not
+    /// disclose its reach and nothing here guesses.
+    fn span_elements(&self) -> Option<IntExprTerm>;
+
+    /// The constructor's read function evaluated at literal coordinates
+    /// (front-indexed), down to the flat ELEMENT index. RUNTIME
+    /// convenience, never planner machinery. Fail-closed on symbolic
+    /// extents, foreign rank, out-of-domain coordinates, a mid-element
+    /// bit offset, and a negative result.
+    fn element_index(&self, coords: &[usize]) -> Result<usize>;
 }
+
+impl PartialEq for dyn LayoutFacts {
+    fn eq(&self, other: &Self) -> bool {
+        self.dyn_eq(other.as_any())
+    }
+}
+impl Eq for dyn LayoutFacts {}
+
+/// The domain extents as literals — `None` if any axis is symbolic.
+fn literal_extents_of(shape: &ShapeTerm) -> Option<Vec<usize>> {
+    shape
+        .0
+        .iter()
+        .map(|e| e.eval_literal().and_then(|v| usize::try_from(v).ok()))
+        .collect()
+}
+
+/// The domain check every `element_index` runs first: literal extents,
+/// matching rank, every coordinate inside its extent.
+fn check_domain(shape: &ShapeTerm, coords: &[usize]) -> Result<Vec<usize>> {
+    let extents =
+        literal_extents_of(shape).ok_or_else(|| anyhow!("layout read: symbolic extents"))?;
+    ensure!(
+        coords.len() == extents.len(),
+        "{} coordinates for a rank-{} layout",
+        coords.len(),
+        extents.len()
+    );
+    for (axis, (&c, &d)) in coords.iter().zip(&extents).enumerate() {
+        ensure!(c < d, "coordinate {c} out of extent {d} (axis {axis})");
+    }
+    Ok(extents)
+}
+
+fn element_of(flat: i64) -> Result<usize> {
+    usize::try_from(flat).map_err(|_| anyhow!("negative element index {flat}"))
+}
+
+impl EgglogConstructor for RightMajorContiguousElementLayout {
+    const NAME: &'static str = "RightMajorContiguousElementLayoutLit";
+    type Sort = Layout;
+    fn decode(node: &ENode<'_>) -> Result<Self> {
+        let shape = shape_term(&node.child_or_bail(0)?)
+            .ok_or_else(|| anyhow!("child 0 is not a decodable Shape"))?;
+        let width = bit_width(&node.child_or_bail(1)?)
+            .ok_or_else(|| anyhow!("child 1 is not a decodable BitWidth"))?;
+        Ok(Self { shape, width })
+    }
+    fn erase(self) -> Arc<dyn LayoutFacts> {
+        Arc::new(self)
+    }
+}
+
+impl LayoutFacts for RightMajorContiguousElementLayout {
+    fn shape(&self) -> &ShapeTerm {
+        &self.shape
+    }
+    fn width(&self) -> BitWidthTerm {
+        self.width
+    }
+    fn span_elements(&self) -> Option<IntExprTerm> {
+        Some(self.span())
+    }
+    fn element_index(&self, coords: &[usize]) -> Result<usize> {
+        let extents = check_domain(&self.shape, coords)?;
+        element_of(
+            coords
+                .iter()
+                .zip(&extents)
+                .fold(0usize, |acc, (&c, &d)| acc * d + c) as i64,
+        )
+    }
+}
+
+impl EgglogConstructor for LeftMajorContiguousElementLayout {
+    const NAME: &'static str = "LeftMajorContiguousElementLayoutLit";
+    type Sort = Layout;
+    fn decode(node: &ENode<'_>) -> Result<Self> {
+        let shape = shape_term(&node.child_or_bail(0)?)
+            .ok_or_else(|| anyhow!("child 0 is not a decodable Shape"))?;
+        let width = bit_width(&node.child_or_bail(1)?)
+            .ok_or_else(|| anyhow!("child 1 is not a decodable BitWidth"))?;
+        Ok(Self { shape, width })
+    }
+    fn erase(self) -> Arc<dyn LayoutFacts> {
+        Arc::new(self)
+    }
+}
+
+impl LayoutFacts for LeftMajorContiguousElementLayout {
+    fn shape(&self) -> &ShapeTerm {
+        &self.shape
+    }
+    fn width(&self) -> BitWidthTerm {
+        self.width
+    }
+    fn span_elements(&self) -> Option<IntExprTerm> {
+        Some(self.span())
+    }
+    fn element_index(&self, coords: &[usize]) -> Result<usize> {
+        let extents = check_domain(&self.shape, coords)?;
+        let mut stride = 1usize;
+        let mut acc = 0usize;
+        for (&c, &d) in coords.iter().zip(&extents) {
+            acc += c * stride;
+            stride *= d;
+        }
+        element_of(acc as i64)
+    }
+}
+
+impl EgglogConstructor for StridedElementLayout {
+    const NAME: &'static str = "StridedElementLayoutLit";
+    type Sort = Layout;
+    fn decode(node: &ENode<'_>) -> Result<Self> {
+        let shape_class = node.child_or_bail(0)?;
+        let chain_class = node.child_or_bail(1)?;
+        let width_class = node.child_or_bail(2)?;
+        let shape =
+            shape_term(&shape_class).ok_or_else(|| anyhow!("child 0 is not a decodable Shape"))?;
+        let width = bit_width(&width_class)
+            .ok_or_else(|| anyhow!("child 2 is not a decodable BitWidth"))?;
+        // THE OWNER-SHAPE GUARD: a coordinate owned by any OTHER shape
+        // is not one of this layout's coordinates and fails the spelling.
+        let chain = affine_chain(&chain_class, &shape_class)
+            .ok_or_else(|| anyhow!("child 1 is not a decodable affine chain over this domain"))?;
+        Ok(Self {
+            shape,
+            chain,
+            width,
+        })
+    }
+    fn erase(self) -> Arc<dyn LayoutFacts> {
+        Arc::new(self)
+    }
+}
+
+impl LayoutFacts for StridedElementLayout {
+    fn shape(&self) -> &ShapeTerm {
+        &self.shape
+    }
+    fn width(&self) -> BitWidthTerm {
+        self.width
+    }
+    fn span_elements(&self) -> Option<IntExprTerm> {
+        Some(self.span())
+    }
+    fn element_index(&self, coords: &[usize]) -> Result<usize> {
+        check_domain(&self.shape, coords)?;
+        let mut total = 0i64;
+        for summand in &self.chain {
+            total += summand.eval_at(coords)?;
+        }
+        element_of(total)
+    }
+}
+
+impl EgglogConstructor for ElementOffsetExpressionLayout {
+    const NAME: &'static str = "ElementOffsetExpressionLayoutLit";
+    type Sort = Layout;
+    fn decode(node: &ENode<'_>) -> Result<Self> {
+        let offset_class = node.child_or_bail(0)?;
+        let shape_class = node.child_or_bail(1)?;
+        let width_class = node.child_or_bail(2)?;
+        let shape =
+            shape_term(&shape_class).ok_or_else(|| anyhow!("child 1 is not a decodable Shape"))?;
+        let width = bit_width(&width_class)
+            .ok_or_else(|| anyhow!("child 2 is not a decodable BitWidth"))?;
+        let offset = int_expr(&offset_class, Some(&shape_class))
+            .ok_or_else(|| anyhow!("child 0 is not a decodable offset expression"))?;
+        Ok(Self {
+            offset,
+            shape,
+            width,
+        })
+    }
+    fn erase(self) -> Arc<dyn LayoutFacts> {
+        Arc::new(self)
+    }
+}
+
+impl LayoutFacts for ElementOffsetExpressionLayout {
+    fn shape(&self) -> &ShapeTerm {
+        &self.shape
+    }
+    fn width(&self) -> BitWidthTerm {
+        self.width
+    }
+    /// An offset function alone does not disclose its reach.
+    fn span_elements(&self) -> Option<IntExprTerm> {
+        None
+    }
+    fn element_index(&self, coords: &[usize]) -> Result<usize> {
+        check_domain(&self.shape, coords)?;
+        element_of(self.offset.eval_at(coords)?)
+    }
+}
+
+impl EgglogConstructor for BitOffsetExpressionLayout {
+    const NAME: &'static str = "BitOffsetExpressionLayoutLit";
+    type Sort = Layout;
+    fn decode(node: &ENode<'_>) -> Result<Self> {
+        let offset_class = node.child_or_bail(0)?;
+        let shape_class = node.child_or_bail(1)?;
+        let width_class = node.child_or_bail(2)?;
+        let shape =
+            shape_term(&shape_class).ok_or_else(|| anyhow!("child 1 is not a decodable Shape"))?;
+        let width = bit_width(&width_class)
+            .ok_or_else(|| anyhow!("child 2 is not a decodable BitWidth"))?;
+        let offset = int_expr(&offset_class, Some(&shape_class))
+            .ok_or_else(|| anyhow!("child 0 is not a decodable offset expression"))?;
+        Ok(Self {
+            offset,
+            shape,
+            width,
+        })
+    }
+    fn erase(self) -> Arc<dyn LayoutFacts> {
+        Arc::new(self)
+    }
+}
+
+impl LayoutFacts for BitOffsetExpressionLayout {
+    fn shape(&self) -> &ShapeTerm {
+        &self.shape
+    }
+    fn width(&self) -> BitWidthTerm {
+        self.width
+    }
+    fn span_elements(&self) -> Option<IntExprTerm> {
+        None
+    }
+    fn element_index(&self, coords: &[usize]) -> Result<usize> {
+        check_domain(&self.shape, coords)?;
+        let bits = self.offset.eval_at(coords)?;
+        ensure!(self.width.0 > 0, "non-positive bit width {}", self.width.0);
+        ensure!(
+            bits % self.width.0 == 0,
+            "bit offset {bits} is not element-aligned to width {}",
+            self.width.0
+        );
+        element_of(bits / self.width.0)
+    }
+}
+
+/// The core preamble's `Layout` constructors and their decoders, IN THIS
+/// ORDER. It is the order `Spellings<Layout>` iterates and therefore
+/// what [`DecodedLayout::present`] prints — a LISTING order, never a
+/// preference: no caller is obliged to take the first.
+pub fn layout_decoders() -> Vec<ConstructorDecoder> {
+    vec![
+        ConstructorDecoder::of::<RightMajorContiguousElementLayout>(),
+        ConstructorDecoder::of::<LeftMajorContiguousElementLayout>(),
+        ConstructorDecoder::of::<StridedElementLayout>(),
+        ConstructorDecoder::of::<ElementOffsetExpressionLayout>(),
+        ConstructorDecoder::of::<BitOffsetExpressionLayout>(),
+    ]
+}
+
+// =============================================================================
+// Term decoders — one e-class of the serialized graph into a term
+// =============================================================================
 
 /// Memo entry for the expression parse: finished, or the in-progress
 /// cycle guard (the index_expr discipline — a cycle fails the SPELLING,
@@ -358,420 +703,225 @@ enum ParseMemo {
     Done(Option<IntExprTerm>),
 }
 
-impl<'a> Reader<'a> {
-    fn new(egraph: &'a EGraph) -> Self {
-        let mut class_nodes: HashMap<&'a ClassId, Vec<&'a NodeId>> = HashMap::new();
-        for (id, node) in &egraph.nodes {
-            class_nodes.entry(&node.eclass).or_default().push(id);
-        }
-        // Deterministic spelling order regardless of map iteration order.
-        for ids in class_nodes.values_mut() {
-            ids.sort();
-        }
-        Self {
-            egraph,
-            class_nodes,
+/// `(BitWidthLit i64)`.
+pub fn bit_width(class: &EClass<'_>) -> Option<BitWidthTerm> {
+    for node in class.nodes_named("BitWidthLit") {
+        if let Some(bits) = node.child(0).and_then(|c| c.i64_literal()) {
+            return Some(BitWidthTerm(bits));
         }
     }
+    None
+}
 
-    /// Every node of `op` in `class` — unsubsumed spellings first,
-    /// subsumed ones as fallback (value PARSING reads denotations, and a
-    /// subsumed node is still a true member of its class; saturation can
-    /// subsume every constructor spelling — the slice_pad lesson).
-    fn nodes_in_class_value(
-        &self,
-        class: &ClassId,
-        op: &str,
-    ) -> impl Iterator<Item = &'a Node> + '_ {
-        let ids = self
-            .class_nodes
-            .get(class)
-            .map(Vec::as_slice)
-            .unwrap_or(&[]);
-        let matching = move |want_subsumed: bool| {
-            let op = op.to_string();
-            ids.iter()
-                .filter_map(|id| self.egraph.nodes.get(*id))
-                .filter(move |node| node.op == op && node.subsumed == want_subsumed)
+/// `(ShapeLit IntExprList)` — one extent expression per axis, outermost
+/// first.
+pub fn shape_term(class: &EClass<'_>) -> Option<ShapeTerm> {
+    for node in class.nodes_named("ShapeLit") {
+        let Some(head) = node.child(0) else {
+            continue;
         };
-        matching(false).chain(matching(true))
-    }
-
-    fn class_of_child(&self, node: &Node, index: usize) -> Option<ClassId> {
-        let child = node.children.get(index)?;
-        Some(self.egraph.nodes.get(child)?.eclass.clone())
-    }
-
-    /// Any literal-i64 node inside a class.
-    fn parse_i64(&self, class: &ClassId) -> Option<i64> {
-        self.class_nodes
-            .get(class)?
-            .iter()
-            .filter_map(|id| self.egraph.nodes.get(*id))
-            .find_map(|node| node.op.parse::<i64>().ok())
-    }
-
-    /// Any literal-string node inside a class (egraph_serialize renders
-    /// string literals as quoted ops).
-    fn parse_string(&self, class: &ClassId) -> Option<String> {
-        self.class_nodes
-            .get(class)?
-            .iter()
-            .filter_map(|id| self.egraph.nodes.get(*id))
-            .find_map(|node| {
-                let op = node.op.as_str();
-                op.strip_prefix('"')?.strip_suffix('"').map(str::to_string)
-            })
-    }
-
-    fn decode_layout(&self, class: &ClassId) -> Result<MirrorLayout> {
-        // The decoding PREFERENCE (most-structured spelling first); any
-        // spelling present is correct, so the first that parses wins and
-        // later constructors are backtracking fallbacks only.
-        let mut present = Vec::new();
-        for node in self.nodes_in_class_value(class, "RightMajorContiguousElementLayoutLit") {
-            present.push("RightMajorContiguousElementLayoutLit");
-            let (Some(shape), Some(width)) = (
-                self.class_of_child(node, 0)
-                    .and_then(|c| self.decode_shape(&c)),
-                self.class_of_child(node, 1)
-                    .and_then(|c| self.decode_bit_width(&c)),
-            ) else {
-                continue;
-            };
-            return Ok(MirrorLayout::RightMajor(
-                RightMajorContiguousElementLayout { shape, width },
-            ));
-        }
-        for node in self.nodes_in_class_value(class, "LeftMajorContiguousElementLayoutLit") {
-            present.push("LeftMajorContiguousElementLayoutLit");
-            let (Some(shape), Some(width)) = (
-                self.class_of_child(node, 0)
-                    .and_then(|c| self.decode_shape(&c)),
-                self.class_of_child(node, 1)
-                    .and_then(|c| self.decode_bit_width(&c)),
-            ) else {
-                continue;
-            };
-            return Ok(MirrorLayout::LeftMajor(LeftMajorContiguousElementLayout {
-                shape,
-                width,
-            }));
-        }
-        for node in self.nodes_in_class_value(class, "StridedElementLayoutLit") {
-            present.push("StridedElementLayoutLit");
-            let (Some(shape_class), Some(chain_class), Some(width_class)) = (
-                self.class_of_child(node, 0),
-                self.class_of_child(node, 1),
-                self.class_of_child(node, 2),
-            ) else {
-                continue;
-            };
-            let (Some(shape), Some(width)) = (
-                self.decode_shape(&shape_class),
-                self.decode_bit_width(&width_class),
-            ) else {
-                continue;
-            };
-            let Some(chain) = self.decode_affine_chain(&chain_class, &shape_class) else {
-                continue;
-            };
-            return Ok(MirrorLayout::Strided(StridedElementLayout {
-                shape,
-                chain,
-                width,
-            }));
-        }
-        for (constructor, bit_form) in [
-            ("ElementOffsetExpressionLayoutLit", false),
-            ("BitOffsetExpressionLayoutLit", true),
-        ] {
-            for node in self.nodes_in_class_value(class, constructor) {
-                present.push(constructor);
-                let (Some(offset_class), Some(shape_class), Some(width_class)) = (
-                    self.class_of_child(node, 0),
-                    self.class_of_child(node, 1),
-                    self.class_of_child(node, 2),
-                ) else {
-                    continue;
-                };
-                let (Some(shape), Some(width)) = (
-                    self.decode_shape(&shape_class),
-                    self.decode_bit_width(&width_class),
-                ) else {
-                    continue;
-                };
-                let mut memo = HashMap::new();
-                let Some(offset) =
-                    self.parse_int_expr(&offset_class, 64, Some(&shape_class), &mut memo)
-                else {
-                    continue;
-                };
-                return Ok(if bit_form {
-                    MirrorLayout::BitOffset(BitOffsetExpressionLayout {
-                        offset,
-                        shape,
-                        width,
-                    })
-                } else {
-                    MirrorLayout::ElementOffset(ElementOffsetExpressionLayout {
-                        offset,
-                        shape,
-                        width,
-                    })
-                });
-            }
-        }
-        if present.is_empty() {
-            bail!(
-                "layout class {class} has no Layout constructor spelling — \
-                 nothing to decode (fail-closed, never a guess)"
-            );
-        }
-        bail!(
-            "layout class {class} has constructor spellings {present:?} but \
-             none parsed into the mirror vocabulary (fail-closed, never a \
-             guess)"
-        )
-    }
-
-    fn decode_bit_width(&self, class: &ClassId) -> Option<BitWidthTerm> {
-        for node in self.nodes_in_class_value(class, "BitWidthLit") {
-            let Some(bits_class) = self.class_of_child(node, 0) else {
-                continue;
-            };
-            if let Some(bits) = self.parse_i64(&bits_class) {
-                return Some(BitWidthTerm(bits));
-            }
-        }
-        None
-    }
-
-    fn decode_shape(&self, class: &ClassId) -> Option<ShapeTerm> {
-        for node in self.nodes_in_class_value(class, "ShapeLit") {
-            let Some(head) = self.class_of_child(node, 0) else {
-                continue;
-            };
-            let mut memo = HashMap::new();
-            if let Some(extents) =
-                self.decode_expr_list(&head, "IntExprCons", "IntExprNil", 64, None, &mut memo)
-            {
-                return Some(ShapeTerm(extents));
-            }
-        }
-        None
-    }
-
-    /// The strided chain: one summand per axis from-end. Coordinates are
-    /// guarded to the layout's OWN shape (a foreign shape's coordinate is
-    /// not this domain's and fails that spelling — the owner-shape guard).
-    fn decode_affine_chain(
-        &self,
-        class: &ClassId,
-        owner_shape: &ClassId,
-    ) -> Option<Vec<IntExprTerm>> {
         let mut memo = HashMap::new();
-        self.decode_expr_list(
-            class,
-            "IntAffineExprCons",
-            "IntAffineExprNil",
-            64,
-            Some(owner_shape),
-            &mut memo,
-        )
+        if let Some(extents) = expr_list(&head, "IntExprCons", "IntExprNil", 64, None, &mut memo) {
+            return Some(ShapeTerm(extents));
+        }
     }
+    None
+}
 
-    /// Cons-spine walk, existential at every level (the backtracking
-    /// doctrine): a saturated list class holds several cons spellings and
-    /// the first may dead-end while a sibling parses fine.
-    fn decode_expr_list(
-        &self,
-        class: &ClassId,
-        cons_op: &str,
-        nil_op: &str,
-        depth: usize,
-        owner_shape: Option<&ClassId>,
-        memo: &mut HashMap<ClassId, ParseMemo>,
-    ) -> Option<Vec<IntExprTerm>> {
-        if depth == 0 {
-            return None;
-        }
-        if self.nodes_in_class_value(class, nil_op).next().is_some() {
-            return Some(Vec::new());
-        }
-        for cons in self.nodes_in_class_value(class, cons_op) {
-            let Some(element) = self.class_of_child(cons, 0) else {
-                continue;
-            };
-            let Some(tail) = self.class_of_child(cons, 1) else {
-                continue;
-            };
-            let Some(expr) = self.parse_int_expr(&element, 64, owner_shape, memo) else {
-                continue;
-            };
-            if let Some(mut rest) =
-                self.decode_expr_list(&tail, cons_op, nil_op, depth - 1, owner_shape, memo)
-            {
-                rest.insert(0, expr);
-                return Some(rest);
-            }
-        }
-        None
+/// The strided chain: one summand per axis from-end. Coordinates are
+/// guarded to the layout's OWN shape (a foreign shape's coordinate is
+/// not this domain's and fails that spelling — the owner-shape guard).
+pub fn affine_chain(class: &EClass<'_>, owner_shape: &EClass<'_>) -> Option<Vec<IntExprTerm>> {
+    let mut memo = HashMap::new();
+    expr_list(
+        class,
+        "IntAffineExprCons",
+        "IntAffineExprNil",
+        64,
+        Some(owner_shape.id()),
+        &mut memo,
+    )
+}
+
+/// One `IntExpr` class into a term, optionally under the owner-shape
+/// guard.
+pub fn int_expr(class: &EClass<'_>, owner_shape: Option<&EClass<'_>>) -> Option<IntExprTerm> {
+    let owner = owner_shape.map(|c| c.id().clone());
+    let mut memo = HashMap::new();
+    parse_int_expr(class, 64, owner.as_ref(), &mut memo)
+}
+
+/// Cons-spine walk, existential at every level (the backtracking
+/// doctrine): a saturated list class holds several cons spellings and
+/// the first may dead-end while a sibling parses fine.
+fn expr_list(
+    class: &EClass<'_>,
+    cons_op: &str,
+    nil_op: &str,
+    depth: usize,
+    owner_shape: Option<&ClassId>,
+    memo: &mut HashMap<ClassId, ParseMemo>,
+) -> Option<Vec<IntExprTerm>> {
+    if depth == 0 {
+        return None;
     }
-
-    /// Parse one IntExpr class, preferring folded literals; memoized with
-    /// the cycle-taint rule (a `None` whose walk touched the in-progress
-    /// guard is contextual and not cached; an untainted `None` — every
-    /// spelling genuinely outside the subset — caches).
-    fn parse_int_expr(
-        &self,
-        class: &ClassId,
-        depth: usize,
-        owner_shape: Option<&ClassId>,
-        memo: &mut HashMap<ClassId, ParseMemo>,
-    ) -> Option<IntExprTerm> {
-        self.parse_int_expr_tainting(class, depth, owner_shape, memo, &mut false)
+    if class.nodes_named(nil_op).next().is_some() {
+        return Some(Vec::new());
     }
-
-    fn parse_int_expr_tainting(
-        &self,
-        class: &ClassId,
-        depth: usize,
-        owner_shape: Option<&ClassId>,
-        memo: &mut HashMap<ClassId, ParseMemo>,
-        tainted: &mut bool,
-    ) -> Option<IntExprTerm> {
-        match memo.get(class) {
-            Some(ParseMemo::Done(cached)) => return cached.clone(),
-            Some(ParseMemo::InProgress) => {
-                *tainted = true;
-                return None;
-            }
-            None => {}
+    for cons in class.nodes_named(cons_op) {
+        let Some(element) = cons.child(0) else {
+            continue;
+        };
+        let Some(tail) = cons.child(1) else {
+            continue;
+        };
+        let Some(expr) = parse_int_expr(&element, 64, owner_shape, memo) else {
+            continue;
+        };
+        if let Some(mut rest) = expr_list(&tail, cons_op, nil_op, depth - 1, owner_shape, memo) {
+            rest.insert(0, expr);
+            return Some(rest);
         }
-        memo.insert(class.clone(), ParseMemo::InProgress);
-        let mut local_taint = false;
-        let parsed =
-            self.parse_int_expr_uncached(class, depth, owner_shape, memo, &mut local_taint);
-        if parsed.is_none() && local_taint {
-            memo.remove(class);
+    }
+    None
+}
+
+/// Parse one IntExpr class, preferring folded literals; memoized with
+/// the cycle-taint rule (a `None` whose walk touched the in-progress
+/// guard is contextual and not cached; an untainted `None` — every
+/// spelling genuinely outside the subset — caches).
+fn parse_int_expr(
+    class: &EClass<'_>,
+    depth: usize,
+    owner_shape: Option<&ClassId>,
+    memo: &mut HashMap<ClassId, ParseMemo>,
+) -> Option<IntExprTerm> {
+    parse_int_expr_tainting(class, depth, owner_shape, memo, &mut false)
+}
+
+fn parse_int_expr_tainting(
+    class: &EClass<'_>,
+    depth: usize,
+    owner_shape: Option<&ClassId>,
+    memo: &mut HashMap<ClassId, ParseMemo>,
+    tainted: &mut bool,
+) -> Option<IntExprTerm> {
+    match memo.get(class.id()) {
+        Some(ParseMemo::Done(cached)) => return cached.clone(),
+        Some(ParseMemo::InProgress) => {
             *tainted = true;
-        } else {
-            memo.insert(class.clone(), ParseMemo::Done(parsed.clone()));
-        }
-        parsed
-    }
-
-    fn parse_int_expr_uncached(
-        &self,
-        class: &ClassId,
-        depth: usize,
-        owner_shape: Option<&ClassId>,
-        memo: &mut HashMap<ClassId, ParseMemo>,
-        tainted: &mut bool,
-    ) -> Option<IntExprTerm> {
-        if depth == 0 {
             return None;
         }
-        if let Some(lit) = self.nodes_in_class_value(class, "IntLit").next() {
-            let value_class = self.class_of_child(lit, 0)?;
-            return Some(IntExprTerm::Lit(self.parse_i64(&value_class)?));
+        None => {}
+    }
+    memo.insert(class.id().clone(), ParseMemo::InProgress);
+    let mut local_taint = false;
+    let parsed = parse_int_expr_uncached(class, depth, owner_shape, memo, &mut local_taint);
+    if parsed.is_none() && local_taint {
+        memo.remove(class.id());
+        *tainted = true;
+    } else {
+        memo.insert(class.id().clone(), ParseMemo::Done(parsed.clone()));
+    }
+    parsed
+}
+
+fn parse_int_expr_uncached(
+    class: &EClass<'_>,
+    depth: usize,
+    owner_shape: Option<&ClassId>,
+    memo: &mut HashMap<ClassId, ParseMemo>,
+    tainted: &mut bool,
+) -> Option<IntExprTerm> {
+    if depth == 0 {
+        return None;
+    }
+    if let Some(lit) = class.nodes_named("IntLit").next() {
+        return Some(IntExprTerm::Lit(lit.child(0)?.i64_literal()?));
+    }
+    for var in class.nodes_named("IntVar") {
+        let Some(name_class) = var.child(0) else {
+            continue;
+        };
+        if let Some(name) = name_class.string_literal() {
+            return Some(IntExprTerm::Var(name));
         }
-        for var in self.nodes_in_class_value(class, "IntVar") {
-            let Some(name_class) = self.class_of_child(var, 0) else {
+    }
+    for coord in class.nodes_named("CoordVar") {
+        // Child 0 is the owner Shape, child 1 the axis (from-end).
+        // The owner-shape guard: when the caller names the layout's
+        // domain, a CoordVar owned by any OTHER shape is not one of
+        // this layout's coordinates and cannot parse.
+        if let Some(expected) = owner_shape {
+            let Some(owner_class) = coord.child(0) else {
                 continue;
             };
-            if let Some(name) = self.parse_string(&name_class) {
-                return Some(IntExprTerm::Var(name));
+            if owner_class.id() != expected {
+                continue;
             }
         }
-        for coord in self.nodes_in_class_value(class, "CoordVar") {
-            // Child 0 is the owner Shape, child 1 the axis (from-end).
-            // The owner-shape guard: when the caller names the layout's
-            // domain, a CoordVar owned by any OTHER shape is not one of
-            // this layout's coordinates and cannot parse.
-            if let Some(expected) = owner_shape {
-                let Some(owner_class) = self.class_of_child(coord, 0) else {
-                    continue;
-                };
-                if owner_class != *expected {
-                    continue;
-                }
-            }
-            let Some(axis_class) = self.class_of_child(coord, 1) else {
+        let Some(axis_class) = coord.child(1) else {
+            continue;
+        };
+        return Some(IntExprTerm::Coord {
+            axis_from_end: axis_class.i64_literal()?,
+        });
+    }
+    type Build = fn(Box<IntExprTerm>, Box<IntExprTerm>) -> IntExprTerm;
+    let binary_kinds: [(&str, Build); 7] = [
+        ("IntAdd", IntExprTerm::Add),
+        ("IntMul", IntExprTerm::Mul),
+        ("IntTruncDiv", IntExprTerm::TruncDiv),
+        ("IntTruncRem", IntExprTerm::TruncRem),
+        ("IntCeilDiv", IntExprTerm::CeilDiv),
+        ("IntMin", IntExprTerm::Min),
+        ("IntMax", IntExprTerm::Max),
+    ];
+    for (kind, build) in binary_kinds {
+        for node in class.nodes_named(kind) {
+            let Some(lhs_class) = node.child(0) else {
                 continue;
             };
-            return Some(IntExprTerm::Coord {
-                axis_from_end: self.parse_i64(&axis_class)?,
-            });
-        }
-        type Build = fn(Box<IntExprTerm>, Box<IntExprTerm>) -> IntExprTerm;
-        let binary_kinds: [(&str, Build); 7] = [
-            ("IntAdd", IntExprTerm::Add),
-            ("IntMul", IntExprTerm::Mul),
-            ("IntTruncDiv", IntExprTerm::TruncDiv),
-            ("IntTruncRem", IntExprTerm::TruncRem),
-            ("IntCeilDiv", IntExprTerm::CeilDiv),
-            ("IntMin", IntExprTerm::Min),
-            ("IntMax", IntExprTerm::Max),
-        ];
-        for (kind, build) in binary_kinds {
-            for node in self.nodes_in_class_value(class, kind) {
-                let Some(lhs_class) = self.class_of_child(node, 0) else {
-                    continue;
-                };
-                let Some(rhs_class) = self.class_of_child(node, 1) else {
-                    continue;
-                };
-                let Some(lhs) =
-                    self.parse_int_expr_tainting(&lhs_class, depth - 1, owner_shape, memo, tainted)
-                else {
-                    continue;
-                };
-                let Some(rhs) =
-                    self.parse_int_expr_tainting(&rhs_class, depth - 1, owner_shape, memo, tainted)
-                else {
-                    continue;
-                };
-                return Some(build(Box::new(lhs), Box::new(rhs)));
-            }
-        }
-        for cast in self.nodes_in_class_value(class, "IntCastFromBool") {
-            let Some(bool_class) = self.class_of_child(cast, 0) else {
-                continue;
-            };
-            let Some(less_than) = self
-                .nodes_in_class_value(&bool_class, "BoolLessThanInt")
-                .next()
-            else {
-                continue;
-            };
-            let Some(lhs_class) = self.class_of_child(less_than, 0) else {
-                continue;
-            };
-            let Some(rhs_class) = self.class_of_child(less_than, 1) else {
+            let Some(rhs_class) = node.child(1) else {
                 continue;
             };
             let Some(lhs) =
-                self.parse_int_expr_tainting(&lhs_class, depth - 1, owner_shape, memo, tainted)
+                parse_int_expr_tainting(&lhs_class, depth - 1, owner_shape, memo, tainted)
             else {
                 continue;
             };
             let Some(rhs) =
-                self.parse_int_expr_tainting(&rhs_class, depth - 1, owner_shape, memo, tainted)
+                parse_int_expr_tainting(&rhs_class, depth - 1, owner_shape, memo, tainted)
             else {
                 continue;
             };
-            return Some(IntExprTerm::LessThanCast(Box::new(lhs), Box::new(rhs)));
+            return Some(build(Box::new(lhs), Box::new(rhs)));
         }
-        None
     }
-}
-
-/// Convenience for decoders that must be total: [`decode_layout`] with
-/// the error contextualized by who was asking.
-pub fn decode_layout_for(egraph: &EGraph, class: &ClassId, who: &str) -> Result<MirrorLayout> {
-    decode_layout(egraph, class).map_err(|err| anyhow!("{who}: {err}"))
+    for cast in class.nodes_named("IntCastFromBool") {
+        let Some(bool_class) = cast.child(0) else {
+            continue;
+        };
+        let Some(less_than) = bool_class.nodes_named("BoolLessThanInt").next() else {
+            continue;
+        };
+        let Some(lhs_class) = less_than.child(0) else {
+            continue;
+        };
+        let Some(rhs_class) = less_than.child(1) else {
+            continue;
+        };
+        let Some(lhs) = parse_int_expr_tainting(&lhs_class, depth - 1, owner_shape, memo, tainted)
+        else {
+            continue;
+        };
+        let Some(rhs) = parse_int_expr_tainting(&rhs_class, depth - 1, owner_shape, memo, tainted)
+        else {
+            continue;
+        };
+        return Some(IntExprTerm::LessThanCast(Box::new(lhs), Box::new(rhs)));
+    }
+    None
 }
 
 // =============================================================================
@@ -788,14 +938,220 @@ pub fn decode_layout_for(egraph: &EGraph, class: &ClassId, who: &str) -> Result<
 // runtimes choose to instantiate it with.
 // =============================================================================
 
-/// One elected value's decoded layout: the mirror layout plus the
-/// value's `dtype-of` fact. `dtype: None` is representable (a value with
-/// no `dtype-of` row) and bails loudly at USE — staging, allocation
-/// typing, readback — never silently.
+/// The `class` a hand-built plan layout carries: fixtures have no
+/// e-graph, and nothing may pin a class id anyway (2026-09-02 ruling —
+/// ids are random every run).
+pub const HAND_BUILT_CLASS: &str = "hand-built";
+
+/// One elected value's decoded layout: EVERY registered `Layout`
+/// spelling its e-class holds, plus the value's `dtype-of` fact.
+///
+/// The spelling SET, not one chosen spelling: all spellings of a layout
+/// class denote ONE function, and which of them a consumer can lower is
+/// that consumer's business (the cuBLASLt bias fence asks for the
+/// LeftMajor spelling; the CUDA codegen asks for whichever it emits
+/// simplest C for). Nothing here ranks them.
+///
+/// `dtype: None` is representable (a value with no `dtype-of` row) and
+/// bails loudly at USE — staging, allocation typing, readback — never
+/// silently.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DecodedLayout {
-    pub mirror: MirrorLayout,
+    /// The layout e-class this was decoded from — DIAGNOSTICS and the
+    /// cache key only; never pinned by a test (serialized ids are random
+    /// every run). Hand-built plans carry [`HAND_BUILT_CLASS`].
+    pub class: ClassId,
     pub dtype: Option<crate::dtype::PlanDtype>,
+    /// Every registered `Layout` constructor present in the class,
+    /// decoded, in registry order.
+    pub spellings: Spellings<Layout>,
+    /// TRANSITIONAL (deleted in the next step): the first spelling in
+    /// registry order, re-spelled as the retiring [`MirrorLayout`] sum,
+    /// so consumers can move off it one file at a time.
+    pub mirror: MirrorLayout,
+}
+
+/// The first decoded spelling, re-spelled as the retiring
+/// [`MirrorLayout`] sum. Registry order IS the order the deleted
+/// preference list used, so this is bit-for-bit what the old decoder
+/// returned.
+fn mirror_of(spellings: &Spellings<Layout>) -> Option<MirrorLayout> {
+    let facts = spellings.any()?;
+    let any = facts.as_any();
+    if let Some(v) = any.downcast_ref::<RightMajorContiguousElementLayout>() {
+        return Some(MirrorLayout::RightMajor(v.clone()));
+    }
+    if let Some(v) = any.downcast_ref::<LeftMajorContiguousElementLayout>() {
+        return Some(MirrorLayout::LeftMajor(v.clone()));
+    }
+    if let Some(v) = any.downcast_ref::<StridedElementLayout>() {
+        return Some(MirrorLayout::Strided(v.clone()));
+    }
+    if let Some(v) = any.downcast_ref::<ElementOffsetExpressionLayout>() {
+        return Some(MirrorLayout::ElementOffset(v.clone()));
+    }
+    if let Some(v) = any.downcast_ref::<BitOffsetExpressionLayout>() {
+        return Some(MirrorLayout::BitOffset(v.clone()));
+    }
+    None
+}
+
+impl DecodedLayout {
+    /// THE DECODER: every registered `Layout` spelling the class holds.
+    ///
+    /// Refuses a class with ZERO decoded spellings (the message lists
+    /// what was named and why each failed), and a class whose decoded
+    /// spellings DISAGREE on `shape()` or `width()` — layout identity is
+    /// domain x interpretation, so a mixed-domain class is a false union
+    /// and never a layout.
+    pub fn from_class(class: &EClass<'_>, dtype: Option<crate::dtype::PlanDtype>) -> Result<Self> {
+        let spellings = class.spellings::<Layout>();
+        let Some(first) = spellings.any() else {
+            if spellings.present().is_empty() {
+                bail!(
+                    "layout class {} has no registered Layout constructor spelling — \
+                     nothing to decode (fail-closed, never a guess); ops in the class: {:?}",
+                    class.id(),
+                    class.ops()
+                );
+            }
+            bail!(
+                "layout class {} has constructor spellings {:?} but none parsed \
+                 (fail-closed, never a guess): {:?}",
+                class.id(),
+                spellings.present(),
+                spellings.failed()
+            );
+        };
+        for other in spellings.iter() {
+            if other.shape() != first.shape() || other.width() != first.width() {
+                bail!(
+                    "layout class {} unions spellings over DIFFERENT domains: `{}` over \
+                     {:?}/{:?} and `{}` over {:?}/{:?}. Layout identity is domain x \
+                     interpretation, so this class is a false union, not a layout — \
+                     refused, never reconciled.",
+                    class.id(),
+                    first.constructor(),
+                    first.shape(),
+                    first.width(),
+                    other.constructor(),
+                    other.shape(),
+                    other.width()
+                );
+            }
+        }
+        let mirror = mirror_of(&spellings).expect("a decoded spelling is one of the five");
+        Ok(Self {
+            class: class.id().clone(),
+            dtype,
+            spellings,
+            mirror,
+        })
+    }
+
+    /// A hand-built layout stating ONE spelling (test fixtures and plan
+    /// literals).
+    pub fn of<C: EgglogConstructor<Sort = Layout> + LayoutFacts>(
+        spelling: C,
+        dtype: Option<crate::dtype::PlanDtype>,
+    ) -> Self {
+        Self::of_spellings(vec![spelling.erase()], dtype)
+    }
+
+    /// A hand-built layout stating SEVERAL spellings of ONE function —
+    /// the degenerate-extent fixture (a `[384, 1]` frame is both
+    /// contiguous orders, and the e-graph puts both literals in one
+    /// class).
+    ///
+    /// Panics on an empty list: a layout with no spelling is not a
+    /// layout, and a fixture that writes one is a test bug, not a
+    /// runtime refusal.
+    pub fn of_spellings(
+        spellings: Vec<Arc<dyn LayoutFacts>>,
+        dtype: Option<crate::dtype::PlanDtype>,
+    ) -> Self {
+        assert!(
+            !spellings.is_empty(),
+            "a hand-built DecodedLayout states at least one spelling"
+        );
+        let spellings = Spellings::from_decoded(spellings);
+        let mirror = mirror_of(&spellings)
+            .expect("a hand-built spelling is one of the five Layout constructors");
+        Self {
+            class: ClassId::from(HAND_BUILT_CLASS),
+            dtype,
+            spellings,
+            mirror,
+        }
+    }
+
+    // ---- class-INVARIANT facts (all spellings denote one function) ----
+
+    /// The layout's DOMAIN shape.
+    pub fn shape(&self) -> &ShapeTerm {
+        self.facts().shape()
+    }
+
+    /// The element access width in bits.
+    pub fn width_bits(&self) -> i64 {
+        self.facts().width().0
+    }
+
+    /// The domain extents as literals — `None` if any axis is symbolic.
+    pub fn literal_extents(&self) -> Option<Vec<usize>> {
+        literal_extents_of(self.shape())
+    }
+
+    /// The storage reach in ELEMENTS, taken from the FIRST spelling that
+    /// discloses one and evaluated. `None` when no spelling discloses a
+    /// reach (the offset-expression forms) or the terms are symbolic —
+    /// allocation-sizing callers bail loudly on `None`, never guess.
+    pub fn literal_span_elements(&self) -> Option<usize> {
+        self.spellings
+            .iter()
+            .find_map(|f| f.span_elements())
+            .and_then(|span| span.eval_literal())
+            .and_then(|v| usize::try_from(v).ok())
+    }
+
+    /// Element `coords` down to the flat ELEMENT index, read through the
+    /// first spelling — every spelling of the class denotes the same
+    /// function, so this answer is the class's.
+    pub fn element_index(&self, coords: &[usize]) -> Result<usize> {
+        self.facts().element_index(coords)
+    }
+
+    // ---- call-site preferences, delegated to the spelling set ----
+
+    /// The decoded `C` spelling, if the class holds one.
+    pub fn first<C: EgglogConstructor<Sort = Layout>>(&self) -> Option<&C> {
+        self.spellings.first::<C>()
+    }
+
+    /// The class holds a decodable `C` spelling.
+    pub fn has<C: EgglogConstructor<Sort = Layout>>(&self) -> bool {
+        self.spellings.has::<C>()
+    }
+
+    /// [`DecodedLayout::first`] or a refusal naming `who` asked.
+    pub fn require<C: EgglogConstructor<Sort = Layout>>(&self, who: &str) -> Result<&C> {
+        self.spellings.require::<C>(who)
+    }
+
+    /// The constructor NAMES this layout's class holds, in registry
+    /// order — what diagnostics print.
+    pub fn present(&self) -> &[&'static str] {
+        self.spellings.present()
+    }
+
+    /// The first spelling's facts. Every constructor of one class
+    /// discloses the same domain and width (checked at decode), so the
+    /// class-invariant readers above go through here.
+    fn facts(&self) -> &dyn LayoutFacts {
+        self.spellings
+            .any()
+            .expect("a DecodedLayout always holds at least one spelling")
+    }
 }
 
 /// The caller-owned decoded-layout cache: `(layout class, dtype-of fact)`
@@ -814,10 +1170,7 @@ pub type LayoutDecodeCache = HashMap<(ClassId, Option<crate::dtype::PlanDtype>),
 /// fact is the one extraction-side value fact folded into the decoded
 /// type, so decoding is a PURE function of that key and one cache serves
 /// every value of the graph AND every later graph over the same e-graph.
-/// A search loop holds one for its whole run: `decode_layout` builds a
-/// fresh `Reader` that walks and sorts every node of the serialized
-/// e-graph, so a per-call cache would pay that index once per distinct
-/// layout class per CANDIDATE. A one-shot caller passes
+/// A search loop holds one for its whole run. A one-shot caller passes
 /// `&mut HashMap::new()`. A decode error is LOUD and refuses the graph:
 /// there is no default layout.
 ///
@@ -828,7 +1181,7 @@ pub type LayoutDecodeCache = HashMap<(ClassId, Option<crate::dtype::PlanDtype>),
 /// each poison clones its tied result's layout class AND dtype fact, so
 /// it hits the `(layout class, dtype)` cache.
 pub fn decode_layout_table(
-    egraph: &EGraph,
+    view: &EGraphView<'_>,
     graph: &crate::layout_ir::ExtractedGraph,
     who: &str,
     cache: &mut LayoutDecodeCache,
@@ -846,16 +1199,15 @@ pub fn decode_layout_table(
         let decoded = match cache.get(&key) {
             Some(decoded) => decoded.clone(),
             None => {
-                let decoded = DecodedLayout {
-                    mirror: decode_layout(egraph, &value.layout.eclass).map_err(|err| {
-                        anyhow!(
-                            "{who}: decoding the layout of value {} (layout class {}): {err}",
-                            value.eclass,
-                            value.layout.eclass
-                        )
-                    })?,
-                    dtype: value.dtype_enum,
-                };
+                let decoded =
+                    DecodedLayout::from_class(&view.class(&value.layout.eclass), value.dtype_enum)
+                        .map_err(|err| {
+                            anyhow!(
+                                "{who}: decoding the layout of value {} (layout class {}): {err}",
+                                value.eclass,
+                                value.layout.eclass
+                            )
+                        })?;
                 cache.insert(key, decoded.clone());
                 decoded
             }
@@ -877,9 +1229,114 @@ pub fn decode_layout_table(
     Ok(table)
 }
 
+// =============================================================================
+// TRANSITIONAL: the retiring `MirrorLayout` decoders, now one line over
+// the spelling set. Deleted in the next step with the type itself.
+// =============================================================================
+
+/// Decode one layout e-class into the retiring [`MirrorLayout`] sum: the
+/// first spelling in registry order.
+pub fn decode_layout(egraph: &EGraph, class: &ClassId) -> Result<MirrorLayout> {
+    let decoders = ConstructorRegistry::new(layout_decoders())?;
+    let view = EGraphView::new(egraph, &decoders);
+    Ok(DecodedLayout::from_class(&view.class(class), None)?.mirror)
+}
+
+/// [`decode_layout`] with the error contextualized by who was asking.
+pub fn decode_layout_for(egraph: &EGraph, class: &ClassId, who: &str) -> Result<MirrorLayout> {
+    decode_layout(egraph, class).map_err(|err| anyhow!("{who}: {err}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// THE ASSEMBLY TRIPWIRE, over core's own preamble: every `Layout`
+    /// constructor the program declares has exactly one decoder, and
+    /// every decoder names a constructor the program declares.
+    #[test]
+    fn core_preamble_layout_constructors_all_have_decoders() {
+        let mut egraph = crate::egglog_snippet::new_egraph();
+        egraph
+            .parse_and_run_program(None, &crate::egglog_snippet::assembled_program_for(&[]))
+            .expect("the core preamble parses");
+        ConstructorRegistry::new(crate::egglog_snippet::core_decoders())
+            .expect("core's decoders are unique")
+            .check(&egraph)
+            .expect("core declares exactly the five Layout constructors it decodes");
+    }
+
+    /// A CONSTRUCTOR WITH NO DECODER IS NAMED — the failure mode the
+    /// tripwire exists for (someone adds a `Layout` constructor to the
+    /// preamble and forgets the struct that reads it back).
+    #[test]
+    fn a_missing_decoder_is_named() {
+        let mut egraph = crate::egglog_snippet::new_egraph();
+        egraph
+            .parse_and_run_program(None, &crate::egglog_snippet::assembled_program_for(&[]))
+            .expect("the core preamble parses");
+        let short: Vec<ConstructorDecoder> = crate::egglog_snippet::core_decoders()
+            .into_iter()
+            .filter(|d| d.name != BitOffsetExpressionLayout::NAME)
+            .collect();
+        let err = ConstructorRegistry::new(short)
+            .expect("still unique")
+            .check(&egraph)
+            .expect_err("a declared constructor with no decoder must be named");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains(
+                "sort Layout: constructor `BitOffsetExpressionLayoutLit` is declared by \
+                 the program but has no registered decoder"
+            ),
+            "{msg}"
+        );
+    }
+
+    /// ...AND THE OTHER DIRECTION: a decoder for a constructor the
+    /// program does not declare is a stale registration, named too.
+    #[test]
+    fn a_stale_decoder_is_named() {
+        let mut egraph = crate::egglog_snippet::new_egraph();
+        egraph
+            .parse_and_run_program(None, &crate::egglog_snippet::assembled_program_for(&[]))
+            .expect("the core preamble parses");
+        let mut decoders = crate::egglog_snippet::core_decoders();
+        decoders.push(ConstructorDecoder {
+            sort: "Layout",
+            name: "NoSuchLayoutLit",
+            decode: |_| bail!("this constructor does not exist"),
+        });
+        let err = ConstructorRegistry::new(decoders)
+            .expect("still unique")
+            .check(&egraph)
+            .expect_err("a decoder naming an undeclared constructor must be named");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains(
+                "decoder for `NoSuchLayoutLit` names a constructor the program does not declare"
+            ),
+            "{msg}"
+        );
+    }
+
+    /// `layout-of` is a `Custom` function row whose OUTPUT sort is
+    /// `Layout`. It is not a spelling and must not be demanded of the
+    /// registry — the check above passing is that proof; this pins the
+    /// row really is there and really is `Custom`.
+    #[test]
+    fn a_custom_row_over_a_decoded_sort_is_not_a_spelling() {
+        use egglog::ast::FunctionSubtype;
+        let mut egraph = crate::egglog_snippet::new_egraph();
+        egraph
+            .parse_and_run_program(None, &crate::egglog_snippet::assembled_program_for(&[]))
+            .expect("the core preamble parses");
+        let layout_of = egraph
+            .get_function("layout-of")
+            .expect("the preamble declares layout-of");
+        assert_eq!(layout_of.func_type().output.name(), "Layout");
+        assert_eq!(layout_of.func_type().subtype, FunctionSubtype::Custom);
+    }
 
     fn lit(v: i64) -> IntExprTerm {
         IntExprTerm::Lit(v)
@@ -993,24 +1450,125 @@ mod tests {
         );
     }
 
-    /// Mirror structs compare structurally — assertion convenience for
-    /// runtime tests (the bufferizer's bound is `Clone + Debug` only;
-    /// no planner check compares layouts).
+    /// A hand-built layout compares structurally on its SPELLING SET —
+    /// assertion convenience for runtime tests (the bufferizer's bound
+    /// is `Clone + Debug` only; no planner check compares layouts).
     #[test]
-    fn mirror_layout_equality_is_structural() {
-        let a = MirrorLayout::RightMajor(RightMajorContiguousElementLayout {
+    fn decoded_layout_equality_is_structural() {
+        let dtype = Some(crate::dtype::PlanDtype::F32);
+        let rm = || RightMajorContiguousElementLayout {
             shape: ShapeTerm(vec![lit(2), lit(3)]),
             width: w32(),
-        });
-        let b = MirrorLayout::RightMajor(RightMajorContiguousElementLayout {
+        };
+        let lm = || LeftMajorContiguousElementLayout {
             shape: ShapeTerm(vec![lit(2), lit(3)]),
             width: w32(),
-        });
-        let c = MirrorLayout::LeftMajor(LeftMajorContiguousElementLayout {
-            shape: ShapeTerm(vec![lit(2), lit(3)]),
-            width: w32(),
-        });
+        };
+        let a = DecodedLayout::of(rm(), dtype);
+        let b = DecodedLayout::of(rm(), dtype);
+        let c = DecodedLayout::of(lm(), dtype);
         assert_eq!(a, b);
         assert_ne!(a, c);
+        // A class holding BOTH orders is a THIRD value: same function,
+        // more spellings, and the call sites can tell.
+        let both = DecodedLayout::of_spellings(vec![rm().erase(), lm().erase()], dtype);
+        assert_ne!(both, a);
+        assert_ne!(both, c);
+        assert!(both.has::<RightMajorContiguousElementLayout>());
+        assert!(both.has::<LeftMajorContiguousElementLayout>());
+        assert_eq!(
+            both.present(),
+            [
+                "RightMajorContiguousElementLayoutLit",
+                "LeftMajorContiguousElementLayoutLit"
+            ]
+        );
+        // Class-invariant facts read the same through either.
+        assert_eq!(both.literal_extents(), Some(vec![2, 3]));
+        assert_eq!(both.width_bits(), 32);
+        assert_eq!(both.literal_span_elements(), Some(6));
+        // ...and the read function is the class's: the FIRST spelling.
+        assert_eq!(both.element_index(&[1, 2]).unwrap(), 5);
+    }
+
+    /// The five constructors evaluate their own read functions, and the
+    /// fail-closed cases refuse.
+    #[test]
+    fn element_index_reads_each_spelling() {
+        let dtype = Some(crate::dtype::PlanDtype::F32);
+        let shape = |dims: &[i64]| ShapeTerm(dims.iter().map(|&d| lit(d)).collect());
+        let rm = DecodedLayout::of(
+            RightMajorContiguousElementLayout {
+                shape: shape(&[2, 3]),
+                width: w32(),
+            },
+            dtype,
+        );
+        assert_eq!(rm.element_index(&[1, 2]).unwrap(), 5);
+        assert!(rm.element_index(&[2, 0]).is_err(), "out of domain");
+        assert!(rm.element_index(&[0]).is_err(), "foreign rank");
+
+        let lm = DecodedLayout::of(
+            LeftMajorContiguousElementLayout {
+                shape: shape(&[2, 3]),
+                width: w32(),
+            },
+            dtype,
+        );
+        assert_eq!(lm.element_index(&[1, 2]).unwrap(), 5);
+
+        let st = DecodedLayout::of(
+            StridedElementLayout {
+                shape: shape(&[3, 2]),
+                chain: vec![mul(coord(0), lit(3)), coord(1)],
+                width: w32(),
+            },
+            dtype,
+        );
+        assert_eq!(st.element_index(&[2, 1]).unwrap(), 5);
+
+        let eo = DecodedLayout::of(
+            ElementOffsetExpressionLayout {
+                offset: add(mul(coord(1), lit(3)), coord(0)),
+                shape: shape(&[2, 3]),
+                width: w32(),
+            },
+            dtype,
+        );
+        assert_eq!(eo.element_index(&[1, 2]).unwrap(), 5);
+        assert_eq!(eo.literal_span_elements(), None, "no disclosed reach");
+
+        let bo = DecodedLayout::of(
+            BitOffsetExpressionLayout {
+                offset: mul(add(mul(coord(1), lit(3)), coord(0)), lit(32)),
+                shape: shape(&[2, 3]),
+                width: w32(),
+            },
+            dtype,
+        );
+        assert_eq!(bo.element_index(&[1, 2]).unwrap(), 5);
+        let misaligned = DecodedLayout::of(
+            BitOffsetExpressionLayout {
+                offset: add(mul(coord(0), lit(32)), lit(8)),
+                shape: shape(&[4]),
+                width: w32(),
+            },
+            dtype,
+        );
+        assert!(
+            misaligned.element_index(&[1]).is_err(),
+            "a mid-element bit offset has no element read"
+        );
+
+        let symbolic = DecodedLayout::of(
+            RightMajorContiguousElementLayout {
+                shape: ShapeTerm(vec![IntExprTerm::Var("n".into()), lit(3)]),
+                width: w32(),
+            },
+            dtype,
+        );
+        assert!(symbolic.element_index(&[0, 0]).is_err());
+        assert_eq!(symbolic.literal_extents(), None);
+        assert_eq!(symbolic.literal_span_elements(), None);
     }
 }

--- a/src/layouts.rs
+++ b/src/layouts.rs
@@ -85,7 +85,7 @@ pub enum IntExprTerm {
 impl IntExprTerm {
     /// Substitute every coordinate with the given per-axis replacement
     /// (axis keyed FROM THE END). Pure tree map; an axis the caller
-    /// supplies no replacement for is a violated mirror invariant and
+    /// supplies no replacement for is a violated decode invariant and
     /// panics loudly.
     fn substitute_coords(&self, replace: &dyn Fn(i64) -> IntExprTerm) -> IntExprTerm {
         let go = |e: &IntExprTerm| Box::new(e.substitute_coords(replace));
@@ -112,7 +112,7 @@ pub struct ShapeTerm(pub Vec<IntExprTerm>);
 
 impl ShapeTerm {
     /// The extent of the axis counted FROM THE END (the CoordVar basis).
-    /// Panics on an out-of-range axis — a violated mirror invariant.
+    /// Panics on an out-of-range axis — a violated decode invariant.
     fn extent_from_end(&self, axis_from_end: i64) -> &IntExprTerm {
         let rank = self.0.len();
         usize::try_from(axis_from_end)
@@ -130,7 +130,7 @@ impl ShapeTerm {
 pub struct BitWidthTerm(pub i64);
 
 // =============================================================================
-// The five mirror structs (field-for-field with preamble constructors)
+// The five constructor structs (field-for-field with the preamble)
 // =============================================================================
 
 /// `(RightMajorContiguousElementLayoutLit Shape BitWidth)`.
@@ -863,7 +863,7 @@ fn parse_int_expr_uncached(
 // from core; the runtimes should just directly import and use these
 // layout structs"). The per-runtime `LayoutDecoder<L>` hook is GONE: it
 // bought a genericity nobody exercised (both runtimes decoded the same
-// mirror struct plus the same dtype fact), and the search that called it
+// decoded layout plus the same dtype fact), and the search that called it
 // now lives in the runtimes anyway.
 //
 // THE BUFFERIZER STILL NEVER READS THIS. `bufferize` stays generic over

--- a/src/layouts.rs
+++ b/src/layouts.rs
@@ -335,6 +335,11 @@ pub struct Layout;
 impl Sort for Layout {
     const NAME: &'static str = "Layout";
     type Facts = dyn LayoutFacts;
+    /// The sort's downcast door: `dyn LayoutFacts` upcasts to `dyn Any`
+    /// because `Any` is a supertrait of `DynFacts` (Rust 1.86+).
+    fn upcast_any(facts: &Self::Facts) -> &dyn std::any::Any {
+        facts
+    }
 }
 
 /// WHAT EVERY LAYOUT CONSTRUCTOR DISCLOSES. Object-safe (no generics,
@@ -368,7 +373,7 @@ pub trait LayoutFacts: DynFacts {
 
 impl PartialEq for dyn LayoutFacts {
     fn eq(&self, other: &Self) -> bool {
-        self.dyn_eq(other.as_any())
+        self.dyn_eq(other as &dyn std::any::Any)
     }
 }
 impl Eq for dyn LayoutFacts {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,11 +53,12 @@ pub mod index_expr;
 pub mod layout_ir;
 pub mod poison;
 pub mod subst_primitive;
-// Convenience mirrors of the five egglog Layout constructors + SpanExpr +
-// decode_layout, for runtimes to pull from one place. THE BUFFERIZER NEVER
-// CALLS ANY OF THIS — the planner stays generic over an opaque layout type,
-// and backends may ignore this module entirely (Austin's fold-into-core
-// amendment, resident-geometry cleanup 2026-08-31).
+// The `Layout` sort's constructor structs, `LayoutFacts`, `DecodedLayout`
+// and the value-keyed table, for runtimes to pull from one place. THE
+// BUFFERIZER NEVER CALLS ANY OF THIS — the planner stays generic over an
+// opaque layout type, and backends may ignore this module entirely
+// (Austin's fold-into-core amendment, resident-geometry cleanup
+// 2026-08-31).
 pub mod layouts;
 pub mod logical_op;
 pub mod search_support;

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -3982,11 +3982,12 @@ mod escape_execution_tests {
         assert_eq!(bytes.len(), 6, "the BACKING buffer is parent-sized");
         // The value's shape comes from the CARRIED LAYOUT's domain — there
         // is no dims field to read.
-        use luminal::layouts::{IntExprTerm, MirrorLayout};
-        assert_eq!(binding.layout.mirror.literal_extents(), Some(vec![3, 2]));
-        let MirrorLayout::Strided(strided) = &binding.layout.mirror else {
-            panic!("the disclosed layout is the composed strided form");
-        };
+        use luminal::layouts::{IntExprTerm, StridedElementLayout};
+        assert_eq!(binding.layout.literal_extents(), Some(vec![3, 2]));
+        let strided = binding
+            .layout
+            .first::<StridedElementLayout>()
+            .expect("the disclosed layout is the composed strided form");
         // Evaluate one chain summand at concrete coords (from-end axes).
         fn eval(expr: &IntExprTerm, coords: &[usize]) -> i64 {
             match expr {

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1458,9 +1458,9 @@ mod harness_tests {
     /// the bounds-row encoding), but they NO LONGER thread onto plan
     /// buffers: `PlanDtype` left the plan and bufferizer vocabulary
     /// entirely. What they thread onto is the RUNTIME'S OWN `L` — here
-    /// `DecodedLayout { mirror, dtype }` — which the reference decoder folds
-    /// at extraction time and which Option B then carries on each
-    /// assignment entry.
+    /// `DecodedLayout { class, dtype, spellings }` — which the reference
+    /// decoder folds at extraction time and which Option B then carries
+    /// on each assignment entry.
     ///
     /// The mixed-dtype gather fixture exercises F32 data, an Int boundary
     /// input, an Int interior iota (a planner-allocated buffer), and an
@@ -3964,7 +3964,7 @@ mod escape_execution_tests {
     /// PROBE 1, the executed-bytes half — OPTION B RESTRUCTURE: the
     /// escaped slot's fetch returns the backing buffer's bytes plus the
     /// slot's HELD LAYOUT (`binding.layout`, verbatim), and elements are
-    /// read by EVALUATING the mirror layout's own expressions — no core
+    /// read by EVALUATING the layout's own expressions — no core
     /// walker (`walk_layout_index` left core; the canonical test-equality
     /// utility lives in the testing crate `test_runtime::test_equality`,
     /// duplicated minimally here because core's own dev-tests cannot

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1475,8 +1475,12 @@ mod harness_tests {
         let egraph = serialize_fixture("boundary_gather.egg");
         let graph = luminal::dps::dps_rewrite(&extract_fixture("boundary_gather.egg"));
         // The POST-DPS graph: value-keyed tables cover poisons.
-        let table = luminal::layouts::decode_layout_table(
+        let view = luminal::egglog_utils::eclass::EGraphView::new(
             &egraph,
+            luminal_reference::decoder_registry(),
+        );
+        let table = luminal::layouts::decode_layout_table(
+            &view,
             &graph,
             "dtype row test",
             &mut luminal::layouts::LayoutDecodeCache::new(),
@@ -3828,18 +3832,18 @@ mod escape_execution_tests {
     /// no dims field, no walk, no vote.
     fn rm_layout(dims: &[i64]) -> DecodedLayout {
         // Dep-world discipline: `luminal::layouts`, never `crate::layouts` —
-        // DecodedLayout is the plain `luminal` build's MirrorLayout, and the
+        // DecodedLayout is the plain `luminal` build's type, and the
         // cfg(test) build's types do not unify with it.
         use luminal::layouts::{
-            BitWidthTerm, IntExprTerm, MirrorLayout, RightMajorContiguousElementLayout, ShapeTerm,
+            BitWidthTerm, IntExprTerm, RightMajorContiguousElementLayout, ShapeTerm,
         };
-        DecodedLayout {
-            mirror: MirrorLayout::RightMajor(RightMajorContiguousElementLayout {
+        DecodedLayout::of(
+            RightMajorContiguousElementLayout {
                 shape: ShapeTerm(dims.iter().map(|&d| IntExprTerm::Lit(d)).collect()),
                 width: BitWidthTerm(32),
-            }),
-            dtype: Some(luminal::dtype::PlanDtype::F32),
-        }
+            },
+            Some(luminal::dtype::PlanDtype::F32),
+        )
     }
 
     /// PROTOTYPE (Option B): the transpose view's COMPOSED layout — the
@@ -3847,21 +3851,19 @@ mod escape_execution_tests {
     /// reading its dense `[2,3]` parent): element (i,j) at parent flat
     /// j*3 + i, spelled as the strided chain from-end [coord0*3, coord1].
     fn transpose_strided_layout() -> DecodedLayout {
-        use luminal::layouts::{
-            BitWidthTerm, IntExprTerm, MirrorLayout, ShapeTerm, StridedElementLayout,
-        };
+        use luminal::layouts::{BitWidthTerm, IntExprTerm, ShapeTerm, StridedElementLayout};
         let coord = |axis_from_end: i64| IntExprTerm::Coord { axis_from_end };
-        DecodedLayout {
-            mirror: MirrorLayout::Strided(StridedElementLayout {
+        DecodedLayout::of(
+            StridedElementLayout {
                 shape: ShapeTerm(vec![IntExprTerm::Lit(3), IntExprTerm::Lit(2)]),
                 chain: vec![
                     IntExprTerm::Mul(Box::new(coord(0)), Box::new(IntExprTerm::Lit(3))),
                     coord(1),
                 ],
                 width: BitWidthTerm(32),
-            }),
-            dtype: Some(luminal::dtype::PlanDtype::F32),
-        }
+            },
+            Some(luminal::dtype::PlanDtype::F32),
+        )
     }
 
     /// A minimal escaped-output plan: input x `[2,3]` (BufferLit 7) is

--- a/tests/test_runtime/src/test_equality.rs
+++ b/tests/test_runtime/src/test_equality.rs
@@ -7,135 +7,31 @@
 //! THIS, bufferizer-independent).
 //!
 //! ONE reader lives here: [`element_index`] — evaluate the runtime's
-//! OWN layout vocabulary (the `luminal::layouts` mirror structs, the
-//! exact value `fetch` returns on the binding) at concrete coordinates,
-//! down to the flat element index into the BACKING buffer. The legacy
+//! OWN layout vocabulary (`luminal::layouts::DecodedLayout`, the exact
+//! value `fetch` returns on the binding) at concrete coordinates, down
+//! to the flat element index into the BACKING buffer. The legacy
 //! hop-chain walker (`walk_hop_index`, ex-core `walk_layout_index`)
 //! died with the hop machinery — the corrected contract deleted
 //! `ComposedAccess` from the plan entirely.
 
-use anyhow::{Result, anyhow, bail, ensure};
-use luminal::layouts::{IntExprTerm, MirrorLayout, ShapeTerm};
+use anyhow::{Result, ensure};
+use luminal::layouts::{DecodedLayout, IntExprTerm};
 
-/// Evaluate a mirror [`IntExprTerm`] at concrete coordinates
+/// Evaluate a layout [`IntExprTerm`] at concrete coordinates
 /// (front-indexed; `Coord{axis_from_end}` reads
-/// `coords[rank-1-axis_from_end]`). Symbolic vars refuse loudly.
+/// `coords[rank-1-axis_from_end]`). Symbolic vars refuse loudly. Core
+/// owns the evaluator now — this keeps the name the suites call.
 pub fn eval_term(expr: &IntExprTerm, coords: &[usize]) -> Result<i64> {
-    let rank = coords.len();
-    Ok(match expr {
-        IntExprTerm::Lit(v) => *v,
-        IntExprTerm::Var(name) => bail!("test equality: symbolic dim `{name}` cannot evaluate"),
-        IntExprTerm::Coord { axis_from_end } => {
-            let axis = usize::try_from(*axis_from_end)
-                .ok()
-                .filter(|&a| a < rank)
-                .ok_or_else(|| anyhow!("coordinate axis {axis_from_end} out of rank {rank}"))?;
-            coords[rank - 1 - axis] as i64
-        }
-        IntExprTerm::Add(a, b) => eval_term(a, coords)? + eval_term(b, coords)?,
-        IntExprTerm::Mul(a, b) => eval_term(a, coords)? * eval_term(b, coords)?,
-        IntExprTerm::TruncDiv(a, b) => {
-            let (a, b) = (eval_term(a, coords)?, eval_term(b, coords)?);
-            ensure!(b != 0, "division by zero in layout expression");
-            // Rust's `/` on i64 IS truncation toward zero.
-            a / b
-        }
-        IntExprTerm::TruncRem(a, b) => {
-            let (a, b) = (eval_term(a, coords)?, eval_term(b, coords)?);
-            ensure!(b != 0, "remainder by zero in layout expression");
-            a % b
-        }
-        IntExprTerm::CeilDiv(a, b) => {
-            let (a, b) = (eval_term(a, coords)?, eval_term(b, coords)?);
-            ensure!(
-                b > 0,
-                "ceil-div by non-positive divisor in layout expression"
-            );
-            a.div_euclid(b) + if a.rem_euclid(b) != 0 { 1 } else { 0 }
-        }
-        IntExprTerm::Min(a, b) => eval_term(a, coords)?.min(eval_term(b, coords)?),
-        IntExprTerm::Max(a, b) => eval_term(a, coords)?.max(eval_term(b, coords)?),
-        IntExprTerm::LessThanCast(a, b) => (eval_term(a, coords)? < eval_term(b, coords)?) as i64,
-    })
-}
-
-fn literal_extents(shape: &ShapeTerm) -> Result<Vec<usize>> {
-    shape
-        .0
-        .iter()
-        .map(|e| match e {
-            IntExprTerm::Lit(v) => usize::try_from(*v)
-                .ok()
-                .filter(|&d| d > 0)
-                .ok_or_else(|| anyhow!("non-positive layout extent {v}")),
-            other => Err(anyhow!("symbolic layout extent {other:?}")),
-        })
-        .collect()
+    expr.eval_at(coords)
 }
 
 /// THE OPTION-B READER: element `coords` of a value interpreted under
 /// its returned layout, down to the flat ELEMENT index into the backing
-/// buffer's storage — evaluating the mirror layout's own expressions.
+/// buffer's storage — evaluating the layout's own read function.
 /// Fail-closed: symbolic extents, foreign-rank coordinates, and
 /// out-of-domain coordinates all bail loudly.
-pub fn element_index(layout: &MirrorLayout, coords: &[usize]) -> Result<usize> {
-    let domain = |shape: &ShapeTerm| -> Result<()> {
-        let extents = literal_extents(shape)?;
-        ensure!(
-            coords.len() == extents.len(),
-            "{} coordinates for a rank-{} layout",
-            coords.len(),
-            extents.len()
-        );
-        for (axis, (&c, &d)) in coords.iter().zip(&extents).enumerate() {
-            ensure!(c < d, "coordinate {c} out of extent {d} (axis {axis})");
-        }
-        Ok(())
-    };
-    let flat = match layout {
-        MirrorLayout::RightMajor(rm) => {
-            domain(&rm.shape)?;
-            let extents = literal_extents(&rm.shape)?;
-            coords
-                .iter()
-                .zip(&extents)
-                .fold(0usize, |acc, (&c, &d)| acc * d + c) as i64
-        }
-        MirrorLayout::LeftMajor(lm) => {
-            domain(&lm.shape)?;
-            let extents = literal_extents(&lm.shape)?;
-            let mut stride = 1usize;
-            let mut acc = 0usize;
-            for (&c, &d) in coords.iter().zip(&extents) {
-                acc += c * stride;
-                stride *= d;
-            }
-            acc as i64
-        }
-        MirrorLayout::Strided(st) => {
-            domain(&st.shape)?;
-            st.chain
-                .iter()
-                .map(|s| eval_term(s, coords))
-                .sum::<Result<i64>>()?
-        }
-        MirrorLayout::ElementOffset(eo) => {
-            domain(&eo.shape)?;
-            eval_term(&eo.offset, coords)?
-        }
-        MirrorLayout::BitOffset(bo) => {
-            domain(&bo.shape)?;
-            let bits = eval_term(&bo.offset, coords)?;
-            let width = bo.width.0;
-            ensure!(width > 0, "non-positive bit width {width}");
-            ensure!(
-                bits % width == 0,
-                "bit offset {bits} is not element-aligned to width {width}"
-            );
-            bits / width
-        }
-    };
-    usize::try_from(flat).map_err(|_| anyhow!("negative element index {flat}"))
+pub fn element_index(layout: &DecodedLayout, coords: &[usize]) -> Result<usize> {
+    layout.element_index(coords)
 }
 
 /// Read every element of a value (row-major coordinate order over
@@ -143,7 +39,11 @@ pub fn element_index(layout: &MirrorLayout, coords: &[usize]) -> Result<usize> {
 /// dense" comparison helper for f32 buffers. Each index is bounds-checked
 /// against the BACKING length (the buffer is the only reach authority —
 /// offset-form layouts disclose none).
-pub fn dense_f32(backing: &[f32], layout: &MirrorLayout, value_dims: &[usize]) -> Result<Vec<f32>> {
+pub fn dense_f32(
+    backing: &[f32],
+    layout: &DecodedLayout,
+    value_dims: &[usize],
+) -> Result<Vec<f32>> {
     let numel: usize = value_dims.iter().product();
     let rank = value_dims.len();
     let mut coords = vec![0usize; rank];
@@ -170,8 +70,8 @@ pub fn dense_f32(backing: &[f32], layout: &MirrorLayout, value_dims: &[usize]) -
 /// Assert two (buffer, layout) pairs denote the SAME tensor of
 /// `value_dims` extents, element by element, within `tolerance`.
 pub fn assert_same_f32(
-    a: (&[f32], &MirrorLayout),
-    b: (&[f32], &MirrorLayout),
+    a: (&[f32], &DecodedLayout),
+    b: (&[f32], &DecodedLayout),
     value_dims: &[usize],
     tolerance: f32,
 ) {
@@ -188,10 +88,18 @@ pub fn assert_same_f32(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use luminal::dtype::PlanDtype;
     use luminal::layouts::{
-        BitOffsetExpressionLayout, BitWidthTerm, ElementOffsetExpressionLayout, MirrorLayout,
+        BitOffsetExpressionLayout, BitWidthTerm, ElementOffsetExpressionLayout,
         RightMajorContiguousElementLayout, ShapeTerm, StridedElementLayout,
     };
+
+    fn typed(
+        spelling: impl luminal::egglog_utils::eclass::EgglogConstructor<Sort = luminal::layouts::Layout>
+        + luminal::layouts::LayoutFacts,
+    ) -> DecodedLayout {
+        DecodedLayout::of(spelling, Some(PlanDtype::F32))
+    }
 
     fn lit(v: i64) -> IntExprTerm {
         IntExprTerm::Lit(v)
@@ -220,14 +128,14 @@ mod tests {
         // Parent x: [2,3] row-major bytes.
         let x: Vec<f32> = (0..6).map(|n| n as f32 * 10.0).collect();
         // The view: [3,2], element (i,j) = x[j,i] at parent flat j*3+i.
-        let view_layout = MirrorLayout::Strided(StridedElementLayout {
+        let view_layout = typed(StridedElementLayout {
             shape: shape(&[3, 2]),
             chain: vec![mul(coord(0), lit(3)), coord(1)],
             width: BitWidthTerm(32),
         });
         // The dense demand: the same tensor materialized row-major.
         let dense: Vec<f32> = vec![x[0], x[3], x[1], x[4], x[2], x[5]];
-        let dense_layout = MirrorLayout::RightMajor(RightMajorContiguousElementLayout {
+        let dense_layout = typed(RightMajorContiguousElementLayout {
             shape: shape(&[3, 2]),
             width: BitWidthTerm(32),
         });
@@ -239,19 +147,19 @@ mod tests {
     /// mid-element bit offset refuses.
     #[test]
     fn offset_forms_read_and_bit_alignment_refuses() {
-        let eo = MirrorLayout::ElementOffset(ElementOffsetExpressionLayout {
+        let eo = typed(ElementOffsetExpressionLayout {
             offset: add(mul(coord(1), lit(3)), coord(0)),
             shape: shape(&[2, 3]),
             width: BitWidthTerm(32),
         });
         assert_eq!(element_index(&eo, &[1, 2]).unwrap(), 5);
-        let bo = MirrorLayout::BitOffset(BitOffsetExpressionLayout {
+        let bo = typed(BitOffsetExpressionLayout {
             offset: mul(add(mul(coord(1), lit(3)), coord(0)), lit(32)),
             shape: shape(&[2, 3]),
             width: BitWidthTerm(32),
         });
         assert_eq!(element_index(&bo, &[1, 2]).unwrap(), 5);
-        let misaligned = MirrorLayout::BitOffset(BitOffsetExpressionLayout {
+        let misaligned = typed(BitOffsetExpressionLayout {
             offset: add(mul(coord(0), lit(32)), lit(8)),
             shape: shape(&[4]),
             width: BitWidthTerm(32),
@@ -266,20 +174,20 @@ mod tests {
     /// backing-length check is the only reach fence.
     #[test]
     fn domain_violations_refuse() {
-        let rm = MirrorLayout::RightMajor(RightMajorContiguousElementLayout {
+        let rm = typed(RightMajorContiguousElementLayout {
             shape: shape(&[2, 3]),
             width: BitWidthTerm(32),
         });
         assert!(element_index(&rm, &[2, 0]).is_err());
         assert!(element_index(&rm, &[0]).is_err());
-        let symbolic = MirrorLayout::RightMajor(RightMajorContiguousElementLayout {
+        let symbolic = typed(RightMajorContiguousElementLayout {
             shape: ShapeTerm(vec![IntExprTerm::Var("n".into()), lit(3)]),
             width: BitWidthTerm(32),
         });
         assert!(element_index(&symbolic, &[0, 0]).is_err());
         // An offset form pointing past the data: element_index itself
         // cannot know — dense_f32's backing check catches it.
-        let escaping = MirrorLayout::ElementOffset(ElementOffsetExpressionLayout {
+        let escaping = typed(ElementOffsetExpressionLayout {
             offset: add(coord(0), lit(100)),
             shape: shape(&[2]),
             width: BitWidthTerm(32),


### PR DESCRIPTION
Design: `docs/design/eclass-decoder.md` (approved 2026-09-05). Executed as
S1 → S6, one commit per step, each compile-green with its gate.

## The API, in five lines

- `EGraphView<'g>` = a serialized e-graph + the decoders that know its
  constructors; `view.class(&id)` is total.
- `EClass::{first,has,require,expect}::<C>()` — the call site NAMES the
  constructor it needs; `present::<S>()` / `spellings::<S>()` /
  `facts::<S>()` are the registry-driven, erased side for generic code.
- `EgglogConstructor` = one egglog constructor mirrored as a Rust struct
  that decodes ONE e-node of it; `Sort` names the sort and its erased
  fact surface (`Layout: Sort<Facts = dyn LayoutFacts>`).
- `ConstructorRegistry` keys decoders by `(sort, constructor)`, refuses
  duplicates, and `check(&egglog::EGraph)` is the assembly TRIPWIRE.
- `DecodedLayout` carries `Spellings<Layout>` — every registered spelling
  its class holds — plus the dtype fact and the class id for diagnostics.

Ordering is decided in exactly one place, `EClass::nodes()`: unsubsumed
first, then by `NodeId`, subsumed kept. Nothing in `eclass.rs` knows
about layouts.

## The bug, and how the fence works now

Whisper tiny.en decodes ONE token, so its q/v projections are
`x[1,384] @ w[384,384] + b[384]` and the cuBLASLt transpose-sandwich
sibling's destination frame is `[m,n] = [384,1]`. At a degenerate extent
the right-major and left-major contiguous index maps over `[m,n]` are the
SAME function — `r*n + c` and `c*m + r` agree when the collapsed axis's
coordinate can only be 0 — and the e-graph knows it: both literals land
in ONE class. The estate's bias decorators mint a bias form only on the
LeftMajor spelling; core's decoder, asked for "the" layout of that class,
answered RightMajor by a fixed preference order; `bind_destination` built
a ROW descriptor; the order fence refused every candidate genome and the
search died with "no candidate genome produced an executable plan".

The question changed. `bind_destination` now binds a bias form's D by

```rust
dest.require::<LeftMajorContiguousElementLayout>(who)?;
LtDesc::col(call.m, call.n, call.m.max(1))
```

— the decorator's premise, spelled at the call site that depends on it.
A class holding both spellings answers yes. There is no degenerate-extent
arm anywhere in the executor, and no extent test to widen by accident:
the added negative pins that a right-major-ONLY class under a bias form
is refused at `[384,1]` too. The fix is the class, not the extent.

## Behaviour change (design §8.9)

A bias-FREE cuBLASLt destination whose class holds BOTH contiguous
spellings — degenerate extents only — now binds COL where it bound ROW.
Non-bias binding states its own preference (LeftMajor → COL, else
RightMajor → ROW, else a capability refusal printing the class's
constructor names). Same elements, same order, same reach
(`validate_against` passes both); visible only as the descriptor's order
attribute. **This is the one behaviour change in the PR.**

## What was deleted

- `MirrorLayout` and its four fact readers; `DecodedLayout.mirror`;
  `decode_layout` / `decode_layout_for`; the `Reader` walk with its
  per-decode class index; the preference list itself.
  `grep -rn MirrorLayout` and `grep -rn '\.mirror'` both return nothing.
- The only test that asserted the preference order
  (`cublaslt_bias_premise.rs`'s "the decoder's most-structured spelling
  is LeftMajor") — it is now `has::<LeftMajor>() && !has::<RightMajor>()`,
  asked of the class.
- Three copies of one coordinate evaluator (core, CL, `test_equality`)
  collapse into `IntExprTerm::eval_at`; the five-arm `element_index` in
  CL, `test_equality` and `view_admission` collapses into each
  constructor answering for its own read function.

## The tripwire

Runs at the four places a runtime assembles for search, against the LIVE
egglog schema (`functions_iter` + `Function::func_type`; `Custom` rows
such as `layout-of` are skipped): every `Constructor` whose output sort
is a decoded sort has exactly one decoder, and every decoder names a
constructor the program declares under that sort. Deliberately dropping
one decoder produces:

```
egglog constructor decoders are incomplete for the assembled program:
  - sort Layout: constructor `BitOffsetExpressionLayoutLit` is declared by the program but has no registered decoder
Every constructor of a decoded sort needs exactly one decoder, registered beside the snippet that declares it (OpMatcher::decoders); see docs/design/eclass-decoder.md.
```

Decoders ride on `OpMatcher::decoders()` (default empty), so a
constructor's declaration and the struct that reads it back travel
together. CUDA-lite declares no `Layout` constructor today; the plumbing
and the pin exist for when one appears.

## The demonstration

`cargo run -p luminal_cuda_lite --example eclass_decoder_demo` — the
whisper site at pin scale (`x[1,8] @ w[8,3] + b[3]`, sibling frame
`m=3 n=1`):

```
DEMO D layout class: present = ["RightMajorContiguousElementLayoutLit", "LeftMajorContiguousElementLayoutLit", "StridedElementLayoutLit", "ElementOffsetExpressionLayoutLit", "BitOffsetExpressionLayoutLit"]
DEMO first::<LeftMajorContiguousElementLayout>()  = Some(LeftMajorContiguousElementLayout { shape: ShapeTerm([Lit(3), Lit(1)]), width: BitWidthTerm(32) })
DEMO first::<RightMajorContiguousElementLayout>() = Some(RightMajorContiguousElementLayout { shape: ShapeTerm([Lit(3), Lit(1)]), width: BitWidthTerm(32) })
DEMO retired preference order would have answered: Some("RightMajorContiguousElementLayoutLit")
DEMO search seed 0 elected a cuBLASLt bias form
DEMO call frame m=3 n=1 k=8 ; destination present = [...]
DEMO bind_destination -> Ok ; d = LtDesc { rows: 3, cols: 1, ld: 3, order: Col } ; c == d is true
DEMO the fence, spelled at the call site: dest.require::<LeftMajorContiguousElementLayout>("demo") = Ok(...)
DEMO right_major([3, 1]) alone under the bias form: Err(cuBLASLt demo: unreachable: the bias decorators require a LeftMajor D; ... whose destination class holds ["RightMajorContiguousElementLayoutLit"] and no LeftMajorContiguousElementLayoutLit ...)
```

Line 4 is the bug; lines 2-3 are why it was never a real disagreement.

## Gates

```
cargo test -p luminal --lib          test result: ok. 255 passed; 0 failed; 6 ignored
cargo test -p luminal_reference      6 targets, all ok (44 + 0 + 0 + 1 + 7 + 0)
cargo test -p luminal_cuda_lite      21 targets, all ok
cargo test -p test_runtime           all ok
cargo test -p luminal_nn             test result: ok. 31 passed; 0 failed
cargo clippy -p luminal -p luminal_reference -p luminal_cuda_lite --all-targets   exit 0
cargo clippy -p luminal_cuda_lite --features device --all-targets                 exit 0
cargo fmt --all -- --check                                                        clean
```

Named pins, all at their required counts: `cublaslt_election` 9,
`cublaslt_bias_premise` 5, `cublaslt_contracts_cpu` 21,
`finalists_lattice` 4, `dim_buckets` 5, `codegen_identity` 13. The nine
`ELECTION-TABLE` rows are **bit-identical** to the trunk capture, and the
five codegen string pins are untouched (the emitted C is byte-for-byte
what it was; §8.7's uniform lowering is deliberately NOT in this PR).

The one pre-existing clippy warning under `--features device`
(`tests/device_profile.rs`, "very complex type") reproduces on trunk and
is untouched here.

## #507

**Superseded by this PR.** Its `exec.rs` guarded arm
(`M::RightMajor(_) if bias && (m == 1 || n == 1) => COL`) never lands —
this design subsumes it with no special case. Its four tests are carried
over here and retargeted, plus the negative the design makes true (a
right-major-only class is refused at a degenerate extent). Not closed —
that is Austin's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Follow-up 2026-09-05 (`8717b267`): the MSRV, and the door

`rust-version = "1.85"` had been false for a while — 27 `&& let` let-chain
sites need 1.88 — so the floor is now **1.91**, the oldest toolchain anyone
builds this with (this Mac 1.91.1, the A100 box 1.95). No member manifest
declares its own `rust-version`, so the root package's line is the whole
statement.

That makes trait upcasting (stable 1.86) legal, and design §2.5's decision is
amended accordingly: `DynFacts::as_any` is DELETED. `Any` was already a
supertrait of `DynFacts`, so a fact object upcasts to `dyn Any` by itself. The
one thing the generic reader cannot do is spell that coercion over
`Sort::Facts`, which is `?Sized` — rustc 1.91.1 refuses it (`the size for
values of type <S as Sort>::Facts cannot be known at compilation time ...
required for the cast ... to &(dyn Any + 'static)`) — so the upcast is spelled
once per SORT as `Sort::upcast_any`, body `facts`, the same
one-line-where-the-type-is-known shape `EgglogConstructor::erase` already has.
Constructor structs still write no boilerplate; `impl PartialEq for dyn
LayoutFacts` upcasts directly.

The op-side door (`AsAnyOp`, `src/buffer_tensor_ir.rs:77-85`, 32 call sites) is
a different trait and is untouched — a separate follow-up.

Gate re-run green on the commit, in a clean target dir (the warm shared one is
contended by another worktree): build / device check / `luminal --lib` 255
passed / `luminal_cuda_lite` 21 targets + doctest / `luminal_reference` 6
targets / clippy exit 0 / fmt clean / demo prints
`d = LtDesc { rows: 3, cols: 1, ld: 3, order: Col }`. Pins bit-identical:
`cublaslt_election` 9, `cublaslt_bias_premise` 5, `cublaslt_contracts_cpu` 21,
`finalists_lattice` 4, `dim_buckets` 5, `codegen_identity` 13.
