### PR TITLE
Serialized e-graph fact-row index: matchers look up facts instead of scanning

### DIFF
--- a/crates/luminal_cuda_lite/src/ops/cublaslt/election.rs
+++ b/crates/luminal_cuda_lite/src/ops/cublaslt/election.rs
@@ -12,6 +12,7 @@
 //! plan are simply unfit; only deterministic test helpers must land on a
 //! viable plan first try.
 
+use crate::extractor::child_class;
 use luminal::layout_ir::OpMatcher;
 
 type ProducerOrdering<'a> =
@@ -88,6 +89,12 @@ pub fn genome_with_ordering(
     use std::collections::{BTreeSet, HashMap};
 
     let index = crate::extractor::producer_index_with_matchers(egraph, matchers);
+    // The serialized index this walk reads the e-graph through. Every
+    // question below is "the nodes of class C" or "the nodes of
+    // constructor F", and each one used to be a pass over the whole
+    // e-graph — nested inside the list walks, so a fixture's election
+    // cost grew with the square of the program.
+    let serialized = luminal::layout_ir::SerializedIndex::new(egraph);
 
     // ------------------------------------------------------------------
     // ROUND 11: VIABILITY-AWARE primary election. The cycle-anatomy
@@ -128,43 +135,26 @@ pub fn genome_with_ordering(
     // input instead of declaring it unreachable.
     let buffer_list_classes = |root_op: &str| -> BTreeSet<ClassId> {
         let mut out: BTreeSet<ClassId> = BTreeSet::new();
-        for node in egraph.nodes.values() {
-            if node.op != root_op {
-                continue;
-            }
-            let mut cur = node
-                .children
-                .first()
-                .and_then(|id| egraph.nodes.get(id))
-                .map(|c| c.eclass.clone());
+        for node_id in serialized.nodes_of_op(root_op) {
+            let node = &egraph[node_id];
+            let mut cur = child_class(egraph, node, 0);
             let mut guard = 0;
             while let Some(list) = cur {
                 guard += 1;
                 if guard > 64 {
                     break;
                 }
-                if egraph
-                    .nodes
-                    .values()
-                    .any(|m| m.eclass == list && m.op == "BufferTensorNil")
-                {
+                let members = || serialized.nodes_of(&list).iter().map(|id| &egraph[id]);
+                if members().any(|m| m.op == "BufferTensorNil") {
                     break;
                 }
-                let Some(cons) = egraph
-                    .nodes
-                    .values()
-                    .find(|m| m.eclass == list && m.op == "BufferTensorCons")
-                else {
+                let Some(cons) = members().find(|m| m.op == "BufferTensorCons") else {
                     break;
                 };
-                if let Some(h) = cons.children.first().and_then(|id| egraph.nodes.get(id)) {
-                    out.insert(h.eclass.clone());
+                if let Some(h) = child_class(egraph, cons, 0) {
+                    out.insert(h);
                 }
-                cur = cons
-                    .children
-                    .get(1)
-                    .and_then(|id| egraph.nodes.get(id))
-                    .map(|c| c.eclass.clone());
+                cur = child_class(egraph, cons, 1);
             }
         }
         out
@@ -173,10 +163,8 @@ pub fn genome_with_ordering(
     let output_buffer_classes = buffer_list_classes("BufferOutputLit");
     let has_explicit_inputs = !input_buffer_classes.is_empty();
     let mut terminals: BTreeSet<ClassId> = BTreeSet::new();
-    for node in egraph.nodes.values() {
-        if node.op != "BufferTensorLit" {
-            continue;
-        }
+    for node_id in serialized.nodes_of_op("BufferTensorLit") {
+        let node = &egraph[node_id];
         if has_explicit_inputs {
             if !input_buffer_classes.contains(&node.eclass) {
                 continue;
@@ -184,53 +172,40 @@ pub fn genome_with_ordering(
         } else if output_buffer_classes.contains(&node.eclass) {
             continue;
         }
-        let Some(lt) = node.children.first().and_then(|id| egraph.nodes.get(id)) else {
+        let Some(lt) = child_class(egraph, node, 0) else {
             continue;
         };
-        terminals.insert(lt.eclass.clone());
+        terminals.insert(lt);
     }
 
     // The Lit input lists of the op class a candidate enode belongs to.
     let lit_input_lists = |op_class: &ClassId| -> Vec<Vec<ClassId>> {
         let mut lists = Vec::new();
-        for n in egraph.nodes.values() {
-            if n.eclass != *op_class || n.op != "LayoutTensorOpLit" {
-                continue;
-            }
+        for n in serialized
+            .nodes_of(op_class)
+            .iter()
+            .map(|id| &egraph[id])
+            .filter(|n| n.op == "LayoutTensorOpLit")
+        {
             let mut items = Vec::new();
-            let mut cur = n
-                .children
-                .first()
-                .and_then(|id| egraph.nodes.get(id))
-                .map(|c| c.eclass.clone());
+            let mut cur = child_class(egraph, n, 0);
             let mut guard = 0;
             while let Some(list) = cur {
                 guard += 1;
                 if guard > 16 {
                     break;
                 }
-                if egraph
-                    .nodes
-                    .values()
-                    .any(|m| m.eclass == list && m.op == "LayoutTensorNil")
-                {
+                let members = || serialized.nodes_of(&list).iter().map(|id| &egraph[id]);
+                if members().any(|m| m.op == "LayoutTensorNil") {
                     break;
                 }
-                let Some(cons) = egraph
-                    .nodes
-                    .values()
-                    .find(|m| m.eclass == list && m.op == "LayoutTensorCons")
-                else {
+                let Some(cons) = members().find(|m| m.op == "LayoutTensorCons") else {
                     break;
                 };
-                if let Some(h) = cons.children.first().and_then(|id| egraph.nodes.get(id)) {
-                    items.push(h.eclass.clone());
+                if let Some(h) = child_class(egraph, cons, 0) {
+                    items.push(h);
                 }
-                cur = cons
-                    .children
-                    .get(1)
-                    .and_then(|id| egraph.nodes.get(id))
-                    .map(|c| c.eclass.clone());
+                cur = child_class(egraph, cons, 1);
             }
             lists.push(items);
         }
@@ -277,7 +252,7 @@ pub fn genome_with_ordering(
         let mut result: Option<crate::extractor::ProducerChoice> = None;
         'cands: for i in ordered(candidates, level) {
             let (_, choice) = &candidates[i];
-            let Some(op_class) = egraph.nodes.get(&choice.enode).map(|n| n.eclass.clone()) else {
+            let Some(op_class) = crate::extractor::node_class(egraph, &choice.enode) else {
                 continue;
             };
             let lists = lit_input_lists(&op_class);

--- a/crates/luminal_cuda_lite/src/ops/cublaslt/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/cublaslt/mod.rs
@@ -38,14 +38,12 @@
 //! frame has call-m = the recorder matmul's n, so the emitted call is
 //! numerically identical to round 9's.
 //!
-//! VIEW ADMISSION (round 10): a descriptor's layout tensor may be a VIEW —
-//! a LayoutTensorLit whose layout is a composed chain over another layout
-//! tensor's bytes, with no BufferTensor of its own. The spec resolves each
-//! descriptor's BUFFER by walking view -> parent (through the composition
-//! tie: view layout == parent layout's bit expression substituted through
-//! the apply's map) until a BufferTensorLit is found; ld comes from the
-//! composed chain itself (`leading_dimension` reads either chain
-//! orientation). Split sources + Ruling 1: m/n/k AND every ld may be
+//! VIEW ADMISSION: a descriptor's layout tensor may be a VIEW — a
+//! LayoutTensorLit whose layout is a composed chain over another layout
+//! tensor's bytes. Its dims, transposes and ld come from that composed
+//! layout alone (`leading_dimension` reads either chain orientation). The
+//! buffer a descriptor reads or writes is bound by the PLAN at execution,
+//! never derived from the e-graph at match time. m/n/k and every ld may be
 //! symbolic (bound at execute time from the dyn map); static pitches are
 //! read from the layout.
 //!
@@ -262,13 +260,6 @@ pub struct LtMatmulSpec {
     pub desc_b_layout_tensor: ClassId,
     pub c_tensor: Option<ClassId>,
     pub bias_tensor: Option<ClassId>,
-    // ---- VIEW ADMISSION (round 10): resolved buffer identities ----
-    // Each descriptor's layout tensor may be a VIEW with no BufferTensor
-    // of its own; these are the buffers the view walk grounds them in
-    // (None = unresolved, e.g. a fresh intermediate the planner allocs).
-    pub desc_a_buffer: Option<ClassId>,
-    pub desc_b_buffer: Option<ClassId>,
-    pub d_buffer: Option<ClassId>,
 }
 
 impl LtMatmulSpec {
@@ -597,71 +588,6 @@ fn leading_dimension(
     rows_prime.clone()
 }
 
-/// The direct buffer of a layout tensor, if a BufferTensorLit names it.
-fn direct_buffer_of(site: &ExtractionSite<'_>, lt_class: &ClassId) -> Option<ClassId> {
-    site.fact_row_child("BufferTensorLit", lt_class, 1)
-}
-
-/// VIEW ADMISSION (round 10): ground a descriptor's layout tensor in a
-/// BUFFER by walking view -> parent. A view layout tensor is
-/// (LayoutTensorLit v L) where v is spelled (LogicalIndexMapApply p map _)
-/// and L is EXACTLY p's layout composed through map — the tie is checked
-/// classwise ((int-subst-of p_expr map) must be L's own bit expression),
-/// so a foreign parent or a foreign layout of the same parent can never
-/// donate its buffer. Depth-bounded; returns None when no grounding
-/// exists (a fresh intermediate the planner may alloc).
-fn resolve_buffer(site: &ExtractionSite<'_>, lt_class: &ClassId, depth: usize) -> Option<ClassId> {
-    if let Some(buffer) = direct_buffer_of(site, lt_class) {
-        return Some(buffer);
-    }
-    if depth == 0 {
-        return None;
-    }
-    let logical = logical_class_of(site, lt_class)?;
-    let layout = layout_class_of(site, lt_class)?;
-    // L's own bit expressions (a class can spell several; collect all).
-    let l_exprs: Vec<ClassId> = site
-        .nodes_in_class_value(&layout, "BitOffsetExpressionLayoutLit")
-        .filter_map(|n| site.class_of_child(n, 0))
-        .collect();
-    if l_exprs.is_empty() {
-        return None;
-    }
-    // Every apply spelling of the view's logical value...
-    for apply in site.nodes_in_class_value(&logical, "LogicalIndexMapApply") {
-        let Some(parent_logical) = site.class_of_child(apply, 0) else {
-            continue;
-        };
-        let Some(map_class) = site.class_of_child(apply, 1) else {
-            continue;
-        };
-        // ...every layout tensor of that parent...
-        for plt in site.fact_nodes("LayoutTensorLit", &parent_logical) {
-            let plt_class = plt.eclass.clone();
-            let Some(p_layout) = site.class_of_child(plt, 1) else {
-                continue;
-            };
-            // ...whose composition through THIS map is L (the tie).
-            let tied = site
-                .nodes_in_class_value(&p_layout, "BitOffsetExpressionLayoutLit")
-                .filter_map(|n| site.class_of_child(n, 0))
-                .any(|p_expr| {
-                    site.fact_nodes("int-subst-of", &p_expr).any(|n| {
-                        site.class_of_child(n, 1).as_ref() == Some(&map_class)
-                            && l_exprs.contains(&n.eclass)
-                    })
-                });
-            if !tied {
-                continue;
-            }
-            if let Some(buffer) = resolve_buffer(site, &plt_class, depth - 1) {
-                return Some(buffer);
-            }
-        }
-    }
-    None
-}
-
 pub fn parse_spec(site: &ExtractionSite<'_>, form: CublasLtForm) -> Option<LtMatmulSpec> {
     let (c_slot, bias_slot, ep_slot) = form.slots();
 
@@ -774,11 +700,6 @@ pub fn parse_spec(site: &ExtractionSite<'_>, form: CublasLtForm) -> Option<LtMat
     multiset_ok(&b_rows, &b_cols, &b_storage, "B");
     multiset_ok(&d_rows, &d_cols, &d_storage, "D");
 
-    // VIEW ADMISSION: ground each descriptor in its buffer (view walk).
-    let desc_a_buffer = resolve_buffer(site, &desc_a_layout_tensor, 8);
-    let desc_b_buffer = resolve_buffer(site, &desc_b_layout_tensor, 8);
-    let d_buffer = resolve_buffer(site, &out_lt_class, 8);
-
     // Payload slots: DIRECT LayoutTensor children (enode-anchored).
     let c_tensor = c_slot.map(|slot| site.child_class(slot));
     let bias_tensor = bias_slot.map(|slot| site.child_class(slot));
@@ -841,9 +762,6 @@ pub fn parse_spec(site: &ExtractionSite<'_>, form: CublasLtForm) -> Option<LtMat
         desc_b_layout_tensor,
         c_tensor,
         bias_tensor,
-        desc_a_buffer,
-        desc_b_buffer,
-        d_buffer,
     };
     spec.validate(&d_rows, &d_cols);
     Some(spec)

--- a/crates/luminal_cuda_lite/src/ops/cublaslt/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/cublaslt/mod.rs
@@ -386,6 +386,26 @@ fn layout_class_of(site: &ExtractionSite<'_>, lt_class: &ClassId) -> Option<Clas
     None
 }
 
+/// The Shape child of the first layout-constructor spelling in this
+/// class, at the slot its DECLARATION gives it (`egglog_preamble.egg`):
+/// the offset-expression spellings carry Shape at child 1, the strided
+/// and contiguous ones at child 0.
+fn layout_shape_class(site: &ExtractionSite<'_>, layout_class: &ClassId) -> Option<ClassId> {
+    for node in site.members(layout_class) {
+        let shape_slot = match node.op.as_str() {
+            "RightMajorContiguousElementLayoutLit"
+            | "LeftMajorContiguousElementLayoutLit"
+            | "StridedElementLayoutLit" => 0,
+            "BitOffsetExpressionLayoutLit" | "ElementOffsetExpressionLayoutLit" => 1,
+            _ => continue,
+        };
+        if let Some(shape) = site.class_of_child(node, shape_slot) {
+            return Some(shape);
+        }
+    }
+    None
+}
+
 fn logical_class_of(site: &ExtractionSite<'_>, lt_class: &ClassId) -> Option<ClassId> {
     for node in site.nodes_in_class_value(lt_class, "LayoutTensorLit") {
         if let Some(logical) = site.class_of_child(node, 0) {
@@ -395,16 +415,14 @@ fn logical_class_of(site: &ExtractionSite<'_>, lt_class: &ClassId) -> Option<Cla
     None
 }
 
-/// The logical tensor's rank-2 storage extents, via its class-level
-/// `shape-of` fact. CANONICAL CHOICE (doctrine point 3): the first
+/// A descriptor's rank-2 storage extents: its layout tensor's own
+/// declared Shape. CANONICAL CHOICE (doctrine point 3): the first
 /// ShapeLit spelling is taken; in extent-1 weld corners a shape class can
 /// hold role-permuted spellings, and every choice describes the same
 /// bytes under the descriptor's form/operation, so the choice is sound.
-fn storage_dims(
-    site: &ExtractionSite<'_>,
-    logical_class: &ClassId,
-) -> Option<Vec<(CuDim, ClassId)>> {
-    let shape_class = site.fact_row_class("shape-of", logical_class)?;
+fn storage_dims(site: &ExtractionSite<'_>, lt_class: &ClassId) -> Option<Vec<(CuDim, ClassId)>> {
+    let layout_class = layout_class_of(site, lt_class)?;
+    let shape_class = layout_shape_class(site, &layout_class)?;
     let shape_lit = site.nodes_in_class_value(&shape_class, "ShapeLit").next()?;
     let mut list_class = site.class_of_child(shape_lit, 0)?;
     let mut dims = Vec::new();
@@ -641,9 +659,9 @@ pub fn parse_spec(site: &ExtractionSite<'_>, form: CublasLtForm) -> Option<LtMat
     // site's b a permutation of (k, n). For a sibling site minted by the
     // sandwich rewrite these are the recorder operands under new roles,
     // and this frame is the SIBLING's — numerically the round-9 call.
-    let a_storage = storage_dims(site, &logical_class_of(site, &desc_a_layout_tensor)?)?;
-    let b_storage = storage_dims(site, &logical_class_of(site, &desc_b_layout_tensor)?)?;
-    let d_storage = storage_dims(site, &logical_out)?;
+    let a_storage = storage_dims(site, &desc_a_layout_tensor)?;
+    let b_storage = storage_dims(site, &desc_b_layout_tensor)?;
+    let d_storage = storage_dims(site, &out_lt_class)?;
     assert_eq!(a_storage.len(), 2, "cuBLASLt marker: rank-2 a expected");
     assert_eq!(b_storage.len(), 2, "cuBLASLt marker: rank-2 b expected");
     assert_eq!(d_storage.len(), 2, "cuBLASLt marker: rank-2 out expected");

--- a/crates/luminal_cuda_lite/src/ops/cublaslt/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/cublaslt/mod.rs
@@ -413,13 +413,7 @@ fn storage_dims(
     site: &ExtractionSite<'_>,
     logical_class: &ClassId,
 ) -> Option<Vec<(CuDim, ClassId)>> {
-    let shape_class = site.egraph.nodes.values().find_map(|node| {
-        if node.op != "shape-of" {
-            return None;
-        }
-        let child = node.children.first()?;
-        (&site.egraph.nodes.get(child)?.eclass == logical_class).then(|| node.eclass.clone())
-    })?;
+    let shape_class = site.fact_row_class("shape-of", logical_class)?;
     let shape_lit = site.nodes_in_class_value(&shape_class, "ShapeLit").next()?;
     let mut list_class = site.class_of_child(shape_lit, 0)?;
     let mut dims = Vec::new();
@@ -605,26 +599,7 @@ fn leading_dimension(
 
 /// The direct buffer of a layout tensor, if a BufferTensorLit names it.
 fn direct_buffer_of(site: &ExtractionSite<'_>, lt_class: &ClassId) -> Option<ClassId> {
-    for node in site.egraph.nodes.values() {
-        if node.op != "BufferTensorLit" {
-            continue;
-        }
-        let Some(lt) = node
-            .children
-            .first()
-            .and_then(|id| site.egraph.nodes.get(id))
-        else {
-            continue;
-        };
-        if &lt.eclass == lt_class {
-            return node
-                .children
-                .get(1)
-                .and_then(|id| site.egraph.nodes.get(id))
-                .map(|c| c.eclass.clone());
-        }
-    }
-    None
+    site.fact_row_child("BufferTensorLit", lt_class, 1)
 }
 
 /// VIEW ADMISSION (round 10): ground a descriptor's layout tensor in a
@@ -661,27 +636,9 @@ fn resolve_buffer(site: &ExtractionSite<'_>, lt_class: &ClassId, depth: usize) -
             continue;
         };
         // ...every layout tensor of that parent...
-        for plt in site.egraph.nodes.values() {
-            if plt.op != "LayoutTensorLit" {
-                continue;
-            }
-            let Some(pl) = plt
-                .children
-                .first()
-                .and_then(|id| site.egraph.nodes.get(id))
-            else {
-                continue;
-            };
-            if pl.eclass != parent_logical {
-                continue;
-            }
+        for plt in site.fact_nodes("LayoutTensorLit", &parent_logical) {
             let plt_class = plt.eclass.clone();
-            let Some(p_layout) = plt
-                .children
-                .get(1)
-                .and_then(|id| site.egraph.nodes.get(id))
-                .map(|c| c.eclass.clone())
-            else {
+            let Some(p_layout) = site.class_of_child(plt, 1) else {
                 continue;
             };
             // ...whose composition through THIS map is L (the tie).
@@ -689,21 +646,8 @@ fn resolve_buffer(site: &ExtractionSite<'_>, lt_class: &ClassId, depth: usize) -
                 .nodes_in_class_value(&p_layout, "BitOffsetExpressionLayoutLit")
                 .filter_map(|n| site.class_of_child(n, 0))
                 .any(|p_expr| {
-                    site.egraph.nodes.values().any(|n| {
-                        n.op == "int-subst-of"
-                            && n.children.len() >= 2
-                            && site
-                                .egraph
-                                .nodes
-                                .get(&n.children[0])
-                                .map(|c| c.eclass == p_expr)
-                                .unwrap_or(false)
-                            && site
-                                .egraph
-                                .nodes
-                                .get(&n.children[1])
-                                .map(|c| c.eclass == map_class)
-                                .unwrap_or(false)
+                    site.fact_nodes("int-subst-of", &p_expr).any(|n| {
+                        site.class_of_child(n, 1).as_ref() == Some(&map_class)
                             && l_exprs.contains(&n.eclass)
                     })
                 });

--- a/crates/luminal_cuda_lite/src/ops/cublaslt/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/cublaslt/mod.rs
@@ -391,7 +391,14 @@ fn layout_class_of(site: &ExtractionSite<'_>, lt_class: &ClassId) -> Option<Clas
 /// the offset-expression spellings carry Shape at child 1, the strided
 /// and contiguous ones at child 0.
 fn layout_shape_class(site: &ExtractionSite<'_>, layout_class: &ClassId) -> Option<ClassId> {
-    for node in site.members(layout_class) {
+    const LAYOUT_CONSTRUCTORS: &[&str] = &[
+        "RightMajorContiguousElementLayoutLit",
+        "LeftMajorContiguousElementLayoutLit",
+        "StridedElementLayoutLit",
+        "BitOffsetExpressionLayoutLit",
+        "ElementOffsetExpressionLayoutLit",
+    ];
+    for node in site.nodes_in_class_value_any(layout_class, LAYOUT_CONSTRUCTORS) {
         let shape_slot = match node.op.as_str() {
             "RightMajorContiguousElementLayoutLit"
             | "LeftMajorContiguousElementLayoutLit"

--- a/crates/luminal_cuda_lite/src/ops/gather/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/gather/mod.rs
@@ -249,8 +249,8 @@ impl OpMatcher for GatherMatcher {
         let mut class = site.child_class(1);
         loop {
             let spine = site
-                .members(&class)
-                .find(|node| node.op == "LayoutTensorCons" || node.op == "LayoutTensorNil")
+                .nodes_in_class_value_any(&class, &["LayoutTensorCons", "LayoutTensorNil"])
+                .next()
                 .unwrap_or_else(|| {
                     panic!(
                         "schema drift: coordinate-list class {class} under enode {} has no \

--- a/crates/luminal_cuda_lite/src/ops/gather/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/gather/mod.rs
@@ -249,13 +249,8 @@ impl OpMatcher for GatherMatcher {
         let mut class = site.child_class(1);
         loop {
             let spine = site
-                .egraph
-                .nodes
-                .values()
-                .find(|node| {
-                    node.eclass == class
-                        && (node.op == "LayoutTensorCons" || node.op == "LayoutTensorNil")
-                })
+                .members(&class)
+                .find(|node| node.op == "LayoutTensorCons" || node.op == "LayoutTensorNil")
                 .unwrap_or_else(|| {
                     panic!(
                         "schema drift: coordinate-list class {class} under enode {} has no \
@@ -271,12 +266,8 @@ impl OpMatcher for GatherMatcher {
                 panic!("schema drift: a LayoutTensorCons in class {class} has no tail child")
             });
             class = site
-                .egraph
-                .nodes
-                .get(tail_id)
-                .unwrap_or_else(|| panic!("dangling list tail node {tail_id}"))
-                .eclass
-                .clone();
+                .class_of_child(spine, 1)
+                .unwrap_or_else(|| panic!("dangling list tail node {tail_id}"));
         }
         Box::new(Gather { rank })
     }

--- a/crates/luminal_cuda_lite/src/ops/scatter/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/scatter/mod.rs
@@ -30,8 +30,8 @@ fn coordinate_rank(site: &ExtractionSite<'_>, child: usize) -> usize {
     let mut class = site.child_class(child);
     loop {
         let spine = site
-            .members(&class)
-            .find(|node| node.op == "LayoutTensorCons" || node.op == "LayoutTensorNil")
+            .nodes_in_class_value_any(&class, &["LayoutTensorCons", "LayoutTensorNil"])
+            .next()
             .unwrap_or_else(|| {
                 panic!(
                     "schema drift: coordinate-list class {class} under enode {} has no \

--- a/crates/luminal_cuda_lite/src/ops/scatter/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/scatter/mod.rs
@@ -30,13 +30,8 @@ fn coordinate_rank(site: &ExtractionSite<'_>, child: usize) -> usize {
     let mut class = site.child_class(child);
     loop {
         let spine = site
-            .egraph
-            .nodes
-            .values()
-            .find(|node| {
-                node.eclass == class
-                    && (node.op == "LayoutTensorCons" || node.op == "LayoutTensorNil")
-            })
+            .members(&class)
+            .find(|node| node.op == "LayoutTensorCons" || node.op == "LayoutTensorNil")
             .unwrap_or_else(|| {
                 panic!(
                     "schema drift: coordinate-list class {class} under enode {} has no \
@@ -52,12 +47,8 @@ fn coordinate_rank(site: &ExtractionSite<'_>, child: usize) -> usize {
             panic!("schema drift: a LayoutTensorCons in class {class} has no tail child")
         });
         class = site
-            .egraph
-            .nodes
-            .get(tail_id)
-            .unwrap_or_else(|| panic!("dangling list tail node {tail_id}"))
-            .eclass
-            .clone();
+            .class_of_child(spine, 1)
+            .unwrap_or_else(|| panic!("dangling list tail node {tail_id}"));
     }
     rank
 }

--- a/crates/luminal_cuda_lite/tests/cublaslt_contracts_cpu.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_contracts_cpu.rs
@@ -47,9 +47,6 @@ fn base_spec(m: i64, n: i64, k: i64) -> LtMatmulSpec {
         desc_b_layout_tensor: cid("b_lt"),
         c_tensor: None,
         bias_tensor: None,
-        desc_a_buffer: None,
-        desc_b_buffer: None,
-        d_buffer: None,
     }
 }
 

--- a/crates/luminal_reference/src/ops/gather/mod.rs
+++ b/crates/luminal_reference/src/ops/gather/mod.rs
@@ -166,8 +166,8 @@ impl OpMatcher for GatherMatcher {
         let mut class = site.child_class(1);
         loop {
             let spine = site
-                .members(&class)
-                .find(|node| node.op == "LayoutTensorCons" || node.op == "LayoutTensorNil")
+                .nodes_in_class_value_any(&class, &["LayoutTensorCons", "LayoutTensorNil"])
+                .next()
                 .unwrap_or_else(|| {
                     panic!(
                         "schema drift: coordinate-list class {class} under enode {} has no \

--- a/crates/luminal_reference/src/ops/gather/mod.rs
+++ b/crates/luminal_reference/src/ops/gather/mod.rs
@@ -166,13 +166,8 @@ impl OpMatcher for GatherMatcher {
         let mut class = site.child_class(1);
         loop {
             let spine = site
-                .egraph
-                .nodes
-                .values()
-                .find(|node| {
-                    node.eclass == class
-                        && (node.op == "LayoutTensorCons" || node.op == "LayoutTensorNil")
-                })
+                .members(&class)
+                .find(|node| node.op == "LayoutTensorCons" || node.op == "LayoutTensorNil")
                 .unwrap_or_else(|| {
                     panic!(
                         "schema drift: coordinate-list class {class} under enode {} has no \
@@ -188,12 +183,8 @@ impl OpMatcher for GatherMatcher {
                 panic!("schema drift: a LayoutTensorCons in class {class} has no tail child")
             });
             class = site
-                .egraph
-                .nodes
-                .get(tail_id)
-                .unwrap_or_else(|| panic!("dangling list tail node {tail_id}"))
-                .eclass
-                .clone();
+                .class_of_child(spine, 1)
+                .unwrap_or_else(|| panic!("dangling list tail node {tail_id}"));
         }
         Box::new(Gather { rank })
     }

--- a/crates/luminal_reference/src/ops/scatter/mod.rs
+++ b/crates/luminal_reference/src/ops/scatter/mod.rs
@@ -36,13 +36,8 @@ fn coordinate_rank(site: &ExtractionSite<'_>, child: usize) -> usize {
     let mut class = site.child_class(child);
     loop {
         let spine = site
-            .egraph
-            .nodes
-            .values()
-            .find(|node| {
-                node.eclass == class
-                    && (node.op == "LayoutTensorCons" || node.op == "LayoutTensorNil")
-            })
+            .members(&class)
+            .find(|node| node.op == "LayoutTensorCons" || node.op == "LayoutTensorNil")
             .unwrap_or_else(|| {
                 panic!(
                     "schema drift: coordinate-list class {class} under enode {} has no \
@@ -58,12 +53,8 @@ fn coordinate_rank(site: &ExtractionSite<'_>, child: usize) -> usize {
             panic!("schema drift: a LayoutTensorCons in class {class} has no tail child")
         });
         class = site
-            .egraph
-            .nodes
-            .get(tail_id)
-            .unwrap_or_else(|| panic!("dangling list tail node {tail_id}"))
-            .eclass
-            .clone();
+            .class_of_child(spine, 1)
+            .unwrap_or_else(|| panic!("dangling list tail node {tail_id}"));
     }
     rank
 }

--- a/crates/luminal_reference/src/ops/scatter/mod.rs
+++ b/crates/luminal_reference/src/ops/scatter/mod.rs
@@ -36,8 +36,8 @@ fn coordinate_rank(site: &ExtractionSite<'_>, child: usize) -> usize {
     let mut class = site.child_class(child);
     loop {
         let spine = site
-            .members(&class)
-            .find(|node| node.op == "LayoutTensorCons" || node.op == "LayoutTensorNil")
+            .nodes_in_class_value_any(&class, &["LayoutTensorCons", "LayoutTensorNil"])
+            .next()
             .unwrap_or_else(|| {
                 panic!(
                     "schema drift: coordinate-list class {class} under enode {} has no \

--- a/src/extraction.rs
+++ b/src/extraction.rs
@@ -37,9 +37,9 @@ use egraph_serialize::{ClassId, EGraph, Node, NodeId};
 use petgraph::graph::{DiGraph, NodeIndex};
 
 use crate::layout_ir::{
-    Access, BufferInfo, ClassIndex, ExtractedDag, ExtractedEdge, ExtractedGraph, ExtractedNode,
-    ExtractionSite, FreedBy, InputNode, LayoutInfo, LayoutIrOp, LayoutTensorInfo, LazyText,
-    LogicalInfo, OpInput, OpMatcher, OpNode, OutputNode, OutputSlot,
+    Access, BufferInfo, ExtractedDag, ExtractedEdge, ExtractedGraph, ExtractedNode, ExtractionSite,
+    FreedBy, InputNode, LayoutInfo, LayoutIrOp, LayoutTensorInfo, LazyText, LogicalInfo, OpInput,
+    OpMatcher, OpNode, OutputNode, OutputSlot, SerializedIndex,
 };
 use crate::logical_op::{LogicalRender, logical_op_for};
 
@@ -61,14 +61,16 @@ struct Extractor<'a> {
     /// has no entry here simply offers no implementation candidate.
     matchers: HashMap<&'static str, &'a dyn OpMatcher>,
     class_nodes: HashMap<ClassId, Vec<NodeId>>,
-    /// The class index every [`ExtractionSite`] this extractor builds
-    /// reads through: class → its e-nodes, ALL of them, in e-graph order.
-    /// Distinct from `class_nodes` above, which is filtered to the
-    /// unsubsumed spellings this extractor's own walks consider — a
-    /// site's value readers deliberately see subsumed spellings too (see
+    /// The serialized index every [`ExtractionSite`] this extractor
+    /// builds reads through: class → its e-nodes, constructor → its
+    /// e-nodes, and (constructor, child 0's class) → its fact rows, ALL
+    /// of them, in e-graph order. Distinct from `class_nodes` above,
+    /// which is filtered to the unsubsumed spellings this extractor's
+    /// own walks consider — a site's value readers deliberately see
+    /// subsumed spellings too (see
     /// [`ExtractionSite::nodes_in_class_value`]), so they need the
     /// unfiltered inverse.
-    site_classes: ClassIndex,
+    site_index: SerializedIndex,
     /// The shared rendering state: the render-time class index and the
     /// per-(class, depth, preference) render memo, behind an `Rc` so the
     /// lazy text closures the extraction hands out can keep it alive
@@ -972,7 +974,7 @@ impl<'a> Extractor<'a> {
             .map(|matcher| (matcher.egglog_constructor(), matcher))
             .collect();
         let class_nodes = class_nodes(egraph);
-        let site_classes = ClassIndex::new(egraph);
+        let site_index = SerializedIndex::new(egraph);
         let render = Rc::new(RenderCtx::new(egraph));
         let (op_specs, mut producer_index) = collect_op_specs(egraph, &render.class_nodes);
         let output_buffer_classes = collect_output_buffer_classes(egraph, &class_nodes);
@@ -1025,7 +1027,7 @@ impl<'a> Extractor<'a> {
             egraph,
             matchers,
             class_nodes,
-            site_classes,
+            site_index,
             render,
             op_specs,
             producer_index,
@@ -1757,7 +1759,7 @@ impl<'a> Extractor<'a> {
                     egraph: self.egraph,
                     node_id,
                     node,
-                    classes: &self.site_classes,
+                    index: &self.site_index,
                 });
                 self.op_cache
                     .borrow_mut()
@@ -4451,9 +4453,19 @@ pub fn chain_strides(egraph: &EGraph, layout: &ClassId) -> Option<Vec<Option<Cha
     Some(out)
 }
 
-fn child_class(egraph: &EGraph, node: &Node, index: usize) -> Option<ClassId> {
+/// The e-class of `node`'s child at `index`, or `None` when there is no
+/// such child or its id does not resolve — the site-free twin of
+/// [`ExtractionSite::class_of_child`], for walks that hold an e-graph
+/// rather than a matched enode.
+pub fn child_class(egraph: &EGraph, node: &Node, index: usize) -> Option<ClassId> {
     let child_id = node.children.get(index)?;
     egraph.nodes.get(child_id).map(|child| child.eclass.clone())
+}
+
+/// The e-class a node id names, or `None` when the id is not in this
+/// e-graph — the total form of [`EGraph::nid_to_cid`], which panics.
+pub fn node_class(egraph: &EGraph, node_id: &NodeId) -> Option<ClassId> {
+    egraph.nodes.get(node_id).map(|node| node.eclass.clone())
 }
 
 #[cfg(test)]

--- a/src/layout_ir/mod.rs
+++ b/src/layout_ir/mod.rs
@@ -468,7 +468,7 @@ impl ExtractionSite<'_> {
     /// in the e-graph's own map. An id the index holds but the e-graph
     /// does not is the same invariant violation
     /// [`SerializedIndex::nodes_of`] describes.
-    pub fn members<'s>(
+    fn members<'s>(
         &'s self,
         class: &egraph_serialize::ClassId,
     ) -> impl Iterator<Item = &'s egraph_serialize::Node> + use<'s> {
@@ -530,10 +530,36 @@ impl ExtractionSite<'_> {
         class: &'a egraph_serialize::ClassId,
         op: &'a str,
     ) -> impl Iterator<Item = &'a egraph_serialize::Node> + 'a {
-        self.nodes_in_class(class, op).chain(
-            self.members(class)
-                .filter(move |node| node.op == op && node.subsumed),
-        )
+        self.nodes_in_class_ordered(class, move |spelling| spelling == op)
+    }
+
+    /// Every node in the class spelling ANY of `ops` — for a value whose
+    /// answer may wear several constructors (a list spine's cons/nil, a
+    /// layout's five spellings). Same order as
+    /// [`Self::nodes_in_class_value`].
+    pub fn nodes_in_class_value_any<'a>(
+        &'a self,
+        class: &'a egraph_serialize::ClassId,
+        ops: &'a [&'a str],
+    ) -> impl Iterator<Item = &'a egraph_serialize::Node> + 'a {
+        self.nodes_in_class_ordered(class, move |spelling| ops.contains(&spelling))
+    }
+
+    /// THE VALUE-READ ORDER both accessors above are built from:
+    /// unsubsumed spellings in e-graph order, subsumed ones after —
+    /// trailing rather than absent, because saturation can subsume every
+    /// spelling of a class and a value reader must not starve.
+    fn nodes_in_class_ordered<'a>(
+        &'a self,
+        class: &'a egraph_serialize::ClassId,
+        keep: impl Fn(&str) -> bool + Copy + 'a,
+    ) -> impl Iterator<Item = &'a egraph_serialize::Node> + 'a {
+        self.members(class)
+            .filter(move |node| keep(&node.op) && !node.subsumed)
+            .chain(
+                self.members(class)
+                    .filter(move |node| keep(&node.op) && node.subsumed),
+            )
     }
 
     /// EVERY non-subsumed node of this op in the class — for parsers that

--- a/src/layout_ir/mod.rs
+++ b/src/layout_ir/mod.rs
@@ -362,51 +362,33 @@ impl Clone for Box<dyn LayoutIrOp> {
 // extractor resolves candidates by looking the enode's constructor name up in
 // a registry built from that list.
 
-/// The lookups the SERIALIZED e-graph does not carry, built once per
+/// The two lookups the SERIALIZED e-graph does not carry, built once per
 /// extraction session and handed to every [`ExtractionSite`]:
 ///
 ///  * BY CLASS — every e-node of an e-class, the inverse of
 ///    [`egraph_serialize::Node::eclass`].
 ///  * BY OP — every e-node spelling a given constructor.
-///  * BY FACT ROW — every e-node spelling a given constructor whose
-///    FIRST child lands in a given class.
 ///
-/// THE ASYMMETRY THIS CLOSES. A site's helpers answer questions of two
-/// forms. "The nodes of class C": what does C spell, what literal does
-/// it hold, which of its spellings is a `ShapeLit`. And "the row of
-/// function F at argument C": what is `(shape-of C)`, which
-/// `BufferTensorLit` names layout tensor C, is there an
-/// `(int-subst-of e m)` in this class. Each one used to be a scan of
-/// the whole e-graph filtered by `eclass ==` or by `op == .. &&
-/// child 0's class ==`, so a matcher asking a few dozen such questions
-/// made a few dozen passes over every node in the program, and its cost
-/// grew with the model rather than with the class or the row it was
-/// reading.
+/// Each was a scan of the whole e-graph filtered by `eclass ==` or by
+/// `op ==`, so a reader's cost grew with the model rather than with the
+/// class it read.
 ///
-/// FACT ROWS COVER BOTH SHAPES the matchers use. A FUNCTION row is
-/// keyed by its argument and read for its own class — `(shape-of L)`
-/// answers "L's shape class". A PARENT PROBE is keyed by its child and
-/// read for its other children or its own class — `(BufferTensorLit lt
-/// buf)` answers "which buffer names lt". Both are "the nodes of op F
-/// whose child 0 is class C", so one index serves both.
+/// BOTH LOOKUPS GO DOWNWARD — from a class to its spellings, or from a
+/// constructor name to its enodes. There is no index from a child to its
+/// parents, because a matcher reads its own enode and the classes below
+/// it and never finds a constructor by one of its arguments.
 ///
 /// EVERY node is indexed, in the e-graph's own order — subsumed
-/// spellings and the `"[...]"` elision marker included, no filtering at
-/// build time. That is what makes the index a drop-in rather than a
-/// change of meaning: each helper still applies exactly the filter it
-/// always applied, to exactly the same nodes, in exactly the same
-/// order, so "the first spelling wins" picks the same spelling it
-/// always picked.
+/// spellings and the `"[...]"` elision marker included — so a helper's
+/// "first spelling wins" picks the spelling the e-graph orders first.
 ///
-/// ONE STRUCT, not one per lookup. The three maps must describe the
-/// SAME e-graph — a site resolves the ids any of them returns in its
-/// own `egraph` — and keeping them in one value the site borrows once
-/// makes that structural instead of a comment on three parallel fields.
+/// ONE STRUCT, not one per lookup: both maps must describe the SAME
+/// e-graph, since a site resolves in its own `egraph` the ids either
+/// returns.
 #[derive(Debug, Clone, Default)]
 pub struct SerializedIndex {
     by_class: HashMap<ClassId, Vec<NodeId>>,
     by_op: HashMap<String, Vec<NodeId>>,
-    by_fact: HashMap<String, HashMap<ClassId, Vec<NodeId>>>,
 }
 
 /// The bucket for `op`, minting it on first sight. Keyed by the op's
@@ -420,48 +402,26 @@ fn op_bucket<'m, V: Default>(map: &'m mut HashMap<String, V>, op: &str) -> &'m m
 }
 
 impl SerializedIndex {
-    /// Index an e-graph's nodes by e-class, by constructor, and by
-    /// (constructor, child 0's class) — one pass.
+    /// Index an e-graph's nodes by e-class and by constructor — one pass.
     pub fn new(egraph: &egraph_serialize::EGraph) -> Self {
         let mut by_class: HashMap<ClassId, Vec<NodeId>> = HashMap::new();
         let mut by_op: HashMap<String, Vec<NodeId>> = HashMap::new();
-        let mut by_fact: HashMap<String, HashMap<ClassId, Vec<NodeId>>> = HashMap::new();
         for (node_id, node) in &egraph.nodes {
             by_class
                 .entry(node.eclass.clone())
                 .or_default()
                 .push(node_id.clone());
             op_bucket(&mut by_op, &node.op).push(node_id.clone());
-            // A node with no children, or one whose child 0 does not
-            // resolve, carries no fact row — exactly the `continue` the
-            // scans this replaces took on an unresolvable child 0.
-            if let Some(arg0) = node
-                .children
-                .first()
-                .and_then(|child| egraph.nodes.get(child))
-            {
-                op_bucket(&mut by_fact, &node.op)
-                    .entry(arg0.eclass.clone())
-                    .or_default()
-                    .push(node_id.clone());
-            }
         }
-        Self {
-            by_class,
-            by_op,
-            by_fact,
-        }
+        Self { by_class, by_op }
     }
 
     /// The class's e-nodes, in e-graph order.
     ///
     /// A miss is NOT "the class is empty" — an e-class exists precisely
-    /// because a node names it, and every class id a matcher can hold was
-    /// read off some node's `eclass`. A miss therefore means this index
-    /// was built from a different e-graph than the one being read, which
-    /// is an invariant violation and not a case to fall back from: the
-    /// scan this replaces would have answered a question about the wrong
-    /// program. Refuse loudly instead.
+    /// because a node names it, so a miss means this index was built
+    /// from a different e-graph than the one being read. Refuse loudly:
+    /// the answer would be about the wrong program.
     pub fn nodes_of(&self, class: &ClassId) -> &[NodeId] {
         self.by_class
             .get(class)
@@ -475,27 +435,10 @@ impl SerializedIndex {
     }
 
     /// Every e-node spelling `op`, in e-graph order. A miss is EMPTY,
-    /// not an error: a program that mints no `BufferInputLit` has no
-    /// explicit inputs, and the scans this replaces read that as an
-    /// empty result too.
+    /// not an error: a program that mints no `BufferInputLit` simply has
+    /// no explicit inputs.
     pub fn nodes_of_op(&self, op: &str) -> &[NodeId] {
         self.by_op.get(op).map(Vec::as_slice).unwrap_or_default()
-    }
-
-    /// The fact rows `op(arg0, ..)` — every e-node spelling `op` whose
-    /// child 0 lands in `arg0` — in e-graph order.
-    ///
-    /// A miss is EMPTY, not an error. Absence of a fact row is a
-    /// legitimate answer everywhere it is asked: a logical value with no
-    /// `shape-of` row, a layout tensor no `BufferTensorLit` names. Every
-    /// scan this replaces fell out of its loop and returned `None`, and
-    /// so does every lookup built on this.
-    pub fn fact_rows(&self, op: &str, arg0: &ClassId) -> &[NodeId] {
-        self.by_fact
-            .get(op)
-            .and_then(|rows| rows.get(arg0))
-            .map(Vec::as_slice)
-            .unwrap_or_default()
     }
 }
 
@@ -508,8 +451,8 @@ impl SerializedIndex {
 ///
 /// `index` is the session's [`SerializedIndex`] over `egraph`. The two
 /// travel together and must describe the same e-graph — every helper
-/// below reads a class or a fact row through the index and resolves the
-/// ids it returns in `egraph`.
+/// below reads a class through the index and resolves the ids it
+/// returns in `egraph`.
 #[derive(Debug, Clone, Copy)]
 pub struct ExtractionSite<'a> {
     pub egraph: &'a egraph_serialize::EGraph,
@@ -530,55 +473,6 @@ impl ExtractionSite<'_> {
         class: &egraph_serialize::ClassId,
     ) -> impl Iterator<Item = &'s egraph_serialize::Node> + use<'s> {
         self.resolve_all(self.index.nodes_of(class))
-    }
-
-    /// THE ONE FACT-ROW READ every row helper below is built from: the
-    /// ids of the `op(arg0, ..)` rows, in e-graph order. Absence is
-    /// EMPTY, never an error — see [`SerializedIndex::fact_rows`].
-    pub fn fact_rows(&self, op: &str, arg0: &egraph_serialize::ClassId) -> &[NodeId] {
-        self.index.fact_rows(op, arg0)
-    }
-
-    /// The `op(arg0, ..)` rows as nodes, in e-graph order.
-    pub fn fact_nodes<'s>(
-        &'s self,
-        op: &str,
-        arg0: &egraph_serialize::ClassId,
-    ) -> impl Iterator<Item = &'s egraph_serialize::Node> + use<'s> {
-        self.resolve_all(self.index.fact_rows(op, arg0))
-    }
-
-    /// The e-class of the FIRST `op(arg0, ..)` row — a function row's
-    /// VALUE (`(shape-of L)` is spelled by a node whose own class holds
-    /// the shape). `None` when no row exists.
-    ///
-    /// FIRST ROW WINS, and the ones behind it are not consulted: the
-    /// scans this replaces returned on their first match, so a second
-    /// row for the same argument was never read.
-    pub fn fact_row_class(
-        &self,
-        op: &str,
-        arg0: &egraph_serialize::ClassId,
-    ) -> Option<egraph_serialize::ClassId> {
-        self.fact_nodes(op, arg0)
-            .next()
-            .map(|row| row.eclass.clone())
-    }
-
-    /// The e-class of the FIRST `op(arg0, ..)` row's child at
-    /// `child_index` — a parent probe's other argument
-    /// (`(BufferTensorLit lt buf)` read at 1 is lt's buffer). `None`
-    /// when no row exists, and also when the first row is too short:
-    /// the scans this replaces committed to their first match and
-    /// returned its child, never falling through to a later row.
-    pub fn fact_row_child(
-        &self,
-        op: &str,
-        arg0: &egraph_serialize::ClassId,
-        child_index: usize,
-    ) -> Option<egraph_serialize::ClassId> {
-        let row = self.fact_nodes(op, arg0).next()?;
-        self.class_of_child(row, child_index)
     }
 
     /// Resolve indexed ids back to their nodes. An id the index holds

--- a/src/layout_ir/mod.rs
+++ b/src/layout_ir/mod.rs
@@ -362,41 +362,95 @@ impl Clone for Box<dyn LayoutIrOp> {
 // extractor resolves candidates by looking the enode's constructor name up in
 // a registry built from that list.
 
-/// Every e-node of an e-class, keyed by class — the inverse of
-/// [`egraph_serialize::Node::eclass`], built once per extraction session
-/// and handed to every [`ExtractionSite`].
+/// The lookups the SERIALIZED e-graph does not carry, built once per
+/// extraction session and handed to every [`ExtractionSite`]:
 ///
-/// THE ASYMMETRY THIS CLOSES. A site's helpers answer questions of the
-/// form "the nodes of class C": what does C spell, what literal does it
-/// hold, which of its spellings is a `ShapeLit`. Each one used to be a
-/// scan of the whole e-graph filtered by `eclass ==`, so a matcher asking
-/// a few dozen such questions made a few dozen passes over every node in
-/// the program, and its cost grew with the model rather than with the
-/// class it was reading. The extractor already owned this index for its
-/// own walks; the site now reads the same shape.
+///  * BY CLASS — every e-node of an e-class, the inverse of
+///    [`egraph_serialize::Node::eclass`].
+///  * BY OP — every e-node spelling a given constructor.
+///  * BY FACT ROW — every e-node spelling a given constructor whose
+///    FIRST child lands in a given class.
 ///
-/// EVERY node is indexed, in the e-graph's own order — subsumed spellings
-/// and the `"[...]"` elision marker included, no filtering at build time.
-/// That is what makes the index a drop-in rather than a change of
-/// meaning: each helper still applies exactly the filter it always
-/// applied, to exactly the same nodes, in exactly the same order, so
-/// "the first spelling wins" picks the same spelling it always picked.
+/// THE ASYMMETRY THIS CLOSES. A site's helpers answer questions of two
+/// forms. "The nodes of class C": what does C spell, what literal does
+/// it hold, which of its spellings is a `ShapeLit`. And "the row of
+/// function F at argument C": what is `(shape-of C)`, which
+/// `BufferTensorLit` names layout tensor C, is there an
+/// `(int-subst-of e m)` in this class. Each one used to be a scan of
+/// the whole e-graph filtered by `eclass ==` or by `op == .. &&
+/// child 0's class ==`, so a matcher asking a few dozen such questions
+/// made a few dozen passes over every node in the program, and its cost
+/// grew with the model rather than with the class or the row it was
+/// reading.
+///
+/// FACT ROWS COVER BOTH SHAPES the matchers use. A FUNCTION row is
+/// keyed by its argument and read for its own class — `(shape-of L)`
+/// answers "L's shape class". A PARENT PROBE is keyed by its child and
+/// read for its other children or its own class — `(BufferTensorLit lt
+/// buf)` answers "which buffer names lt". Both are "the nodes of op F
+/// whose child 0 is class C", so one index serves both.
+///
+/// EVERY node is indexed, in the e-graph's own order — subsumed
+/// spellings and the `"[...]"` elision marker included, no filtering at
+/// build time. That is what makes the index a drop-in rather than a
+/// change of meaning: each helper still applies exactly the filter it
+/// always applied, to exactly the same nodes, in exactly the same
+/// order, so "the first spelling wins" picks the same spelling it
+/// always picked.
+///
+/// ONE STRUCT, not one per lookup. The three maps must describe the
+/// SAME e-graph — a site resolves the ids any of them returns in its
+/// own `egraph` — and keeping them in one value the site borrows once
+/// makes that structural instead of a comment on three parallel fields.
 #[derive(Debug, Clone, Default)]
-pub struct ClassIndex {
-    nodes: HashMap<ClassId, Vec<NodeId>>,
+pub struct SerializedIndex {
+    by_class: HashMap<ClassId, Vec<NodeId>>,
+    by_op: HashMap<String, Vec<NodeId>>,
+    by_fact: HashMap<String, HashMap<ClassId, Vec<NodeId>>>,
 }
 
-impl ClassIndex {
-    /// Index an e-graph's nodes by their e-class.
+/// The bucket for `op`, minting it on first sight. Keyed by the op's
+/// own text so a lookup can hash a `&str`; the `String` is allocated
+/// once per DISTINCT constructor rather than once per node.
+fn op_bucket<'m, V: Default>(map: &'m mut HashMap<String, V>, op: &str) -> &'m mut V {
+    if !map.contains_key(op) {
+        map.insert(op.to_string(), V::default());
+    }
+    map.get_mut(op).expect("bucket just minted")
+}
+
+impl SerializedIndex {
+    /// Index an e-graph's nodes by e-class, by constructor, and by
+    /// (constructor, child 0's class) — one pass.
     pub fn new(egraph: &egraph_serialize::EGraph) -> Self {
-        let mut nodes: HashMap<ClassId, Vec<NodeId>> = HashMap::new();
+        let mut by_class: HashMap<ClassId, Vec<NodeId>> = HashMap::new();
+        let mut by_op: HashMap<String, Vec<NodeId>> = HashMap::new();
+        let mut by_fact: HashMap<String, HashMap<ClassId, Vec<NodeId>>> = HashMap::new();
         for (node_id, node) in &egraph.nodes {
-            nodes
+            by_class
                 .entry(node.eclass.clone())
                 .or_default()
                 .push(node_id.clone());
+            op_bucket(&mut by_op, &node.op).push(node_id.clone());
+            // A node with no children, or one whose child 0 does not
+            // resolve, carries no fact row — exactly the `continue` the
+            // scans this replaces took on an unresolvable child 0.
+            if let Some(arg0) = node
+                .children
+                .first()
+                .and_then(|child| egraph.nodes.get(child))
+            {
+                op_bucket(&mut by_fact, &node.op)
+                    .entry(arg0.eclass.clone())
+                    .or_default()
+                    .push(node_id.clone());
+            }
         }
-        Self { nodes }
+        Self {
+            by_class,
+            by_op,
+            by_fact,
+        }
     }
 
     /// The class's e-nodes, in e-graph order.
@@ -409,12 +463,39 @@ impl ClassIndex {
     /// scan this replaces would have answered a question about the wrong
     /// program. Refuse loudly instead.
     pub fn nodes_of(&self, class: &ClassId) -> &[NodeId] {
-        self.nodes.get(class).map(Vec::as_slice).unwrap_or_else(|| {
-            panic!(
-                "class index invariant: class {class} has no entry — the index \
+        self.by_class
+            .get(class)
+            .map(Vec::as_slice)
+            .unwrap_or_else(|| {
+                panic!(
+                    "class index invariant: class {class} has no entry — the index \
                      was built from a different e-graph than the site reads"
-            )
-        })
+                )
+            })
+    }
+
+    /// Every e-node spelling `op`, in e-graph order. A miss is EMPTY,
+    /// not an error: a program that mints no `BufferInputLit` has no
+    /// explicit inputs, and the scans this replaces read that as an
+    /// empty result too.
+    pub fn nodes_of_op(&self, op: &str) -> &[NodeId] {
+        self.by_op.get(op).map(Vec::as_slice).unwrap_or_default()
+    }
+
+    /// The fact rows `op(arg0, ..)` — every e-node spelling `op` whose
+    /// child 0 lands in `arg0` — in e-graph order.
+    ///
+    /// A miss is EMPTY, not an error. Absence of a fact row is a
+    /// legitimate answer everywhere it is asked: a logical value with no
+    /// `shape-of` row, a layout tensor no `BufferTensorLit` names. Every
+    /// scan this replaces fell out of its loop and returned `None`, and
+    /// so does every lookup built on this.
+    pub fn fact_rows(&self, op: &str, arg0: &ClassId) -> &[NodeId] {
+        self.by_fact
+            .get(op)
+            .and_then(|rows| rows.get(arg0))
+            .map(Vec::as_slice)
+            .unwrap_or_default()
     }
 }
 
@@ -425,31 +506,92 @@ impl ClassIndex {
 /// this struct is the sanctioned way to grow the extraction contract —
 /// matchers take `&ExtractionSite`, so new fields cost existing impls nothing.
 ///
-/// `classes` is the session's [`ClassIndex`] over `egraph`. The two travel
-/// together and must describe the same e-graph — every helper below reads
-/// a class through the index and resolves the ids it returns in `egraph`.
+/// `index` is the session's [`SerializedIndex`] over `egraph`. The two
+/// travel together and must describe the same e-graph — every helper
+/// below reads a class or a fact row through the index and resolves the
+/// ids it returns in `egraph`.
 #[derive(Debug, Clone, Copy)]
 pub struct ExtractionSite<'a> {
     pub egraph: &'a egraph_serialize::EGraph,
     pub node_id: &'a NodeId,
     pub node: &'a egraph_serialize::Node,
-    pub classes: &'a ClassIndex,
+    pub index: &'a SerializedIndex,
 }
 
 impl ExtractionSite<'_> {
-    /// THE ONE CLASS READ every helper below is built from: the members of
-    /// `class`, in e-graph order. The index gives the class's node ids in
-    /// O(1); resolving each id back to its node is a lookup in the
-    /// e-graph's own map. An id the index holds but the e-graph does not
-    /// is the same invariant violation [`ClassIndex::nodes_of`] describes.
-    fn members<'s>(
+    /// THE ONE CLASS READ every class helper below is built from: the
+    /// members of `class`, in e-graph order. The index gives the class's
+    /// node ids in O(1); resolving each id back to its node is a lookup
+    /// in the e-graph's own map. An id the index holds but the e-graph
+    /// does not is the same invariant violation
+    /// [`SerializedIndex::nodes_of`] describes.
+    pub fn members<'s>(
         &'s self,
         class: &egraph_serialize::ClassId,
     ) -> impl Iterator<Item = &'s egraph_serialize::Node> + use<'s> {
+        self.resolve_all(self.index.nodes_of(class))
+    }
+
+    /// THE ONE FACT-ROW READ every row helper below is built from: the
+    /// ids of the `op(arg0, ..)` rows, in e-graph order. Absence is
+    /// EMPTY, never an error — see [`SerializedIndex::fact_rows`].
+    pub fn fact_rows(&self, op: &str, arg0: &egraph_serialize::ClassId) -> &[NodeId] {
+        self.index.fact_rows(op, arg0)
+    }
+
+    /// The `op(arg0, ..)` rows as nodes, in e-graph order.
+    pub fn fact_nodes<'s>(
+        &'s self,
+        op: &str,
+        arg0: &egraph_serialize::ClassId,
+    ) -> impl Iterator<Item = &'s egraph_serialize::Node> + use<'s> {
+        self.resolve_all(self.index.fact_rows(op, arg0))
+    }
+
+    /// The e-class of the FIRST `op(arg0, ..)` row — a function row's
+    /// VALUE (`(shape-of L)` is spelled by a node whose own class holds
+    /// the shape). `None` when no row exists.
+    ///
+    /// FIRST ROW WINS, and the ones behind it are not consulted: the
+    /// scans this replaces returned on their first match, so a second
+    /// row for the same argument was never read.
+    pub fn fact_row_class(
+        &self,
+        op: &str,
+        arg0: &egraph_serialize::ClassId,
+    ) -> Option<egraph_serialize::ClassId> {
+        self.fact_nodes(op, arg0)
+            .next()
+            .map(|row| row.eclass.clone())
+    }
+
+    /// The e-class of the FIRST `op(arg0, ..)` row's child at
+    /// `child_index` — a parent probe's other argument
+    /// (`(BufferTensorLit lt buf)` read at 1 is lt's buffer). `None`
+    /// when no row exists, and also when the first row is too short:
+    /// the scans this replaces committed to their first match and
+    /// returned its child, never falling through to a later row.
+    pub fn fact_row_child(
+        &self,
+        op: &str,
+        arg0: &egraph_serialize::ClassId,
+        child_index: usize,
+    ) -> Option<egraph_serialize::ClassId> {
+        let row = self.fact_nodes(op, arg0).next()?;
+        self.class_of_child(row, child_index)
+    }
+
+    /// Resolve indexed ids back to their nodes. An id the index holds
+    /// but the e-graph does not is an invariant violation, not a case
+    /// to skip.
+    fn resolve_all<'s>(
+        &'s self,
+        ids: &'s [NodeId],
+    ) -> impl Iterator<Item = &'s egraph_serialize::Node> + use<'s> {
         let egraph = self.egraph;
-        self.classes.nodes_of(class).iter().map(move |node_id| {
+        ids.iter().map(move |node_id| {
             egraph.nodes.get(node_id).unwrap_or_else(|| {
-                panic!("class index invariant: indexed node {node_id} is not in the e-graph")
+                panic!("serialized index invariant: indexed node {node_id} is not in the e-graph")
             })
         })
     }

--- a/tests/test_runtime/tests/cublaslt_marker.rs
+++ b/tests/test_runtime/tests/cublaslt_marker.rs
@@ -108,24 +108,6 @@ fn fixture1_plain_2d_amk_bkn_spec_field_by_field() {
     assert_eq!(inputs.len(), 2);
     assert_eq!(op.operand_name(0), "a");
     assert_eq!(op.operand_name(1), "b");
-
-    // VIEW ADMISSION (round 10): the elected op lives on the sandwich
-    // sibling, whose D layout tensor is a transpose VIEW with no
-    // BufferTensor of its own; the spec's view walk must ground all three
-    // descriptors in real buffers — D through the view to the recorder's
-    // boundary buffer.
-    assert!(spec.desc_a_buffer.is_some(), "A grounded in w's buffer");
-    assert!(spec.desc_b_buffer.is_some(), "B grounded in x's buffer");
-    assert!(
-        spec.d_buffer.is_some(),
-        "D grounded THROUGH the transpose view in the caller's out buffer"
-    );
-    assert_ne!(
-        spec.desc_a_buffer, spec.desc_b_buffer,
-        "distinct operand buffers"
-    );
-    assert_ne!(spec.d_buffer, spec.desc_a_buffer);
-    assert_ne!(spec.d_buffer, spec.desc_b_buffer);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/test_runtime/tests/cublaslt_marker_round2_attack.rs
+++ b/tests/test_runtime/tests/cublaslt_marker_round2_attack.rs
@@ -27,7 +27,7 @@ use std::panic::AssertUnwindSafe;
 
 use luminal::dtype::DType;
 use luminal::graph::Graph;
-use luminal::layout_ir::{ClassIndex, ExtractedGraph, ExtractedNode, ExtractionSite};
+use luminal::layout_ir::{ExtractedGraph, ExtractedNode, ExtractionSite, SerializedIndex};
 use luminal::prelude::egraph_serialize::{ClassId, EGraph};
 use test_runtime::cublaslt_marker::{
     CuDim, CuEpilogue, CublasLt, CublasLtForm, LtMatmulSpec, parse_spec,
@@ -241,7 +241,7 @@ fn flavored_cublaslt(
 /// real test: not "the elected one is right" but "none of them is wrong".
 fn specs_of_every_enode(s: &EGraph, form: CublasLtForm) -> Vec<LtMatmulSpec> {
     let name = form.constructor_name();
-    let classes = ClassIndex::new(s);
+    let index = SerializedIndex::new(s);
     s.nodes
         .iter()
         .filter(|(_, n)| n.op == name)
@@ -250,7 +250,7 @@ fn specs_of_every_enode(s: &EGraph, form: CublasLtForm) -> Vec<LtMatmulSpec> {
                 egraph: s,
                 node_id: id,
                 node,
-                classes: &classes,
+                index: &index,
             };
             parse_spec(&site, form)
         })
@@ -3028,14 +3028,14 @@ fn attack_p1_form_layout_mismatch_panics_loudly() {
         6,
         "the hand-built descriptor pollinates 6 combos"
     );
-    let classes = ClassIndex::new(&s);
+    let index = SerializedIndex::new(&s);
     for (id, node) in &bad {
         let msg = panic_message(|| {
             let site = ExtractionSite {
                 egraph: &s,
                 node_id: id,
                 node,
-                classes: &classes,
+                index: &index,
             };
             parse_spec(&site, CublasLtForm::Base)
         });
@@ -3933,13 +3933,13 @@ fn attack_u6_c_layout_mismatch_panics_loudly() {
     );
     assert_eq!(accs.len(), 1, "only the hand-built term exists");
     let (id, node) = accs[0];
-    let classes = ClassIndex::new(&s);
+    let index = SerializedIndex::new(&s);
     let msg = panic_message(|| {
         let site = ExtractionSite {
             egraph: &s,
             node_id: id,
             node,
-            classes: &classes,
+            index: &index,
         };
         parse_spec(&site, CublasLtForm::Accumulate)
     });

--- a/tests/test_runtime/tests/r10_debug.rs
+++ b/tests/test_runtime/tests/r10_debug.rs
@@ -126,7 +126,7 @@ fn r10_debug_fixture1() {
                 if let Some(c) = (*op.op).as_any().downcast_ref::<CublasLt>() {
                     if let Some(spec) = &c.spec {
                         println!(
-                            "  spec m={} n={} k={} ta={} tb={} lda={} ldb={} ldd={} a_buf={:?} b_buf={:?} d_buf={:?}",
+                            "  spec m={} n={} k={} ta={} tb={} lda={} ldb={} ldd={}",
                             spec.m,
                             spec.n,
                             spec.k,
@@ -134,10 +134,7 @@ fn r10_debug_fixture1() {
                             spec.trans_b,
                             spec.lda,
                             spec.ldb,
-                            spec.ldd,
-                            spec.desc_a_buffer,
-                            spec.desc_b_buffer,
-                            spec.d_buffer
+                            spec.ldd
                         );
                     } else {
                         println!("  spec: None");

--- a/tests/test_runtime/tests/r8d_chain_probe.rs
+++ b/tests/test_runtime/tests/r8d_chain_probe.rs
@@ -19,7 +19,7 @@
 
 use std::collections::BTreeSet;
 
-use luminal::layout_ir::{ClassIndex, ExtractionSite};
+use luminal::layout_ir::{ExtractionSite, SerializedIndex};
 use luminal::prelude::egraph_serialize::{ClassId, EGraph};
 use test_runtime::cublaslt_marker::{CublasLtForm, parse_spec};
 
@@ -259,7 +259,7 @@ fn r8d_candidate_count_on_the_shared_weight() {
     // internal cross-checks panic on any operation/descriptor
     // inconsistency, and the COL clamp is checked here explicitly.
     let mut checked = 0usize;
-    let classes = ClassIndex::new(&s);
+    let index = SerializedIndex::new(&s);
     for (id, node) in s.nodes.iter() {
         if node.op != "LayoutTensorOpCublasLt" {
             continue;
@@ -268,7 +268,7 @@ fn r8d_candidate_count_on_the_shared_weight() {
             egraph: &s,
             node_id: id,
             node,
-            classes: &classes,
+            index: &index,
         };
         let spec =
             parse_spec(&site, CublasLtForm::Base).expect("every candidate parses (no silent None)");


### PR DESCRIPTION
Stacked on #518 (`feat/extraction-site-class-index`). Do not merge before it.

#518 closed "the nodes of class C" — the site's class helpers stopped scanning. This PR closes the other reads the matchers made against the serialized e-graph, and along the way removes the one place that read *upward*. After this, no matcher scans `egraph.nodes`, and no matcher finds a constructor row by one of its arguments.

## Commits

1. **The serialized e-graph grows a fact-row index / matchers look up facts instead of scanning** — the original change: `ClassIndex` becomes `SerializedIndex`, and every whole-graph scan in the cuBLASLt parser, the cuBLASLt election, and the gather/scatter spine walks becomes an index lookup.
2. **cuBLASLt spec drops the view→buffer walk: buffers are the plan's, never the matcher's** — `resolve_buffer`/`direct_buffer_of` and the three `LtMatmulSpec` buffer fields are deleted. They walked from a descriptor's layout tensor *up* to the `BufferTensorLit` that binds it; nothing at runtime read the result (the executor binds buffers from the plan), only one prototype-era test asserted it. A layout does not identify a buffer, and extraction operates on layout-level information only.
3. **cuBLASLt storage dims read the layout's own shape; the fact-row index goes** — `storage_dims` reads the descriptor's shape downward (layout tensor → layout → the Shape child every layout constructor carries) instead of the class-level `shape-of` fact. With that, the `(op, arg0) → rows` map has no caller and is removed.
4. **Class reads go through one policy: the raw member walk goes private** — `members` is private again; `nodes_in_class_value` and a new `nodes_in_class_value_any(class, &[ops])` are both one-liners over a single ordered core (unsubsumed spellings first, subsumed ones trailing, because saturation can subsume every spelling of a class and a value reader must not starve). The four spine walks and the layout-shape read go through it, so no matcher sees raw class order.

## API as landed

```rust
pub struct SerializedIndex {
    by_class: HashMap<ClassId, Vec<NodeId>>,
    by_op:    HashMap<String, Vec<NodeId>>,
}
impl SerializedIndex {
    pub fn new(egraph: &egraph_serialize::EGraph) -> Self;   // one pass
    pub fn nodes_of(&self, class: &ClassId) -> &[NodeId];     // panics on a foreign class (as #518)
    pub fn nodes_of_op(&self, op: &str) -> &[NodeId];         // miss = empty
}

impl ExtractionSite<'_> {
    pub fn nodes_in_class_value(&self, class: &ClassId, op: &str) -> impl Iterator<Item = &Node>;
    pub fn nodes_in_class_value_any(&self, class: &ClassId, ops: &[&str]) -> impl Iterator<Item = &Node>;
    // node_in_class / nodes_in_class (strict, unsubsumed only) unchanged
}
```

There is no child→parent index: a matcher never finds a constructor by one of its arguments. `luminal::extraction::child_class` is public and gains a `node_class` twin for walks that hold an e-graph rather than a matched site.

## Grep proof (tip)

```
$ grep -rn '"BufferTensorLit"\|"LayoutTensorLit"\|"int-subst-of"\|"shape-of"\|fact_row\|by_fact' crates/luminal_cuda_lite/src/ops/cublaslt/mod.rs src/layout_ir src/extraction.rs
crates/luminal_cuda_lite/src/ops/cublaslt/mod.rs:381:    for node in site.nodes_in_class_value(lt_class, "LayoutTensorLit") {
crates/luminal_cuda_lite/src/ops/cublaslt/mod.rs:390:    for node in site.nodes_in_class_value(lt_class, "LayoutTensorLit") {
$ grep -n "pub fn members" src/layout_ir/mod.rs
(none)
```

The two survivors are downward class-member reads.

## Measured (commit 1 tip, qwen3 anatomy, 25 genomes, release; before = #518 tip)

| | 8L before | 8L after | 16L before | 16L after |
|---|---|---|---|---|
| `parse_spec` per call | 9.22 ms | 0.11 ms | 21.97 ms | 0.16 ms |
| extraction per genome (mean) | 133.7 ms | 19.4 ms | 556.6 ms | 41.1 ms |

8→16 exponent for extraction per genome: 2.06 → 1.08. Commits 2–4 delete the code that the index made fast (the walk was the indexed hot path) and were not separately re-measured; they cannot add cost.

## Gates (tip b68dd2c5)

`cargo test -p luminal --lib` 255 passed; `cargo test -p luminal_cuda_lite` 21 binaries all ok (98 passed); `cargo test -p test_runtime` 42 binaries all ok (212 passed); `cargo test -p luminal_reference` all ok; `cargo fmt --all -- --check` clean; `cargo clippy -p luminal -p luminal_cuda_lite -p luminal_reference --lib` warning set identical to base. Zero test edits beyond removing the three prototype-era assertions on the deleted buffer fields (`cublaslt_marker.rs`, `r10_debug.rs`, `cublaslt_contracts_cpu.rs`).
