### PR TITLE
ExtractionSite carries the class index: matcher lookups stop scanning the e-graph

### DIFF
--- a/src/extraction.rs
+++ b/src/extraction.rs
@@ -37,9 +37,9 @@ use egraph_serialize::{ClassId, EGraph, Node, NodeId};
 use petgraph::graph::{DiGraph, NodeIndex};
 
 use crate::layout_ir::{
-    Access, BufferInfo, ExtractedDag, ExtractedEdge, ExtractedGraph, ExtractedNode, ExtractionSite,
-    FreedBy, InputNode, LayoutInfo, LayoutIrOp, LayoutTensorInfo, LazyText, LogicalInfo, OpInput,
-    OpMatcher, OpNode, OutputNode, OutputSlot,
+    Access, BufferInfo, ClassIndex, ExtractedDag, ExtractedEdge, ExtractedGraph, ExtractedNode,
+    ExtractionSite, FreedBy, InputNode, LayoutInfo, LayoutIrOp, LayoutTensorInfo, LazyText,
+    LogicalInfo, OpInput, OpMatcher, OpNode, OutputNode, OutputSlot,
 };
 use crate::logical_op::{LogicalRender, logical_op_for};
 
@@ -61,6 +61,14 @@ struct Extractor<'a> {
     /// has no entry here simply offers no implementation candidate.
     matchers: HashMap<&'static str, &'a dyn OpMatcher>,
     class_nodes: HashMap<ClassId, Vec<NodeId>>,
+    /// The class index every [`ExtractionSite`] this extractor builds
+    /// reads through: class → its e-nodes, ALL of them, in e-graph order.
+    /// Distinct from `class_nodes` above, which is filtered to the
+    /// unsubsumed spellings this extractor's own walks consider — a
+    /// site's value readers deliberately see subsumed spellings too (see
+    /// [`ExtractionSite::nodes_in_class_value`]), so they need the
+    /// unfiltered inverse.
+    site_classes: ClassIndex,
     /// The shared rendering state: the render-time class index and the
     /// per-(class, depth, preference) render memo, behind an `Rc` so the
     /// lazy text closures the extraction hands out can keep it alive
@@ -956,6 +964,7 @@ impl<'a> Extractor<'a> {
             .map(|matcher| (matcher.egglog_constructor(), matcher))
             .collect();
         let class_nodes = class_nodes(egraph);
+        let site_classes = ClassIndex::new(egraph);
         let render = Rc::new(RenderCtx::new(egraph));
         let (op_specs, mut producer_index) = collect_op_specs(egraph, &render.class_nodes);
         let output_buffer_classes = collect_output_buffer_classes(egraph, &class_nodes);
@@ -1008,6 +1017,7 @@ impl<'a> Extractor<'a> {
             egraph,
             matchers,
             class_nodes,
+            site_classes,
             render,
             op_specs,
             producer_index,
@@ -1737,6 +1747,7 @@ impl<'a> Extractor<'a> {
                     egraph: self.egraph,
                     node_id,
                     node,
+                    classes: &self.site_classes,
                 });
                 self.op_cache
                     .borrow_mut()

--- a/src/extraction.rs
+++ b/src/extraction.rs
@@ -108,6 +108,14 @@ struct Extractor<'a> {
     /// node, the row's own eclass holds the value member); pinned by
     /// `dtype_index_reads_serialized_rows` in test_support.
     dtype_index: std::cell::RefCell<Option<HashMap<ClassId, crate::dtype::PlanDtype>>>,
+    /// GENOME-INDEPENDENT boundary-declaration indexes: the serialized
+    /// `buffer-access-of` / `buffer-freed-by` rows, scanned once —
+    /// BufferId class → the declared permission / free responsibility.
+    /// Same row encoding as the bounds and dtype indexes above. These
+    /// are read once per buffer per assembled graph, so un-indexed they
+    /// cost (buffers x nodes) per genome.
+    buffer_access_index: std::cell::RefCell<Option<HashMap<ClassId, Access>>>,
+    buffer_freed_by_index: std::cell::RefCell<Option<HashMap<ClassId, FreedBy>>>,
     /// GENOME-INDEPENDENT stable-key memo (measured 2026-08-10: eager
     /// per-comparison rendering was 99% of deep extraction — 7395/7471
     /// sampled stacks inside `is_better`). The rendered form of an enode
@@ -1030,6 +1038,8 @@ impl<'a> Extractor<'a> {
             bounds_index: Default::default(),
             tensor_bytes_cache: Default::default(),
             dtype_index: Default::default(),
+            buffer_access_index: Default::default(),
+            buffer_freed_by_index: Default::default(),
             stable_key_cache: Default::default(),
             choice_candidate_cache: Default::default(),
         }
@@ -3486,54 +3496,89 @@ impl<'a> Extractor<'a> {
     /// the program declared nothing, which input-program validation rejects
     /// for every buffer — declarations are always explicit.
     fn buffer_access(&self, buffer_id_class: &ClassId) -> Option<Access> {
-        for (node_id, node) in &self.egraph.nodes {
-            if node.subsumed || node.op != "buffer-access-of" {
-                continue;
+        self.with_buffer_access_index(|index| index.get(buffer_id_class).copied())
+    }
+
+    /// The serialized `buffer-access-of` rows, indexed once: BufferId
+    /// class -> the declared [`Access`]. Rows are walked in e-graph order
+    /// and the FIRST row naming a buffer wins, which is exactly what the
+    /// scan this replaces did by returning on its first match.
+    fn with_buffer_access_index<R>(&self, read: impl FnOnce(&HashMap<ClassId, Access>) -> R) -> R {
+        let mut slot = self.buffer_access_index.borrow_mut();
+        if slot.is_none() {
+            let mut index: HashMap<ClassId, Access> = HashMap::new();
+            for (node_id, node) in &self.egraph.nodes {
+                if node.subsumed || node.op != "buffer-access-of" {
+                    continue;
+                }
+                let Some(arg_class) = child_class(self.egraph, node, 0) else {
+                    continue;
+                };
+                let std::collections::hash_map::Entry::Vacant(entry) = index.entry(arg_class)
+                else {
+                    continue;
+                };
+                let access_class = self.egraph.nid_to_cid(node_id);
+                entry.insert(
+                    if self
+                        .renderer()
+                        .node_with_op(access_class, "ReadOnly")
+                        .is_some()
+                    {
+                        Access::ReadOnly
+                    } else {
+                        Access::ReadWrite
+                    },
+                );
             }
-            let Some(arg_class) = child_class(self.egraph, node, 0) else {
-                continue;
-            };
-            if &arg_class != buffer_id_class {
-                continue;
-            }
-            let access_class = self.egraph.nid_to_cid(node_id);
-            if self
-                .renderer()
-                .node_with_op(access_class, "ReadOnly")
-                .is_some()
-            {
-                return Some(Access::ReadOnly);
-            }
-            return Some(Access::ReadWrite);
+            *slot = Some(index);
         }
-        None
+        read(slot.as_ref().expect("buffer access index just built"))
     }
 
     /// Look up storage deallocation responsibility via `buffer-freed-by`.
     /// `None` = undeclared, which input-program validation rejects for every
     /// buffer — there is deliberately no default.
     fn buffer_freed_by(&self, buffer_id_class: &ClassId) -> Option<FreedBy> {
-        for (node_id, node) in &self.egraph.nodes {
-            if node.subsumed || node.op != "buffer-freed-by" {
-                continue;
+        self.with_buffer_freed_by_index(|index| index.get(buffer_id_class).copied())
+    }
+
+    /// The serialized `buffer-freed-by` rows, indexed once: BufferId class
+    /// -> the declared [`FreedBy`]. First row wins, as above.
+    fn with_buffer_freed_by_index<R>(
+        &self,
+        read: impl FnOnce(&HashMap<ClassId, FreedBy>) -> R,
+    ) -> R {
+        let mut slot = self.buffer_freed_by_index.borrow_mut();
+        if slot.is_none() {
+            let mut index: HashMap<ClassId, FreedBy> = HashMap::new();
+            for (node_id, node) in &self.egraph.nodes {
+                if node.subsumed || node.op != "buffer-freed-by" {
+                    continue;
+                }
+                let Some(arg_class) = child_class(self.egraph, node, 0) else {
+                    continue;
+                };
+                let std::collections::hash_map::Entry::Vacant(entry) = index.entry(arg_class)
+                else {
+                    continue;
+                };
+                let freed_class = self.egraph.nid_to_cid(node_id);
+                entry.insert(
+                    if self
+                        .renderer()
+                        .node_with_op(freed_class, "ProgramFrees")
+                        .is_some()
+                    {
+                        FreedBy::Program
+                    } else {
+                        FreedBy::Caller
+                    },
+                );
             }
-            let Some(arg_class) = child_class(self.egraph, node, 0) else {
-                continue;
-            };
-            if &arg_class != buffer_id_class {
-                continue;
-            }
-            let freed_class = self.egraph.nid_to_cid(node_id);
-            if self
-                .renderer()
-                .node_with_op(freed_class, "ProgramFrees")
-                .is_some()
-            {
-                return Some(FreedBy::Program);
-            }
-            return Some(FreedBy::Caller);
+            *slot = Some(index);
         }
-        None
+        read(slot.as_ref().expect("buffer freed-by index just built"))
     }
 
     fn output_tooltip(&self, class: &ClassId, source_enode: Option<&NodeId>) -> String {

--- a/src/layout_ir/mod.rs
+++ b/src/layout_ir/mod.rs
@@ -362,29 +362,105 @@ impl Clone for Box<dyn LayoutIrOp> {
 // extractor resolves candidates by looking the enode's constructor name up in
 // a registry built from that list.
 
+/// Every e-node of an e-class, keyed by class — the inverse of
+/// [`egraph_serialize::Node::eclass`], built once per extraction session
+/// and handed to every [`ExtractionSite`].
+///
+/// THE ASYMMETRY THIS CLOSES. A site's helpers answer questions of the
+/// form "the nodes of class C": what does C spell, what literal does it
+/// hold, which of its spellings is a `ShapeLit`. Each one used to be a
+/// scan of the whole e-graph filtered by `eclass ==`, so a matcher asking
+/// a few dozen such questions made a few dozen passes over every node in
+/// the program, and its cost grew with the model rather than with the
+/// class it was reading. The extractor already owned this index for its
+/// own walks; the site now reads the same shape.
+///
+/// EVERY node is indexed, in the e-graph's own order — subsumed spellings
+/// and the `"[...]"` elision marker included, no filtering at build time.
+/// That is what makes the index a drop-in rather than a change of
+/// meaning: each helper still applies exactly the filter it always
+/// applied, to exactly the same nodes, in exactly the same order, so
+/// "the first spelling wins" picks the same spelling it always picked.
+#[derive(Debug, Clone, Default)]
+pub struct ClassIndex {
+    nodes: HashMap<ClassId, Vec<NodeId>>,
+}
+
+impl ClassIndex {
+    /// Index an e-graph's nodes by their e-class.
+    pub fn new(egraph: &egraph_serialize::EGraph) -> Self {
+        let mut nodes: HashMap<ClassId, Vec<NodeId>> = HashMap::new();
+        for (node_id, node) in &egraph.nodes {
+            nodes
+                .entry(node.eclass.clone())
+                .or_default()
+                .push(node_id.clone());
+        }
+        Self { nodes }
+    }
+
+    /// The class's e-nodes, in e-graph order.
+    ///
+    /// A miss is NOT "the class is empty" — an e-class exists precisely
+    /// because a node names it, and every class id a matcher can hold was
+    /// read off some node's `eclass`. A miss therefore means this index
+    /// was built from a different e-graph than the one being read, which
+    /// is an invariant violation and not a case to fall back from: the
+    /// scan this replaces would have answered a question about the wrong
+    /// program. Refuse loudly instead.
+    pub fn nodes_of(&self, class: &ClassId) -> &[NodeId] {
+        self.nodes.get(class).map(Vec::as_slice).unwrap_or_else(|| {
+            panic!(
+                "class index invariant: class {class} has no entry — the index \
+                     was built from a different e-graph than the site reads"
+            )
+        })
+    }
+}
+
 /// The matched enode, handed to [`OpMatcher::extract`]. A borrowed view of
 /// everything a matcher may read while building an instance. Today's
 /// instances are nullary and ignore it; ops whose instances carry extracted
 /// data (layouts, axes, index maps) read their children through it. Extending
 /// this struct is the sanctioned way to grow the extraction contract —
 /// matchers take `&ExtractionSite`, so new fields cost existing impls nothing.
+///
+/// `classes` is the session's [`ClassIndex`] over `egraph`. The two travel
+/// together and must describe the same e-graph — every helper below reads
+/// a class through the index and resolves the ids it returns in `egraph`.
 #[derive(Debug, Clone, Copy)]
 pub struct ExtractionSite<'a> {
     pub egraph: &'a egraph_serialize::EGraph,
     pub node_id: &'a NodeId,
     pub node: &'a egraph_serialize::Node,
+    pub classes: &'a ClassIndex,
 }
 
 impl ExtractionSite<'_> {
+    /// THE ONE CLASS READ every helper below is built from: the members of
+    /// `class`, in e-graph order. The index gives the class's node ids in
+    /// O(1); resolving each id back to its node is a lookup in the
+    /// e-graph's own map. An id the index holds but the e-graph does not
+    /// is the same invariant violation [`ClassIndex::nodes_of`] describes.
+    fn members<'s>(
+        &'s self,
+        class: &egraph_serialize::ClassId,
+    ) -> impl Iterator<Item = &'s egraph_serialize::Node> + use<'s> {
+        let egraph = self.egraph;
+        self.classes.nodes_of(class).iter().map(move |node_id| {
+            egraph.nodes.get(node_id).unwrap_or_else(|| {
+                panic!("class index invariant: indexed node {node_id} is not in the e-graph")
+            })
+        })
+    }
+
     /// The matched enode's child at `index` as a literal f64 (schema-drift
     /// panic contract as [`Self::child_i64`]).
     pub fn child_f64(&self, index: usize) -> f64 {
         let class = self.child_class(index);
-        for node in self.egraph.nodes.values() {
-            if node.eclass == class {
-                if let Ok(value) = node.op.parse::<f64>() {
-                    return value;
-                }
+        for node in self.members(&class) {
+            if let Ok(value) = node.op.parse::<f64>() {
+                return value;
             }
         }
         panic!(
@@ -400,10 +476,8 @@ impl ExtractionSite<'_> {
         class: &egraph_serialize::ClassId,
         op: &str,
     ) -> Option<&egraph_serialize::Node> {
-        self.egraph
-            .nodes
-            .values()
-            .find(|node| node.eclass == *class && node.op == op && !node.subsumed)
+        self.members(class)
+            .find(|node| node.op == op && !node.subsumed)
     }
 
     /// Every node of this op in the class for VALUE PARSING, unsubsumed
@@ -421,10 +495,8 @@ impl ExtractionSite<'_> {
         op: &'a str,
     ) -> impl Iterator<Item = &'a egraph_serialize::Node> + 'a {
         self.nodes_in_class(class, op).chain(
-            self.egraph
-                .nodes
-                .values()
-                .filter(move |node| node.eclass == *class && node.op == op && node.subsumed),
+            self.members(class)
+                .filter(move |node| node.op == op && node.subsumed),
         )
     }
 
@@ -435,18 +507,13 @@ impl ExtractionSite<'_> {
         class: &'a egraph_serialize::ClassId,
         op: &'a str,
     ) -> impl Iterator<Item = &'a egraph_serialize::Node> + 'a {
-        self.egraph
-            .nodes
-            .values()
-            .filter(move |node| node.eclass == *class && node.op == op && !node.subsumed)
+        self.members(class)
+            .filter(move |node| node.op == op && !node.subsumed)
     }
 
     /// Any literal-i64 node inside an arbitrary class.
     pub fn node_in_class_parse_i64(&self, class: &egraph_serialize::ClassId) -> Option<i64> {
-        self.egraph
-            .nodes
-            .values()
-            .filter(|node| node.eclass == *class)
+        self.members(class)
             .find_map(|node| node.op.parse::<i64>().ok())
     }
 
@@ -465,11 +532,9 @@ impl ExtractionSite<'_> {
     /// child, anything else is schema drift (see the validity contract).
     pub fn child_i64(&self, index: usize) -> i64 {
         let class = self.child_class(index);
-        for node in self.egraph.nodes.values() {
-            if node.eclass == class {
-                if let Ok(value) = node.op.parse::<i64>() {
-                    return value;
-                }
+        for node in self.members(&class) {
+            if let Ok(value) = node.op.parse::<i64>() {
+                return value;
             }
         }
         panic!(

--- a/tests/test_runtime/tests/cublaslt_marker_round2_attack.rs
+++ b/tests/test_runtime/tests/cublaslt_marker_round2_attack.rs
@@ -27,7 +27,7 @@ use std::panic::AssertUnwindSafe;
 
 use luminal::dtype::DType;
 use luminal::graph::Graph;
-use luminal::layout_ir::{ExtractedGraph, ExtractedNode, ExtractionSite};
+use luminal::layout_ir::{ClassIndex, ExtractedGraph, ExtractedNode, ExtractionSite};
 use luminal::prelude::egraph_serialize::{ClassId, EGraph};
 use test_runtime::cublaslt_marker::{
     CuDim, CuEpilogue, CublasLt, CublasLtForm, LtMatmulSpec, parse_spec,
@@ -241,6 +241,7 @@ fn flavored_cublaslt(
 /// real test: not "the elected one is right" but "none of them is wrong".
 fn specs_of_every_enode(s: &EGraph, form: CublasLtForm) -> Vec<LtMatmulSpec> {
     let name = form.constructor_name();
+    let classes = ClassIndex::new(s);
     s.nodes
         .iter()
         .filter(|(_, n)| n.op == name)
@@ -249,6 +250,7 @@ fn specs_of_every_enode(s: &EGraph, form: CublasLtForm) -> Vec<LtMatmulSpec> {
                 egraph: s,
                 node_id: id,
                 node,
+                classes: &classes,
             };
             parse_spec(&site, form)
         })
@@ -3026,12 +3028,14 @@ fn attack_p1_form_layout_mismatch_panics_loudly() {
         6,
         "the hand-built descriptor pollinates 6 combos"
     );
+    let classes = ClassIndex::new(&s);
     for (id, node) in &bad {
         let msg = panic_message(|| {
             let site = ExtractionSite {
                 egraph: &s,
                 node_id: id,
                 node,
+                classes: &classes,
             };
             parse_spec(&site, CublasLtForm::Base)
         });
@@ -3929,11 +3933,13 @@ fn attack_u6_c_layout_mismatch_panics_loudly() {
     );
     assert_eq!(accs.len(), 1, "only the hand-built term exists");
     let (id, node) = accs[0];
+    let classes = ClassIndex::new(&s);
     let msg = panic_message(|| {
         let site = ExtractionSite {
             egraph: &s,
             node_id: id,
             node,
+            classes: &classes,
         };
         parse_spec(&site, CublasLtForm::Accumulate)
     });

--- a/tests/test_runtime/tests/r8d_chain_probe.rs
+++ b/tests/test_runtime/tests/r8d_chain_probe.rs
@@ -19,7 +19,7 @@
 
 use std::collections::BTreeSet;
 
-use luminal::layout_ir::ExtractionSite;
+use luminal::layout_ir::{ClassIndex, ExtractionSite};
 use luminal::prelude::egraph_serialize::{ClassId, EGraph};
 use test_runtime::cublaslt_marker::{CublasLtForm, parse_spec};
 
@@ -259,6 +259,7 @@ fn r8d_candidate_count_on_the_shared_weight() {
     // internal cross-checks panic on any operation/descriptor
     // inconsistency, and the COL clamp is checked here explicitly.
     let mut checked = 0usize;
+    let classes = ClassIndex::new(&s);
     for (id, node) in s.nodes.iter() {
         if node.op != "LayoutTensorOpCublasLt" {
             continue;
@@ -267,6 +268,7 @@ fn r8d_candidate_count_on_the_shared_weight() {
             egraph: &s,
             node_id: id,
             node,
+            classes: &classes,
         };
         let spec =
             parse_spec(&site, CublasLtForm::Base).expect("every candidate parses (no silent None)");


### PR DESCRIPTION
Stacked on #517 (`feat/extraction-worklist`). Two commits.

Post-#517, matcher parsing is what extraction spends its time on. The
cause is an asymmetry: every question a matcher asks its `ExtractionSite`
is about ONE e-class, and every one of them was answered by a scan of the
whole e-graph filtered by `eclass ==`. The extractor has owned the inverse
index all along and never handed it to the site.

Austin's framing — "probably the class id needs to be part of the function
signature, what does it look like when that is the case?" — turns out to
need no signature change at all. The class id is already an argument of
every helper that scans; what was missing was the map to look it up in.

## Before / after

The struct gains one borrow:

```rust
// BEFORE
#[derive(Debug, Clone, Copy)]
pub struct ExtractionSite<'a> {
    pub egraph: &'a egraph_serialize::EGraph,
    pub node_id: &'a NodeId,
    pub node: &'a egraph_serialize::Node,
}

// AFTER
#[derive(Debug, Clone, Copy)]
pub struct ExtractionSite<'a> {
    pub egraph: &'a egraph_serialize::EGraph,
    pub node_id: &'a NodeId,
    pub node: &'a egraph_serialize::Node,
    pub classes: &'a ClassIndex,
}
```

and the new type is deliberately small:

```rust
#[derive(Debug, Clone, Default)]
pub struct ClassIndex {
    nodes: HashMap<ClassId, Vec<NodeId>>,
}

impl ClassIndex {
    pub fn new(egraph: &egraph_serialize::EGraph) -> Self { .. }
    pub fn nodes_of(&self, class: &ClassId) -> &[NodeId] { .. }
}
```

**Every helper keeps its exact signature.** Verbatim, unchanged in both
directions:

```rust
pub fn child_f64(&self, index: usize) -> f64
pub fn child_i64(&self, index: usize) -> i64
pub fn child_class(&self, index: usize) -> egraph_serialize::ClassId
pub fn node_in_class(&self, class: &egraph_serialize::ClassId, op: &str)
    -> Option<&egraph_serialize::Node>
pub fn node_in_class_parse_i64(&self, class: &egraph_serialize::ClassId) -> Option<i64>
pub fn class_of_child(&self, node: &egraph_serialize::Node, index: usize)
    -> Option<egraph_serialize::ClassId>
pub fn nodes_in_class<'a>(&'a self, class: &'a egraph_serialize::ClassId, op: &'a str)
    -> impl Iterator<Item = &'a egraph_serialize::Node> + 'a
pub fn nodes_in_class_value<'a>(&'a self, class: &'a egraph_serialize::ClassId, op: &'a str)
    -> impl Iterator<Item = &'a egraph_serialize::Node> + 'a
```

Only the bodies moved, onto one new private helper:

```rust
fn members<'s>(
    &'s self,
    class: &egraph_serialize::ClassId,
) -> impl Iterator<Item = &'s egraph_serialize::Node> + use<'s>
```

## What changed for matchers

Nothing, unless they build a site by hand. All 39 `nodes_in_class_value`
call sites, all 43 `class_of_child` ones, the `child_i64`/`child_f64`
readers and the ~60 `extract` impls across `luminal`, `luminal_reference`,
`luminal_cuda_lite` and `test_runtime` are untouched.

The edit is the struct field plus the five places that construct a site:
`Extractor::candidate_for_producer` (`src/extraction.rs`), and four
hand-built sites in the marker attack tests
(`tests/test_runtime/tests/cublaslt_marker_round2_attack.rs` x3,
`tests/test_runtime/tests/r8d_chain_probe.rs` x1), which now build a
`ClassIndex` alongside their fixture e-graph.

## Why the index is unfiltered

It holds every node of every class — subsumed spellings and the `"[...]"`
elision marker included — in the e-graph's own order. That is what makes
it a drop-in rather than a change of meaning: each helper applies exactly
the filter it always applied, to the same nodes, in the same order, so
"the first spelling wins" picks the spelling it always picked.

The extractor's existing `class_nodes` could not serve, because it drops
the subsumed members that the value readers must see (`nodes_in_class_value`
reaches behind the matching fence deliberately — the 2026-08-05 slice_pad
regression is why).

`nodes_of` refuses rather than falling back. A class id always comes from
some node's `eclass`, so a miss is not "no such class" — it means the index
and the e-graph being read are different programs, and the scan it replaces
would have answered a question about the wrong one.

## Second commit: the boundary declarations

`Extractor::buffer_access` / `buffer_freed_by` scanned every node for a
`buffer-access-of` / `buffer-freed-by` row, once per buffer per assembled
graph. They are the same fact-row shape `bounds_index` and `dtype_index`
already index, so they get the same `RefCell<Option<..>>`-filled-on-first-read
treatment. First-row-wins order is preserved; an undeclared buffer still
reads `None` rather than a default.

## Measured

qwen3-4B anatomy under the default (marker-registered) registry, seed 0,
25 genomes, host. Extraction figures drop genome 0 (cold caches).

| | 8 layers (44k classes / 116k nodes) | 16 layers (68k / 201k) |
|---|---|---|
| `parse_spec` Base | 25.36 -> **9.45** ms/call | 59.47 -> **22.32** ms/call |
| `parse_spec` Accumulate | 24.08 -> **9.08** ms/call | 62.13 -> **22.98** ms/call |
| extract, mean | 407.67 -> **134.27** ms | 1785.04 -> **561.82** ms |
| extract, median | 271.67 -> **100.91** ms | 1230.61 -> **431.02** ms |
| extract, last 10 | 191.17 -> **73.20** ms | 630.00 -> **222.52** ms |

Split by commit, extraction per genome (mean):

| | 8 layers | 16 layers |
|---|---|---|
| #517 tip | 407.67 | 1785.04 |
| + class index | 149.05 | 617.11 |
| + buffer indexes | 134.27 | 561.82 |

So the buffer declaration lookups alone were ~15 ms/genome at 8 layers and
~55 ms at 16. Overall 3.0x at 8 layers and 3.2x at 16.

## What is left, and why it is not in this PR

`parse_spec` still grows with the model (9.45 -> 22.32 ms/call across a
doubling). What remains is not a class read. `storage_dims`,
`direct_buffer_of` and `resolve_buffer` reach around the helpers into
`site.egraph` and scan for FACT ROWS — a `shape-of` / `BufferTensorLit` /
`int-subst-of` node whose child 0 lands in a given class. There are ~25
such escapes across the cuBLASLt, gather and scatter matchers.

That wants the `(op, argument class) -> row` index shape, which is the
bounds/dtype one, not this one — a different index with a different
owner. I have not built it: where it should live (on the site, or as
another session index the site borrows) is a design question the brief
did not settle. Happy to take it next if you want it.

## Gates

`cargo build -p luminal --lib`, `cargo test -p luminal --lib` (255 passed),
`cargo test -p luminal_cuda_lite` (all green), `cargo test -p test_runtime
--test scc_sampler --test r10_debug` (7 + 6), `cargo fmt --all -- --check`,
`cargo clippy -p luminal -p luminal_cuda_lite --lib` (19 warnings, down
from 21 pre-existing; no new ones, no errors).

Pins bit-identical: election 9, bias_premise 5, contracts_cpu 21,
finalists_lattice 4, dim_buckets 5, codegen_identity 13. The two edited
test files also re-run green: `r8d_chain_probe` 50, `cublaslt_marker_round2_attack` 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
