### PR TITLE
egglog: tree decomposition off for every saturation (57x on a 4B model, identical fixpoints)

### DIFF
--- a/src/egglog_snippet.rs
+++ b/src/egglog_snippet.rs
@@ -116,6 +116,17 @@ pub fn new_egraph() -> egglog::EGraph {
     use egglog::sort::Z;
 
     let mut egraph = egglog::EGraph::default();
+    // Tree decomposition OFF for every e-graph we build (measured 2026-09-05).
+    // egglog plans each rule's query with a tree decomposition — a per-rule,
+    // per-iteration cost that exceeded its benefit everywhere we measured, at a
+    // BIT-IDENTICAL fixpoint every time: same iterations, same tuples, every
+    // check passing. qwen3-4B saturation on the A100: 36 layers 3,905 s -> 68 s
+    // (57x), 16 layers 433 s -> 20 s; the two cuBLASLt matmul-recognition arms
+    // alone fell from ~1,845 s each to ~11 s at 36 layers. Host suites: 632
+    // tests, zero outcome changes. egglog's per-rule `:no-decomp` label is OR'd
+    // with this flag if a rule ever needs the planner back. Reproducer:
+    // docs/egglog-regressions/cublaslt-matmul-recognition/ (local branch today).
+    egraph.no_decomp = true;
     egglog::add_primitive!(&mut egraph, "bigint-to-i64" = |a: Z| -?> i64 {
         i64::try_from(&*a).ok()
     });

--- a/src/egglog_snippet.rs
+++ b/src/egglog_snippet.rs
@@ -116,16 +116,9 @@ pub fn new_egraph() -> egglog::EGraph {
     use egglog::sort::Z;
 
     let mut egraph = egglog::EGraph::default();
-    // Tree decomposition OFF for every e-graph we build (measured 2026-09-05).
-    // egglog plans each rule's query with a tree decomposition — a per-rule,
-    // per-iteration cost that exceeded its benefit everywhere we measured, at a
-    // BIT-IDENTICAL fixpoint every time: same iterations, same tuples, every
-    // check passing. qwen3-4B saturation on the A100: 36 layers 3,905 s -> 68 s
-    // (57x), 16 layers 433 s -> 20 s; the two cuBLASLt matmul-recognition arms
-    // alone fell from ~1,845 s each to ~11 s at 36 layers. Host suites: 632
-    // tests, zero outcome changes. egglog's per-rule `:no-decomp` label is OR'd
-    // with this flag if a rule ever needs the planner back. Reproducer:
-    // docs/egglog-regressions/cublaslt-matmul-recognition/ (local branch today).
+    // Tree decomposition is off for now: egglog's decomposition planner was
+    // a large performance regression on our saturations (identical fixpoints
+    // either way). Temporary until the planner is revisited.
     egraph.no_decomp = true;
     egglog::add_primitive!(&mut egraph, "bigint-to-i64" = |a: Z| -?> i64 {
         i64::try_from(&*a).ok()


### PR DESCRIPTION
One line in `luminal::egglog_snippet::new_egraph()`:

```rust
egraph.no_decomp = true;
```

egglog plans each rule's query with a tree decomposition. On our programs that
planning is a per-rule, per-iteration cost that exceeds its benefit everywhere
we measured, and turning it off reaches a **bit-identical fixpoint every time** —
same iteration count, same tuple count, every `(check ...)` still passing. No
knob, no env var, no option: the setting is the same for every e-graph we build.

## Mac host (release, qwen3-4B truncated to N transformer layers)

Saturation only, one process, the reproducer's runner. `default planner` is
today's behaviour.

| N (layers) | default planner | decomposition off | speedup | iterations | tuples |
|-----------:|----------------:|------------------:|--------:|-----------:|-------:|
| 1  |   2.031 s | 0.949 s |  2.1x |   258 |  40,574 |
| 2  |   3.323 s | 1.222 s |  2.7x |   350 |  51,499 |
| 4  |   7.258 s | 1.763 s |  4.1x |   533 |  73,345 |
| 8  |  20.913 s | 3.234 s |  6.5x |   901 | 117,045 |
| 16 | 143.627 s | 7.375 s | 19.5x | 1,637 | 204,445 |
| 24 | 424.713 s | 13.126 s | 32.4x | 2,373 | 291,845 |

The iteration and tuple columns are one column, not two: they are identical in
both halves of every row. The speedup grows with the program.

## A100 (same programs, 2026-09-05)

| N (layers) | default planner | decomposition off | speedup |
|-----------:|----------------:|------------------:|--------:|
| 16 |   433 s | 19.9 s | 21.8x |
| 36 (full model) | 3,905 s | 68.3 s | **57x** |

Same fixpoint on both sides (36 layers: 422,945 tuples, 3,477 iterations). The
two cuBLASLt matmul-recognition arms alone fell from ~1,845 s each to ~11 s at
36 layers. Saturation of a 4B model goes from ~65 min to ~1 min.

## Host suites: zero outcome changes

Every workspace suite, with and without the line, on this Mac:

| suite | result |
|---|---|
| `cargo test -p luminal --lib` | 244 passed; 0 failed; 6 ignored |
| `cargo test -p luminal_reference` | 52 passed; 0 failed; 2 ignored |
| `cargo test -p luminal_cuda_lite` | 93 passed; 0 failed; 3 ignored |
| `cargo test -p test_runtime` | 212 passed; 0 failed; 1 ignored |
| `cargo test -p luminal_nn` | 31 passed; 0 failed; 0 ignored |

632 tests, no FAILED or panicked lines, identical counts on both sides. The five
cuBLASLt pins are bit-identical: `cublaslt_election` 9, `cublaslt_bias_premise`
3, `cublaslt_contracts_cpu` 19, `finalists_lattice` 4, `dim_buckets` 5.
`cargo build --workspace --all-targets`, `cargo clippy -p luminal --lib` and
`cargo fmt --all -- --check` all clean.

The small test graphs move a little in the same direction — medians of
interleaved A/B reps of the same prebuilt test binaries:

| gate | decomposition on | decomposition off |
|---|---:|---:|
| `luminal --lib` | 15.92 s | 15.09 s |
| `luminal_cuda_lite` | 56.08 s | 48.78 s |

Decomposition off won every paired rep, but these graphs are small: the effect
this PR is about is a big-model effect.

## The escape hatch, if a rule ever wants the planner back

egglog's per-rule `:no-decomp` label still exists, and the rule-level flag is
OR'd with this global one (`self.no_decomp || rule.no_decomp`). A rule that ever
needs decomposition would need the opposite — flipping this line off and
labelling the rest — but nothing we measured wants it.

We did measure the per-rule route first: nine `:no-decomp` labels on the
recognition and descriptor arms take the 36-layer A100 program to 166 s, against
68 s for this one line, because a diffuse tail of other rules pays the same tax.
That branch is kept locally as the fallback record.

## Reproducer

`docs/egglog-regressions/cublaslt-matmul-recognition/` — the exact dumped
programs, a standalone runner, and `scripts/decomp.sh` for the on/off pair. It
lives on a local branch today.

A100 end-to-end qwen3 run pending: search wall was 83 min, of which ~65 min was
saturation, so expect ~20 min; the ~16 min of extraction is untouched by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
