### PR TITLE
Preserve dynamic bucket values during CUDA graph warmup

### DIFF
--- a/crates/luminal_cuda_lite/src/kernel/to_host.rs
+++ b/crates/luminal_cuda_lite/src/kernel/to_host.rs
@@ -1246,23 +1246,33 @@ impl CudaGraphOp {
         }
     }
 
-    pub(crate) fn enable_residency(&self, dims: &[Symbol]) {
+    fn capture_sensitive_dyn_dims(&self) -> FxHashSet<Symbol> {
+        self.cublaslt_users_by_dyn_dim
+            .keys()
+            .copied()
+            .chain(self.captured_host_dyn_dims.iter().copied())
+            .chain(self.internal_buffer_dyn_dims.iter().copied())
+            .collect()
+    }
+
+    pub(crate) fn enable_residency(&self, dims: &[Symbol], strict: bool) {
         assert!(
             !self.residency_frozen.get(),
             "CUDA graph residency is already frozen"
         );
         self.release_materialization();
-        let mut relevant: FxHashSet<_> = self
-            .cublaslt_users_by_dyn_dim
-            .keys()
-            .copied()
-            .chain(self.captured_host_dyn_dims.iter().copied())
-            .chain(self.internal_buffer_dyn_dims.iter().copied())
-            .collect();
-        assert!(
-            relevant.iter().all(|dim| dims.contains(dim)),
-            "capture-sensitive dimensions {relevant:?} must be declared in startup shape_dims"
-        );
+        let mut relevant = self.capture_sensitive_dyn_dims();
+        if strict {
+            assert!(
+                relevant.iter().all(|dim| dims.contains(dim)),
+                "capture-sensitive dimensions {relevant:?} must be declared in startup shape_dims"
+            );
+        } else {
+            // Cache only the requested specialization dimensions. Other
+            // dimensions keep their exact values and use materialize_impl's
+            // normal parameter-update / library-recapture path on a cache hit.
+            relevant.retain(|dim| dims.contains(dim));
+        }
         if !self.state.borrow().flashinfer_ops.is_empty() {
             relevant.extend(dims);
         }
@@ -1318,6 +1328,12 @@ impl CudaGraphOp {
         let resident = resident
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("CUDA graph residency was not enabled"))?;
+        anyhow::ensure!(
+            self.capture_sensitive_dyn_dims()
+                .iter()
+                .all(|dim| resident.dims.contains(dim)),
+            "cannot freeze CUDA graph warmup with uncached capture-sensitive dimensions"
+        );
         anyhow::ensure!(
             resident.active_key.is_some() && self.is_materialized(),
             "every CUDA graph bucket must be prepared before serving"

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -694,9 +694,32 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         })
     }
 
-    /// Begin startup capture of finite shape variants sharing one arena.
-    /// Other dimensions remain patchable through the dynamic ABI.
+    /// Begin optional CUDA graph warmup without restricting dynamic execution.
+    ///
+    /// `cached_dims` are performance hints: keep separate materializations for
+    /// their values when the lowered graph benefits from doing so. Other
+    /// dimensions may still change anywhere within the compiled bucket ranges;
+    /// execution updates parameters or rematerializes affected library calls.
+    /// Previously unseen cached values are also prepared on demand. Pass `[]`
+    /// to reuse one mutable materialization per compiled graph.
+    ///
+    /// Call `prepare_cuda_graphs` with representative inputs to warm selected
+    /// shapes. No finish/freeze call is needed. Use `begin_cuda_graph_preparation`
+    /// only when explicitly requiring a finite, immutable set of captures.
+    pub fn begin_cuda_graph_warmup(&mut self, cached_dims: &[Symbol]) {
+        self.begin_cuda_graph_residency(cached_dims, false);
+    }
+
+    /// Begin strict startup capture of finite shape variants sharing one arena.
+    /// Every capture-sensitive dimension of the selected lowering must be in
+    /// `shape_dims`. After `finish_cuda_graph_preparation`, unseen capture shapes
+    /// are errors even inside a compile bucket. This is an opt-in restriction;
+    /// ordinary dynamic execution and `begin_cuda_graph_warmup` do not impose it.
     pub fn begin_cuda_graph_preparation(&mut self, shape_dims: &[Symbol]) {
+        self.begin_cuda_graph_residency(shape_dims, true);
+    }
+
+    fn begin_cuda_graph_residency(&mut self, shape_dims: &[Symbol], strict: bool) {
         assert!(
             !self.cuda_graphs_frozen,
             "CUDA graph residency is already frozen"
@@ -704,14 +727,15 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         self.cuda_stream.synchronize().unwrap();
         self.set_max_materialized_buckets(None);
         for graph in self.cuda_graphs() {
-            graph.enable_residency(shape_dims);
+            graph.enable_residency(shape_dims, strict);
         }
         self.materialized_bucket_lru.clear();
         self.release_pooled_memory();
     }
 
-    /// Materialize one serving shape using the caller's current, valid input
-    /// descriptors. Does not launch the model or modify its KV state.
+    /// Materialize one shape using the caller's current, valid input descriptors.
+    /// Does not launch the model or modify its KV state. Warming a representative
+    /// does not specialize the logical dimensions to that value or freeze graphs.
     pub fn prepare_cuda_graphs(&mut self, dyn_map: &DynMap) -> anyhow::Result<()> {
         anyhow::ensure!(
             !self.cuda_graphs_frozen,

--- a/crates/luminal_cuda_lite/src/tests/bucket_tests.rs
+++ b/crates/luminal_cuda_lite/src/tests/bucket_tests.rs
@@ -27,6 +27,42 @@ fn bucket_options(buckets: &[DimBucket]) -> CompileOptions {
 }
 
 #[test]
+fn warmup_generated_kernel_preserves_dynamic_bucket_values() {
+    let Some(stream) = get_cuda_stream() else {
+        return;
+    };
+    let (mut cx, input, output) = build_dynamic_add_graph();
+    cx.build_search_space::<CudaRuntime>(bucket_options(&[
+        DimBucket::new(1, 4).representative(2),
+        DimBucket::new(5, 8).representative(6),
+    ]));
+    let mut rt = CudaRuntime::initialize(stream);
+    cx.set_dim('s', 2);
+    rt.set_data(input, vec![1.0f32; 8 * 4]);
+    rt = cx.search_with_rng(
+        rt,
+        CompileOptions::default().search_graph_limit(5),
+        &mut SmallRng::seed_from_u64(43),
+    );
+    rt.begin_cuda_graph_warmup(&[]);
+    for s in [2, 6] {
+        cx.set_dim('s', s);
+        rt.set_data(input, vec![0.0f32; s * 4]);
+        rt.prepare_cuda_graphs(&cx.dyn_map).unwrap();
+    }
+    for (iteration, s) in [1, 4, 5, 8, 3, 6, 2, 1].into_iter().enumerate() {
+        cx.set_dim('s', s);
+        let values = (0..s * 4)
+            .map(|i| i as f32 + iteration as f32)
+            .collect::<Vec<_>>();
+        let expected = values.iter().map(|v| v * 2.0).collect::<Vec<_>>();
+        rt.set_data(input, values);
+        rt.execute(&cx.dyn_map);
+        assert_eq!(rt.get_f32(output), expected);
+    }
+}
+
+#[test]
 fn resident_recurrent_output_preserves_input_allocation() {
     let Some(stream) = get_cuda_stream() else {
         return;

--- a/crates/luminal_cuda_lite/src/tests/cublaslt_rewrite_tests.rs
+++ b/crates/luminal_cuda_lite/src/tests/cublaslt_rewrite_tests.rs
@@ -1299,7 +1299,130 @@ fn bucket_range_and_singleton_cublaslt_buckets_are_captured() {
 }
 
 #[test]
+fn warmup_cublaslt_preserves_exact_dynamic_bucket_values() {
+    let Some(stream) = get_cuda_stream() else {
+        return;
+    };
+    if !cublaslt_available_for_runtime(&stream)
+        || !crate::host::cublaslt::cublaslt_graph_capture_supported(&stream)
+    {
+        return;
+    }
+    let n = 11;
+    let mut cx = Graph::new();
+    let a = cx.tensor(('s', 'c')).persist();
+    let b = cx.tensor(('c', n)).persist();
+    let out = a.matmul(b).output();
+    cx.set_dim('s', 2);
+    cx.set_dim('c', 16);
+    // Exercise the unfused alternative regardless of which implementation
+    // happens to win a performance search on the test GPU.
+    let llir = extract_forced_cublaslt_llir_where(&mut cx, "dynamic warmup", |_| true);
+    let dim_buckets = [
+        (
+            Symbol::from('s'),
+            vec![DimBucket::new(1, 4), DimBucket::new(5, 8)],
+        ),
+        (
+            Symbol::from('c'),
+            vec![DimBucket::new(1, 32), DimBucket::new(33, 64)],
+        ),
+    ]
+    .into_iter()
+    .collect();
+    let mut buckets = Vec::new();
+    for (si, s) in [(0, 2), (1, 6)] {
+        for (ci, c) in [(0, 16), (1, 48)] {
+            buckets.push((
+                [(Symbol::from('s'), si), (Symbol::from('c'), ci)]
+                    .into_iter()
+                    .collect(),
+                [(Symbol::from('s'), s), (Symbol::from('c'), c)]
+                    .into_iter()
+                    .collect(),
+                llir.clone(),
+            ));
+        }
+    }
+    let mut rt = CudaRuntime::initialize(stream);
+    rt.set_data_with_capacity(a, vec![0.0f32; 8 * 64], 8 * 64 * 4);
+    rt.set_data_with_capacity(b, vec![0.0f32; 64 * n], 64 * n * 4);
+    rt.load_llir_buckets(&dim_buckets, &buckets);
+    // c is capture-sensitive in cuBLASLt, but is deliberately not a cache
+    // key. Startup must not demand knowledge of the selected op's dependencies.
+    rt.begin_cuda_graph_warmup(&['s'.into()]);
+    for s in [2, 6] {
+        for c in [16, 48] {
+            cx.set_dim('s', s);
+            cx.set_dim('c', c);
+            rt.set_data(a, vec![0.0f32; s * c]);
+            rt.set_data(b, vec![0.0f32; c * n]);
+            rt.prepare_cuda_graphs(&cx.dyn_map).unwrap();
+        }
+    }
+    // Explicit strict freezing must still reject this incomplete cache key.
+    assert!(
+        rt.finish_cuda_graph_preparation()
+            .unwrap_err()
+            .to_string()
+            .contains("uncached capture-sensitive dimensions")
+    );
+    let cases = [
+        (2, 7),
+        (2, 19),
+        (2, 7), // same cached variant: grow, shrink, reset
+        (1, 1),
+        (4, 32),
+        (5, 33),
+        (8, 64), // both bucket boundaries
+        (3, 7),
+        (7, 51),
+        (2, 19),
+        (1, 1), // unseen and reused cached values
+    ];
+    for (iteration, (s, c)) in cases.into_iter().enumerate() {
+        cx.set_dim('s', s);
+        cx.set_dim('c', c);
+        let seed = 0xC004_0000 + iteration as u64;
+        let av = random_f32_vec(s * c, seed, -0.08, 0.08);
+        let bv = random_f32_vec(c * n, seed + 100, -0.08, 0.08);
+        let expected = reference_matmul_2d(&av, &bv, s, n, c);
+        rt.set_data(a, av);
+        rt.set_data(b, bv);
+        rt.execute(&cx.dyn_map);
+        assert_close(&rt.get_f32(out), &expected, 1e-5, 1e-5);
+        assert!(
+            rt.debug_cuda_graph_summaries()
+                .iter()
+                .any(|summary| summary.n_cublaslt == 1)
+        );
+    }
+    // Dimension changes alone must invalidate the affected library plan,
+    // even when persistent input pointers and contents are unchanged.
+    let av = random_f32_vec(8 * 64, 0xC004_1000, -0.08, 0.08);
+    let bv = random_f32_vec(64 * n, 0xC004_1001, -0.08, 0.08);
+    rt.set_data(a, av.clone());
+    rt.set_data(b, bv.clone());
+    for (s, c) in [(2, 16), (2, 7), (2, 19), (2, 7)] {
+        cx.set_dim('s', s);
+        cx.set_dim('c', c);
+        let expected = reference_matmul_2d(&av[..s * c], &bv[..c * n], s, n, c);
+        rt.execute(&cx.dyn_map);
+        assert_close(&rt.get_f32(out), &expected, 1e-5, 1e-5);
+    }
+}
+
+#[test]
 fn resident_cublaslt_variants_switch_without_recapture() {
+    check_cublaslt_variants_switch_without_recapture(true);
+}
+
+#[test]
+fn warmup_cublaslt_variants_switch_without_recapture() {
+    check_cublaslt_variants_switch_without_recapture(false);
+}
+
+fn check_cublaslt_variants_switch_without_recapture(strict: bool) {
     let Some(stream) = get_cuda_stream() else {
         return;
     };
@@ -1333,14 +1456,20 @@ fn resident_cublaslt_variants_switch_without_recapture() {
     let b_values = random_f32_vec(k * n, 17, -0.1, 0.1);
     rt.set_data(b, b_values.clone());
     rt.load_llir_buckets(&dim_buckets, &buckets);
-    rt.begin_cuda_graph_preparation(&['s'.into()]);
+    if strict {
+        rt.begin_cuda_graph_preparation(&['s'.into()]);
+    } else {
+        rt.begin_cuda_graph_warmup(&['s'.into()]);
+    }
     assert!(rt.debug_retained_host_memory_bytes() >= 2 * 32 * 1024 * 1024);
     for s in [4, 2, 1] {
         cx.set_dim('s', s);
         rt.set_data(a, vec![0.0f32; s * k]);
         rt.prepare_cuda_graphs(&cx.dyn_map).unwrap();
     }
-    rt.finish_cuda_graph_preparation().unwrap();
+    if strict {
+        rt.finish_cuda_graph_preparation().unwrap();
+    }
     // These tiny GEMMs do not need the 32 MiB workspace preference limit.
     // Final residency validation must charge their actual allocations, even
     // with several retained shapes, instead of multiplying that limit.
@@ -1361,10 +1490,16 @@ fn resident_cublaslt_variants_switch_without_recapture() {
     }
     cx.set_dim('s', 3);
     rt.set_data(a, vec![0.0f32; 3 * k]);
-    assert!(
-        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| rt.execute(&cx.dyn_map))).is_err()
-    );
-    assert_eq!(rt.cuda_graph_residency_stats(), baseline);
+    if strict {
+        assert!(
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| rt.execute(&cx.dyn_map)))
+                .is_err()
+        );
+        assert_eq!(rt.cuda_graph_residency_stats(), baseline);
+    } else {
+        rt.execute(&cx.dyn_map);
+        assert_eq!(rt.get_f32(out), vec![0.0; 3 * n]);
+    }
 }
 
 #[test]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -131,6 +131,8 @@ impl DimBucket {
 
     /// The representative value used during search profiling.
     /// Defaults to midpoint `(min + max) / 2`.
+    /// This is not a runtime shape constraint or implicit padding: executions
+    /// still use the exact dynamic value anywhere in the bucket's range.
     pub fn representative_value(&self) -> usize {
         self.representative_override
             .unwrap_or((self.min + self.max) / 2)


### PR DESCRIPTION
CUDA graph warmup must preserve the exact dynamic values allowed by compile buckets. The inference server previously used strict residency to cache its token and descriptor shapes; a valid dense attention lowering then failed startup because cuBLASLt also captured context length, which the fused attention alternative reads dynamically.

Add `begin_cuda_graph_warmup(cached_dims)`. Cache dimensions are performance hints: other dimensions retain the existing parameter-update and library-recapture path, and unseen cached values can materialize on demand. Previously warmed compatible shapes still switch without recapture. The explicit strict preparation/freeze API keeps its existing restrictions, and cannot accidentally freeze an adaptive cache that omits a capture-sensitive dimension. Document that bucket representatives are profiling values, not runtime padding or shape restrictions.

Validation on NVIDIA B300:

- 32 non-ignored cuBLASLt tests passed (71 opt-in tests ignored), including forced dense matmul warmup, nonrepresentative values, growth/shrink/reset, bucket boundaries, unchanged persistent inputs, and prepared-shape reuse.
- 12 bucket tests passed, including generated-kernel warmup across bucket boundaries.
- `cargo clippy --release -p luminal_cuda_lite --all-targets -- -D warnings` and `cargo fmt --all --check` passed.

Warmup permits backend recapture when a library plan depends on a changed dimension; it does not promise constant execution latency. No model spelling, rewrite eligibility, or candidate-selection preference is changed.

Consumer integration: https://github.com/luminal-ai/luminal-inference-server/pull/8. The full Llama 3 8B server starts on B300 with dense attention selected and passes all 33 HTTP checks, including mixed prompt lengths above the profiling representative.
