### PR TITLE
Profile representative workloads and preserve CUDA numerical semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ off by default; set to `1` to enable unless noted.
 
 ### Search & compile behavior
 
+`Graph::build_search_space` builds independent dynamic-dimension buckets in parallel, preserving bucket order and interval isolation. Worker count is capped by the bucket count and the caller’s Rayon thread budget, which is divided among workers. Each worker owns an e-graph, so parallel builds use more host memory. GPU candidate profiling is unaffected.
+
 | Flag | Effect |
 |---|---|
 | `LUMINAL_SEARCH_SEED` | Overrides the search RNG seed in the examples (integer). |

--- a/crates/luminal_cuda_lite/README.md
+++ b/crates/luminal_cuda_lite/README.md
@@ -62,3 +62,95 @@ Choice-set validation detects correlated e-class cycles before LLIR loading.
 Random initial genomes repair only those reachable cycles; later mutations may
 still produce them, in which case candidate filtering discards them without
 profiling and continues searching the remaining legal alternatives.
+
+### Representative profiling workloads
+
+Search can rank equivalent programs on explicit graph-input examples instead of
+its legacy runtime-bound synthetic inputs. This API is shared by Lite and the
+full CUDA runtime and has no model-specific types or scheduling rules.
+
+Build the search space first, then install a workload before search:
+
+```rust,ignore
+use luminal_cuda_lite::runtime::{ProfileInputs, ProfileWorkload};
+
+let workload = ProfileWorkload::new()
+    .shared_input(coefficients)
+    .case("sample-a", dims_a, ProfileInputs::new().input(input, values_a), 0.6)
+    .case("sample-b", dims_b, ProfileInputs::new().input(input, values_b), 0.4);
+runtime.set_profile_workload(&graph, workload)?;
+runtime = graph.search_with_rng(runtime, search_options, &mut rng);
+```
+
+Each case supplies exact dimensions and physical input bytes. Declare every
+graph input in each case or explicitly share it read-only. `.mirrored_input`
+keeps host metadata coherent with device data. `.view` binds byte ranges from a
+shared `ProfileStorage` when inputs alias. Graph strides and views remain part
+of the graph. Contents must satisfy the application's index/layout contracts;
+byte-length and dtype-schema checks cannot establish arbitrary semantic validity.
+
+`runtime.capture_profile_inputs(&[tensor_a, tensor_b], &dims)` produces the same
+`ProfileInputs` from current bindings, preserving overlapping storage and existing
+host mirrors. Capture before execution, after installing inputs and state.
+Snapshots are host-backed; search allocates one reusable set of device buffers
+sized for the cases. Shared read-only inputs are not duplicated. Original caller
+bindings, contents of replayed inputs, and output registrations are protected
+from profiling and restored on completion or unwind.
+
+Every case is restored before preparation and again before timed execution, so
+warmup, candidate ordering and in-place updates cannot evolve the next trial's
+inputs. Kernel alias effects and `HostOp::profile_mutated_inputs` prevent writes
+to declared shared inputs. A destructive alternative is also rejected if its
+cross-input aliases invalidate the graph's exclusive-use proof. Custom HostOps
+with semantic state outside tensors implement `capture_profile_state`; its
+`ProfileState` restores that state before trials and after evaluation, including
+failure. The default hook declares no hidden semantic state. Operations that
+cannot be replayed must return an error from that hook. RNG state can be supplied
+as an ordinary tensor or included in an opaque-state snapshot.
+
+Positive case weights describe relative invocation frequency over the entire
+workload. Search evaluates all assigned cases in both exploration and CUDA-graph
+finalist reranking. It sums globally weighted latency contributions when choosing
+a resource-compatible bucket set; per-case measurements are available through
+`runtime.profile_evaluations()`. Incomplete workloads that exceed their execution
+budget are rejected, rather than scored using only the measured subset. A
+single-case early-stop threshold is not applied to a multi-case aggregate.
+
+The default metric uses wall-clock timing, including ordinary runtime
+preparation, parameter updates, dispatch and completion. Select
+`.timing_method(luminal::op::TimingMethod::DeviceTimestamp)` for device timestamps. Both modes exclude
+sample restoration and untimed warmup. These measure steady repeated invocations,
+not application queueing, cold compilation or a state-evolving multi-step trace.
+No artificial dimension changes are imposed on explicit workload trials.
+
+Each case gets one warmup and `CompileOptions::trials` measured executions
+(default three), averaged for its score, subject to execution timeouts. Set
+`LUMINAL_CUDA_PROFILE_EXEC=1` to print coarse `SEARCH_PHASE`, `SEARCH_EXEC`,
+and `SEARCH_PROFILE_BEGIN/END` records. These separate search/extraction,
+compilation and installation, direct preparation or CUDA graph materialization,
+state restoration, and launch through completion. The profile records include
+actual trial counts and metric sums for warmup versus measured executions.
+Metric sums overlap execution wall time; do not add them to wall phases.
+
+Samples do not change semantic bucket ranges or prove content-dependent rewrite
+legality. Missing bucket coverage, duplicate IDs/bindings, invalid weights,
+inconsistent byte lengths, stale search spaces and conflicting `profile_dims`
+overrides are rejected. Static graphs use empty dimension maps. If rebuilding
+the search space, reinstall the workload against the new space.
+
+Run the complete non-LLM example with:
+
+```sh
+cargo run --release -p luminal_cuda_lite --example representative_profiles
+```
+
+The example captures two matrix workloads, searches on them, and checks an unseen
+valid shape. This initial implementation provides in-memory workloads and CUDA
+replay; on-disk corpus serialization, application-specific collectors, multi-step
+traces and replay for other device backends remain separate extensions.
+
+For large stateful workloads, `.device_snapshots(true)` caches immutable sample
+backing on the GPU and resets trials with device-to-device copies. Shared
+`ProfileStorage` objects are uploaded only once across cases. This trades extra
+VRAM for lower replay overhead; allocation failure leaves caller bindings intact.
+The default continues to replay host snapshots without retaining device copies.

--- a/crates/luminal_cuda_lite/examples/representative_profiles.rs
+++ b/crates/luminal_cuda_lite/examples/representative_profiles.rs
@@ -1,0 +1,46 @@
+//! cargo run --release -p luminal_cuda_lite --example representative_profiles
+//! Ordinary matrix arithmetic; no inference-server or model dependencies.
+use luminal::prelude::*;
+use luminal_cuda_lite::runtime::{CudaRuntime, ProfileWorkload};
+use rand::{SeedableRng, rngs::SmallRng};
+
+fn main() -> anyhow::Result<()> {
+    let mut graph = Graph::new();
+    let a = graph.tensor(('m', 4)).persist();
+    let b = graph.tensor((4, 4)).persist();
+    let output = a.matmul(b).output();
+    graph.build_search_space::<CudaRuntime>(
+        CompileOptions::default().dim_buckets('m', &[DimBucket::new(1, 4).representative(2)]),
+    );
+    let mut runtime = CudaRuntime::new()?;
+    runtime.set_data(b, vec![1f32; 16]);
+    let mut workload = ProfileWorkload::new().shared_input(b);
+    for rows in [2, 4] {
+        graph.set_dim('m', rows);
+        runtime.set_data(a, vec![rows as f32; rows * 4]);
+        let snapshot = runtime.capture_profile_inputs(&[a], &graph.dyn_map)?;
+        workload = workload.case(format!("rows-{rows}"), graph.dyn_map.clone(), snapshot, 1.);
+    }
+    runtime.set_profile_workload(&graph, workload)?;
+    runtime = graph.search_with_rng(
+        runtime,
+        CompileOptions::default().search_graph_limit(5).trials(3),
+        &mut SmallRng::seed_from_u64(43),
+    );
+    for evaluation in runtime
+        .profile_evaluations()
+        .iter()
+        .filter(|e| e.cuda_graph)
+    {
+        println!(
+            "CUDA-graph workload score {:?}: {:?}",
+            evaluation.weighted_cost, evaluation.cases
+        );
+    }
+    // Examples tune performance; they do not restrict the bucket's valid shapes.
+    graph.set_dim('m', 3);
+    runtime.set_data(a, vec![2f32; 12]);
+    runtime.execute(&graph.dyn_map);
+    assert_eq!(runtime.get_f32(output), vec![8f32; 12]);
+    Ok(())
+}

--- a/crates/luminal_cuda_lite/src/counterfactual.rs
+++ b/crates/luminal_cuda_lite/src/counterfactual.rs
@@ -1,0 +1,154 @@
+//! Temporary diagnostic: replace complete operation outputs with captured
+//! boundary bytes on one fixed supplied invocation. Never candidate fitness.
+use super::*;
+
+impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
+    pub fn request_region_counterfactual(&mut self, bucket: usize, path: std::path::PathBuf) {
+        self.counterfactual_request = Some((bucket, path));
+    }
+
+    pub(crate) fn profile_region_counterfactuals(
+        &mut self,
+        llir: &LLIRGraph,
+        bucket: usize,
+    ) -> anyhow::Result<serde_json::Value> {
+        let cases = self
+            .profile_case_indices(bucket)
+            .ok_or_else(|| anyhow::anyhow!("counterfactual requires supplied inputs"))?;
+        anyhow::ensure!(
+            cases.len() == 1,
+            "counterfactual uses exactly one fixed case"
+        );
+        let owners: Vec<_> = self
+            .compiled_buckets
+            .iter()
+            .flat_map(|b| b.exec_graph.node_weights())
+            .filter(|op| op.internal.as_any().is::<CudaGraphOp>())
+            .map(|op| op.internal.clone())
+            .collect();
+        let graphs: Vec<_> = owners
+            .iter()
+            .filter_map(|op| op.as_any().downcast_ref::<CudaGraphOp>())
+            .collect();
+        anyhow::ensure!(!graphs.is_empty(), "no captured graph to probe");
+        let experts = vec!["FusedMoE", "GroupedMoE", "GroupedMoEParallel"];
+        let dense = vec![
+            "cublaslt",
+            "MixedAffine",
+            "MixedMatmul",
+            "ThinMatmul",
+            "ThinMatmulBias",
+            "Gemv",
+            "GemvBias",
+        ];
+        let small = vec![
+            "FusedRegion",
+            "Cast",
+            "RMSNorm",
+            "Gather",
+            "Embed",
+            "RoPEHalf",
+            "Iota",
+            "Constant",
+            "Add",
+            "Mul",
+            "Sin",
+            "Exp2",
+            "Recip",
+            "Sqrt",
+            "LessThan",
+            "Sum",
+            "Max",
+        ];
+        let groups = [
+            ("experts", experts.clone()),
+            ("dense", dense.clone()),
+            ("small", small.clone()),
+            ("attention", vec!["FlashAttention3"]),
+            ("dense_and_small", [dense.clone(), small.clone()].concat()),
+            ("experts_dense_small", [experts, dense, small].concat()),
+        ];
+        let all: Vec<String> = groups
+            .iter()
+            .flat_map(|(_, names)| names.iter().map(|s| s.to_string()))
+            .collect();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+            || -> anyhow::Result<_> {
+                self.capture_profile_op_states(llir)?;
+                self.activate_profile_case(cases[0])?;
+                let dims = self.profile_case_dims(cases[0]);
+                let (before, _) = self.profile_loaded_cuda_graph(llir, &dims, 5, None, None);
+                // Compare every small registered output (including actual tokens).
+                // Large persistent caches remain governed by the replay contract.
+                let output_ids: Vec<_> = self
+                    .active()
+                    .output_producers
+                    .keys()
+                    .copied()
+                    .filter(|id| self.resolve_output_buffer(*id).len() <= 1024 * 1024)
+                    .collect();
+                let expected: Vec<_> = output_ids
+                    .iter()
+                    .map(|id| self.get_output_data(*id))
+                    .collect();
+                for graph in &graphs {
+                    graph.record_boundaries(&all);
+                }
+                self.profiling = true;
+                self.profile_cuda_graphs = true;
+                self.execute(&dims);
+                self.cuda_stream.synchronize()?;
+                self.cancel_search_profile();
+                let mut measurements = Vec::new();
+                for (label, names) in groups {
+                    let names: Vec<String> = names.iter().map(|s| s.to_string()).collect();
+                    for graph in &graphs {
+                        graph.replay_boundaries(&names);
+                    }
+                    let (duration, _) = self.profile_loaded_cuda_graph(llir, &dims, 5, None, None);
+                    let actual: Vec<_> = output_ids
+                        .iter()
+                        .map(|id| self.get_output_data(*id))
+                        .collect();
+                    anyhow::ensure!(
+                        actual == expected,
+                        "counterfactual {label} changed a checked output"
+                    );
+                    let (nodes, bytes) = graphs
+                        .iter()
+                        .map(|g| g.boundary_probe_counts())
+                        .fold((0, 0), |(n, b), (n1, b1)| (n + n1, b + b1));
+                    measurements.push(serde_json::json!({"region": label, "milliseconds": duration.as_secs_f64()*1000., "replaced_operations": nodes, "copied_bytes": bytes, "checked_output_bytes_equal": true}));
+                    eprintln!(
+                        "COUNTERFACTUAL bucket={bucket} region={label} ms={:.6}",
+                        duration.as_secs_f64() * 1000.
+                    );
+                }
+                for graph in &graphs {
+                    graph.clear_boundaries();
+                }
+                let (after, _) = self.profile_loaded_cuda_graph(llir, &dims, 5, None, None);
+                let restored: Vec<_> = output_ids
+                    .iter()
+                    .map(|id| self.get_output_data(*id))
+                    .collect();
+                anyhow::ensure!(
+                    restored == expected,
+                    "restored graph changed a checked output"
+                );
+                Ok(
+                    serde_json::json!({"bucket": bucket, "dims": format!("{dims:?}"),
+                "scope": "Fixed-case output substitution; copies included; not a correct serving program or a performance win.",
+                "baseline_before_ms": before.as_secs_f64()*1000., "baseline_after_ms": after.as_secs_f64()*1000.,
+                "checked_output_count": expected.len(), "measurements": measurements}),
+                )
+            },
+        ));
+        self.cancel_search_profile();
+        for graph in &graphs {
+            graph.clear_boundaries();
+        }
+        self.release_profile_op_states()?;
+        result.unwrap_or_else(|_| Err(anyhow::anyhow!("counterfactual diagnostic panicked")))
+    }
+}

--- a/crates/luminal_cuda_lite/src/host/cublaslt/algorithm_tests.rs
+++ b/crates/luminal_cuda_lite/src/host/cublaslt/algorithm_tests.rs
@@ -1,0 +1,274 @@
+use super::*;
+use crate::{
+    runtime::CudaRuntime,
+    tests::utilities::{ForcedExtractionConfig, get_cuda_stream, try_extract_forced_op_llir_where},
+};
+
+fn data(len: usize, weight: bool) -> Vec<bf16> {
+    (0..len)
+        .map(|i| {
+            bf16::from_f32(if weight {
+                (((i * 17 + 5) % 29) as i32 - 14) as f32 / 128.0
+            } else {
+                (((i * 13 + 3) % 31) as i32 - 15) as f32 / 128.0
+            })
+        })
+        .collect()
+}
+
+#[test]
+fn ranked_algorithms_keep_full_precision_for_unaligned_inputs() {
+    let stream = get_cuda_stream().expect("CUDA required for algorithm regression");
+    let lt = try_create_cublaslt(stream.clone()).unwrap();
+    let (m, n, k) = (512, 2, 2880);
+    let (a, b) = (data(m * k, true), data(n * k, false));
+    let expected: Vec<_> = (0..n)
+        .flat_map(|j| {
+            let (a, b) = (&a, &b);
+            (0..m).map(move |i| {
+                bf16::from_f32(
+                    (0..k)
+                        .map(|z| a[i * k + z].to_f32() * b[j * k + z].to_f32())
+                        .sum(),
+                )
+            })
+        })
+        .collect();
+    let mut padded_a = vec![bf16::ZERO];
+    padded_a.extend(a);
+    let mut padded_b = vec![bf16::ZERO];
+    padded_b.extend(b);
+    let da = stream
+        .clone_htod(&padded_a.iter().map(|v| v.to_bits()).collect::<Vec<_>>())
+        .unwrap();
+    let db = stream
+        .clone_htod(&padded_b.iter().map(|v| v.to_bits()).collect::<Vec<_>>())
+        .unwrap();
+    let dc = stream.alloc_zeros::<u16>(m * n + 1).unwrap();
+    let ptrs = LtMatmulPointers {
+        a: da.device_ptr(&stream).0 + 2,
+        b: db.device_ptr(&stream).0 + 2,
+        c: dc.device_ptr(&stream).0 + 2,
+        d: dc.device_ptr(&stream).0 + 2,
+        bias: None,
+        a_scale: None,
+        b_scale: None,
+    };
+    let op = CuBlasLt {
+        m: m.into(),
+        n: n.into(),
+        k: k.into(),
+        a_layout: cublasOperation_t::CUBLAS_OP_T,
+        b_layout: cublasOperation_t::CUBLAS_OP_N,
+        lda: k.into(),
+        ldb: k.into(),
+        ldc: m.into(),
+        ldd: m.into(),
+        a_dtype: DType::Bf16,
+        b_dtype: DType::Bf16,
+        c_dtype: DType::Bf16,
+        d_dtype: DType::Bf16,
+        compute_type: cublasComputeType_t::CUBLAS_COMPUTE_32F_FAST_16BF,
+        scale_dtype: DType::F32,
+        ..Default::default()
+    };
+    let mut spec = op
+        .resolve_matmul_spec(&FxHashMap::default())
+        .unwrap()
+        .with_pointers(ptrs);
+    assert_eq!(spec.alignments, [2; 4]);
+    for rank in 0..CUBLASLT_ALGORITHM_CHOICES {
+        spec.algorithm_rank = rank;
+        let prepared = prepare_cublaslt_matmul(&stream, &lt, &spec, ptrs).unwrap();
+        prepared.enqueue(&stream, ptrs).unwrap();
+        stream.synchronize().unwrap();
+        let result: Vec<_> = stream
+            .clone_dtoh(&dc)
+            .unwrap()
+            .into_iter()
+            .map(bf16::from_bits)
+            .collect();
+        assert_eq!(result[0], bf16::ZERO, "output sentinel at rank {rank}");
+        assert_eq!(
+            &result[1..],
+            expected.as_slice(),
+            "rank {rank} must round only after FP32 reduction"
+        );
+    }
+}
+
+#[test]
+fn ranked_rewrites_execute_and_rebind_pointer_alignment() {
+    let stream = get_cuda_stream().expect("CUDA required for ranked graph regression");
+    let (m, n, k) = (2, 16, 32);
+    let mut cx = Graph::new();
+    let a = cx.tensor((m, k)).as_dtype(DType::Bf16).persist();
+    let b = cx.tensor((n, k)).as_dtype(DType::Bf16).persist();
+    let out = a.matmul(b.t()).cast(DType::Bf16).output();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let ad = data(m * k, false);
+    let bd = data(n * k, true);
+    let expected: Vec<_> = (0..m)
+        .flat_map(|i| {
+            let (ad, bd) = (&ad, &bd);
+            (0..n).map(move |j| {
+                bf16::from_f32(
+                    (0..k)
+                        .map(|z| ad[i * k + z].to_f32() * bd[j * k + z].to_f32())
+                        .sum(),
+                )
+            })
+        })
+        .collect();
+    let mut padded = vec![bf16::ZERO];
+    padded.extend(ad.clone());
+    let misaligned = stream
+        .clone_htod(&padded.iter().map(|v| v.to_bits()).collect::<Vec<_>>())
+        .unwrap();
+    for rank in 0..CUBLASLT_ALGORITHM_CHOICES {
+        let llir = try_extract_forced_op_llir_where(
+            &cx,
+            &["cublaslt_algorithm"],
+            ForcedExtractionConfig::new(731).attempts_per_node(64),
+            |llir| {
+                llir.node_weights().any(|op| {
+                    op.to_dialect::<dyn HostOp>()
+                        .and_then(|host| host.as_any().downcast_ref::<CuBlasLt>())
+                        .is_some_and(|op| op.algorithm_rank == rank)
+                })
+            },
+        )
+        .unwrap_or_else(|error| panic!("rank {rank} was not reachable: {error}"));
+        let mut rt = CudaRuntime::initialize(stream.clone());
+        rt.load_llir(&llir);
+        rt.set_data(a, ad.clone());
+        rt.set_data(b, bd.clone());
+        rt.execute(&cx.dyn_map);
+        assert_eq!(rt.get_bf16(out), expected, "aligned rank {rank}");
+        unsafe {
+            rt.set_device_ptr(a, misaligned.device_ptr(&stream).0 + 2, ad.len() * 2);
+        }
+        rt.execute(&cx.dyn_map);
+        assert_eq!(rt.get_bf16(out), expected, "unaligned rank {rank}");
+        rt.set_data(a, ad.clone());
+        rt.execute(&cx.dyn_map);
+        assert_eq!(rt.get_bf16(out), expected, "restored aligned rank {rank}");
+    }
+}
+
+#[test]
+fn ranked_row_and_column_lowerings_agree_for_wide_outputs() {
+    let stream = get_cuda_stream().expect("CUDA required for layout regression");
+    let (m, n, k) = (8, 2880, 4096);
+    let mut cx = Graph::new();
+    let a = cx.tensor((m, k)).as_dtype(DType::Bf16).persist();
+    let b = cx.tensor((n, k)).as_dtype(DType::Bf16).persist();
+    let out = a.matmul(b.t()).cast(DType::Bf16).output();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let ad = data(m * k, false);
+    let bd = data(n * k, true);
+    // Dyadic products and bounded sums are exactly representable in FP32.
+    // This catches layout/reduction errors without demanding an unspecified
+    // floating-point accumulation order for arbitrary real-valued inputs.
+    let expected: Vec<_> = (0..m)
+        .flat_map(|i| {
+            let (ad, bd) = (&ad, &bd);
+            (0..n).map(move |j| {
+                bf16::from_f32(
+                    (0..k)
+                        .map(|z| ad[i * k + z].to_f32() * bd[j * k + z].to_f32())
+                        .sum(),
+                )
+            })
+        })
+        .collect();
+    for order in [
+        cublasLtOrder_t::CUBLASLT_ORDER_ROW,
+        cublasLtOrder_t::CUBLASLT_ORDER_COL,
+    ] {
+        for rank in 0..CUBLASLT_ALGORITHM_CHOICES {
+            let llir = try_extract_forced_op_llir_where(
+                &cx,
+                &["cublaslt_algorithm"],
+                ForcedExtractionConfig::new(917).attempts_per_node(128),
+                |llir| {
+                    llir.node_weights().any(|op| {
+                        op.to_dialect::<dyn HostOp>()
+                            .and_then(|host| host.as_any().downcast_ref::<CuBlasLt>())
+                            .is_some_and(|op| op.algorithm_rank == rank && op.d_order == order)
+                    })
+                },
+            )
+            .unwrap_or_else(|error| panic!("rank {rank}, order {order:?}: {error}"));
+            let mut rt = CudaRuntime::initialize(stream.clone());
+            rt.load_llir(&llir);
+            rt.set_data(a, ad.clone());
+            rt.set_data(b, bd.clone());
+            rt.execute(&cx.dyn_map);
+            assert_eq!(rt.get_bf16(out), expected, "rank {rank}, order {order:?}");
+        }
+    }
+}
+
+#[test]
+fn ranked_scaled_algorithms_preserve_mutable_fp8_scales() {
+    let stream = get_cuda_stream().expect("CUDA required for scaled algorithm regression");
+    let (m, n, k) = (16, 16, 16);
+    let mut cx = Graph::new();
+    let a = cx.tensor((m, k)).persist();
+    let input_scale = cx.tensor(()).persist();
+    let weight_scale = cx.tensor(()).persist();
+    let b = cx.tensor((n, k)).as_dtype(DType::F8E4M3).persist();
+    let quant = (a / input_scale.expand_rhs((m, k))).cast(DType::F8E4M3);
+    let out = (quant.matmul(b.t()).cast(DType::F32)
+        * (input_scale * weight_scale).expand_rhs((m, n)))
+    .output();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let av: Vec<_> = (0..m * k)
+        .map(|i| ((i * 3 + i / 7) % 5) as f32 - 2.0)
+        .collect();
+    let bv: Vec<_> = (0..n * k)
+        .map(|i| ((i * 2 + i / 9) % 5) as f32 - 2.0)
+        .collect();
+    let bytes: Vec<u8> = bv
+        .iter()
+        .map(|v| [0xC0, 0xB8, 0, 0x38, 0x40][(*v + 2.0) as usize])
+        .collect();
+    let reference: Vec<f32> = (0..m)
+        .flat_map(|i| {
+            let (av, bv) = (&av, &bv);
+            (0..n).map(move |j| (0..k).map(|z| av[i * k + z] * bv[j * k + z]).sum())
+        })
+        .collect();
+    for rank in 0..CUBLASLT_ALGORITHM_CHOICES {
+        let llir = try_extract_forced_op_llir_where(
+            &cx,
+            &["cublaslt_scaled_algorithm"],
+            ForcedExtractionConfig::new(922).attempts_per_node(64),
+            |llir| {
+                llir.node_weights().any(|op| {
+                    op.to_dialect::<dyn HostOp>()
+                        .and_then(|host| host.as_any().downcast_ref::<CuBlasLt>())
+                        .is_some_and(|op| {
+                            op.algorithm_rank == rank && op.a_scale_input && op.b_scale_input
+                        })
+                })
+            },
+        )
+        .unwrap_or_else(|error| panic!("scaled rank {rank} was not reachable: {error}"));
+        let mut rt = CudaRuntime::initialize(stream.clone());
+        rt.load_llir(&llir);
+        rt.set_data(b, bytes.clone());
+        for (xs, ws) in [(0.25, 2.0), (0.5, 1.5)] {
+            rt.set_data(a, av.iter().map(|v| v * xs).collect::<Vec<_>>());
+            rt.set_data(input_scale, vec![xs]);
+            rt.set_data(weight_scale, vec![ws]);
+            rt.execute(&cx.dyn_map);
+            assert_eq!(
+                rt.get_f32(out),
+                reference.iter().map(|v| v * xs * ws).collect::<Vec<_>>(),
+                "scaled rank {rank}"
+            );
+        }
+    }
+}

--- a/crates/luminal_cuda_lite/src/host/cublaslt/cublaslt_beta_rewrite.egg
+++ b/crates/luminal_cuda_lite/src/host/cublaslt/cublaslt_beta_rewrite.egg
@@ -1,3 +1,6 @@
+; A pointwise operation after F16/BF16 matmul observes its rounded result.
+; cuBLASLt epilogues/scales run before output conversion, so only F32
+; intermediates may cross this boundary. Keep low-precision rounding explicit.
 ; Fuse a row-major Add on top of an existing cuBLASLt matmul into
 ; D = alpha * A * B + beta * C.
 ;
@@ -9,6 +12,7 @@
 ; beta rules only fuse C layouts that map to the current COL-ordered D layout.
 (rule
     (
+        (= ?d_dtype (F32))
         (= ?matmul (Op (cublaslt
             ?m ?n ?k
             ?a_layout ?b_layout
@@ -67,6 +71,7 @@
 
 (rule
     (
+        (= ?d_dtype (F32))
         (= ?matmul (Op (cublaslt
             ?m ?n ?k
             ?a_layout ?b_layout
@@ -125,6 +130,7 @@
 
 (rule
     (
+        (= ?d_dtype (F32))
         (= ?matmul (Op (cublaslt
             ?m ?n ?k
             ?a_layout ?b_layout
@@ -183,6 +189,7 @@
 
 (rule
     (
+        (= ?d_dtype (F32))
         (= ?matmul (Op (cublaslt
             ?m ?n ?k
             ?a_layout ?b_layout
@@ -245,6 +252,7 @@
 ; ROW-ordered cuBLASLt C[m,n] descriptor with ldc=row_stride.
 (rule
     (
+        (= ?d_dtype (F32))
         (= ?matmul (Op (cublaslt
             ?m ?n ?k
             ?a_layout ?b_layout
@@ -303,6 +311,7 @@
 
 (rule
     (
+        (= ?d_dtype (F32))
         (= ?matmul (Op (cublaslt
             ?m ?n ?k
             ?a_layout ?b_layout
@@ -361,6 +370,7 @@
 
 (rule
     (
+        (= ?d_dtype (F32))
         (= ?matmul (Op (cublaslt
             ?m ?n ?k
             ?a_layout ?b_layout
@@ -419,6 +429,7 @@
 
 (rule
     (
+        (= ?d_dtype (F32))
         (= ?matmul (Op (cublaslt
             ?m ?n ?k
             ?a_layout ?b_layout

--- a/crates/luminal_cuda_lite/src/host/cublaslt/cublaslt_epilogue_rewrite.egg
+++ b/crates/luminal_cuda_lite/src/host/cublaslt/cublaslt_epilogue_rewrite.egg
@@ -1,3 +1,6 @@
+; A pointwise operation after F16/BF16 matmul observes its rounded result.
+; cuBLASLt epilogues/scales run before output conversion, so only F32
+; intermediates may cross this boundary. Keep low-precision rounding explicit.
 ; cuBLASLt epilogue rewrites.
 ;
 ; ReLU in the frontend lowers through maximum_f32(0.0):
@@ -585,6 +588,7 @@
 
 (rule
     (
+        (= ?d_dtype (F32))
         (= ?matmul (Op (cublaslt
             ?m ?n ?k
             ?a_layout ?b_layout
@@ -634,6 +638,7 @@
 
 (rule
     (
+        (= ?d_dtype (F32))
         (= ?matmul (Op (cublaslt
             ?m ?n ?k
             ?a_layout ?b_layout
@@ -683,6 +688,7 @@
 
 (rule
     (
+        (= ?d_dtype (F32))
         (= ?matmul (Op (cublaslt
             ?m ?n ?k
             ?a_layout ?b_layout
@@ -732,6 +738,7 @@
 
 (rule
     (
+        (= ?d_dtype (F32))
         (= ?matmul (Op (cublaslt
             ?m ?n ?k
             ?a_layout ?b_layout

--- a/crates/luminal_cuda_lite/src/host/cublaslt/cublaslt_mixed_precision.egg
+++ b/crates/luminal_cuda_lite/src/host/cublaslt/cublaslt_mixed_precision.egg
@@ -1,0 +1,67 @@
+; Widening F16/BF16 operands to F32 is exact. Preserve the F32
+; product/accumulator/output contract while letting cuBLASLt read 16-bit storage.
+(relation cublaslt_widenable_dtype (DType))
+(cublaslt_widenable_dtype (F16))
+(cublaslt_widenable_dtype (Bf16))
+(rule (
+    (= ?out (Op (cublaslt
+        ?m ?n ?k ?al ?bl ?ao ?bo ?co ?do
+        ?lda ?ldb ?ldc ?ldd ?batch ?sa ?sb ?sc ?sd
+        (F32) (F32) (F32) (F32) "default" "default" ?alpha 0.0 "DEFAULT")
+        (ICons ?ac (ICons ?bc (INil)))))
+    (= ?ac (Op (Cast ?asize (F32)) (ICons ?a (INil))))
+    (= ?bc (Op (Cast ?bsize (F32)) (ICons ?b (INil))))
+    (= (dtype ?a) ?dt) (= (dtype ?b) ?dt)
+    (cublaslt_widenable_dtype ?dt)
+) (
+    (let ?mixed (Op (cublaslt
+        ?m ?n ?k ?al ?bl ?ao ?bo ?co ?do
+        ?lda ?ldb ?ldc ?ldd ?batch ?sa ?sb ?sc ?sd
+        ?dt ?dt (F32) (F32) "32F" "F32" ?alpha 0.0 "DEFAULT")
+        (ICons ?a (ICons ?b (INil)))))
+    (union ?out ?mixed) (set (dtype ?mixed) (F32))
+) :ruleset matmul_backend :name "cublaslt exact widened low-precision operands")
+
+; A final cast may be folded only over the whole canonical output. Never
+; remove a low-precision rounding which occurs BEFORE a pointwise operation.
+(rule (
+    (= ?out (Op (Cast ?size ?dt) (ICons ?mm (INil))))
+    (cublaslt_widenable_dtype ?dt)
+    (= ?mm (Op (cublaslt
+        ?m ?n ?k ?al ?bl ?ao ?bo ?co ?do
+        ?lda ?ldb ?ldc ?ldd ?batch ?sa ?sb ?sc ?sd
+        ?dt ?dt (F32) (F32) "32F" "F32" ?alpha 0.0 "DEFAULT")
+        (ICons ?a (ICons ?b (INil)))))
+    (cublaslt_exact_pointwise_output ?mm ?do ?m ?n ?ldd ?batch ?sd
+        (F32) ?shape ?strides ?zeros ?size)
+) (
+    (let ?narrow (Op (cublaslt
+        ?m ?n ?k ?al ?bl ?ao ?bo ?co ?do
+        ?lda ?ldb ?ldc ?ldd ?batch ?sa ?sb ?sc ?sd
+        ?dt ?dt ?dt ?dt "32F" "F32" ?alpha 0.0 "DEFAULT")
+        (ICons ?a (ICons ?b (INil)))))
+    (union ?out ?narrow) (set (dtype ?narrow) ?dt)
+) :ruleset matmul_backend :name "cublaslt narrow final mixed-precision product")
+
+; The bias is widened from the SAME low-precision dtype as the final output.
+; Recover its storage too, since cuBLASLt's default bias dtype follows D.
+(rule (
+    (= ?out (Op (Cast ?size ?dt) (ICons ?mm (INil))))
+    (cublaslt_widenable_dtype ?dt)
+    (= ?mm (Op (cublaslt
+        ?m ?n ?k ?al ?bl ?ao ?bo ?co ?do
+        ?lda ?ldb ?ldc ?ldd ?batch ?sa ?sb ?sc ?sd
+        ?dt ?dt (F32) (F32) "32F" "F32" ?alpha 0.0 "BIAS")
+        (ICons ?a (ICons ?b (ICons ?bias32 (INil))))))
+    (= ?bias32 (Op (Cast ?bias_size (F32)) (ICons ?bias (INil))))
+    (= (dtype ?bias) ?dt)
+    (cublaslt_exact_pointwise_output ?mm ?do ?m ?n ?ldd ?batch ?sd
+        (F32) ?shape ?strides ?zeros ?size)
+) (
+    (let ?narrow (Op (cublaslt
+        ?m ?n ?k ?al ?bl ?ao ?bo ?co ?do
+        ?lda ?ldb ?ldc ?ldd ?batch ?sa ?sb ?sc ?sd
+        ?dt ?dt ?dt ?dt "32F" "F32" ?alpha 0.0 "BIAS")
+        (ICons ?a (ICons ?b (ICons ?bias (INil))))))
+    (union ?out ?narrow) (set (dtype ?narrow) ?dt)
+) :ruleset matmul_backend :name "cublaslt narrow final mixed-precision affine")

--- a/crates/luminal_cuda_lite/src/host/cublaslt/cublaslt_scale_rewrite.egg
+++ b/crates/luminal_cuda_lite/src/host/cublaslt/cublaslt_scale_rewrite.egg
@@ -1,8 +1,12 @@
+; A pointwise operation after F16/BF16 matmul observes its rounded result.
+; cuBLASLt epilogues/scales run before output conversion, so only F32
+; intermediates may cross this boundary. Keep low-precision rounding explicit.
 ; Scalar alpha/beta rewrites for cuBLASLt. These rules target scalar constants
 ; expanded across the matmul/add shape, i.e. zero strides on every logical axis.
 
 (rule
     (
+        (= ?d_dtype (F32))
         (= ?matmul (Op (cublaslt
             ?m ?n ?k
             ?a_layout ?b_layout
@@ -50,6 +54,7 @@
 
 (rule
     (
+        (= ?d_dtype (F32))
         (= ?matmul (Op (cublaslt
             ?m ?n ?k
             ?a_layout ?b_layout
@@ -97,6 +102,8 @@
 
 (rule
     (
+        (= ?c_dtype (F32))
+        (= ?d_dtype (F32))
         (= ?matmul (Op (cublaslt
             ?m ?n ?k
             ?a_layout ?b_layout
@@ -161,6 +168,8 @@
 
 (rule
     (
+        (= ?c_dtype (F32))
+        (= ?d_dtype (F32))
         (= ?matmul (Op (cublaslt
             ?m ?n ?k
             ?a_layout ?b_layout
@@ -225,6 +234,8 @@
 
 (rule
     (
+        (= ?c_dtype (F32))
+        (= ?d_dtype (F32))
         (= ?matmul (Op (cublaslt
             ?m ?n ?k
             ?a_layout ?b_layout
@@ -289,6 +300,8 @@
 
 (rule
     (
+        (= ?c_dtype (F32))
+        (= ?d_dtype (F32))
         (= ?matmul (Op (cublaslt
             ?m ?n ?k
             ?a_layout ?b_layout

--- a/crates/luminal_cuda_lite/src/host/cublaslt/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/cublaslt/mod.rs
@@ -215,6 +215,7 @@ impl EgglogOp for CuBlasLt {
             Rule::raw(include_str!["cublaslt_CmCm_rewrite.egg"]), // col col
             Rule::raw(include_str!["cublaslt_fp8_rewrite.egg"]),
             Rule::raw(include_str!["cublaslt_output_witness.egg"]),
+            Rule::raw(include_str!["cublaslt_mixed_precision.egg"]),
             Rule::raw(include_str!["cublaslt_scale_rewrite.egg"]),
             Rule::raw(include_str!["cublaslt_beta_rewrite.egg"]),
             Rule::raw(include_str!["cublaslt_epilogue_rewrite.egg"]),

--- a/crates/luminal_cuda_lite/src/host/cublaslt/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/cublaslt/mod.rs
@@ -7,7 +7,7 @@ use half::{bf16, f16};
 use luminal::{
     dtype::DType,
     egglog_utils::{
-        api::{Rule, SortDef, sort},
+        api::{Field, Rule, SortDef, sort},
         base::{DTYPE, EXPRESSION, F64, OP_KIND, STRING},
         extract_dtype, extract_expr,
     },
@@ -57,7 +57,6 @@ fn parse_cublas_op(s: &str) -> cublasOperation_t {
 
 type CuBlasLtResourcePrepareCache = Mutex<Option<(Vec<(Symbol, usize)>, CuBlasLtPrepareKey)>>;
 
-#[derive(Debug)]
 #[allow(dead_code)]
 pub struct CuBlasLt {
     m: Expression,
@@ -89,8 +88,52 @@ pub struct CuBlasLt {
     epilogue: cublasLtEpilogue_t,
     a_scale_input: bool,
     b_scale_input: bool,
+    algorithm_rank: usize,
     cublaslt: OnceLock<Arc<CudaBlasLT>>,
     resource_prepare_cache: CuBlasLtResourcePrepareCache,
+}
+
+// Preserve the canonical default spelling used by saved schedule fingerprints.
+// Every non-default algorithm rank participates in search deduplication.
+impl std::fmt::Debug for CuBlasLt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug = f.debug_struct("CuBlasLt");
+        debug.field("m", &self.m);
+        debug.field("n", &self.n);
+        debug.field("k", &self.k);
+        debug.field("a_layout", &self.a_layout);
+        debug.field("b_layout", &self.b_layout);
+        debug.field("a_order", &self.a_order);
+        debug.field("b_order", &self.b_order);
+        debug.field("c_order", &self.c_order);
+        debug.field("d_order", &self.d_order);
+        debug.field("lda", &self.lda);
+        debug.field("ldb", &self.ldb);
+        debug.field("ldc", &self.ldc);
+        debug.field("ldd", &self.ldd);
+        debug.field("batch_count", &self.batch_count);
+        debug.field("stride_a", &self.stride_a);
+        debug.field("stride_b", &self.stride_b);
+        debug.field("stride_c", &self.stride_c);
+        debug.field("stride_d", &self.stride_d);
+        debug.field("a_dtype", &self.a_dtype);
+        debug.field("b_dtype", &self.b_dtype);
+        debug.field("c_dtype", &self.c_dtype);
+        debug.field("d_dtype", &self.d_dtype);
+        debug.field("compute_type", &self.compute_type);
+        debug.field("scale_dtype", &self.scale_dtype);
+        debug.field("alpha", &self.alpha);
+        debug.field("beta", &self.beta);
+        debug.field("epilogue", &self.epilogue);
+        debug.field("a_scale_input", &self.a_scale_input);
+        debug.field("b_scale_input", &self.b_scale_input);
+        if self.algorithm_rank != 0 {
+            debug.field("algorithm_rank", &self.algorithm_rank);
+        }
+        debug.field("cublaslt", &self.cublaslt);
+        debug.field("resource_prepare_cache", &self.resource_prepare_cache);
+        debug.finish()
+    }
 }
 
 // Useless default for IntoEgglogOp
@@ -126,6 +169,7 @@ impl Default for CuBlasLt {
             epilogue: cublasLtEpilogue_t::CUBLASLT_EPILOGUE_DEFAULT,
             a_scale_input: false,
             b_scale_input: false,
+            algorithm_rank: 0,
             cublaslt: OnceLock::new(),
             resource_prepare_cache: Mutex::new(None),
         }
@@ -229,91 +273,10 @@ impl EgglogOp for CuBlasLt {
         egraph: &'a luminal::egglog_utils::SerializedEGraph,
         kind_children: &[&'a ENodeId],
         input_enodes: Vec<&'a ENodeId>,
-        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        _list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
         expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
     ) -> (LLIROp, Vec<&'a ENodeId>) {
-        // Extract dimensions from egglog
-        let m = extract_expr(egraph, kind_children[0], expr_cache).unwrap();
-        let n = extract_expr(egraph, kind_children[1], expr_cache).unwrap();
-        let k = extract_expr(egraph, kind_children[2], expr_cache).unwrap();
-
-        // Extract transpose/layout strings from egglog
-        let a_layout_str = &egraph.enodes[kind_children[3]].0;
-        let b_layout_str = &egraph.enodes[kind_children[4]].0;
-        let a_layout = parse_cublas_op(a_layout_str);
-        let b_layout = parse_cublas_op(b_layout_str);
-        let a_order = parse_cublaslt_order(&egraph.enodes[kind_children[5]].0);
-        let b_order = parse_cublaslt_order(&egraph.enodes[kind_children[6]].0);
-        let c_order = parse_cublaslt_order(&egraph.enodes[kind_children[7]].0);
-        let d_order = parse_cublaslt_order(&egraph.enodes[kind_children[8]].0);
-
-        // Extract leading dimensions from egglog
-        let lda = extract_expr(egraph, kind_children[9], expr_cache).unwrap();
-        let ldb = extract_expr(egraph, kind_children[10], expr_cache).unwrap();
-        let ldc = extract_expr(egraph, kind_children[11], expr_cache).unwrap();
-        let ldd = extract_expr(egraph, kind_children[12], expr_cache).unwrap();
-
-        // Extract batch parameters
-        let batch_count = extract_expr(egraph, kind_children[13], expr_cache).unwrap();
-        let stride_a = extract_expr(egraph, kind_children[14], expr_cache).unwrap();
-        let stride_b = extract_expr(egraph, kind_children[15], expr_cache).unwrap();
-        let stride_c = extract_expr(egraph, kind_children[16], expr_cache).unwrap();
-        let stride_d = extract_expr(egraph, kind_children[17], expr_cache).unwrap();
-
-        // Extract cuBLASLt type tuple from egglog. Existing rewrites emit the
-        // same dtype for A/B/C/D, but keeping these fields separate lets later
-        // rewrites model mixed-input and mixed-output matmuls without changing
-        // the host launch helper again.
-        let a_dtype = extract_dtype(egraph, kind_children[18]);
-        let b_dtype = extract_dtype(egraph, kind_children[19]);
-        let c_dtype = extract_dtype(egraph, kind_children[20]);
-        let d_dtype = extract_dtype(egraph, kind_children[21]);
-        let compute_type_str = &egraph.enodes[kind_children[22]].0;
-        let scale_dtype_str = &egraph.enodes[kind_children[23]].0;
-        let compute_type = parse_cublaslt_compute_type(compute_type_str, a_dtype);
-        let scale_dtype = parse_cublaslt_scale_dtype(scale_dtype_str, a_dtype);
-        let alpha = parse_cublaslt_scalar(&egraph.enodes[kind_children[24]].0);
-        let beta = parse_cublaslt_scalar(&egraph.enodes[kind_children[25]].0);
-        let epilogue = parse_cublaslt_epilogue(&egraph.enodes[kind_children[26]].0);
-
-        let extracted_state = Self {
-            m,
-            n,
-            k,
-            a_layout,
-            b_layout,
-            a_order,
-            b_order,
-            c_order,
-            d_order,
-            lda,
-            ldb,
-            ldc,
-            ldd,
-            batch_count,
-            stride_a,
-            stride_b,
-            stride_c,
-            stride_d,
-            a_dtype,
-            b_dtype,
-            c_dtype,
-            d_dtype,
-            compute_type,
-            scale_dtype,
-            alpha,
-            beta,
-            epilogue,
-            a_scale_input: false,
-            b_scale_input: false,
-            cublaslt: OnceLock::new(),
-            resource_prepare_cache: Mutex::new(None),
-        };
-        trace!(?extracted_state);
-
-        let extracted = LLIROp::new::<dyn HostOp>(Box::new(extracted_state) as Box<dyn HostOp>);
-
-        (extracted, input_enodes)
+        extract_cublaslt(egraph, kind_children, input_enodes, expr_cache, false)
     }
 
     fn cleanup(&self) -> bool {
@@ -336,85 +299,175 @@ impl EgglogOp for CuBlasLtScaled {
         egraph: &'a luminal::egglog_utils::SerializedEGraph,
         kind_children: &[&'a ENodeId],
         input_enodes: Vec<&'a ENodeId>,
-        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        _list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
         expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
     ) -> (LLIROp, Vec<&'a ENodeId>) {
-        let m = extract_expr(egraph, kind_children[0], expr_cache).unwrap();
-        let n = extract_expr(egraph, kind_children[1], expr_cache).unwrap();
-        let k = extract_expr(egraph, kind_children[2], expr_cache).unwrap();
-
-        let a_layout = parse_cublas_op(&egraph.enodes[kind_children[3]].0);
-        let b_layout = parse_cublas_op(&egraph.enodes[kind_children[4]].0);
-        let a_order = parse_cublaslt_order(&egraph.enodes[kind_children[5]].0);
-        let b_order = parse_cublaslt_order(&egraph.enodes[kind_children[6]].0);
-        let c_order = parse_cublaslt_order(&egraph.enodes[kind_children[7]].0);
-        let d_order = parse_cublaslt_order(&egraph.enodes[kind_children[8]].0);
-
-        let lda = extract_expr(egraph, kind_children[9], expr_cache).unwrap();
-        let ldb = extract_expr(egraph, kind_children[10], expr_cache).unwrap();
-        let ldc = extract_expr(egraph, kind_children[11], expr_cache).unwrap();
-        let ldd = extract_expr(egraph, kind_children[12], expr_cache).unwrap();
-
-        let batch_count = extract_expr(egraph, kind_children[13], expr_cache).unwrap();
-        let stride_a = extract_expr(egraph, kind_children[14], expr_cache).unwrap();
-        let stride_b = extract_expr(egraph, kind_children[15], expr_cache).unwrap();
-        let stride_c = extract_expr(egraph, kind_children[16], expr_cache).unwrap();
-        let stride_d = extract_expr(egraph, kind_children[17], expr_cache).unwrap();
-
-        let a_dtype = extract_dtype(egraph, kind_children[18]);
-        let b_dtype = extract_dtype(egraph, kind_children[19]);
-        let c_dtype = extract_dtype(egraph, kind_children[20]);
-        let d_dtype = extract_dtype(egraph, kind_children[21]);
-        let compute_type_str = &egraph.enodes[kind_children[22]].0;
-        let scale_dtype_str = &egraph.enodes[kind_children[23]].0;
-        let compute_type = parse_cublaslt_compute_type(compute_type_str, a_dtype);
-        let scale_dtype = parse_cublaslt_scale_dtype(scale_dtype_str, a_dtype);
-        let alpha = parse_cublaslt_scalar(&egraph.enodes[kind_children[24]].0);
-        let beta = parse_cublaslt_scalar(&egraph.enodes[kind_children[25]].0);
-        let epilogue = parse_cublaslt_epilogue(&egraph.enodes[kind_children[26]].0);
-
-        let extracted_state = CuBlasLt {
-            m,
-            n,
-            k,
-            a_layout,
-            b_layout,
-            a_order,
-            b_order,
-            c_order,
-            d_order,
-            lda,
-            ldb,
-            ldc,
-            ldd,
-            batch_count,
-            stride_a,
-            stride_b,
-            stride_c,
-            stride_d,
-            a_dtype,
-            b_dtype,
-            c_dtype,
-            d_dtype,
-            compute_type,
-            scale_dtype,
-            alpha,
-            beta,
-            epilogue,
-            a_scale_input: true,
-            b_scale_input: true,
-            cublaslt: OnceLock::new(),
-            resource_prepare_cache: Mutex::new(None),
-        };
-        trace!(?extracted_state);
-
-        let extracted = LLIROp::new::<dyn HostOp>(Box::new(extracted_state) as Box<dyn HostOp>);
-
-        (extracted, input_enodes)
+        extract_cublaslt(egraph, kind_children, input_enodes, expr_cache, true)
     }
 
     fn cleanup(&self) -> bool {
         false
+    }
+}
+
+fn extract_cublaslt<'a>(
+    egraph: &'a SerializedEGraph,
+    kind_children: &[&'a ENodeId],
+    input_enodes: Vec<&'a ENodeId>,
+    expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    scaled: bool,
+) -> (LLIROp, Vec<&'a ENodeId>) {
+    // Extract dimensions from egglog
+    let m = extract_expr(egraph, kind_children[0], expr_cache).unwrap();
+    let n = extract_expr(egraph, kind_children[1], expr_cache).unwrap();
+    let k = extract_expr(egraph, kind_children[2], expr_cache).unwrap();
+
+    // Extract transpose/layout strings from egglog
+    let a_layout_str = &egraph.enodes[kind_children[3]].0;
+    let b_layout_str = &egraph.enodes[kind_children[4]].0;
+    let a_layout = parse_cublas_op(a_layout_str);
+    let b_layout = parse_cublas_op(b_layout_str);
+    let a_order = parse_cublaslt_order(&egraph.enodes[kind_children[5]].0);
+    let b_order = parse_cublaslt_order(&egraph.enodes[kind_children[6]].0);
+    let c_order = parse_cublaslt_order(&egraph.enodes[kind_children[7]].0);
+    let d_order = parse_cublaslt_order(&egraph.enodes[kind_children[8]].0);
+
+    // Extract leading dimensions from egglog
+    let lda = extract_expr(egraph, kind_children[9], expr_cache).unwrap();
+    let ldb = extract_expr(egraph, kind_children[10], expr_cache).unwrap();
+    let ldc = extract_expr(egraph, kind_children[11], expr_cache).unwrap();
+    let ldd = extract_expr(egraph, kind_children[12], expr_cache).unwrap();
+
+    // Extract batch parameters
+    let batch_count = extract_expr(egraph, kind_children[13], expr_cache).unwrap();
+    let stride_a = extract_expr(egraph, kind_children[14], expr_cache).unwrap();
+    let stride_b = extract_expr(egraph, kind_children[15], expr_cache).unwrap();
+    let stride_c = extract_expr(egraph, kind_children[16], expr_cache).unwrap();
+    let stride_d = extract_expr(egraph, kind_children[17], expr_cache).unwrap();
+
+    // Extract cuBLASLt type tuple from egglog. Existing rewrites emit the
+    // same dtype for A/B/C/D, but keeping these fields separate lets later
+    // rewrites model mixed-input and mixed-output matmuls without changing
+    // the host launch helper again.
+    let a_dtype = extract_dtype(egraph, kind_children[18]);
+    let b_dtype = extract_dtype(egraph, kind_children[19]);
+    let c_dtype = extract_dtype(egraph, kind_children[20]);
+    let d_dtype = extract_dtype(egraph, kind_children[21]);
+    let compute_type_str = &egraph.enodes[kind_children[22]].0;
+    let scale_dtype_str = &egraph.enodes[kind_children[23]].0;
+    let compute_type = parse_cublaslt_compute_type(compute_type_str, a_dtype);
+    let scale_dtype = parse_cublaslt_scale_dtype(scale_dtype_str, a_dtype);
+    let alpha = parse_cublaslt_scalar(&egraph.enodes[kind_children[24]].0);
+    let beta = parse_cublaslt_scalar(&egraph.enodes[kind_children[25]].0);
+    let epilogue = parse_cublaslt_epilogue(&egraph.enodes[kind_children[26]].0);
+
+    let extracted_state = CuBlasLt {
+        m,
+        n,
+        k,
+        a_layout,
+        b_layout,
+        a_order,
+        b_order,
+        c_order,
+        d_order,
+        lda,
+        ldb,
+        ldc,
+        ldd,
+        batch_count,
+        stride_a,
+        stride_b,
+        stride_c,
+        stride_d,
+        a_dtype,
+        b_dtype,
+        c_dtype,
+        d_dtype,
+        compute_type,
+        scale_dtype,
+        alpha,
+        beta,
+        epilogue,
+        a_scale_input: scaled,
+        b_scale_input: scaled,
+        algorithm_rank: kind_children.get(27).map_or(0, |rank| {
+            extract_expr(egraph, rank, expr_cache)
+                .unwrap()
+                .to_usize()
+                .expect("constant algorithm rank")
+        }),
+        cublaslt: OnceLock::new(),
+        resource_prepare_cache: Mutex::new(None),
+    };
+    trace!(?extracted_state);
+
+    let extracted = LLIROp::new::<dyn HostOp>(Box::new(extracted_state) as Box<dyn HostOp>);
+
+    (extracted, input_enodes)
+}
+
+const CUBLASLT_ALGORITHM_CHOICES: usize = 16;
+
+/// Ranked legal cuBLASLt algorithms are ordinary compiler-search alternatives.
+/// Each dynamic shape queries its own list; ranks past its end select the last
+/// available algorithm, so a chosen program remains defined across its bucket.
+#[derive(Debug, Default)]
+pub struct CuBlasLtTuned<const SCALED: bool>;
+
+impl<const SCALED: bool> EgglogOp for CuBlasLtTuned<SCALED> {
+    fn sort(&self) -> SortDef {
+        let mut def = cublaslt_sort(if SCALED {
+            "cublaslt_scaled_algorithm"
+        } else {
+            "cublaslt_algorithm"
+        });
+        def.fields.push(Field {
+            name: "algorithm_rank".into(),
+            sort: EXPRESSION.name.into(),
+        });
+        def
+    }
+    fn n_inputs(&self) -> usize {
+        if SCALED { 4 } else { 2 }
+    }
+    fn cleanup(&self) -> bool {
+        false
+    }
+    fn rewrites(&self) -> Vec<Rule> {
+        let base = if SCALED {
+            "cublaslt_scaled"
+        } else {
+            "cublaslt"
+        };
+        let args = cublaslt_sort(base)
+            .fields
+            .iter()
+            .map(|f| format!("?{}", f.name))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let tuned = self.sort().name;
+        (0..CUBLASLT_ALGORITHM_CHOICES)
+            .map(|rank| {
+                Rule::raw(format!(
+                    r#"(rule
+            ((= ?out (Op ({base} {args}) ?inputs)))
+            ((let ?tuned (Op ({tuned} {args} (MNum {rank})) ?inputs))
+             (union ?out ?tuned) (set (dtype ?tuned) ?d_dtype))
+            :ruleset matmul_backend :name "{tuned} rank {rank}")"#
+                ))
+            })
+            .collect()
+    }
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        children: &[&'a ENodeId],
+        inputs: Vec<&'a ENodeId>,
+        _lists: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expressions: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        extract_cublaslt(egraph, children, inputs, expressions, SCALED)
     }
 }
 
@@ -638,9 +691,16 @@ pub(crate) struct LtMatmulSpec {
     d: LtMatrixSpec,
     compute: LtComputeSpec,
     workspace_size: usize,
+    algorithm_rank: usize,
+    alignments: [u32; 4],
 }
 
 impl LtMatmulSpec {
+    fn with_pointers(mut self, ptrs: LtMatmulPointers) -> Self {
+        self.alignments =
+            [ptrs.a, ptrs.b, ptrs.c, ptrs.d].map(|ptr| 1 << ptr.trailing_zeros().min(8));
+        self
+    }
     pub(crate) fn persistent_device_bytes(self) -> usize {
         let scale_bytes = [self.a.dtype, self.b.dtype, self.c.dtype, self.d.dtype]
             .into_iter()
@@ -832,6 +892,15 @@ impl PreparedCuBlasLtMatmul {
         stream: &Arc<CudaStream>,
         ptrs: LtMatmulPointers,
     ) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.spec
+                .with_pointers(ptrs)
+                .alignments
+                .into_iter()
+                .zip(self.spec.alignments)
+                .all(|(actual, required)| actual >= required),
+            "cuBLASLt pointer alignment changed after preparation"
+        );
         self.update_descriptor_pointers(stream, ptrs)?;
         let alpha_ptr = self.spec.compute.alpha.as_ptr();
         let beta_ptr = self.spec.compute.beta.as_ptr();
@@ -1148,14 +1217,12 @@ pub(crate) fn prepare_cublaslt_matmul_with_workspace(
             .find(|(cached_spec, _)| cached_spec == spec)
             .map(|(_, heuristic)| unsafe { std::ptr::read(heuristic) })
     };
-    const AUTOTUNE_CANDIDATES: usize = 16;
-    let mut candidates: Vec<cublasLtMatmulHeuristicResult_t> = Vec::new();
     let from_cache = cached_heuristic.is_some();
     if let Some(cached) = cached_heuristic {
         heuristic = cached;
     } else {
         let mut algo_count: i32 = 0;
-        let mut results: [cublasLtMatmulHeuristicResult_t; AUTOTUNE_CANDIDATES] =
+        let mut results: [cublasLtMatmulHeuristicResult_t; CUBLASLT_ALGORITHM_CHOICES] =
             unsafe { std::mem::zeroed() };
         unsafe {
             cublasLtMatmulPreferenceCreate(&mut resources.preference).result()?;
@@ -1167,6 +1234,34 @@ pub(crate) fn prepare_cublaslt_matmul_with_workspace(
             )
             .result()?;
 
+            // Match actual buffer alignment and preserve compute-precision
+            // partial sums before the final output conversion.
+            for (attr, alignment) in [
+                cublasLtMatmulPreferenceAttributes_t::CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_A_BYTES,
+                cublasLtMatmulPreferenceAttributes_t::CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_B_BYTES,
+                cublasLtMatmulPreferenceAttributes_t::CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_C_BYTES,
+                cublasLtMatmulPreferenceAttributes_t::CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_D_BYTES,
+            ]
+            .into_iter()
+            .zip(spec.alignments)
+            {
+                cublasLtMatmulPreferenceSetAttribute(
+                    resources.preference,
+                    attr,
+                    &alignment as *const _ as *const std::ffi::c_void,
+                    std::mem::size_of::<u32>(),
+                )
+                .result()?;
+            }
+            let reduction: u32 = 2; // CUBLASLT_REDUCTION_SCHEME_COMPUTE_TYPE; NONE is always allowed.
+            cublasLtMatmulPreferenceSetAttribute(
+                resources.preference,
+                cublasLtMatmulPreferenceAttributes_t::CUBLASLT_MATMUL_PREF_REDUCTION_SCHEME_MASK,
+                &reduction as *const _ as *const std::ffi::c_void,
+                std::mem::size_of::<u32>(),
+            )
+            .result()?;
+
             cublasLtMatmulAlgoGetHeuristic(
                 *cublaslt.handle(),
                 resources.matmul_desc,
@@ -1175,7 +1270,7 @@ pub(crate) fn prepare_cublaslt_matmul_with_workspace(
                 resources.c_desc,
                 resources.d_desc,
                 resources.preference,
-                AUTOTUNE_CANDIDATES as i32,
+                CUBLASLT_ALGORITHM_CHOICES as i32,
                 results.as_mut_ptr(),
                 &mut algo_count,
             )
@@ -1185,20 +1280,14 @@ pub(crate) fn prepare_cublaslt_matmul_with_workspace(
                 return Err(anyhow::anyhow!("No suitable cuBLASLT algorithm found"));
             }
         }
-        candidates.extend_from_slice(&results[..algo_count as usize]);
-        heuristic = candidates[0];
+        heuristic = results[spec.algorithm_rank.min(algo_count as usize - 1)];
     }
     // The preference's workspace limit controls which algorithms cuBLASLt may
     // return; it is not the amount selected algorithm actually needs. Allocate
     // only that algorithm's requirement. Most Llama GEMM/GEMV choices need no
     // workspace, so allocating the full 32 MiB limit here was the dominant
     // cold graph-construction cost.
-    let should_autotune = !from_cache && candidates.len() > 1 && autotune_allowed(stream, ptrs);
-    let required_workspace_bytes = if should_autotune {
-        spec.workspace_size
-    } else {
-        heuristic.workspaceSize
-    };
+    let required_workspace_bytes = heuristic.workspaceSize;
     let workspace = match recycled_workspace {
         Some(workspace) if workspace.len() >= required_workspace_bytes => workspace,
         _ if required_workspace_bytes == 0 => Arc::new(stream.null::<u8>()?),
@@ -1206,7 +1295,7 @@ pub(crate) fn prepare_cublaslt_matmul_with_workspace(
     };
     let (workspace_ptr, workspace_guard) = workspace.device_ptr(stream);
     drop(workspace_guard);
-    let mut prepared = PreparedCuBlasLtMatmul {
+    let prepared = PreparedCuBlasLtMatmul {
         cublaslt: cublaslt.clone(),
         spec: *spec,
         resources,
@@ -1222,11 +1311,6 @@ pub(crate) fn prepare_cublaslt_matmul_with_workspace(
     };
 
     if !from_cache {
-        if should_autotune
-            && let Some(best) = autotune_select(stream, &mut prepared, &candidates, ptrs)
-        {
-            prepared.heuristic = best;
-        }
         heuristic_cache
             .lock()
             .unwrap()
@@ -1234,93 +1318,6 @@ pub(crate) fn prepare_cublaslt_matmul_with_workspace(
     }
 
     Ok(prepared)
-}
-
-/// Autotuning launches real matmuls, which is only safe when the stream is
-/// not mid-capture (the benchmark kernels would be recorded into the graph)
-/// and the operand pointers are live.
-fn autotune_allowed(stream: &Arc<CudaStream>, ptrs: LtMatmulPointers) -> bool {
-    // Opt-in: measured on Llama 3 8B decode, the heuristic's first choice was
-    // already within noise of the benchmarked best (the GEMV slack is fixed
-    // per-launch cost, not algorithm choice), while the one-time benchmark
-    // sweep added ~60ms to first-step latency.
-    if std::env::var_os("LUMINAL_CUBLASLT_AUTOTUNE").is_none_or(|v| v != "1") {
-        return false;
-    }
-    if ptrs.a == 0 || ptrs.b == 0 || ptrs.d == 0 {
-        return false;
-    }
-    let mut status = cudarc::driver::sys::CUstreamCaptureStatus::CU_STREAM_CAPTURE_STATUS_NONE;
-    let ok = unsafe {
-        cudarc::driver::sys::cuStreamIsCapturing(stream.cu_stream(), &mut status)
-            == cudarc::driver::sys::CUresult::CUDA_SUCCESS
-    };
-    ok && status == cudarc::driver::sys::CUstreamCaptureStatus::CU_STREAM_CAPTURE_STATUS_NONE
-}
-
-/// Benchmark each heuristic candidate with the real operands and return the
-/// fastest. The D buffer is scratch from the runtime's perspective (it is
-/// rewritten every step), so benchmarking writes are harmless. Runs once per
-/// `LtMatmulSpec` (results are cached by the caller).
-fn autotune_select(
-    stream: &Arc<CudaStream>,
-    prepared: &mut PreparedCuBlasLtMatmul,
-    candidates: &[cublasLtMatmulHeuristicResult_t],
-    ptrs: LtMatmulPointers,
-) -> Option<cublasLtMatmulHeuristicResult_t> {
-    const REPS: usize = 16;
-    let log = std::env::var_os("LUMINAL_CUBLASLT_AUTOTUNE_LOG").is_some_and(|v| v == "1");
-    let timing_flags = Some(crate::cudarc::driver::sys::CUevent_flags::CU_EVENT_DEFAULT);
-    let start = stream.context().new_event(timing_flags).ok()?;
-    let end = stream.context().new_event(timing_flags).ok()?;
-    let mut best: Option<(f32, usize)> = None;
-    for (idx, candidate) in candidates.iter().enumerate() {
-        prepared.heuristic = unsafe { std::ptr::read(candidate) };
-        // Warmup + validity check: a candidate may fail at execution.
-        if prepared.enqueue(stream, ptrs).is_err() {
-            continue;
-        }
-        if stream.synchronize().is_err() {
-            return None;
-        }
-        if start.record(stream).is_err() {
-            return None;
-        }
-        let mut failed = false;
-        for _ in 0..REPS {
-            if prepared.enqueue(stream, ptrs).is_err() {
-                failed = true;
-                break;
-            }
-        }
-        if failed || end.record(stream).is_err() || end.synchronize().is_err() {
-            continue;
-        }
-        let Ok(elapsed_ms) = start.elapsed_ms(&end) else {
-            continue;
-        };
-        let elapsed_us = elapsed_ms * 1_000.0 / REPS as f32;
-        if log {
-            eprintln!(
-                "CUBLASLT_AUTOTUNE m={} n={} k={} candidate={} workspace={} elapsed_us={elapsed_us:.6}",
-                prepared.spec.problem.m,
-                prepared.spec.problem.n,
-                prepared.spec.problem.k,
-                idx,
-                candidate.workspaceSize,
-            );
-        }
-        if best.is_none_or(|(b, _)| elapsed_us < b) {
-            best = Some((elapsed_us, idx));
-        }
-    }
-    if log && let Some((elapsed_us, idx)) = best {
-        eprintln!(
-            "CUBLASLT_AUTOTUNE_SELECTED m={} n={} k={} candidate={} elapsed_us={elapsed_us:.6}",
-            prepared.spec.problem.m, prepared.spec.problem.n, prepared.spec.problem.k, idx,
-        );
-    }
-    best.map(|(_, idx)| unsafe { std::ptr::read(&candidates[idx]) })
 }
 
 fn run_cublaslt_matmul(
@@ -1377,6 +1374,8 @@ pub(crate) fn cublaslt_graph_capture_supported(stream: &Arc<CudaStream>) -> bool
                 epilogue: cublasLtEpilogue_t::CUBLASLT_EPILOGUE_DEFAULT,
             },
             workspace_size: 1024 * 1024,
+            algorithm_rank: 0,
+            alignments: [256; 4],
         };
         let ptrs = LtMatmulPointers {
             a,
@@ -1618,6 +1617,8 @@ impl CuBlasLt {
                 epilogue: self.epilogue,
             },
             workspace_size: Self::WORKSPACE_SIZE_BYTES,
+            algorithm_rank: self.algorithm_rank,
+            alignments: [256; 4],
         })
     }
 
@@ -1725,7 +1726,10 @@ impl CuBlasLt {
         )
         .entered();
 
-        Ok(CuBlasLtResolvedGraphCall { spec, ptrs })
+        Ok(CuBlasLtResolvedGraphCall {
+            spec: spec.with_pointers(ptrs),
+            ptrs,
+        })
     }
 
     pub(crate) fn prepare_resolved_for_graph_with_workspace(
@@ -1841,7 +1845,7 @@ impl HostOp for CuBlasLt {
 
         let cublaslt = self.get_cublaslt(stream)?;
 
-        run_cublaslt_matmul(stream, &cublaslt, &spec, ptrs)?;
+        run_cublaslt_matmul(stream, &cublaslt, &spec.with_pointers(ptrs), ptrs)?;
 
         // No stream.synchronize() here — CUDA stream ordering guarantees
         // sequential execution. The runtime syncs once at the end of execute().
@@ -2231,3 +2235,6 @@ mod tests {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod algorithm_tests;

--- a/crates/luminal_cuda_lite/src/host/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/mod.rs
@@ -181,7 +181,38 @@ impl DeviceBuffer {
 /// Host operations that execute on the CPU but orchestrate GPU work.
 ///
 /// This includes operations like cuBLAS calls and CUDA graph executions.
+/// Backend-owned snapshot for an opaque operation's semantic state. RNG state
+/// can use this hook when it cannot be represented as ordinary graph inputs.
+pub trait ProfileState {
+    fn restore(&self, stream: &Arc<CudaStream>) -> anyhow::Result<()>;
+}
+impl ProfileState for () {
+    fn restore(&self, _: &Arc<CudaStream>) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
 pub trait HostOp: Debug + as_any::AsAny + EgglogOp {
+    /// Snapshot semantic state hidden outside graph buffers before representative
+    /// profiling. The snapshot restores identical state before each trial and
+    /// after candidate evaluation, including failure. The default declares all
+    /// semantic state explicit in graph tensors; caches/scratch overwritten by
+    /// execution need no snapshot. Stateful custom ops must implement this hook
+    /// or return an error when replay is unsupported.
+    fn capture_profile_state(
+        &self,
+        _stream: &Arc<CudaStream>,
+    ) -> anyhow::Result<Box<dyn ProfileState>> {
+        Ok(Box::new(()))
+    }
+
+    /// Graph inputs this operation may modify, indexed in data-input order.
+    /// The default declares inputs read-only. Custom mutating HostOps must list
+    /// their writes so representative replay can protect shared read-only inputs.
+    fn profile_mutated_inputs(&self) -> Vec<usize> {
+        vec![]
+    }
+
     /// Execute the operation with access to buffers via a map.
     ///
     /// # Arguments

--- a/crates/luminal_cuda_lite/src/host/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/mod.rs
@@ -110,6 +110,7 @@ pub struct DeviceBuffer {
     capacity: usize,
     host_ptr: u64,
     host_len: usize,
+    input_format: Option<&'static str>,
 }
 
 impl DeviceBuffer {
@@ -120,6 +121,7 @@ impl DeviceBuffer {
             capacity: len,
             host_ptr: 0,
             host_len: 0,
+            input_format: None,
         }
     }
 
@@ -130,6 +132,16 @@ impl DeviceBuffer {
         self.host_ptr = bytes.as_ptr() as u64;
         self.host_len = bytes.len();
         self
+    }
+
+    pub(crate) fn with_input_format(mut self, format: &'static str) -> Self {
+        self.input_format = Some(format);
+        self
+    }
+
+    /// Explicit physical ABI attached to a prepared, read-only input.
+    pub fn input_format(self) -> Option<&'static str> {
+        self.input_format
     }
 
     pub fn ptr(self) -> u64 {

--- a/crates/luminal_cuda_lite/src/host/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/mod.rs
@@ -17,6 +17,8 @@ pub mod workspace;
 pub type BaseOps = (
     cublaslt::CuBlasLt,
     cublaslt::CuBlasLtScaled,
+    cublaslt::CuBlasLtTuned<false>,
+    cublaslt::CuBlasLtTuned<true>,
     moe::GLUMoE,
     flashinfer::FlashInferAttention,
 );

--- a/crates/luminal_cuda_lite/src/host/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/mod.rs
@@ -9,6 +9,7 @@ use luminal::{op::EgglogOp, prelude::*};
 pub(crate) mod cublaslt;
 pub mod flashinfer;
 pub mod moe;
+pub mod workspace;
 
 /// Generic host operations shared unchanged by Lite and CUDA supersets.
 /// Hardware- or model-specialized attention operations belong to the
@@ -192,6 +193,11 @@ impl ProfileState for () {
     }
 }
 
+/// Allocation owners pinned by one captured graph generation. Implementations
+/// allocate on the supplied execution stream (not a temporary capture stream)
+/// and return every owner whose raw address is recorded in the graph.
+pub type CudaGraphCaptureResources = Vec<Arc<dyn std::any::Any + Send + Sync>>;
+
 pub trait HostOp: Debug + as_any::AsAny + EgglogOp {
     /// Snapshot semantic state hidden outside graph buffers before representative
     /// profiling. The snapshot restores identical state before each trial and
@@ -319,6 +325,22 @@ pub trait HostOp: Debug + as_any::AsAny + EgglogOp {
         _dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
         anyhow::bail!("HostOp did not implement CUDA graph capture preparation")
+    }
+
+    /// Prepare a child capture and transfer ownership of its scratch to that
+    /// graph generation. Resident variants retain independent owners, including
+    /// old allocations after growth. The default preserves existing HostOps.
+    fn prepare_cuda_graph_capture_resources(
+        &self,
+        capture_stream: &Arc<CudaStream>,
+        _execution_stream: &Arc<CudaStream>,
+        self_node: NodeIndex,
+        inputs: &[NodeIndex],
+        buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
+        dyn_map: &DynMap,
+    ) -> anyhow::Result<CudaGraphCaptureResources> {
+        self.prepare_cuda_graph_capture(capture_stream, self_node, inputs, buffers, dyn_map)?;
+        Ok(vec![])
     }
 
     /// Refresh execution-specific metadata immediately before launching a

--- a/crates/luminal_cuda_lite/src/host/workspace.rs
+++ b/crates/luminal_cuda_lite/src/host/workspace.rs
@@ -1,0 +1,156 @@
+//! Share scratch within an ordered capture stream without making its lifetime
+//! process-global. Owners retain immutable allocation generations; cache entries
+//! are weak, so replacing or retiring a graph releases its unreferenced storage.
+
+use cudarc::driver::{CudaSlice, CudaStream, DevicePtr, sys::CUstreamCaptureStatus};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex, OnceLock, Weak},
+};
+
+#[derive(Debug)]
+pub struct Workspace {
+    allocation: CudaSlice<u8>,
+    ptr: u64,
+    execution_stream: usize,
+}
+impl Workspace {
+    pub fn ptr(&self) -> u64 {
+        self.ptr
+    }
+    pub fn allocation(&self) -> &CudaSlice<u8> {
+        &self.allocation
+    }
+}
+
+type WorkspaceEntries = HashMap<(usize, usize), Weak<Workspace>>;
+
+#[derive(Debug, Default)]
+pub struct WorkspaceCache {
+    entries: OnceLock<Mutex<WorkspaceEntries>>,
+}
+impl WorkspaceCache {
+    pub const fn new() -> Self {
+        Self {
+            entries: OnceLock::new(),
+        }
+    }
+
+    /// `ordered_stream` identifies scratch reuse. Allocate on the stream that
+    /// will EXECUTE the graph, which may differ from its recording stream, so
+    /// dropping the last owner enqueues a free after that graph's pending work.
+    /// Every graph must retain the returned owner for its complete lifetime.
+    /// Growth creates a new allocation; older captured pointers remain valid.
+    pub fn acquire(
+        &self,
+        ordered_stream: &Arc<CudaStream>,
+        execution_stream: &Arc<CudaStream>,
+        bytes: usize,
+    ) -> anyhow::Result<Arc<Workspace>> {
+        anyhow::ensure!(
+            ordered_stream.context().cu_ctx() == execution_stream.context().cu_ctx(),
+            "workspace streams belong to different CUDA contexts"
+        );
+        let key = (
+            ordered_stream.context().cu_ctx() as usize,
+            ordered_stream.cu_stream() as usize,
+        );
+        let mut cache = self
+            .entries
+            .get_or_init(|| Mutex::new(HashMap::new()))
+            .lock()
+            .expect("workspace cache poisoned");
+        cache.retain(|_, entry| entry.strong_count() != 0);
+        if let Some(existing) = cache.get(&key).and_then(Weak::upgrade)
+            && existing.allocation.len() >= bytes.max(1)
+            && existing.execution_stream == execution_stream.cu_stream() as usize
+        {
+            return Ok(existing);
+        }
+        anyhow::ensure!(
+            ordered_stream.capture_status()?
+                == CUstreamCaptureStatus::CU_STREAM_CAPTURE_STATUS_NONE,
+            "workspace must be prepared before capture"
+        );
+        let allocation = unsafe { execution_stream.alloc::<u8>(bytes.max(1))? };
+        let ptr = allocation.device_ptr(execution_stream).0;
+        let workspace = Arc::new(Workspace {
+            allocation,
+            ptr,
+            execution_stream: execution_stream.cu_stream() as usize,
+        });
+        cache.insert(key, Arc::downgrade(&workspace));
+        Ok(workspace)
+    }
+    /// Resolve an already-owned allocation while recording a graph. This never
+    /// allocates and must not outlive the owner's captured graph generation.
+    pub fn prepared(
+        &self,
+        stream: &Arc<CudaStream>,
+        bytes: usize,
+    ) -> anyhow::Result<Arc<Workspace>> {
+        let key = (
+            stream.context().cu_ctx() as usize,
+            stream.cu_stream() as usize,
+        );
+        let workspace = self.entries.get().and_then(|entries| {
+            entries
+                .lock()
+                .expect("workspace cache poisoned")
+                .get(&key)
+                .and_then(Weak::upgrade)
+        });
+        workspace
+            .filter(|w| w.allocation.len() >= bytes.max(1))
+            .ok_or_else(|| anyhow::anyhow!("workspace must have a live owner before capture"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cudarc::driver::CudaContext;
+
+    #[test]
+    fn cache_is_weak_and_growth_preserves_owned_generations() {
+        let context = CudaContext::new(0).unwrap();
+        let capture = context.new_stream().unwrap();
+        let execution = context.new_stream().unwrap();
+        let other = context.new_stream().unwrap();
+        let cache = WorkspaceCache::new();
+        let first = cache.acquire(&capture, &execution, 64).unwrap();
+        let again = cache.acquire(&capture, &execution, 32).unwrap();
+        assert!(Arc::ptr_eq(&first, &again));
+        unsafe {
+            cudarc::driver::result::memcpy_htod_sync(first.ptr(), &[23u8; 64]).unwrap();
+        }
+        let grown = cache.acquire(&capture, &execution, 1024).unwrap();
+        assert_ne!(first.ptr(), grown.ptr());
+        assert_eq!(
+            execution.clone_dtoh(first.allocation()).unwrap(),
+            vec![23; 64]
+        );
+        let distinct = cache.acquire(&capture, &other, 1024).unwrap();
+        assert_ne!(
+            grown.ptr(),
+            distinct.ptr(),
+            "unordered execution streams share scratch"
+        );
+        let weak = [
+            Arc::downgrade(&first),
+            Arc::downgrade(&grown),
+            Arc::downgrade(&distinct),
+        ];
+        drop((first, again, grown, distinct));
+        execution.synchronize().unwrap();
+        other.synchronize().unwrap();
+        assert!(weak.iter().all(|w| w.upgrade().is_none()));
+        assert!(cache.prepared(&capture, 1).is_err());
+        let stream_weak = Arc::downgrade(&execution);
+        drop(execution);
+        assert!(
+            stream_weak.upgrade().is_none(),
+            "cache roots retired streams"
+        );
+    }
+}

--- a/crates/luminal_cuda_lite/src/kernel/cuda_graph.rs
+++ b/crates/luminal_cuda_lite/src/kernel/cuda_graph.rs
@@ -129,6 +129,57 @@ impl CudaGraphHandle {
     }
 
     /// Adds an empty dependency node to the graph.
+    pub(crate) unsafe fn add_device_copy(
+        &mut self,
+        dependencies: &[CUgraphNode],
+        destination: u64,
+        source: u64,
+        bytes: usize,
+    ) -> Result<CUgraphNode, DriverError> {
+        self.ctx.bind_to_thread()?;
+        let params = sys::CUDA_MEMCPY3D {
+            srcXInBytes: 0,
+            srcY: 0,
+            srcZ: 0,
+            srcLOD: 0,
+            srcMemoryType: sys::CUmemorytype::CU_MEMORYTYPE_DEVICE,
+            srcHost: std::ptr::null(),
+            srcArray: std::ptr::null_mut(),
+            reserved0: std::ptr::null_mut(),
+            srcHeight: 0,
+            srcDevice: source,
+            srcPitch: bytes,
+            dstXInBytes: 0,
+            dstY: 0,
+            dstZ: 0,
+            dstLOD: 0,
+            dstMemoryType: sys::CUmemorytype::CU_MEMORYTYPE_DEVICE,
+            dstHost: std::ptr::null_mut(),
+            dstArray: std::ptr::null_mut(),
+            reserved1: std::ptr::null_mut(),
+            dstHeight: 0,
+            dstDevice: destination,
+            dstPitch: bytes,
+            WidthInBytes: bytes,
+            Height: 1,
+            Depth: 1,
+        };
+        let mut node = MaybeUninit::uninit();
+        unsafe {
+            sys::cuGraphAddMemcpyNode(
+                node.as_mut_ptr(),
+                self.cu_graph,
+                dependencies.as_ptr(),
+                dependencies.len(),
+                &params,
+                self.ctx.cu_ctx(),
+            )
+            .result()?;
+            Ok(node.assume_init())
+        }
+    }
+
+    /// Adds an empty dependency node to the graph.
     pub fn add_empty_node(
         &mut self,
         dependencies: &[CUgraphNode],

--- a/crates/luminal_cuda_lite/src/kernel/fusion/elementwise.rs
+++ b/crates/luminal_cuda_lite/src/kernel/fusion/elementwise.rs
@@ -65,6 +65,10 @@ impl EgglogOp for CudaUnaryElementwise {
         1
     }
 
+    fn egglog_declarations(&self) -> Vec<String> {
+        vec!["(relation cuda_cast_grid (IR EList EList))".into()]
+    }
+
     fn rewrites(&self) -> Vec<Rule> {
         let mut rules = Vec::new();
         for (hlir, opcode) in [
@@ -118,6 +122,47 @@ impl EgglogOp for CudaUnaryElementwise {
                 (union ?cast ?fe)
                 (set (dtype ?fe) ?dt_out)
              ) :ruleset kernel_lower :name \"cuda-elem-singleton-Cast\")",
+        ));
+
+        // A Cast describes a flat buffer, while its neighbours may describe
+        // the same buffer with several axes. Offer the cast in that grid only
+        // when it spans the whole buffer in row-major order. Keep every cast
+        // and its rounding; no numerical conversion is cancelled here.
+        for (name, boundary) in [
+            (
+                "producer",
+                "(= ?x (Op (FusionEnd ?shape ?stride ?dt) ?inputs))",
+            ),
+            (
+                "consumer",
+                "(= ?boundary (Op (FusionStart ?shape ?stride ?out_dt) (ICons ?cast (INil))))",
+            ),
+        ] {
+            rules.push(Rule::raw(format!(
+                "(rule (
+                    (= ?cast (Op (Cast ?size ?out_dt) (ICons ?x (INil))))
+                    {boundary}
+                 ) (
+                    (cuda_cast_grid ?cast ?shape ?stride)
+                    (let ?row_major (RowMajor ?shape))
+                 ) :ruleset kernel_lower :name \"cuda-cast-grid-{name}\")"
+            )));
+        }
+        rules.push(Rule::raw(
+            "(rule (
+                (cuda_cast_grid ?cast ?shape ?stride)
+                (= ?cast (Op (Cast ?size ?dt_out) (ICons ?x (INil))))
+                (= ?stride (RowMajor ?shape))
+                (= ?size (n_elements ?shape))
+                (= ?dt_in (dtype ?x))
+             ) (
+                (let ?fs (Op (FusionStart ?shape ?stride ?dt_in) (ICons ?x (INil))))
+                (let ?elem (Op (CudaUnaryElementwise \"Cast\" ?shape ?stride ?stride ?dt_out)
+                               (ICons ?fs (INil))))
+                (let ?fe (Op (FusionEnd ?shape ?stride ?dt_out) (ICons ?elem (INil))))
+                (union ?cast ?fe)
+                (set (dtype ?fe) ?dt_out)
+             ) :ruleset kernel_lower :name \"cuda-cast-row-major-grid\")",
         ));
 
         rules

--- a/crates/luminal_cuda_lite/src/kernel/fusion/markers.rs
+++ b/crates/luminal_cuda_lite/src/kernel/fusion/markers.rs
@@ -166,8 +166,9 @@ impl EgglogOp for FusionEnd {
         // versus absorbed partition.  Subsumption removes that spelling from
         // both future matching and extraction, so each boundary is fused once
         // and the e-graph retains only the canonical absorbed representation.
-        vec![Rule::raw(
-            "(rule (
+        vec![
+            Rule::raw(
+                "(rule (
                 (= ?producer_fe
                    (Op (FusionEnd ?shape ?stride ?dt) (ICons ?producer_inner (INil))))
                 (= ?boundary
@@ -178,7 +179,26 @@ impl EgglogOp for FusionEnd {
                     (Op (FusionStart ?shape ?stride ?dt) (ICons ?producer_fe (INil))))
              ) :ruleset fusion_inline_safe_late
                 :name \"inline-safe-FE-through-FS\")",
-        )]
+            ),
+            // A materialized cast is pointwise in storage order. Reading any
+            // broadcast, sliced or permuted view of it equals casting the source
+            // at that same address. Preserve the conversion as a region-local op;
+            // never cancel rounding or commute another operation through a view.
+            // Retain the original strided read so measured search can compare
+            // materialization with duplicated conversion work under fanout, and
+            // existing selected schedules remain valid seeds.
+            Rule::raw(
+                "(rule (
+                (= ?cast (Op (KernelCast ?size ?in_dt ?out_dt) (ICons ?x (INil))))
+                (= ?boundary (Op (FusionStart ?shape ?stride ?out_dt) (ICons ?cast (INil))))
+             ) (
+                (let ?source (Op (FusionStart ?shape ?stride ?in_dt) (ICons ?x (INil))))
+                (let ?inner (Op (CudaUnaryElementwise \"Cast\" ?shape ?stride ?stride ?out_dt)
+                                (ICons ?source (INil))))
+                (union ?boundary ?inner)
+             ) :ruleset fusion_inline_safe_late :name \"inline-cast-through-strided-read\")",
+            ),
+        ]
     }
 
     fn cleanup(&self) -> bool {

--- a/crates/luminal_cuda_lite/src/kernel/gemv.rs
+++ b/crates/luminal_cuda_lite/src/kernel/gemv.rs
@@ -1,14 +1,11 @@
-//! Warp-per-row GEMV for M=1 decode matmuls.
+//! Cooperative GEMV for single-row matmuls.
 //!
 //! Matches the same row-major × column-major `GenericMatmul` pattern as the
 //! cuBLASLt RmCm rewrite, restricted to m == 1 and 16-bit dtypes, and unions
 //! a lean kernel into the same eclass — measured search then chooses among
 //! cuBLASLt, GenericMatmul, the lowered reduction, and this kernel per shape.
-//! Rationale (measured on Llama 3 8B decode): the nvjet GEMV
-//! kernels carry ~5µs of fixed launch/tail cost per call, which dominates the
-//! small projections (o-proj: 13.2µs vs an 8.3µs traffic floor). One warp per
-//! output row with vectorized 16-byte loads and F32 accumulation has ~1µs of
-//! fixed cost and no splitK reduction pass.
+//! Search varies rows per block and cooperative warps per output row. Each
+//! choice reduces locally in F32 without a separate reduction kernel.
 
 use std::sync::Arc;
 
@@ -29,12 +26,90 @@ use luminal::{
     prelude::*,
 };
 
+/// Searchable (output rows per block, cooperative warps per row) geometries.
+pub fn gemv_launch_choices() -> impl Iterator<Item = (usize, usize)> {
+    [1, 2, 4, 8].into_iter().flat_map(|rows| {
+        [1, 2, 4, 8]
+            .into_iter()
+            .filter_map(move |warps| (rows * warps <= 32).then_some((rows, warps)))
+    })
+}
+
+/// Shared single-row matrix product codegen. `store` consumes F32 `acc` and
+/// valid `row` on one lane; callers supply the graph's output rounding/epilogue.
+pub fn gemv_body(
+    n: Expression,
+    k: Expression,
+    dtype: DType,
+    rows: usize,
+    warps: usize,
+    store: &str,
+) -> String {
+    assert!(matches!(dtype, DType::Bf16 | DType::F16));
+    assert!(gemv_launch_choices().any(|choice| choice == (rows, warps)));
+    let ty = cuda_dtype(dtype);
+    let vectorized = k.to_usize().is_some_and(|k| k % 8 == 0);
+    let (n, k) = (n.to_kernel(), k.to_kernel());
+    let dot = if vectorized {
+        format!(
+            r#"
+            const uint4* xr = (const uint4*)x;
+            const uint4* wr = (const uint4*)(w + row * ({k}));
+            for (long long c = split * 32 + lane; c < ({k}) / 8; c += 32 * {warps}) {{
+                uint4 xv = xr[c], wv = wr[c];
+                const {ty}* xe = (const {ty}*)&xv;
+                const {ty}* we = (const {ty}*)&wv;
+                #pragma unroll
+                for (int e = 0; e < 8; e++) acc += (float)xe[e] * (float)we[e];
+            }}"#
+        )
+    } else {
+        format!(
+            r#"
+            const {ty}* wr = w + row * ({k});
+            for (long long i = split * 32 + lane; i < ({k}); i += 32 * {warps}) {{
+                acc += (float)x[i] * (float)wr[i];
+            }}"#
+        )
+    };
+    let reduce_store = if warps == 1 {
+        format!("if (lane == 0 && row < ({n})) {{ {store} }}")
+    } else {
+        format!(
+            r#"
+        __shared__ float partial[{rows} * {warps}];
+        if (lane == 0) partial[warp] = acc;
+        // Tail rows must reach this barrier too, even when they have no dot.
+        __syncthreads();
+        if (split == 0 && lane == 0 && row < ({n})) {{
+            acc = partial[(warp / {warps}) * {warps}];
+            #pragma unroll
+            for (int i = 1; i < {warps}; i++) acc += partial[(warp / {warps}) * {warps} + i];
+            {store}
+        }}"#
+        )
+    };
+    format!(
+        r#"
+        int lane = threadIdx.x & 31;
+        int warp = threadIdx.x >> 5;
+        int split = warp % {warps};
+        long long row = (long long)blockIdx.x * {rows} + warp / {warps};
+        float acc = 0.0f;
+        if (row < ({n})) {{ {dot} }}
+        #pragma unroll
+        for (int s = 16; s > 0; s /= 2) acc += __shfl_down_sync(0xffffffff, acc, s);
+        {reduce_store}"#
+    )
+}
+
 #[derive(Default, Debug, Clone)]
 pub struct KernelGemv {
     n: Expression,
     k: Expression,
     dtype: DType,
-    warps_per_block: usize,
+    rows_per_block: usize,
+    warps_per_row: usize,
 }
 
 impl EgglogOp for KernelGemv {
@@ -46,7 +121,8 @@ impl EgglogOp for KernelGemv {
                 ("n", EXPRESSION),
                 ("k", EXPRESSION),
                 ("dtype", DTYPE),
-                ("warps_per_block", EXPRESSION),
+                ("rows_per_block", EXPRESSION),
+                ("warps_per_row", EXPRESSION),
             ],
         )
     }
@@ -124,7 +200,7 @@ impl EgglogOp for KernelGemv {
                             (= ?dt ({dt}))
                         )
                         (
-                            (let ?gemv (Op (KernelGemv ?n ?k ({dt}) (MNum 8)) (ICons ?a (ICons ?b (INil)))))
+                            (let ?gemv (Op (KernelGemv ?n ?k ({dt}) (MNum 8) (MNum 1)) (ICons ?a (ICons ?b (INil)))))
                             (union ?sum ?gemv)
                             (set (dtype ?gemv) ({dt}))
                         )
@@ -133,16 +209,16 @@ impl EgglogOp for KernelGemv {
                     )"
                 ))
             })
-            .chain([1, 2, 4].map(|warps| Rule::raw(format!(
+            .chain(gemv_launch_choices().filter(|&(rows, warps)| (rows, warps) != (8, 1)).map(|(rows, warps)| Rule::raw(format!(
                 "(rule
-                    ((= ?out (Op (KernelGemv ?n ?k ?dt (MNum 8)) ?inputs)))
+                    ((= ?out (Op (KernelGemv ?n ?k ?dt (MNum 8) (MNum 1)) ?inputs)))
                     (
-                        (let ?tuned (Op (KernelGemv ?n ?k ?dt (MNum {warps})) ?inputs))
+                        (let ?tuned (Op (KernelGemv ?n ?k ?dt (MNum {rows}) (MNum {warps})) ?inputs))
                         (union ?out ?tuned)
                         (set (dtype ?tuned) ?dt)
                     )
                     :ruleset matmul_backend
-                    :name \"kernel gemv {warps} warps per block\"
+                    :name \"kernel gemv {rows} rows per block {warps} warps per row\"
                 )"
             ))))
             .collect()
@@ -165,7 +241,11 @@ impl EgglogOp for KernelGemv {
                 n: extract_expr(egraph, kind_children[0], expr_cache).unwrap(),
                 k: extract_expr(egraph, kind_children[1], expr_cache).unwrap(),
                 dtype: extract_dtype(egraph, kind_children[2]),
-                warps_per_block: extract_expr(egraph, kind_children[3], expr_cache)
+                rows_per_block: extract_expr(egraph, kind_children[3], expr_cache)
+                    .unwrap()
+                    .to_usize()
+                    .expect("GEMV row count must be constant"),
+                warps_per_row: extract_expr(egraph, kind_children[4], expr_cache)
                     .unwrap()
                     .to_usize()
                     .expect("GEMV warp count must be constant"),
@@ -189,8 +269,8 @@ impl KernelOp for KernelGemv {
         Expression,
         FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
-        let warps_per_block = self.warps_per_block;
-        assert!(matches!(warps_per_block, 1 | 2 | 4 | 8));
+        let rows_per_block = self.rows_per_block;
+        let warps_per_row = self.warps_per_row;
         let vars = self
             .n
             .dyn_vars()
@@ -205,40 +285,14 @@ impl KernelOp for KernelGemv {
         } else {
             ", const int* dyn_dims"
         };
-        let n = self.n.to_kernel();
-        let k = self.k.to_kernel();
-
-        // 16-byte vectorized lane loads (8 × 16-bit) when K is statically a
-        // multiple of 8; scalar loop otherwise. F32 accumulation throughout.
-        let vectorized = self.k.to_usize().map(|k| k % 8 == 0).unwrap_or(false);
-        let body = if vectorized {
-            format!(
-                r#"
-        const uint4* xr = (const uint4*)x;
-        const uint4* wr = (const uint4*)(w + row * ({k}));
-        long long chunks = ({k}) / 8;
-        float acc = 0.0f;
-        for (long long c = lane; c < chunks; c += 32) {{
-            uint4 xv = xr[c];
-            uint4 wv = wr[c];
-            const {ty}* xe = (const {ty}*)&xv;
-            const {ty}* we = (const {ty}*)&wv;
-            #pragma unroll
-            for (int e = 0; e < 8; e++) {{
-                acc += (float)xe[e] * (float)we[e];
-            }}
-        }}"#
-            )
-        } else {
-            format!(
-                r#"
-        const {ty}* wr = w + row * ({k});
-        float acc = 0.0f;
-        for (long long i = lane; i < ({k}); i += 32) {{
-            acc += (float)x[i] * (float)wr[i];
-        }}"#
-            )
-        };
+        let body = gemv_body(
+            self.n,
+            self.k,
+            self.dtype,
+            rows_per_block,
+            warps_per_row,
+            &format!("out[row] = ({ty})acc;"),
+        );
 
         let kernel = format!(
             "{includes}
@@ -246,18 +300,7 @@ impl KernelOp for KernelGemv {
 {dyn_defines}
 extern \"C\" {{
     __global__ void gemv_k({ty} *out, const {ty} *x, const {ty} *w{dyn_dims_param}) {{
-        long long row = (long long)blockIdx.x * {warps_per_block} + (threadIdx.x >> 5);
-        if (row >= ({n})) return;
-        int lane = threadIdx.x & 31;
 {body}
-
-        #pragma unroll
-        for (int s = 16; s > 0; s /= 2) {{
-            acc += __shfl_down_sync(FULL_MASK, acc, s);
-        }}
-        if (lane == 0) {{
-            out[row] = ({ty})acc;
-        }}
     }}
 }}"
         );
@@ -276,8 +319,12 @@ extern \"C\" {{
             func,
             module,
             kernel,
-            (self.n.ceil_div(warps_per_block), 1.into(), 1.into()),
-            ((warps_per_block * 32).into(), 1.into(), 1.into()),
+            (self.n.ceil_div(rows_per_block), 1.into(), 1.into()),
+            (
+                (rows_per_block * warps_per_row * 32).into(),
+                1.into(),
+                1.into(),
+            ),
             0.into(),
             FxHashMap::default(),
         )

--- a/crates/luminal_cuda_lite/src/kernel/gemv.rs
+++ b/crates/luminal_cuda_lite/src/kernel/gemv.rs
@@ -29,14 +29,12 @@ use luminal::{
     prelude::*,
 };
 
-const TPB: usize = 256;
-const WARPS_PER_BLOCK: usize = TPB / 32;
-
 #[derive(Default, Debug, Clone)]
 pub struct KernelGemv {
     n: Expression,
     k: Expression,
     dtype: DType,
+    warps_per_block: usize,
 }
 
 impl EgglogOp for KernelGemv {
@@ -44,7 +42,12 @@ impl EgglogOp for KernelGemv {
         sort(
             OP_KIND,
             "KernelGemv",
-            &[("n", EXPRESSION), ("k", EXPRESSION), ("dtype", DTYPE)],
+            &[
+                ("n", EXPRESSION),
+                ("k", EXPRESSION),
+                ("dtype", DTYPE),
+                ("warps_per_block", EXPRESSION),
+            ],
         )
     }
 
@@ -121,7 +124,7 @@ impl EgglogOp for KernelGemv {
                             (= ?dt ({dt}))
                         )
                         (
-                            (let ?gemv (Op (KernelGemv ?n ?k ({dt})) (ICons ?a (ICons ?b (INil)))))
+                            (let ?gemv (Op (KernelGemv ?n ?k ({dt}) (MNum 8)) (ICons ?a (ICons ?b (INil)))))
                             (union ?sum ?gemv)
                             (set (dtype ?gemv) ({dt}))
                         )
@@ -130,6 +133,18 @@ impl EgglogOp for KernelGemv {
                     )"
                 ))
             })
+            .chain([1, 2, 4].map(|warps| Rule::raw(format!(
+                "(rule
+                    ((= ?out (Op (KernelGemv ?n ?k ?dt (MNum 8)) ?inputs)))
+                    (
+                        (let ?tuned (Op (KernelGemv ?n ?k ?dt (MNum {warps})) ?inputs))
+                        (union ?out ?tuned)
+                        (set (dtype ?tuned) ?dt)
+                    )
+                    :ruleset matmul_backend
+                    :name \"kernel gemv {warps} warps per block\"
+                )"
+            ))))
             .collect()
     }
 
@@ -150,6 +165,10 @@ impl EgglogOp for KernelGemv {
                 n: extract_expr(egraph, kind_children[0], expr_cache).unwrap(),
                 k: extract_expr(egraph, kind_children[1], expr_cache).unwrap(),
                 dtype: extract_dtype(egraph, kind_children[2]),
+                warps_per_block: extract_expr(egraph, kind_children[3], expr_cache)
+                    .unwrap()
+                    .to_usize()
+                    .expect("GEMV warp count must be constant"),
             }) as Box<dyn KernelOp>),
             input_enodes,
         )
@@ -170,6 +189,8 @@ impl KernelOp for KernelGemv {
         Expression,
         FxHashMap<Symbol, CudaSlice<u8>>,
     ) {
+        let warps_per_block = self.warps_per_block;
+        assert!(matches!(warps_per_block, 1 | 2 | 4 | 8));
         let vars = self
             .n
             .dyn_vars()
@@ -225,7 +246,7 @@ impl KernelOp for KernelGemv {
 {dyn_defines}
 extern \"C\" {{
     __global__ void gemv_k({ty} *out, const {ty} *x, const {ty} *w{dyn_dims_param}) {{
-        long long row = (long long)blockIdx.x * {WARPS_PER_BLOCK} + (threadIdx.x >> 5);
+        long long row = (long long)blockIdx.x * {warps_per_block} + (threadIdx.x >> 5);
         if (row >= ({n})) return;
         int lane = threadIdx.x & 31;
 {body}
@@ -255,8 +276,8 @@ extern \"C\" {{
             func,
             module,
             kernel,
-            (self.n.ceil_div(WARPS_PER_BLOCK), 1.into(), 1.into()),
-            (TPB.into(), 1.into(), 1.into()),
+            (self.n.ceil_div(warps_per_block), 1.into(), 1.into()),
+            ((warps_per_block * 32).into(), 1.into(), 1.into()),
             0.into(),
             FxHashMap::default(),
         )

--- a/crates/luminal_cuda_lite/src/kernel/hlir.rs
+++ b/crates/luminal_cuda_lite/src/kernel/hlir.rs
@@ -1009,7 +1009,7 @@ extern \"C\" {{
 }
 
 // KernelScatter: inverse of gather - out = copy(dest); out[indexes[i]] = src[i]
-// Two-phase: memcpy graph node copies dest→output, then scatter kernel runs in same CUDA graph.
+// Blocks copy and update disjoint output tiles, with a local barrier between phases.
 #[derive(Debug, Clone)]
 pub struct KernelScatter {
     dest_shape: Vec<Expression>,
@@ -1167,8 +1167,22 @@ impl KernelOp for KernelScatter {
             ", const int* dyn_dims"
         };
 
-        // Single-kernel scatter: copy dest→output then scatter src→output[indexes]
-        // Launched as 1 block of 1024 threads with __syncthreads() barrier.
+        // Each block owns its round-robin output tiles for both phases. The
+        // lowering above guarantees contiguous row-major output, so a block
+        // barrier orders every copy against the updates to that same tile.
+        // Bound the grid by hardware parallelism: every block scans the index
+        // list, but only its owner loads and writes an update's source value.
+        let multiprocessors = stream
+            .context()
+            .attribute(
+                cudarc::driver::sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT,
+            )
+            .expect("query scatter multiprocessor count") as usize;
+        let blocks = self
+            .output_size()
+            .ceil_div(1024)
+            .min(multiprocessors)
+            .max(1);
         let n_src_elements = self
             .index_shape
             .iter()
@@ -1198,14 +1212,15 @@ extern \"C\" {{
         // Phase 1: materialize dest into the contiguous output layout.
         // dest may be a strided or broadcast view, so copying dest[i] would read
         // past the physical source buffer for expanded tensors.
-        for (long long const_z = tid; const_z < n_dest; const_z += blockDim.x) {{
+        for (long long const_z = (long long)blockIdx.x * blockDim.x + tid;
+             const_z < n_dest; const_z += (long long)blockDim.x * gridDim.x) {{
             out[{copy_out_idx}] = dest[{copy_dest_idx}];
         }}
         __syncthreads();
         // Phase 2: scatter src → output[indexes[i]]
         for (long long const_z = tid; const_z < n_src; const_z += blockDim.x) {{
             int idx = indexes[{scatter_idx_idx}];
-            if (idx >= 0 && idx < n_dest) {{
+            if (idx >= 0 && idx < n_dest && (idx / blockDim.x) % gridDim.x == blockIdx.x) {{
                 out[idx] = src[{scatter_src_idx}];
             }}
         }}
@@ -1226,7 +1241,7 @@ extern \"C\" {{
             func,
             module,
             scatter_kernel,
-            (1.into(), 1.into(), 1.into()),    // grid: 1 block
+            (blocks, 1.into(), 1.into()),
             (1024.into(), 1.into(), 1.into()), // block: 1024 threads
             0.into(),
             FxHashMap::default(),

--- a/crates/luminal_cuda_lite/src/kernel/mod.rs
+++ b/crates/luminal_cuda_lite/src/kernel/mod.rs
@@ -39,6 +39,7 @@ pub type Ops = (
     argmax::KernelArgmax,
     gemv::KernelGemv,
     rms_norm::KernelRMSNorm,
+    rms_norm::RMSNormKernel,
     rope::RoPEHalfKernel,
     rope::RoPEScatterKernel,
     rope::KernelRoPE,

--- a/crates/luminal_cuda_lite/src/kernel/mod.rs
+++ b/crates/luminal_cuda_lite/src/kernel/mod.rs
@@ -22,6 +22,7 @@ pub mod quant_f8;
 pub mod rms_norm;
 pub mod rope;
 pub mod swiglu;
+pub mod thin_matmul;
 pub mod topk;
 
 pub use conv2d::KernelConv2D;
@@ -38,6 +39,7 @@ pub type Ops = (
     hlir::Ops,
     argmax::KernelArgmax,
     gemv::KernelGemv,
+    thin_matmul::KernelThinMatmul<false>,
     rms_norm::KernelRMSNorm,
     rms_norm::RMSNormKernel,
     rope::RoPEHalfKernel,

--- a/crates/luminal_cuda_lite/src/kernel/rms_norm.rs
+++ b/crates/luminal_cuda_lite/src/kernel/rms_norm.rs
@@ -11,12 +11,14 @@
 //! Layout: x `(rows, cols)` contiguous in `dtype` with dynamic `rows`;
 //! w `(cols,)` F32. One block per row; F32 warp + block reduction.
 
-use std::sync::Arc;
+use std::{fmt::Display, sync::Arc};
 
 use cudarc::driver::{CudaFunction, CudaModule, CudaSlice, CudaStream};
 use luminal::{
-    dtype::DType, op::CustomOp, op::LLIROp, prelude::FxHashMap, prelude::GraphTensor,
-    prelude::Symbol, shape::Expression,
+    dtype::DType,
+    op::{CustomOp, HLIROp, LLIROp},
+    prelude::{FxHashMap, GraphTensor, NodeIndex, ShapeTracker, Symbol},
+    shape::Expression,
 };
 
 use crate::compile_module_image_for_current_device;
@@ -30,6 +32,9 @@ pub struct RMSNormKernel {
     pub cols: usize,
     pub eps: f32,
     pub dtype: DType,
+    /// Storage dtype; conversion to `dtype` happens before either reduction or scaling.
+    pub input_dtype: DType,
+    pub threads: usize,
 }
 
 impl KernelOp for RMSNormKernel {
@@ -48,44 +53,61 @@ impl KernelOp for RMSNormKernel {
     ) {
         let cols = self.cols;
         let eps = self.eps;
+        let tpb = self.threads;
+        assert!(matches!(self.dtype, DType::F32 | DType::F16 | DType::Bf16));
+        assert!(matches!(tpb, 128 | 256 | 512 | 1024));
+        assert!(
+            self.input_dtype == self.dtype
+                || (self.input_dtype == DType::F32
+                    && matches!(self.dtype, DType::F16 | DType::Bf16))
+        );
+        let input_ty = crate::cuda_dtype(self.input_dtype);
+        // Keep the logical reduction groups unchanged when absorbing a cast.
+        // F32 storage needs two 16-byte loads for eight rounded 16-bit values.
+        let elements = 128 / self.dtype.bits();
+        let vectors = self.input_dtype.bits() / self.dtype.bits();
+        let loads = (0..vectors)
+            .map(|i| format!("xv[c * {vectors} + {i}]"))
+            .collect::<Vec<_>>()
+            .join(", ");
         let ty = crate::cuda_dtype(self.dtype);
-        let includes = crate::kernel::hlir::dtype_includes(&[self.dtype]);
+        let includes = crate::kernel::hlir::dtype_includes(&[self.dtype, self.input_dtype]);
         let kernel = format!(
             r#"{includes}
 #define WARP_SIZE 32
 #define FULL_MASK 0xffffffff
 extern "C" __global__ void rms_norm_k(
     {ty}* __restrict__ out,
-    const {ty}* __restrict__ x,
+    const {input_ty}* __restrict__ x,
     const float* __restrict__ w
 ) {{
     const int COLS = {cols};
-    __shared__ float warp_sums[{TPB} / WARP_SIZE];
+    __shared__ float warp_sums[{tpb} / WARP_SIZE];
     long long row = blockIdx.x;
     int tid = threadIdx.x;
     int lane_id = tid % WARP_SIZE;
     int warp_id = tid / WARP_SIZE;
 
-    const {ty}* xr = x + row * COLS;
+    const {input_ty}* xr = x + row * COLS;
     {ty}* yr = out + row * COLS;
 
     float partial = 0.0f;
-#if {cols} % 8 == 0
+#if {cols} % {elements} == 0
     {{
         const uint4* xv = (const uint4*)xr;
-        for (int c = tid; c < COLS / 8; c += {TPB}) {{
-            uint4 chunk = xv[c];
-            const {ty}* xe = (const {ty}*)&chunk;
+        for (int c = tid; c < COLS / {elements}; c += {tpb}) {{
+            const uint4 chunks[{vectors}] = {{{loads}}};
+            const {input_ty}* xe = (const {input_ty}*)chunks;
             #pragma unroll
-            for (int e = 0; e < 8; e++) {{
-                float v = (float)xe[e];
+            for (int e = 0; e < {elements}; e++) {{
+                float v = (float)({ty})xe[e];
                 partial += v * v;
             }}
         }}
     }}
 #else
-    for (int i = tid; i < COLS; i += {TPB}) {{
-        float v = (float)xr[i];
+    for (int i = tid; i < COLS; i += {tpb}) {{
+        float v = (float)({ty})xr[i];
         partial += v * v;
     }}
 #endif
@@ -100,21 +122,21 @@ extern "C" __global__ void rms_norm_k(
     __syncthreads();
 
     if (warp_id == 0) {{
-        int cnt = {TPB} / WARP_SIZE;
+        int cnt = {tpb} / WARP_SIZE;
         float block_sum = tid < cnt ? warp_sums[tid] : 0.0f;
         #pragma unroll
         for (int s = cnt / 2; s > 0; s /= 2) {{
             block_sum += __shfl_down_sync(FULL_MASK, block_sum, s);
         }}
         if (tid == 0) {{
-            warp_sums[0] = rsqrtf(block_sum / (float)COLS + {eps:.10}f);
+            warp_sums[0] = rsqrtf(block_sum / (float)COLS + {eps:e}f);
         }}
     }}
     __syncthreads();
     float rinv = warp_sums[0];
 
-    for (int i = tid; i < COLS; i += {TPB}) {{
-        yr[i] = ({ty})((float)xr[i] * rinv * w[i]);
+    for (int i = tid; i < COLS; i += {tpb}) {{
+        yr[i] = ({ty})((float)({ty})xr[i] * rinv * w[i]);
     }}
 }}
 "#
@@ -140,7 +162,7 @@ extern "C" __global__ void rms_norm_k(
                 Expression::from(1usize),
             ),
             (
-                Expression::from(TPB),
+                Expression::from(tpb),
                 Expression::from(1usize),
                 Expression::from(1usize),
             ),
@@ -163,7 +185,7 @@ extern "C" __global__ void rms_norm_k(
 
     fn bytes_loaded(&self) -> Expression {
         // Two passes over x plus the weight row.
-        (self.rows * self.cols * self.dtype.bits() * 2).ceil_div(8) + self.cols * 4
+        (self.rows * self.cols * self.input_dtype.bits() * 2).ceil_div(8) + self.cols * 4
     }
 
     fn bytes_stored(&self) -> Expression {
@@ -194,24 +216,49 @@ impl CustomOp for RMSNormCustom {
 /// `w` is `(cols,)` F32. Returns `(rows, cols)` in `x`'s dtype.
 pub fn fused_rms_norm(x: GraphTensor, w: GraphTensor, eps: f32) -> GraphTensor {
     assert_eq!(w.dtype, DType::F32, "RMSNorm weight must be F32");
+    assert_eq!(w.dims().len(), 1, "RMSNorm weight must be a vector");
+    assert!(
+        matches!(x.dtype, DType::F32 | DType::F16 | DType::Bf16),
+        "RMSNorm requires F32, F16 or BF16 input"
+    );
     let x_dims = x.dims();
     assert_eq!(x_dims.len(), 2, "RMSNorm x must be 2-D (rows, cols)");
     let rows = x_dims[0];
     let cols = x_dims[1].to_usize().expect("RMSNorm cols must be static");
+    assert!(cols > 0, "RMSNorm reduction must be nonempty");
     assert_eq!(
         w.dims()[0].to_usize().expect("RMSNorm weight dim"),
         cols,
         "RMSNorm weight length mismatch"
     );
 
+    let contiguous = |t: GraphTensor| {
+        if t.shape.is_contiguous() {
+            return t;
+        }
+        let indices = t.graph().arange(t.shape.n_elements());
+        let mut gathered = t.gather(indices);
+        gathered.shape = ShapeTracker::new_with_element_bits(t.dims(), t.dtype.bits());
+        gathered
+    };
+    let x = contiguous(x);
+    let w = contiguous(w);
     let kern = RMSNormKernel {
         rows,
         cols,
         eps,
         dtype: x.dtype,
+        input_dtype: x.dtype,
+        threads: TPB,
     };
     let cx = unsafe { &mut *x.graph_ref };
-    cx.custom_op(RMSNormCustom(kern), vec![x, w], (rows, cols), x.dtype)
+    let id = cx.add_op(kern, &[x.id, w.id]);
+    GraphTensor::from_id(
+        id,
+        ShapeTracker::new_with_element_bits((rows, cols), x.dtype.bits()),
+        cx,
+        x.dtype,
+    )
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -387,8 +434,142 @@ impl EgglogOp for KernelRMSNorm {
                 cols,
                 eps: eps as f32,
                 dtype: DType::Bf16,
+                input_dtype: DType::Bf16,
+                threads: TPB,
             }) as Box<dyn KernelOp>),
             input_enodes,
         )
     }
 }
+
+// The explicit primitive is a normal searchable IR node. It keeps rsqrt and
+// conversion boundaries independent of the decomposed sqrt/reciprocal pattern.
+impl Default for RMSNormKernel {
+    fn default() -> Self {
+        Self {
+            rows: 1.into(),
+            cols: 1,
+            eps: 1e-5,
+            dtype: DType::F32,
+            input_dtype: DType::F32,
+            threads: TPB,
+        }
+    }
+}
+
+impl Display for RMSNormKernel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FusedRMSNorm")
+    }
+}
+
+impl HLIROp for RMSNormKernel {
+    fn to_egglog(&self, inputs: &[(NodeIndex, String)]) -> String {
+        use luminal::egglog_utils::list_to_egglog;
+        assert_eq!(inputs.len(), 2);
+        format!(
+            "(Op (FusedRMSNorm {} {} {} {:?} ({:?}) ({:?}) {}) {})",
+            self.rows.to_egglog(),
+            Expression::from(self.cols).to_egglog(),
+            ShapeTracker::new((self.rows, self.cols))
+                .n_elements()
+                .to_egglog(),
+            self.eps as f64,
+            self.dtype,
+            self.input_dtype,
+            Expression::from(self.threads).to_egglog(),
+            list_to_egglog(&[&inputs[0].1, &inputs[1].1], "ICons", "INil")
+        )
+    }
+
+    fn output_dtype(&self, _: &[DType]) -> DType {
+        self.dtype
+    }
+}
+
+impl EgglogOp for RMSNormKernel {
+    fn sort(&self) -> SortDef {
+        use luminal::egglog_utils::base::{DTYPE, EXPRESSION};
+        sort(
+            OP_KIND,
+            "FusedRMSNorm",
+            &[
+                ("rows", EXPRESSION),
+                ("cols", EXPRESSION),
+                ("size", EXPRESSION),
+                ("eps", F64),
+                ("dtype", DTYPE),
+                ("input_dtype", DTYPE),
+                ("threads", EXPRESSION),
+            ],
+        )
+    }
+
+    fn n_inputs(&self) -> usize {
+        2
+    }
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        let mut rules = vec![Rule::raw(
+            r#"
+            (rule ((= ?out (Op (FusedRMSNorm ?rows ?cols ?size ?eps ?dt ?input_dt ?threads) ?inputs)))
+                ((set (dtype ?out) ?dt)) :ruleset dtype_prop :name "explicit rmsnorm dtype")
+            (rule (
+                (= ?out (Op (FusedRMSNorm ?rows ?cols ?size ?eps ?dt ?dt ?threads)
+                    (ICons ?cast (ICons ?w (INil)))))
+                (= ?cast (Op (Cast ?size ?dt) (ICons ?x (INil))))
+                (= (dtype ?x) (F32))
+                (!= ?dt (F32))
+            ) (
+                (let ?fused (Op (FusedRMSNorm ?rows ?cols ?size ?eps ?dt (F32) ?threads)
+                    (ICons ?x (ICons ?w (INil)))))
+                (union ?out ?fused)
+                (set (dtype ?fused) ?dt)
+            ) :ruleset kernel_fuse_late :name "explicit rmsnorm absorb rounded input cast")
+        "#
+            .to_string(),
+        )];
+        rules.extend([128, 256, 512].map(|threads| Rule::raw(format!(r#"
+            (rule ((= ?out (Op (FusedRMSNorm ?rows ?cols ?size ?eps ?dt ?input_dt (MNum 1024)) ?inputs)))
+                ((let ?tuned (Op (FusedRMSNorm ?rows ?cols ?size ?eps ?dt ?input_dt (MNum {threads})) ?inputs))
+                 (union ?out ?tuned) (set (dtype ?tuned) ?dt))
+                :ruleset kernel_fuse_late :name "explicit rmsnorm {threads} threads")
+        "#))));
+        rules
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        _list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        use luminal::egglog_utils::{extract_dtype, extract_expr};
+        let mut expr = |i| extract_expr(egraph, kind_children[i], expr_cache).unwrap();
+        let kernel = Self {
+            rows: expr(0),
+            cols: expr(1).to_usize().unwrap(),
+            eps: egraph.enodes[kind_children[3]]
+                .0
+                .replace('"', "")
+                .parse::<f64>()
+                .unwrap() as f32,
+            dtype: extract_dtype(egraph, kind_children[4]),
+            input_dtype: extract_dtype(egraph, kind_children[5]),
+            threads: expr(6).to_usize().unwrap(),
+        };
+        (
+            LLIROp::new::<dyn KernelOp>(Box::new(kernel) as Box<dyn KernelOp>),
+            input_enodes,
+        )
+    }
+}
+
+#[cfg(test)]
+#[path = "rms_norm_tests.rs"]
+mod tests;

--- a/crates/luminal_cuda_lite/src/kernel/rms_norm_tests.rs
+++ b/crates/luminal_cuda_lite/src/kernel/rms_norm_tests.rs
@@ -1,0 +1,319 @@
+use super::*;
+use crate::runtime::CudaRuntime;
+use cudarc::driver::{CudaContext, DevicePtr, LaunchConfig, PushKernelArg};
+use half::{bf16, f16};
+use luminal::prelude::*;
+
+fn round(x: f32, dtype: DType) -> f32 {
+    match dtype {
+        DType::Bf16 => bf16::from_f32(x).to_f32(),
+        DType::F16 => f16::from_f32(x).to_f32(),
+        _ => x,
+    }
+}
+
+fn bytes(data: &[f32], dtype: DType) -> Vec<u8> {
+    data.iter()
+        .flat_map(|&x| match dtype {
+            DType::Bf16 => bf16::from_f32(x).to_bits().to_le_bytes().to_vec(),
+            DType::F16 => f16::from_f32(x).to_bits().to_le_bytes().to_vec(),
+            _ => x.to_le_bytes().to_vec(),
+        })
+        .collect()
+}
+
+fn floats(data: &[u8], dtype: DType) -> Vec<f32> {
+    data.chunks_exact(dtype.bits() / 8)
+        .map(|v| match dtype {
+            DType::Bf16 => bf16::from_bits(u16::from_le_bytes(v.try_into().unwrap())).to_f32(),
+            DType::F16 => f16::from_bits(u16::from_le_bytes(v.try_into().unwrap())).to_f32(),
+            _ => f32::from_le_bytes(v.try_into().unwrap()),
+        })
+        .collect()
+}
+
+// Read the real saturated graph and run every extracted normalization choice.
+// This also verifies the public helper no longer hides its operation from search.
+fn choices(rows: usize, cols: usize, dtype: DType, dynamic: bool) -> Vec<(usize, DType, LLIROp)> {
+    let mut cx = Graph::default();
+    let r = if dynamic {
+        's'.into()
+    } else {
+        Expression::from(rows)
+    };
+    cx.set_dim('s', rows);
+    let x = cx.tensor((r, cols));
+    let w = cx.tensor(cols);
+    fused_rms_norm(x.cast(dtype), w, 1e-12).output();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let egraph = cx.egraph().unwrap();
+    let mut choices = Vec::new();
+    for (_, fields) in egraph
+        .enodes
+        .values()
+        .filter(|(name, _)| name == "FusedRMSNorm")
+    {
+        let children = fields
+            .iter()
+            .map(|c| &egraph.eclasses[c].1[0])
+            .collect::<Vec<_>>();
+        let threads =
+            luminal::egglog_utils::extract_expr(egraph, children[6], &mut FxHashMap::default())
+                .unwrap()
+                .to_usize()
+                .unwrap();
+        let input_dtype = luminal::egglog_utils::extract_dtype(egraph, children[5]);
+        let (op, _) = RMSNormKernel::default().extract(
+            egraph,
+            &children,
+            vec![],
+            &mut FxHashMap::default(),
+            &mut FxHashMap::default(),
+        );
+        choices.push((threads, input_dtype, op));
+    }
+    choices.sort_by_key(|(threads, input, _)| (*threads, input.bits()));
+    let expected_count = if dtype == DType::F32 { 4 } else { 8 };
+    assert_eq!(
+        choices.len(),
+        expected_count,
+        "dtype={dtype:?}, dynamic={dynamic}, cols={cols}"
+    );
+    for threads in [128, 256, 512, 1024] {
+        assert!(choices.iter().any(|(t, d, _)| *t == threads && *d == dtype));
+        assert!(
+            choices
+                .iter()
+                .any(|(t, d, _)| *t == threads && *d == DType::F32)
+        );
+    }
+    choices
+}
+
+#[test]
+fn searchable_rmsnorm_all_choices_preserve_cast_and_match_scalar_reference() {
+    let stream = CudaContext::new(0).unwrap().default_stream();
+    let mut cache = FxHashMap::default();
+    let rows = 3;
+    for dtype in [DType::F32, DType::F16, DType::Bf16] {
+        for (cols, dynamic) in [(131, false), (136, true), (2880, false)] {
+            let x: Vec<_> = (0..rows * cols)
+                .map(|i| {
+                    let scale = if i < cols { 1e-6 } else { 1.0 };
+                    scale * (((i * 1543 % 2003) as f32) / 1001. - 1.)
+                })
+                .collect();
+            let w: Vec<_> = (0..cols).map(|i| (i % 19) as f32 / 13. - 0.4).collect();
+            let mut expected = Vec::new();
+            for row in x.chunks_exact(cols) {
+                let sum: f64 = row.iter().map(|&v| (round(v, dtype) as f64).powi(2)).sum();
+                let inv = (sum / cols as f64 + 1e-12_f32 as f64).sqrt().recip();
+                expected.extend(row.iter().zip(&w).map(|(&v, &w)| {
+                    round((round(v, dtype) as f64 * inv * w as f64) as f32, dtype)
+                }));
+            }
+            let xf = stream.clone_htod(&bytes(&x, DType::F32)).unwrap();
+            let xn = stream.clone_htod(&bytes(&x, dtype)).unwrap();
+            let wg = stream.clone_htod(&w).unwrap();
+            let out = stream
+                .alloc_zeros::<u8>(rows * cols * dtype.bits() / 8)
+                .unwrap();
+            let mut paired = std::collections::BTreeMap::<usize, Vec<Vec<u8>>>::new();
+            for (threads, input_dtype, op) in choices(rows, cols, dtype, dynamic) {
+                let kernel = op.to_dialect::<dyn KernelOp>().unwrap();
+                let (f, _m, _, _, _, _, _) = kernel.compile(&stream, &mut cache);
+                let xp = if input_dtype == DType::F32 {
+                    xf.device_ptr(&stream).0
+                } else {
+                    xn.device_ptr(&stream).0
+                };
+                let wp = wg.device_ptr(&stream).0;
+                let yp = out.device_ptr(&stream).0;
+                unsafe {
+                    stream
+                        .launch_builder(&f)
+                        .arg(&yp)
+                        .arg(&xp)
+                        .arg(&wp)
+                        .launch(LaunchConfig {
+                            grid_dim: (rows as u32, 1, 1),
+                            block_dim: (threads as u32, 1, 1),
+                            shared_mem_bytes: 0,
+                        })
+                        .unwrap();
+                }
+                let actual_bytes = stream.clone_dtoh(&out).unwrap();
+                let actual = floats(&actual_bytes, dtype);
+                let tolerance = match dtype {
+                    DType::Bf16 => 0.008,
+                    DType::F16 => 0.001,
+                    _ => 2e-6,
+                };
+                for (i, (&a, &e)) in actual.iter().zip(&expected).enumerate() {
+                    assert!(
+                        (a - e).abs() <= tolerance * e.abs().max(1e-6),
+                        "dtype={dtype:?}, cols={cols}, threads={threads}, input={input_dtype:?}, i={i}: {a} != {e}"
+                    );
+                }
+                paired.entry(threads).or_default().push(actual_bytes);
+            }
+            // Absorbing the input cast must retain every bit at a fixed reduction schedule.
+            if dtype != DType::F32 {
+                for outputs in paired.values() {
+                    assert_eq!(outputs[0], outputs[1]);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn searchable_rmsnorm_materializes_transposed_input() {
+    let stream = CudaContext::new(0).unwrap().default_stream();
+    let mut cx = Graph::default();
+    let x = cx.tensor((5, 3));
+    let w = cx.tensor((5, 2));
+    let weight_view = w.slice((.., 0..1)).squeeze(1);
+    let y = fused_rms_norm(x.t(), weight_view, 0.0).output();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let data: Vec<f32> = (0..15).map(|i| i as f32 / 7. - 1.).collect();
+    let weights = vec![1f32, 9., 1., 8., 1., 7., 1., 6., 1., 5.];
+    let mut rt = CudaRuntime::initialize(stream);
+    rt.set_data(x, data.clone());
+    rt.set_data(w, weights.clone());
+    rt = cx.search(rt, CompileOptions::default().search_graph_limit(8));
+    rt.set_data(x, data.clone());
+    rt.set_data(w, weights);
+    rt.execute(&cx.dyn_map);
+    let actual = rt.get_f32(y.id);
+    for row in 0..3 {
+        let sum: f64 = (0..5).map(|col| (data[col * 3 + row] as f64).powi(2)).sum();
+        let inv = (sum / 5.).sqrt().recip();
+        for col in 0..5 {
+            assert!((actual[row * 5 + col] as f64 - data[col * 3 + row] as f64 * inv).abs() < 2e-6);
+        }
+    }
+}
+
+#[test]
+#[ignore = "performance experiment; requires an otherwise idle GPU"]
+fn benchmark_searchable_rmsnorm_cast_choices() {
+    use crate::kernel::CudaGraphHandle;
+    use cudarc::driver::sys::CUevent_flags;
+    let stream = CudaContext::new(0).unwrap().new_stream().unwrap();
+    let mut cache = FxHashMap::default();
+    let cols = 2880;
+    eprintln!("rmsnorm_bench,rows,cols,threads,fused_input_cast,trial,microseconds");
+    for rows in [1, 2, 4, 8, 16, 32, 64] {
+        let x = stream.clone_htod(&vec![0.1234567f32; rows * cols]).unwrap();
+        let cast = stream.alloc_zeros::<u16>(rows * cols).unwrap();
+        let w = stream.clone_htod(&vec![1f32; cols]).unwrap();
+        let y = stream.alloc_zeros::<u16>(rows * cols).unwrap();
+        let xp = x.device_ptr(&stream).0;
+        let cp = cast.device_ptr(&stream).0;
+        let wp = w.device_ptr(&stream).0;
+        let yp = y.device_ptr(&stream).0;
+        let cast_source = format!(
+            r#"#include <cuda_bf16.h>
+            extern "C" __global__ void cast_input(__nv_bfloat16 *y, const float *x) {{
+                int i = blockIdx.x * blockDim.x + threadIdx.x;
+                if (i < {}) y[i] = __float2bfloat16_rn(x[i]);
+            }}"#,
+            rows * cols
+        );
+        let module = stream
+            .context()
+            .load_module(
+                compile_module_image_for_current_device(stream.context(), &cast_source).unwrap(),
+            )
+            .unwrap();
+        let cast_f = module.load_function("cast_input").unwrap();
+        for (threads, input_dtype, op) in choices(rows, cols, DType::Bf16, false) {
+            let kernel = op.to_dialect::<dyn KernelOp>().unwrap();
+            let (f, _module, _, _, _, _, _) = kernel.compile(&stream, &mut cache);
+            let fused = input_dtype == DType::F32;
+            let norm_x = if fused { xp } else { cp };
+            stream.synchronize().unwrap();
+            CudaGraphHandle::begin_standalone_capture(&stream).unwrap();
+            for _ in 0..64 {
+                unsafe {
+                    if !fused {
+                        stream
+                            .launch_builder(&cast_f)
+                            .arg(&cp)
+                            .arg(&xp)
+                            .launch(LaunchConfig {
+                                grid_dim: ((rows * cols).div_ceil(256) as u32, 1, 1),
+                                block_dim: (256, 1, 1),
+                                shared_mem_bytes: 0,
+                            })
+                            .unwrap();
+                    }
+                    stream
+                        .launch_builder(&f)
+                        .arg(&yp)
+                        .arg(&norm_x)
+                        .arg(&wp)
+                        .launch(LaunchConfig {
+                            grid_dim: (rows as u32, 1, 1),
+                            block_dim: (threads as u32, 1, 1),
+                            shared_mem_bytes: 0,
+                        })
+                        .unwrap();
+                }
+            }
+            let graph = CudaGraphHandle::end_standalone_capture(&stream).unwrap();
+            let exec = graph.instantiate().unwrap();
+            for _ in 0..3 {
+                exec.launch(&stream).unwrap();
+            }
+            for trial in 0..5 {
+                let start = stream
+                    .context()
+                    .new_event(Some(CUevent_flags::CU_EVENT_DEFAULT))
+                    .unwrap();
+                let end = stream
+                    .context()
+                    .new_event(Some(CUevent_flags::CU_EVENT_DEFAULT))
+                    .unwrap();
+                start.record(&stream).unwrap();
+                for _ in 0..10 {
+                    exec.launch(&stream).unwrap();
+                }
+                end.record(&stream).unwrap();
+                end.synchronize().unwrap();
+                let us = start.elapsed_ms(&end).unwrap() * 1000. / 640.;
+                eprintln!("rmsnorm_bench,{rows},{cols},{threads},{fused},{trial},{us:.6}");
+            }
+        }
+    }
+}
+
+#[test]
+fn searchable_rmsnorm_cast_fusion_survives_shared_residual() {
+    let mut cx = Graph::default();
+    cx.set_dim('s', 8);
+    let x = cx.tensor(('s', 2880));
+    let residual = cx.tensor(('s', 2880));
+    let w = cx.tensor(2880);
+    let sum = x + residual;
+    sum.output();
+    fused_rms_norm(sum.cast(DType::Bf16), w, 1e-5).output();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let egraph = cx.egraph().unwrap();
+    let fused = egraph
+        .enodes
+        .values()
+        .filter(|(name, _)| name == "FusedRMSNorm")
+        .filter(|(_, fields)| {
+            egraph.eclasses[&fields[5]]
+                .1
+                .iter()
+                .any(|id| egraph.enodes[id].0 == "F32")
+        })
+        .count();
+    assert_eq!(
+        fused, 4,
+        "every block size should retain an absorbed-cast alternative after elementwise fusion"
+    );
+}

--- a/crates/luminal_cuda_lite/src/kernel/thin_matmul.rs
+++ b/crates/luminal_cuda_lite/src/kernel/thin_matmul.rs
@@ -1,0 +1,496 @@
+//! Cooperative SIMT matrix products, with optional rounded bias/promotion.
+//! Layout proofs and all launch choices live in egglog. The plain variant is
+//! shared by Lite; full CUDA also registers the bias variant of the same code.
+
+use std::sync::Arc;
+
+use cudarc::driver::{CudaFunction, CudaModule, CudaSlice, CudaStream};
+use luminal::{
+    egglog_utils::{
+        api::{Rule, SortDef, sort},
+        base::{DTYPE, EXPRESSION, OP_KIND},
+        extract_dtype, extract_expr,
+    },
+    op::*,
+    prelude::*,
+};
+
+use crate::{
+    compile_module_image_for_current_device, cuda_dtype,
+    kernel::{
+        KernelOp,
+        hlir::{dtype_includes, generate_dyn_dims_defines},
+    },
+};
+
+/// (input rows per tile, output columns per tile, warps per column).
+/// The widest row tiles remain alternatives; resource validation and measured
+/// search decide their suitability rather than a shape-specific Rust policy.
+pub fn thin_matmul_choices() -> impl Iterator<Item = (usize, usize, usize)> {
+    [1, 2, 4, 8, 16, 32, 64].into_iter().flat_map(|m| {
+        [1, 2, 4, 8].into_iter().flat_map(move |n| {
+            [1, 2, 4, 8]
+                .into_iter()
+                .filter_map(move |s| (n * s <= 8).then_some((m, n, s)))
+        })
+    })
+}
+
+#[derive(Default, Clone)]
+pub struct KernelThinMatmul<const BIAS: bool, const MIXED: bool = false> {
+    m: Expression,
+    n: Expression,
+    k: Expression,
+    dtype: DType,
+    output_dtype: DType,
+    round_dtype: DType,
+    tile_m: usize,
+    tile_n: usize,
+    warps_per_column: usize,
+}
+
+// Keep legacy program fingerprints stable when only new alternatives are added.
+impl<const BIAS: bool, const MIXED: bool> std::fmt::Debug for KernelThinMatmul<BIAS, MIXED> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut out = f.debug_struct("KernelThinMatmul");
+        out.field("m", &self.m)
+            .field("n", &self.n)
+            .field("k", &self.k)
+            .field("dtype", &self.dtype)
+            .field("output_dtype", &self.output_dtype);
+        if MIXED {
+            out.field("round_dtype", &self.round_dtype);
+        }
+        out.field("tile_m", &self.tile_m)
+            .field("tile_n", &self.tile_n)
+            .field("warps_per_column", &self.warps_per_column)
+            .finish()
+    }
+}
+
+impl<const BIAS: bool, const MIXED: bool> KernelThinMatmul<BIAS, MIXED> {
+    fn name() -> &'static str {
+        if MIXED {
+            if BIAS {
+                "KernelMixedAffine"
+            } else {
+                "KernelMixedMatmul"
+            }
+        } else if BIAS {
+            "KernelThinMatmulBias"
+        } else {
+            "KernelThinMatmul"
+        }
+    }
+}
+
+impl<const BIAS: bool, const MIXED: bool> EgglogOp for KernelThinMatmul<BIAS, MIXED> {
+    fn sort(&self) -> SortDef {
+        let mut fields = vec![
+            ("m", EXPRESSION),
+            ("n", EXPRESSION),
+            ("k", EXPRESSION),
+            ("dtype", DTYPE),
+            ("output_dtype", DTYPE),
+            ("tile_m", EXPRESSION),
+            ("tile_n", EXPRESSION),
+            ("warps_per_column", EXPRESSION),
+        ];
+        if MIXED {
+            fields.push(("round_dtype", DTYPE));
+        }
+        sort(OP_KIND, Self::name(), &fields)
+    }
+    fn n_inputs(&self) -> usize {
+        if BIAS { 3 } else { 2 }
+    }
+    fn cleanup(&self) -> bool {
+        false
+    }
+    fn egglog_declarations(&self) -> Vec<String> {
+        vec!["(relation thin_matmul_output_extent (IR Expression))".to_string()]
+    }
+    fn rewrites(&self) -> Vec<Rule> {
+        if MIXED {
+            return self.mixed_rewrites();
+        }
+        let name = Self::name();
+        let mut rules = vec![if BIAS {
+            Rule::raw(
+                r#"(rule
+                (
+                    (= ?sum (Op (KernelThinMatmul ?m ?n ?k ?dt ?dt
+                        (MNum 1) (MNum 8) (MNum 1))
+                        (ICons ?x (ICons ?w (INil)))))
+                    (= ?out (Op (Add (ECons ?m (ECons ?n (ENil)))
+                        ?out_strides (ECons (MNum 0) (ECons (MIter) (ENil))) ?out_strides)
+                        (ICons ?sum (ICons ?bias (INil)))))
+                    (= ?out_strides (ECons (MMul (MIter) ?n) (ECons (MIter) (ENil))))
+                    (= (dtype ?bias) ?dt)
+                    (= (dtype ?out) ?dt)
+                )
+                (
+                    (let ?fused (Op (KernelThinMatmulBias ?m ?n ?k ?dt ?dt
+                        (MNum 1) (MNum 8) (MNum 1))
+                        (ICons ?x (ICons ?w (ICons ?bias (INil))))))
+                    (union ?out ?fused)
+                    (set (dtype ?fused) ?dt)
+                    (thin_matmul_output_extent ?fused (MMul ?m ?n))
+                )
+                :ruleset matmul_backend
+                :name "thin matmul rounded column bias"
+            )"#,
+            )
+        } else {
+            Rule::raw(
+                r#"(rule
+                (
+                    (= ?sum (Op (GenericMatmul
+                        (ECons ?m (ECons ?n (ENil))) ?mul_shape ?k
+                        (ECons (MMul (MIter) ?k) (ECons (MNum 0) (ECons (MIter) (ENil))))
+                        (ECons (MNum 0) (ECons (MMul (MIter) ?k) (ECons (MIter) (ENil))))
+                        ?sum_in_stride (MIter) ?sum_out_stride ?dt)
+                        (ICons ?x (ICons ?w (INil)))))
+                    (generic_matmul_exact_2d ?sum ?m ?n ?k ?dt)
+                    (low_precision_matmul_dtype ?dt)
+                    (= (dtype ?x) ?dt)
+                    (= (dtype ?w) ?dt)
+                )
+                (
+                    (let ?kernel (Op (KernelThinMatmul ?m ?n ?k ?dt ?dt
+                        (MNum 1) (MNum 8) (MNum 1))
+                        (ICons ?x (ICons ?w (INil)))))
+                    (union ?sum ?kernel)
+                    (set (dtype ?kernel) ?dt)
+                    (thin_matmul_output_extent ?kernel (MMul ?m ?n))
+                )
+                :ruleset matmul_backend
+                :name "cooperative thin matmul contiguous row-major transposed-weight layout"
+            )"#,
+            )
+        }];
+        // Keep the evaluated extent in a relation: expr folding can subsume
+        // the raw MMul node, so matching its spelling loses static promotions.
+        // Equality with the Cast extent also rejects casts of a partial view.
+        rules.push(Rule::raw(format!(
+            r#"(rule
+            (
+                (= ?product (Op ({name} ?m ?n ?k ?dt ?dt
+                    (MNum 1) (MNum 8) (MNum 1)) ?inputs))
+                (thin_matmul_output_extent ?product ?elements)
+                (= ?out (Op (Cast ?elements (F32)) (ICons ?product (INil))))
+            )
+            (
+                (let ?promoted (Op ({name} ?m ?n ?k ?dt (F32)
+                    (MNum 1) (MNum 8) (MNum 1)) ?inputs))
+                (union ?out ?promoted)
+                (set (dtype ?promoted) (F32))
+            )
+            :ruleset matmul_backend
+            :name "{name} promotion preserves low-precision output rounding"
+        )"#
+        )));
+        rules.extend(thin_matmul_choices().filter(|&v| v != (1, 8, 1)).map(|(m,n,s)| {
+            Rule::raw(format!(r#"(rule
+                ((= ?out (Op ({name} ?m ?n ?k ?dt ?out_dt (MNum 1) (MNum 8) (MNum 1)) ?inputs)))
+                (
+                    (let ?tuned (Op ({name} ?m ?n ?k ?dt ?out_dt (MNum {m}) (MNum {n}) (MNum {s})) ?inputs))
+                    (union ?out ?tuned)
+                    (set (dtype ?tuned) ?out_dt)
+                )
+                :ruleset matmul_backend
+                :name "{name} tile {m} by {n} with {s} warps per column"
+            )"#))
+        }));
+        rules
+    }
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        children: &[&'a ENodeId],
+        inputs: Vec<&'a ENodeId>,
+        _lists: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expressions: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        let mut expression = |i: usize| extract_expr(egraph, children[i], expressions).unwrap();
+        let op = Self {
+            m: expression(0),
+            n: expression(1),
+            k: expression(2),
+            dtype: extract_dtype(egraph, children[3]),
+            output_dtype: extract_dtype(egraph, children[4]),
+            round_dtype: extract_dtype(egraph, children[if MIXED { 8 } else { 3 }]),
+            tile_m: expression(5).to_usize().expect("constant tile_m"),
+            tile_n: expression(6).to_usize().expect("constant tile_n"),
+            warps_per_column: expression(7).to_usize().expect("constant warps_per_column"),
+        };
+        (LLIROp::new::<dyn KernelOp>(Box::new(op)), inputs)
+    }
+}
+
+impl<const BIAS: bool, const MIXED: bool> KernelOp for KernelThinMatmul<BIAS, MIXED> {
+    fn compile(
+        &self,
+        stream: &Arc<CudaStream>,
+        cache: &mut FxHashMap<String, (Arc<CudaModule>, CudaFunction)>,
+    ) -> (
+        CudaFunction,
+        Arc<CudaModule>,
+        String,
+        (Expression, Expression, Expression),
+        (Expression, Expression, Expression),
+        Expression,
+        FxHashMap<Symbol, CudaSlice<u8>>,
+    ) {
+        assert!(matches!(self.dtype, DType::Bf16 | DType::F16));
+        assert!(self.output_dtype == self.dtype || self.output_dtype == DType::F32);
+        let (tm, tn, s) = (self.tile_m, self.tile_n, self.warps_per_column);
+        assert!(thin_matmul_choices().any(|v| v == (tm, tn, s)));
+        let vars = self.all_dyn_vars();
+        let (defines, _) = generate_dyn_dims_defines(&vars);
+        let dims = if vars.is_empty() {
+            ""
+        } else {
+            ", const int* dyn_dims"
+        };
+        let includes = dtype_includes(&[self.dtype, self.output_dtype]);
+        let ty = cuda_dtype(self.dtype);
+        let out_ty = cuda_dtype(self.output_dtype);
+        let (m, n, k) = (self.m.to_kernel(), self.n.to_kernel(), self.k.to_kernel());
+        let bias = if BIAS {
+            format!(", const {}* bias", if MIXED { "float" } else { ty })
+        } else {
+            String::new()
+        };
+        let epilogue = if MIXED {
+            let round_ty = cuda_dtype(self.round_dtype);
+            let value = if BIAS { "sum + bias[col]" } else { "sum" };
+            format!("out[row * ({n}) + col] = ({out_ty})(({round_ty})({value}));")
+        } else if BIAS {
+            format!(
+                "{ty} rounded = ({ty})sum; rounded = ({ty})((float)rounded + (float)bias[col]); out[row * ({n}) + col] = ({out_ty})rounded;"
+            )
+        } else {
+            format!("out[row * ({n}) + col] = ({out_ty})(({ty})sum);")
+        };
+        let reduction = if s > 1 {
+            format!(
+                r#"
+            __shared__ float partial[{tm} * {tn} * {s}];
+            #pragma unroll
+            for (int t=0;t<{tm};t++) if (lane==0) partial[t*{tn}*{s}+warp]=acc[t];
+            __syncthreads();
+            if (split==0 && lane==0 && col<({n})) {{
+                #pragma unroll
+                for (int t=0;t<{tm};t++) {{
+                    long long row=first_row+t;
+                    if (row<({m})) {{
+                        float sum=partial[t*{tn}*{s}+warp];
+                        #pragma unroll
+                        for (int p=1;p<{s};p++) sum+=partial[t*{tn}*{s}+warp+p];
+                        {epilogue}
+                    }}
+                }}
+            }}"#
+            )
+        } else {
+            format!(
+                r#"
+            if (lane==0 && col<({n})) {{
+                #pragma unroll
+                for (int t=0;t<{tm};t++) {{
+                    long long row=first_row+t;
+                    if (row<({m})) {{ float sum=acc[t]; {epilogue} }}
+                }}
+            }}"#
+            )
+        };
+        let name = if MIXED {
+            if BIAS {
+                "mixed_affine_k"
+            } else {
+                "mixed_matmul_k"
+            }
+        } else if BIAS {
+            "thin_matmul_bias_k"
+        } else {
+            "thin_matmul_k"
+        };
+        let source = format!(
+            r#"{includes}
+{defines}
+extern "C" __global__ void {name}({out_ty}* out, const {ty}* x, const {ty}* w{bias}{dims}) {{
+    int lane=threadIdx.x%32, warp=threadIdx.x/32, split=warp%{s};
+    long long col=(long long)blockIdx.x*{tn}+warp/{s};
+    long long first_row=(long long)blockIdx.y*{tm};
+    float acc[{tm}]={{}};
+    if (col<({n})) {{
+        if (({k})%8==0 && (((unsigned long long)x | (unsigned long long)w)&15)==0) {{
+            for (long long j=split*32+lane;j<({k})/8;j+=32*{s}) {{
+                uint4 weight=((const uint4*)(w+col*({k})))[j];
+                #pragma unroll
+                for (int t=0;t<{tm};t++) if (first_row+t<({m})) {{
+                    uint4 input=((const uint4*)(x+(first_row+t)*({k})))[j];
+                    #pragma unroll
+                    for (int v=0;v<8;v++) acc[t]+=(float)(({ty}*)&weight)[v]*(float)(({ty}*)&input)[v];
+                }}
+            }}
+        }} else {{
+            for (long long j=split*32+lane;j<({k});j+=32*{s}) {{
+                float weight=(float)w[col*({k})+j];
+                #pragma unroll
+                for (int t=0;t<{tm};t++) if (first_row+t<({m})) acc[t]+=weight*(float)x[(first_row+t)*({k})+j];
+            }}
+        }}
+    }}
+    #pragma unroll
+    for (int t=0;t<{tm};t++) {{
+        #pragma unroll
+        for (int d=16;d;d/=2) acc[t]+=__shfl_down_sync(0xffffffff,acc[t],d);
+    }}
+    {reduction}
+}}"#
+        );
+        let (module, function) = if let Some((module, function)) = cache.get(&source) {
+            (module.clone(), function.clone())
+        } else {
+            let image = compile_module_image_for_current_device(stream.context(), &source).unwrap();
+            let module = stream.context().load_module(image).unwrap();
+            let function = module.load_function(name).unwrap();
+            cache.insert(source.clone(), (module.clone(), function.clone()));
+            (module, function)
+        };
+        (
+            function,
+            module,
+            source,
+            (
+                self.n.ceil_div(tn).max(1),
+                self.m.ceil_div(tm).max(1),
+                1.into(),
+            ),
+            ((32 * tn * s).into(), 1.into(), 1.into()),
+            0.into(),
+            FxHashMap::default(),
+        )
+    }
+    fn collect_dyn_vars_into(&self, vars: &mut FxHashSet<Symbol>) {
+        for dim in [self.m, self.n, self.k] {
+            dim.collect_dyn_vars_into(vars);
+        }
+    }
+    fn output_size(&self) -> Expression {
+        self.m * self.n
+    }
+    fn output_bytes(&self) -> Expression {
+        (self.output_size() * self.output_dtype.bits()).ceil_div(8)
+    }
+    fn output_dtype(&self) -> DType {
+        self.output_dtype
+    }
+    fn bytes_loaded(&self) -> Expression {
+        ((self.m * self.k + self.n * self.k) * self.dtype.bits()
+            + if BIAS {
+                self.n * if MIXED { 32 } else { self.dtype.bits() }
+            } else {
+                0.into()
+            })
+        .ceil_div(8)
+    }
+    fn bytes_stored(&self) -> Expression {
+        self.output_bytes()
+    }
+    fn flops(&self) -> Expression {
+        self.m * self.n * self.k * 2 + if BIAS { self.m * self.n } else { 0.into() }
+    }
+    fn kernel_name(&self) -> &'static str {
+        if MIXED {
+            if BIAS { "MixedAffine" } else { "MixedMatmul" }
+        } else if BIAS {
+            "ThinMatmulBias"
+        } else {
+            "ThinMatmul"
+        }
+    }
+}
+
+impl<const BIAS: bool, const MIXED: bool> KernelThinMatmul<BIAS, MIXED> {
+    // The storage, accumulation and final rounding contracts are independent:
+    // widened operands are exact, bias is added in F32, and a final low-precision
+    // round must survive any subsequent promotion to F32.
+    fn mixed_rewrites(&self) -> Vec<Rule> {
+        let name = Self::name();
+        let mut rules = vec![Rule::raw(if BIAS {
+            r#"(rule (
+                (= ?sum (Op (KernelMixedMatmul ?m ?n ?k ?dt (F32)
+                    (MNum 1) (MNum 8) (MNum 1) (F32))
+                    (ICons ?x (ICons ?w (INil)))))
+                (= ?out (Op (Add (ECons ?m (ECons ?n (ENil)))
+                    ?strides (ECons (MNum 0) (ECons (MIter) (ENil))) ?strides)
+                    (ICons ?sum (ICons ?bias (INil)))))
+                (= ?strides (ECons (MMul (MIter) ?n) (ECons (MIter) (ENil))))
+                (= (dtype ?bias) (F32)) (= (dtype ?out) (F32))
+            ) (
+                (let ?fused (Op (KernelMixedAffine ?m ?n ?k ?dt (F32)
+                    (MNum 1) (MNum 8) (MNum 1) (F32))
+                    (ICons ?x (ICons ?w (ICons ?bias (INil))))))
+                (union ?out ?fused) (set (dtype ?fused) (F32))
+                (thin_matmul_output_extent ?fused (MMul ?m ?n))
+            ) :ruleset matmul_backend :name "mixed affine F32 bias before final rounding")"#
+        } else {
+            r#"(rule (
+                (= ?sum (Op (GenericMatmul
+                    (ECons ?m (ECons ?n (ENil))) ?mul_shape ?k
+                    (ECons (MMul (MIter) ?k) (ECons (MNum 0) (ECons (MIter) (ENil))))
+                    (ECons (MNum 0) (ECons (MMul (MIter) ?k) (ECons (MIter) (ENil))))
+                    ?sum_in_stride (MIter) ?sum_out_stride (F32))
+                    (ICons ?xc (ICons ?wc (INil)))))
+                (generic_matmul_exact_2d ?sum ?m ?n ?k (F32))
+                (= ?xc (Op (Cast ?xs (F32)) (ICons ?x (INil))))
+                (= ?wc (Op (Cast ?ws (F32)) (ICons ?w (INil))))
+                (= (dtype ?x) ?dt) (= (dtype ?w) ?dt)
+                (low_precision_matmul_dtype ?dt)
+            ) (
+                (let ?kernel (Op (KernelMixedMatmul ?m ?n ?k ?dt (F32)
+                    (MNum 1) (MNum 8) (MNum 1) (F32))
+                    (ICons ?x (ICons ?w (INil)))))
+                (union ?sum ?kernel) (set (dtype ?kernel) (F32))
+                (thin_matmul_output_extent ?kernel (MMul ?m ?n))
+            ) :ruleset matmul_backend :name "mixed matmul exact widened operands")"#
+        })];
+        rules.push(Rule::raw(format!(
+            r#"(rule (
+            (= ?product (Op ({name} ?m ?n ?k ?dt (F32)
+                (MNum 1) (MNum 8) (MNum 1) (F32)) ?inputs))
+            (thin_matmul_output_extent ?product ?size)
+            (= ?out (Op (Cast ?size ?dt) (ICons ?product (INil))))
+        ) (
+            (let ?narrow (Op ({name} ?m ?n ?k ?dt ?dt
+                (MNum 1) (MNum 8) (MNum 1) ?dt) ?inputs))
+            (union ?out ?narrow) (set (dtype ?narrow) ?dt)
+            (thin_matmul_output_extent ?narrow ?size)
+        ) :ruleset matmul_backend :name "{name} final output rounding")"#
+        )));
+        rules.push(Rule::raw(format!(
+            r#"(rule (
+            (= ?product (Op ({name} ?m ?n ?k ?dt ?dt
+                (MNum 1) (MNum 8) (MNum 1) ?dt) ?inputs))
+            (thin_matmul_output_extent ?product ?size)
+            (= ?out (Op (Cast ?size (F32)) (ICons ?product (INil))))
+        ) (
+            (let ?promoted (Op ({name} ?m ?n ?k ?dt (F32)
+                (MNum 1) (MNum 8) (MNum 1) ?dt) ?inputs))
+            (union ?out ?promoted) (set (dtype ?promoted) (F32))
+        ) :ruleset matmul_backend :name "{name} promotion preserves final rounding")"#
+        )));
+        rules.extend(thin_matmul_choices().filter(|&v| v != (1, 8, 1)).map(|(m,n,s)| {
+            Rule::raw(format!(r#"(rule
+                ((= ?out (Op ({name} ?m ?n ?k ?dt ?out_dt (MNum 1) (MNum 8) (MNum 1) ?round) ?inputs)))
+                (
+                    (let ?tuned (Op ({name} ?m ?n ?k ?dt ?out_dt (MNum {m}) (MNum {n}) (MNum {s}) ?round) ?inputs))
+                    (union ?out ?tuned) (set (dtype ?tuned) ?out_dt)
+                ) :ruleset matmul_backend :name "{name} tile {m} by {n} with {s} warps per column")"#))
+        }));
+        rules
+    }
+}

--- a/crates/luminal_cuda_lite/src/kernel/to_host.rs
+++ b/crates/luminal_cuda_lite/src/kernel/to_host.rs
@@ -968,6 +968,14 @@ pub struct CudaGraphOp {
     resident: RefCell<Option<ResidentGraphVariants>>,
     residency_frozen: std::cell::Cell<bool>,
     graph_builds: std::cell::Cell<usize>,
+    boundary_probe: RefCell<Option<BoundaryProbe>>,
+}
+
+struct BoundaryProbe {
+    replay: bool,
+    names: FxHashSet<String>,
+    copies: FxHashMap<NodeIndex, CudaSlice<u8>>,
+    replaced: FxHashSet<NodeIndex>,
 }
 
 struct ArenaBufferOrderAccumulator {
@@ -1253,6 +1261,7 @@ impl CudaGraphOp {
             resident: RefCell::new(None),
             residency_frozen: std::cell::Cell::new(false),
             graph_builds: std::cell::Cell::new(0),
+            boundary_probe: RefCell::new(None),
         }
     }
 
@@ -2494,6 +2503,124 @@ impl CudaGraphOp {
         Self::reset_materialization_state(&mut state);
     }
 
+    pub(crate) fn record_boundaries(&self, names: &[String]) {
+        self.release_materialization();
+        *self.boundary_probe.borrow_mut() = Some(BoundaryProbe {
+            replay: false,
+            names: names.iter().cloned().collect(),
+            copies: FxHashMap::default(),
+            replaced: FxHashSet::default(),
+        });
+    }
+
+    pub(crate) fn replay_boundaries(&self, names: &[String]) {
+        self.release_materialization();
+        let mut probe = self.boundary_probe.borrow_mut();
+        let probe = probe.as_mut().expect("record boundaries before replay");
+        probe.replay = true;
+        probe.names = names.iter().cloned().collect();
+        probe.replaced.clear();
+    }
+
+    pub(crate) fn boundary_probe_counts(&self) -> (usize, usize) {
+        let probe = self.boundary_probe.borrow();
+        let probe = probe.as_ref().expect("active boundary probe");
+        (
+            probe.replaced.len(),
+            probe.replaced.iter().map(|n| probe.copies[n].len()).sum(),
+        )
+    }
+
+    pub(crate) fn clear_boundaries(&self) {
+        self.release_materialization();
+        self.boundary_probe.borrow_mut().take();
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn boundary_copy(
+        &self,
+        state: &CudaGraphOpState,
+        step: CompiledStep,
+        graph: &mut CudaGraphHandle,
+        dependencies: &[CUgraphNode],
+        buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
+        dims: &DynMap,
+        replay: bool,
+    ) -> anyhow::Result<Option<CUgraphNode>> {
+        let mut probe = self.boundary_probe.borrow_mut();
+        let Some(probe) = probe.as_mut().filter(|p| p.replay == replay) else {
+            return Ok(None);
+        };
+        let (node, name, size) = match step {
+            CompiledStep::Kernel(i) => {
+                let k = &state.kernels[i];
+                // An aliased output may represent a mutation larger than the
+                // returned view. Never model that effect as a pure output copy.
+                if k.kernel_op.output_aliases_input().is_some() {
+                    return Ok(None);
+                }
+                (
+                    k.node,
+                    k.kernel_op.kernel_name(),
+                    k.kernel_op.output_bytes(),
+                )
+            }
+            CompiledStep::CuBlasLt(i) => {
+                let op = &state.cublaslt_ops[i];
+                (op.node, "cublaslt", op.host_op.output_bytes())
+            }
+            CompiledStep::CapturedHost(i) => {
+                let op = &state.captured_host_ops[i];
+                (
+                    op.node,
+                    op.host_op.stats_name().unwrap_or("CapturedHost"),
+                    op.host_op.output_bytes(),
+                )
+            }
+            CompiledStep::FlashInferDecode(_) => return Ok(None),
+        };
+        if !probe.names.contains(name) {
+            return Ok(None);
+        }
+        let bytes = size
+            .exec(dims)
+            .ok_or_else(|| anyhow::anyhow!("unresolved probe size"))?;
+        if bytes == 0 {
+            return Ok(None);
+        }
+        let output = buffers
+            .get(&node)
+            .ok_or_else(|| anyhow::anyhow!("missing probe output"))?;
+        anyhow::ensure!(bytes <= output.len(), "probe output exceeds allocation");
+        if !replay && !probe.copies.contains_key(&node) {
+            probe
+                .copies
+                .insert(node, self.stream.alloc_zeros::<u8>(bytes)?);
+        }
+        if replay {
+            probe.replaced.insert(node);
+        }
+        let copy = probe
+            .copies
+            .get(&node)
+            .ok_or_else(|| anyhow::anyhow!("unrecorded probe boundary"))?;
+        anyhow::ensure!(bytes == copy.len(), "probe dimensions changed");
+        let saved = copy.device_ptr(&self.stream).0;
+        let (dst, src) = if replay {
+            (output.ptr(), saved)
+        } else {
+            (saved, output.ptr())
+        };
+        unsafe {
+            graph
+                .add_device_copy(dependencies, dst, src, bytes)
+                .map(Some)
+                .map_err(Into::into)
+        }
+    }
+
+    /// E-class costs for proposal guidance only. Timing events serialize
+    /// steps, so these must never replace clean whole-graph candidate fitness.
     /// Emit a diagnostic-only breakdown of one completed graph launch. Step
     /// timing nodes are inserted only when `LUMINAL_CUDA_PROFILE_GRAPH_STEPS`
     /// is present at materialization time, so production graphs carry no event
@@ -2550,6 +2677,11 @@ impl CudaGraphOp {
         changed_buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
         dyn_map: &DynMap,
     ) -> anyhow::Result<bool> {
+        // Diagnostic copies carry their own pointers. Their graph is rebuilt
+        // on a binding change rather than applying kernel-only node updates.
+        if self.boundary_probe.borrow().is_some() {
+            return Ok(false);
+        }
         let mut state = self.state.borrow_mut();
         if state.cuda_graph.is_none() || state.cuda_graph_exec.is_none() {
             return Ok(false);
@@ -3065,6 +3197,14 @@ impl CudaGraphOp {
 
         // Check if we need to update the graph
         let buffer_ptrs_changed = current_buffer_ptrs != state.last_buffer_ptrs;
+        if self.boundary_probe.borrow().is_some() {
+            // The first build refreshed last_dyn_values. Do not use the stale
+            // pre-build dirty set to update kernels replaced by copy nodes.
+            if buffer_ptrs_changed || *dyn_map != state.last_dyn_values {
+                self.build_graph(&mut state, stream, buffers, dyn_map)?;
+            }
+            return Ok(());
+        }
         let needs_update = dyn_map_changed || buffer_ptrs_changed;
 
         if needs_update {
@@ -4117,10 +4257,13 @@ impl CudaGraphOp {
             op.child_graph = None;
         }
 
-        let tracing_enabled = enabled!(Level::TRACE)
+        let step_profile = std::env::var_os("LUMINAL_CUDA_PROFILE_GRAPH_STEPS").is_some();
+        // Both modes reuse this event pool. Do not record a step boundary a
+        // second time as a kernel tracing event in the same launch.
+        let tracing_enabled = !step_profile
+            && enabled!(Level::TRACE)
             && state.cublaslt_ops.is_empty()
             && state.flashinfer_ops.is_empty();
-        let step_profile = std::env::var_os("LUMINAL_CUDA_PROFILE_GRAPH_STEPS").is_some();
         if tracing_enabled || step_profile {
             let needed_events = if step_profile {
                 state.steps.len() + 1
@@ -4191,6 +4334,13 @@ impl CudaGraphOp {
             debug_assert!(deps.iter().all(|node| !node.is_null()));
 
             let step = state.steps[step_index];
+            if let Some(copy) =
+                self.boundary_copy(state, step, &mut graph, &deps, buffers, dyn_map, true)?
+            {
+                state.step_entry_nodes[step_index] = copy;
+                state.step_output_nodes[step_index] = copy;
+                continue;
+            }
             match step {
                 CompiledStep::Kernel(idx) => {
                     {
@@ -4432,6 +4582,18 @@ impl CudaGraphOp {
                     state.step_entry_nodes[step_index] = child_node;
                     state.step_output_nodes[step_index] = child_node;
                 }
+            }
+            let output = state.step_output_nodes[step_index];
+            if let Some(copy) = self.boundary_copy(
+                state,
+                step,
+                &mut graph,
+                std::slice::from_ref(&output),
+                buffers,
+                dyn_map,
+                false,
+            )? {
+                state.step_output_nodes[step_index] = copy;
             }
             if step_profile {
                 let output = state.step_output_nodes[step_index];

--- a/crates/luminal_cuda_lite/src/kernel/to_host.rs
+++ b/crates/luminal_cuda_lite/src/kernel/to_host.rs
@@ -30,7 +30,7 @@ use tracing::{Level, enabled, span};
 
 use crate::{
     host::{
-        DeviceBuffer, HostOp,
+        CudaGraphCaptureResources, DeviceBuffer, HostOp,
         cublaslt::{
             CuBlasLt, CuBlasLtCaptureSignature, CuBlasLtPrepareKey, LtMatmulPointers,
             PreparedCuBlasLtMatmul,
@@ -219,6 +219,7 @@ struct CompiledCapturedHost {
     host_op: Arc<Box<dyn HostOp>>,
     child_graph: Option<CudaGraphHandle>,
     graph_node: Option<CUgraphNode>,
+    resources: CudaGraphCaptureResources,
 }
 
 impl CompiledCapturedHost {
@@ -233,13 +234,21 @@ impl CompiledCapturedHost {
     }
 
     fn prepare_graph_capture(
-        &self,
-        stream: &Arc<CudaStream>,
+        &mut self,
+        capture_stream: &Arc<CudaStream>,
+        execution_stream: &Arc<CudaStream>,
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
         dyn_map: &DynMap,
     ) -> anyhow::Result<()> {
-        let host = self.host_op.as_ref().as_ref();
-        host.prepare_cuda_graph_capture(stream, self.node, &self.inputs, buffers, dyn_map)
+        self.resources = self.host_op.prepare_cuda_graph_capture_resources(
+            capture_stream,
+            execution_stream,
+            self.node,
+            &self.inputs,
+            buffers,
+            dyn_map,
+        )?;
+        Ok(())
     }
 }
 
@@ -811,6 +820,7 @@ impl ResidentGraphVariant {
                 host_op: op.host_op.clone(),
                 child_graph: None,
                 graph_node: None,
+                resources: vec![],
             })
             .collect();
         variant.kernel_nodes = vec![None; state.kernels.len()];
@@ -2448,6 +2458,7 @@ impl CudaGraphOp {
         for op in &mut state.captured_host_ops {
             op.child_graph = None;
             op.graph_node = None;
+            op.resources.clear();
         }
         state.dyn_dims_buffer = None;
     }
@@ -4085,6 +4096,11 @@ impl CudaGraphOp {
         let ctx = stream.context().clone();
         let mut graph = CudaGraphHandle::new(ctx.clone())?;
         let old_exec = state.cuda_graph_exec.take();
+        let old_resources: Vec<_> = state
+            .captured_host_ops
+            .iter_mut()
+            .flat_map(|op| std::mem::take(&mut op.resources))
+            .collect();
 
         let num_kernels = state.kernels.len();
         state.kernel_params.clear();
@@ -4393,8 +4409,8 @@ impl CudaGraphOp {
                 CompiledStep::CapturedHost(idx) => {
                     let capture_stream = self.capture_stream()?;
                     {
-                        let op = &state.captured_host_ops[idx];
-                        op.prepare_graph_capture(&capture_stream, buffers, dyn_map)?;
+                        let op = &mut state.captured_host_ops[idx];
+                        op.prepare_graph_capture(&capture_stream, stream, buffers, dyn_map)?;
                     }
                     CudaGraphHandle::begin_standalone_capture(&capture_stream)?;
                     {
@@ -4445,6 +4461,7 @@ impl CudaGraphOp {
 
         state.cuda_graph = Some(graph);
         state.cuda_graph_exec = Some(exec);
+        drop(old_resources);
         state.cublaslt_prepare_cache = prepared_cache_plan;
         state.cublaslt_workspace_pool = workspace_pool_plan;
         state.flashinfer_prepare_cache = flashinfer_prepare_cache_plan;
@@ -5063,6 +5080,7 @@ pub(crate) fn kernel_to_host_with_prepared(
                     host_op: Arc::clone(host_op),
                     child_graph: None,
                     graph_node: None,
+                    resources: vec![],
                 });
                 captured_host_step_by_node.insert(*node, idx);
             }

--- a/crates/luminal_cuda_lite/src/lib.rs
+++ b/crates/luminal_cuda_lite/src/lib.rs
@@ -11,6 +11,7 @@ mod resource;
 pub mod runtime;
 mod search;
 mod search_image_cache;
+mod temporary_fast_paths;
 use std::{
     cell::Cell,
     ffi::{CStr, CString},

--- a/crates/luminal_cuda_lite/src/lib.rs
+++ b/crates/luminal_cuda_lite/src/lib.rs
@@ -10,6 +10,7 @@ pub mod kernel;
 mod resource;
 pub mod runtime;
 mod search;
+mod search_image_cache;
 use std::{
     cell::Cell,
     ffi::{CStr, CString},
@@ -563,6 +564,11 @@ pub fn compile_module_image_for_current_device<S: AsRef<str>>(
     {
         panic!("kernel source too large for nvrtc ({src_len} bytes > {limit})");
     }
+    let search_image_key = search_image_cache::key(&module_key, &nvrtc_options);
+    if let Some(image) = search_image_cache::lookup(&search_image_key) {
+        record_module_image(&module_key, &image);
+        return Ok(Ptx::from_binary(image));
+    }
     if src_len > 128 * 1024 {
         eprintln!("nvrtc: compiling a large kernel ({src_len} bytes)");
     }
@@ -644,6 +650,7 @@ pub fn compile_module_image_for_current_device<S: AsRef<str>>(
     }
 
     record_module_image(&module_key, &cubin);
+    search_image_cache::record(search_image_key, &cubin);
     Ok(Ptx::from_binary(cubin))
 }
 

--- a/crates/luminal_cuda_lite/src/prepared_input.rs
+++ b/crates/luminal_cuda_lite/src/prepared_input.rs
@@ -1,0 +1,207 @@
+//! Explicit, owned physical input representations. No pointer-keyed data cache.
+use super::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) struct PreparedInput {
+    pub format: &'static str,
+    pub capacity: usize,
+}
+
+/// Owns managed storage while runtime bindings expose non-owning device views.
+pub(super) struct PreparedUnifiedOwner {
+    pub buffer: cudarc::driver::UnifiedSlice<u8>,
+    stream: Arc<CudaStream>,
+}
+impl Drop for PreparedUnifiedOwner {
+    fn drop(&mut self) {
+        // HostOps and captured kernels use raw pointers; their completion must
+        // precede UnifiedSlice's synchronous free, independently of its events.
+        self.stream
+            .synchronize()
+            .expect("prepared allocation synchronization failed");
+    }
+}
+
+/// Resolve declared input writes through storage aliases, independent of op names.
+pub(super) fn input_writes(llir: &LLIRGraph) -> anyhow::Result<FxHashSet<NodeIndex>> {
+    let incoming = |node| {
+        llir.edges_directed(node, Direction::Incoming)
+            .sorted_by_key(|e| e.id())
+            .map(|e| e.source())
+            .collect::<Vec<_>>()
+    };
+    let root = |mut node: NodeIndex| {
+        for _ in 0..=llir.node_count() {
+            if let Some(input) = llir[node].to_op::<Input>() {
+                return Some(NodeIndex::new(input.node));
+            }
+            let alias = llir[node]
+                .to_dialect::<dyn KernelOp>()?
+                .output_aliases_input()?;
+            node = *incoming(node).get(alias)?;
+        }
+        None
+    };
+    let mut writes = FxHashSet::default();
+    for node in llir.node_indices() {
+        let inputs = incoming(node);
+        let indices = if let Some(kernel) = llir[node].to_dialect::<dyn KernelOp>() {
+            kernel
+                .output_aliases_input()
+                .filter(|_| kernel.mutates_aliased_input())
+                .into_iter()
+                .collect()
+        } else if let Some(host) = llir[node].to_dialect::<dyn HostOp>() {
+            host.profile_mutated_inputs()
+        } else {
+            vec![]
+        };
+        for index in indices {
+            let source = inputs
+                .get(index)
+                .ok_or_else(|| anyhow::anyhow!("invalid declared input-write index"))?;
+            if let Some(input) = root(*source) {
+                writes.insert(input);
+            }
+        }
+    }
+    Ok(writes)
+}
+
+impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
+    /// Inspect an input's current logical view and explicitly declared physical ABI.
+    /// This non-owning view is valid only while its runtime binding is retained.
+    pub fn input_buffer(&self, id: impl ToId) -> Option<DeviceBuffer> {
+        Self::input_device_buffer(
+            id.to_id(),
+            &self.cuda_stream,
+            &self.hlir_buffers,
+            &self.external_buffers,
+            &self.prepared_inputs,
+        )
+    }
+
+    /// Install a read-only, explicitly formatted input allocation. The format is
+    /// an operation-defined physical ABI, not a tensor dtype. `logical_bytes`
+    /// bounds its primary view; HostOps can inspect the full allocation capacity
+    /// and format to consume additional representations stored by that ABI.
+    ///
+    /// The caller must construct all representations coherently. Ordinary input
+    /// setters clear this declaration. Graph writes and recurrent commits to a
+    /// prepared input are rejected. Representative workloads must share it.
+    pub fn set_prepared_buffer(
+        &mut self,
+        id: impl ToId,
+        buffer: CudaSlice<u8>,
+        logical_bytes: usize,
+        format: &'static str,
+    ) {
+        let id = id.to_id();
+        assert!(!format.is_empty() && logical_bytes <= buffer.len());
+        assert!(
+            self.compiled_buckets
+                .iter()
+                .all(|b| !b.input_writes.contains(&id)),
+            "prepared input is written by a retained graph"
+        );
+        let capacity = buffer.len();
+        let ptr = buffer.device_ptr(&self.cuda_stream).0;
+        assert!(
+            self.output_ptr_registrations
+                .values()
+                .all(|&(out, len)| !device_ranges_overlap(ptr, capacity, out, len)),
+            "prepared input overlaps an external output"
+        );
+        self.set_buffer(id, buffer);
+        let CudaInput::Buffer { len, .. } = self.hlir_buffers.get_mut(&id).unwrap() else {
+            unreachable!()
+        };
+        *len = logical_bytes;
+        self.prepared_inputs
+            .insert(id, PreparedInput { format, capacity });
+        self.changed_hlir.insert(id);
+    }
+
+    /// Install owned managed memory with the same read-only prepared ABI.
+    /// CUDA may evict cold pages under device-memory pressure. The caller must
+    /// warm representative workloads and account for migration in measurements.
+    /// Captured pointers remain stable. Ordinary input replacement releases this
+    /// owner only after stream completion; workloads must declare it shared.
+    pub fn set_prepared_unified_buffer(
+        &mut self,
+        id: impl ToId,
+        buffer: cudarc::driver::UnifiedSlice<u8>,
+        logical_bytes: usize,
+        format: &'static str,
+    ) {
+        let id = id.to_id();
+        assert!(!format.is_empty() && logical_bytes <= buffer.len());
+        assert!(
+            self.compiled_buckets
+                .iter()
+                .all(|b| !b.input_writes.contains(&id)),
+            "prepared input is written by a retained graph"
+        );
+        let capacity = buffer.len();
+        let ptr = buffer.device_ptr(&self.cuda_stream).0;
+        assert!(
+            self.output_ptr_registrations
+                .values()
+                .all(|&(out, len)| !device_ranges_overlap(ptr, capacity, out, len)),
+            "prepared input overlaps an external output"
+        );
+        unsafe {
+            self.set_device_ptr(id, ptr, logical_bytes);
+        }
+        self.prepared_inputs
+            .insert(id, PreparedInput { format, capacity });
+        self.prepared_unified_owners.insert(
+            id,
+            PreparedUnifiedOwner {
+                buffer,
+                stream: self.cuda_stream.clone(),
+            },
+        );
+        self.changed_hlir.insert(id);
+    }
+
+    pub(super) fn clear_prepared_input(&mut self, id: NodeIndex) {
+        self.prepared_unified_owners.remove(&id);
+        if self.prepared_inputs.remove(&id).is_some() {
+            self.changed_hlir.insert(id);
+        }
+    }
+
+    pub(super) fn validate_prepared_input_effects(&self, llir: &LLIRGraph) -> anyhow::Result<()> {
+        if !self.prepared_inputs.is_empty() {
+            anyhow::ensure!(
+                input_writes(llir)?
+                    .iter()
+                    .all(|id| !self.prepared_inputs.contains_key(id)),
+                "candidate writes a prepared read-only input"
+            );
+        }
+        Ok(())
+    }
+
+    pub(super) fn input_device_buffer(
+        id: NodeIndex,
+        stream: &Arc<CudaStream>,
+        inputs: &FxHashMap<NodeIndex, CudaInput>,
+        external: &FxHashMap<NodeIndex, std::mem::ManuallyDrop<CudaSlice<u8>>>,
+        prepared: &FxHashMap<NodeIndex, PreparedInput>,
+    ) -> Option<DeviceBuffer> {
+        let mut buffer = match inputs.get(&id)? {
+            CudaInput::Buffer { buf, len } => {
+                DeviceBuffer::new(buf.device_ptr(stream).0, *len).with_capacity(buf.len())
+            }
+            CudaInput::Ptr(ptr) => DeviceBuffer::new(*ptr, external.get(&id)?.len()),
+        };
+        if let Some(layout) = prepared.get(&id) {
+            buffer = buffer
+                .with_capacity(layout.capacity)
+                .with_input_format(layout.format);
+        }
+        Some(buffer)
+    }
+}

--- a/crates/luminal_cuda_lite/src/profile.rs
+++ b/crates/luminal_cuda_lite/src/profile.rs
@@ -170,6 +170,20 @@ pub struct ProfileEvaluation {
     pub weighted_cost: Duration,
 }
 
+impl ProfileEvaluation {
+    pub(crate) fn display(&self) -> String {
+        format!(
+            "weighted workload score={:?}; measured case latencies=[{}]",
+            self.weighted_cost,
+            self.cases
+                .iter()
+                .map(|case| format!("{}: {:?}", case.case_id, case.duration))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+}
+
 pub(super) struct ReplaySession {
     assigned: Vec<Vec<usize>>,
     slots: Vec<CudaSlice<u8>>,

--- a/crates/luminal_cuda_lite/src/profile.rs
+++ b/crates/luminal_cuda_lite/src/profile.rs
@@ -16,6 +16,31 @@ impl ProfileStorage {
     pub fn new(data: impl ToCudaInput) -> Self {
         Self(data.into_cuda_bytes().into())
     }
+
+    fn captured(bytes: Vec<u8>) -> Self {
+        const CHUNK: usize = 64 * 1024;
+        if bytes.len() < 1024 * 1024 {
+            return Self(bytes.into());
+        }
+        let nonzero: Vec<_> = bytes
+            .chunks(CHUNK)
+            .enumerate()
+            .filter_map(|(i, chunk)| chunk.iter().any(|&v| v != 0).then_some(i))
+            .collect();
+        if nonzero.len() * CHUNK > bytes.len() / 2 {
+            return Self(bytes.into());
+        }
+        // D2H writes commit every page, even for mostly untouched state.
+        // Copy only nonzero chunks into a fresh zeroed allocation: untouched
+        // pages can remain lazy while ordinary slices and overlapping views
+        // retain exactly the same bytes. Dense snapshots retain their allocation.
+        let mut sparse = vec![0; bytes.len()];
+        for i in nonzero {
+            let range = i * CHUNK..((i + 1) * CHUNK).min(bytes.len());
+            sparse[range.clone()].copy_from_slice(&bytes[range]);
+        }
+        Self(sparse.into())
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -400,14 +425,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                     result::memcpy_dtoh_sync(&mut bytes, start)?;
                 }
             }
-            // A device read commits every destination page, including untouched
-            // zero-filled state. A fresh zeroed allocation can retain lazy zero
-            // pages instead; Arc<Vec<_>> then owns it without an eager copy.
-            // The captured values and all overlapping views remain identical.
-            if bytes.len() >= 1024 * 1024 && bytes.iter().all(|&byte| byte == 0) {
-                bytes = vec![0; bytes.len()];
-            }
-            let storage = ProfileStorage(bytes.into());
+            let storage = ProfileStorage::captured(bytes);
             for &(ptr, end, tensor) in &ranges[i..j] {
                 let range = (ptr - start) as usize..(end - start) as usize;
                 let mirror = self.hlir_host_mirrors.get(&tensor.id);

--- a/crates/luminal_cuda_lite/src/profile.rs
+++ b/crates/luminal_cuda_lite/src/profile.rs
@@ -9,7 +9,9 @@ use std::ops::Range;
 /// Immutable backing bytes. Views of the same storage preserve aliasing and are
 /// restored together, once per reset. Bytes use the graph input's physical ABI.
 #[derive(Clone, Debug)]
-pub struct ProfileStorage(Arc<[u8]>);
+// Retain the caller's allocation. Converting Vec into Arc<[u8]> copies every
+// byte and physically commits lazily allocated zero pages for large states.
+pub struct ProfileStorage(Arc<Vec<u8>>);
 impl ProfileStorage {
     pub fn new(data: impl ToCudaInput) -> Self {
         Self(data.into_cuda_bytes().into())
@@ -398,6 +400,13 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                     result::memcpy_dtoh_sync(&mut bytes, start)?;
                 }
             }
+            // A device read commits every destination page, including untouched
+            // zero-filled state. A fresh zeroed allocation can retain lazy zero
+            // pages instead; Arc<Vec<_>> then owns it without an eager copy.
+            // The captured values and all overlapping views remain identical.
+            if bytes.len() >= 1024 * 1024 && bytes.iter().all(|&byte| byte == 0) {
+                bytes = vec![0; bytes.len()];
+            }
             let storage = ProfileStorage(bytes.into());
             for &(ptr, end, tensor) in &ranges[i..j] {
                 let range = (ptr - start) as usize..(end - start) as usize;
@@ -664,12 +673,12 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         if workload.device_snapshots && session.active != Some(case) {
             let sample = &workload.cases[case];
             let groups = sample.inputs.groups();
-            let keys: FxHashSet<_> = groups.iter().map(|g| g.0.as_ptr() as usize).collect();
+            let keys: FxHashSet<_> = groups.iter().map(|g| Arc::as_ptr(&g.0) as usize).collect();
             // Release inactive storage before allocating its replacement, so
             // memory scales with the largest case rather than the case count.
             session.snapshots.retain(|key, _| keys.contains(key));
             for group in groups {
-                let key = group.0.as_ptr() as usize;
+                let key = Arc::as_ptr(&group.0) as usize;
                 if let std::collections::hash_map::Entry::Vacant(entry) =
                     session.snapshots.entry(key)
                 {
@@ -698,7 +707,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                     self.cuda_stream
                         .upgrade_device_ptr::<u8>(ptr, group.0.len())
                 });
-                if let Some(source) = session.snapshots.get(&(group.0.as_ptr() as usize)) {
+                if let Some(source) = session.snapshots.get(&(Arc::as_ptr(&group.0) as usize)) {
                     self.cuda_stream.memcpy_dtod(source, &mut *destination)?;
                 } else {
                     self.cuda_stream

--- a/crates/luminal_cuda_lite/src/profile.rs
+++ b/crates/luminal_cuda_lite/src/profile.rs
@@ -362,19 +362,37 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                 );
             }
         }
-        // Allocate before altering caller bindings, so allocation failures leave
-        // the original runtime usable. Device capacity checks see these slots.
+        // The previous program is about to be searched again. Its captured
+        // graphs and high-water intermediate arena are disposable caches, and
+        // keeping them alive while allocating replay storage can exhaust the
+        // device before the first candidate is evaluated. Preserve the compiled
+        // program and caller bindings so even an allocation failure can lazily
+        // rematerialize the original program on its next execution.
+        self.release_all_arenas();
+        self.release_pooled_memory();
+        let workload = self.profile_workload.as_ref().unwrap();
         let slots = capacities
             .into_iter()
-            .map(|n| self.cuda_stream.alloc_zeros(n))
-            .collect::<Result<Vec<_>, _>>()?;
+            .enumerate()
+            .map(|(i, n)| {
+                self.cuda_stream.alloc_zeros(n).map_err(|error| {
+                    anyhow::anyhow!(
+                        "profile replay slot {i} ({n} bytes): {error}; device free/total: {:?}",
+                        self.cuda_stream.context().mem_get_info()
+                    )
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
         let mut snapshots = FxHashMap::default();
         if workload.device_snapshots {
             for case in &workload.cases {
                 for group in case.inputs.groups() {
                     let key = group.0.as_ptr() as usize;
                     if let std::collections::hash_map::Entry::Vacant(entry) = snapshots.entry(key) {
-                        entry.insert(self.cuda_stream.clone_htod(group.0.as_ref())?);
+                        let snapshot = self.cuda_stream.clone_htod(group.0.as_ref()).map_err(|error| {
+                            anyhow::anyhow!("profile snapshot for case {:?} ({} bytes): {error}; device free/total: {:?}", case.id, group.0.len(), self.cuda_stream.context().mem_get_info())
+                        })?;
+                        entry.insert(snapshot);
                     }
                 }
             }

--- a/crates/luminal_cuda_lite/src/profile.rs
+++ b/crates/luminal_cuda_lite/src/profile.rs
@@ -136,6 +136,7 @@ pub struct ProfileWorkload {
     shared: Vec<InputSchema>,
     timing_method: luminal::op::TimingMethod,
     device_snapshots: bool,
+    warmup_trials: Option<usize>,
     reused_inputs: ProfileInputs,
     space_token: Option<Arc<Box<dyn luminal::op::EgglogOp>>>,
 }
@@ -149,6 +150,15 @@ impl ProfileWorkload {
     /// invocation timing, not an application scheduler or multi-step trace metric.
     pub fn timing_method(mut self, method: luminal::op::TimingMethod) -> Self {
         self.timing_method = method;
+        self
+    }
+    /// Untimed exact replays before measuring each candidate (default: one).
+    /// Use additional replays when lazy initialization or managed-memory
+    /// residency persists beyond the first invocation. These use the same
+    /// case and restore its state before every invocation; no data is generated.
+    pub fn warmup_trials(mut self, trials: usize) -> Self {
+        assert!(trials > 0, "profile warmup count must be positive");
+        self.warmup_trials = Some(trials);
         self
     }
     /// Cache immutable sample backing on the device. Repeated resets use device
@@ -629,6 +639,13 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         }
         self.cancel_search_profile();
         // Slots drop only after graph releases and restoration of all bindings.
+    }
+
+    pub(crate) fn profile_warmup_trials(&self) -> usize {
+        self.profile_workload
+            .as_ref()
+            .and_then(|w| w.warmup_trials)
+            .unwrap_or(1)
     }
 
     pub(crate) fn profile_case_indices(&self, bucket: usize) -> Option<Vec<usize>> {

--- a/crates/luminal_cuda_lite/src/profile.rs
+++ b/crates/luminal_cuda_lite/src/profile.rs
@@ -1,0 +1,656 @@
+//! Fixed-input replay for CUDA search. Input snapshots live on the host; one
+//! reusable set of device allocations is shared by all examples/candidates.
+use super::*;
+use luminal::search::{
+    ProfileCase, ProfileMeasurement, assign_profile_cases, weighted_profile_cost,
+};
+use std::ops::Range;
+
+/// Immutable backing bytes. Views of the same storage preserve aliasing and are
+/// restored together, once per reset. Bytes use the graph input's physical ABI.
+#[derive(Clone, Debug)]
+pub struct ProfileStorage(Arc<[u8]>);
+impl ProfileStorage {
+    pub fn new(data: impl ToCudaInput) -> Self {
+        Self(data.into_cuda_bytes().into())
+    }
+}
+
+#[derive(Clone, Debug)]
+struct InputSchema {
+    id: NodeIndex,
+    graph: usize,
+    dtype: DType,
+    bytes: Expression,
+}
+impl InputSchema {
+    fn new(t: GraphTensor) -> Self {
+        Self {
+            id: t.id,
+            graph: t.graph_ref as usize,
+            dtype: t.dtype,
+            bytes: (t.shape.physical_span() * t.dtype.bits() + 7) / 8,
+        }
+    }
+    fn validate(&self, graph: &Graph) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.graph == graph as *const Graph as usize,
+            "profile input belongs to another graph"
+        );
+        anyhow::ensure!(
+            graph
+                .input_meta
+                .get(&self.id)
+                .is_some_and(|(_, dtype)| *dtype == self.dtype),
+            "profile binding {:?} is not an input with dtype {:?}",
+            self.id,
+            self.dtype
+        );
+        Ok(())
+    }
+    fn length(&self, dims: &DynMap) -> anyhow::Result<usize> {
+        self.bytes
+            .exec(dims)
+            .ok_or_else(|| anyhow::anyhow!("missing dimensions for profile input {:?}", self.id))
+    }
+}
+#[derive(Clone, Debug)]
+struct Binding {
+    schema: InputSchema,
+    storage: ProfileStorage,
+    range: Range<usize>,
+    mirror: bool,
+}
+
+/// Frozen input bindings for one sample. All supplied bytes are restored, even
+/// when a candidate aliases an output to an input. Omit large immutable inputs
+/// only by explicitly declaring them shared on `ProfileWorkload`.
+#[derive(Clone, Debug, Default)]
+pub struct ProfileInputs {
+    bindings: Vec<Binding>,
+}
+impl ProfileInputs {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn input(self, tensor: GraphTensor, data: impl ToCudaInput) -> Self {
+        let storage = ProfileStorage::new(data);
+        let len = storage.0.len();
+        self.view(tensor, &storage, 0..len, false)
+    }
+    pub fn mirrored_input(self, tensor: GraphTensor, data: impl ToCudaInput) -> Self {
+        let storage = ProfileStorage::new(data);
+        let len = storage.0.len();
+        self.view(tensor, &storage, 0..len, true)
+    }
+    /// Bind an input to a physical byte range; graph views/strides remain in the
+    /// graph. Overlapping ranges must share the same `ProfileStorage` object.
+    pub fn view(
+        mut self,
+        tensor: GraphTensor,
+        storage: &ProfileStorage,
+        range: Range<usize>,
+        mirror: bool,
+    ) -> Self {
+        self.bindings.push(Binding {
+            schema: InputSchema::new(tensor),
+            storage: storage.clone(),
+            range,
+            mirror,
+        });
+        self
+    }
+    fn groups(&self) -> Vec<ProfileStorage> {
+        let mut groups: Vec<ProfileStorage> = vec![];
+        for b in self.bindings.iter().sorted_by_key(|b| b.schema.id) {
+            if !groups.iter().any(|s| Arc::ptr_eq(&s.0, &b.storage.0)) {
+                groups.push(b.storage.clone());
+            }
+        }
+        groups
+    }
+}
+
+/// An explicit workload for any supported graph. Case weights describe global
+/// invocation frequency. Shared inputs stay in the runtime and are never copied
+/// per case; candidates that mutate them are invalid for this replay contract.
+#[derive(Clone, Debug, Default)]
+pub struct ProfileWorkload {
+    cases: Vec<ProfileCase<ProfileInputs>>,
+    shared: Vec<InputSchema>,
+    timing_method: luminal::op::TimingMethod,
+    device_snapshots: bool,
+    space_token: Option<Arc<Box<dyn luminal::op::EgglogOp>>>,
+}
+impl ProfileWorkload {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    /// Device timestamps measure launched device work; host timing includes
+    /// ordinary planning, parameter updates and dispatch through completion.
+    /// Both exclude snapshot loading and untimed warmup. This is steady repeated
+    /// invocation timing, not an application scheduler or multi-step trace metric.
+    pub fn timing_method(mut self, method: luminal::op::TimingMethod) -> Self {
+        self.timing_method = method;
+        self
+    }
+    /// Cache immutable sample backing on the device. Repeated resets use device
+    /// copies instead of host transfers, at the cost of extra device memory.
+    /// Shared backing objects are uploaded once across all cases.
+    pub fn device_snapshots(mut self, enabled: bool) -> Self {
+        self.device_snapshots = enabled;
+        self
+    }
+    pub fn cases(&self) -> &[ProfileCase<ProfileInputs>] {
+        &self.cases
+    }
+    pub fn shared_input(mut self, tensor: GraphTensor) -> Self {
+        self.shared.push(InputSchema::new(tensor));
+        self
+    }
+    pub fn case(
+        mut self,
+        id: impl Into<String>,
+        dims: DynMap,
+        inputs: ProfileInputs,
+        weight: f64,
+    ) -> Self {
+        self.cases.push(ProfileCase::new(id, dims, inputs, weight));
+        self
+    }
+}
+
+/// One candidate's complete per-case measurements (direct or graph execution).
+#[derive(Clone, Debug)]
+pub struct ProfileEvaluation {
+    pub bucket: usize,
+    pub cuda_graph: bool,
+    pub timing_method: luminal::op::TimingMethod,
+    pub cases: Vec<ProfileMeasurement>,
+    pub weighted_cost: Duration,
+}
+
+pub(super) struct ReplaySession {
+    assigned: Vec<Vec<usize>>,
+    slots: Vec<CudaSlice<u8>>,
+    snapshots: FxHashMap<usize, CudaSlice<u8>>,
+    active: Option<usize>,
+    host_states: Vec<Box<dyn crate::host::ProfileState>>,
+    saved_inputs: FxHashMap<NodeIndex, CudaInput>,
+    saved_mirrors: FxHashMap<NodeIndex, Vec<u8>>,
+    saved_external: FxHashMap<NodeIndex, std::mem::ManuallyDrop<CudaSlice<u8>>>,
+    saved_outputs: FxHashMap<NodeIndex, (u64, usize)>,
+}
+
+impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
+    /// Validate and freeze a workload before `graph.search_with_rng`. Supplying
+    /// no workload preserves legacy runtime-bound/synthetic profiling behavior.
+    /// Each graph input must be declared in every case or explicitly shared.
+    pub fn set_profile_workload(
+        &mut self,
+        graph: &Graph,
+        mut workload: ProfileWorkload,
+    ) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.profile_replay.is_none(),
+            "cannot replace workload during replay"
+        );
+        anyhow::ensure!(!workload.cases.is_empty(), "profile workload has no cases");
+        workload.space_token = graph
+            .search_space()
+            .ok_or_else(|| anyhow::anyhow!("build the search space before installing a workload"))?
+            .ops
+            .first()
+            .cloned();
+        anyhow::ensure!(
+            workload
+                .cases
+                .iter()
+                .map(|c| c.weight)
+                .sum::<f64>()
+                .is_finite(),
+            "profile weight sum overflows"
+        );
+        let expected: FxHashSet<_> = graph.input_meta.keys().copied().collect();
+        let mut shared = FxHashSet::default();
+        for s in &workload.shared {
+            s.validate(graph)?;
+            anyhow::ensure!(shared.insert(s.id), "duplicate shared profile input");
+        }
+        let mut ids = FxHashSet::default();
+        for case in &workload.cases {
+            anyhow::ensure!(
+                !case.id.is_empty() && ids.insert(&case.id),
+                "empty or duplicate profile case ID"
+            );
+            anyhow::ensure!(
+                case.weight.is_finite() && case.weight > 0.,
+                "invalid profile weight"
+            );
+            let mut seen = shared.clone();
+            for b in &case.inputs.bindings {
+                b.schema.validate(graph)?;
+                anyhow::ensure!(
+                    seen.insert(b.schema.id),
+                    "duplicate profile input {:?}",
+                    b.schema.id
+                );
+                anyhow::ensure!(
+                    b.range.start <= b.range.end && b.range.end <= b.storage.0.len(),
+                    "invalid profile storage view"
+                );
+                let bits = b.schema.dtype.bits();
+                anyhow::ensure!(
+                    bits % 8 != 0 || b.range.start % (bits / 8) == 0,
+                    "profile input view is not aligned to its dtype"
+                );
+                anyhow::ensure!(
+                    b.range.len() == b.schema.length(&case.dims)?,
+                    "case {} input {:?}: byte length does not match exact dimensions",
+                    case.id,
+                    b.schema.id
+                );
+            }
+            anyhow::ensure!(
+                seen == expected,
+                "case {} must bind every graph input or declare it shared",
+                case.id
+            );
+        }
+        self.profile_workload = Some(workload);
+        self.profile_evaluations.clear();
+        Ok(())
+    }
+    pub fn clear_profile_workload(&mut self) {
+        assert!(self.profile_replay.is_none());
+        self.profile_workload = None;
+    }
+    pub fn profile_evaluations(&self) -> &[ProfileEvaluation] {
+        &self.profile_evaluations
+    }
+
+    /// Snapshot selected boundary inputs using their current physical bindings.
+    /// Capture immediately before execution, after installing coherent metadata.
+    /// Overlapping device ranges are captured as one backing allocation. Explicit
+    /// tensor state (including RNG state) uses this same mechanism.
+    pub fn capture_profile_inputs(
+        &self,
+        tensors: &[GraphTensor],
+        dims: &DynMap,
+    ) -> anyhow::Result<ProfileInputs> {
+        self.cuda_stream.synchronize()?;
+        let mut ranges = vec![];
+        for &tensor in tensors {
+            let (ptr, len) = self
+                .current_hlir_device_binding(tensor.id)
+                .ok_or_else(|| anyhow::anyhow!("missing capture input {:?}", tensor.id))?;
+            anyhow::ensure!(
+                len == InputSchema::new(tensor).length(dims)?,
+                "capture input length does not match dimensions"
+            );
+            let end = ptr
+                .checked_add(len as u64)
+                .ok_or_else(|| anyhow::anyhow!("capture address overflow"))?;
+            ranges.push((ptr, end, tensor));
+        }
+        ranges.sort_by_key(|r| r.0);
+        let mut result_inputs = ProfileInputs::new();
+        let mut i = 0;
+        while i < ranges.len() {
+            let start = ranges[i].0;
+            let mut end = ranges[i].1;
+            let mut j = i + 1;
+            while j < ranges.len() && ranges[j].0 < end {
+                end = end.max(ranges[j].1);
+                j += 1;
+            }
+            let mut bytes = vec![0u8; (end - start) as usize];
+            if !bytes.is_empty() {
+                unsafe {
+                    result::memcpy_dtoh_sync(&mut bytes, start)?;
+                }
+            }
+            let storage = ProfileStorage(bytes.into());
+            for &(ptr, end, tensor) in &ranges[i..j] {
+                let range = (ptr - start) as usize..(end - start) as usize;
+                let mirror = self.hlir_host_mirrors.get(&tensor.id);
+                if let Some(mirror) = mirror {
+                    anyhow::ensure!(
+                        mirror.as_slice() == &storage.0[range.clone()],
+                        "capture host mirror disagrees with device input"
+                    );
+                }
+                result_inputs = result_inputs.view(tensor, &storage, range, mirror.is_some());
+            }
+            i = j;
+        }
+        Ok(result_inputs)
+    }
+
+    pub(crate) fn begin_profile_replay(
+        &mut self,
+        contexts: &[luminal::search::BucketContext<'_>],
+    ) -> anyhow::Result<()> {
+        let Some(workload) = &self.profile_workload else {
+            return Ok(());
+        };
+        anyhow::ensure!(
+            contexts.first().is_some_and(|c| c
+                .space
+                .ops
+                .first()
+                .zip(workload.space_token.as_ref())
+                .is_some_and(|(a, b)| Arc::ptr_eq(a, b))),
+            "profile workload belongs to another search space"
+        );
+        let assigned = assign_profile_cases(&workload.cases, contexts)?;
+        let mut capacities: Vec<usize> = vec![];
+        for case in &workload.cases {
+            for (i, group) in case.inputs.groups().iter().enumerate() {
+                if capacities.len() <= i {
+                    capacities.push(0);
+                }
+                capacities[i] = capacities[i].max(group.0.len().max(1));
+            }
+            for s in &workload.shared {
+                let (_, len) = self
+                    .current_hlir_device_binding(s.id)
+                    .ok_or_else(|| anyhow::anyhow!("missing shared input {:?}", s.id))?;
+                anyhow::ensure!(
+                    len == s.length(&case.dims)?,
+                    "shared input size varies or does not match sample dimensions"
+                );
+            }
+        }
+        // Allocate before altering caller bindings, so allocation failures leave
+        // the original runtime usable. Device capacity checks see these slots.
+        let slots = capacities
+            .into_iter()
+            .map(|n| self.cuda_stream.alloc_zeros(n))
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut snapshots = FxHashMap::default();
+        if workload.device_snapshots {
+            for case in &workload.cases {
+                for group in case.inputs.groups() {
+                    let key = group.0.as_ptr() as usize;
+                    if let std::collections::hash_map::Entry::Vacant(entry) = snapshots.entry(key) {
+                        entry.insert(self.cuda_stream.clone_htod(group.0.as_ref())?);
+                    }
+                }
+            }
+        }
+        self.cuda_stream.synchronize()?;
+        let shared_ids: Vec<_> = workload.shared.iter().map(|s| s.id).collect();
+        self.release_all_bucket_cuda_graphs();
+        let shared_bindings: Vec<_> = shared_ids
+            .iter()
+            .map(|&id| {
+                let (ptr, len) = self.current_hlir_device_binding(id).unwrap();
+                (id, ptr, len, self.hlir_host_mirrors.get(&id).cloned())
+            })
+            .collect();
+        let session = ReplaySession {
+            assigned,
+            slots,
+            snapshots,
+            active: None,
+            host_states: vec![],
+            saved_inputs: std::mem::take(&mut self.hlir_buffers),
+            saved_mirrors: std::mem::take(&mut self.hlir_host_mirrors),
+            saved_external: std::mem::take(&mut self.external_buffers),
+            saved_outputs: std::mem::take(&mut self.output_ptr_registrations),
+        };
+        self.invalidate_output_registration_resolution();
+        self.profile_replay = Some(session);
+        for (id, ptr, len, mirror) in shared_bindings {
+            unsafe {
+                self.set_device_ptr(id, ptr, len);
+            }
+            if let Some(bytes) = mirror {
+                self.hlir_host_mirrors.insert(id, bytes);
+            }
+        }
+        self.profile_evaluations.clear();
+        Ok(())
+    }
+
+    pub(crate) fn finish_profile_replay(&mut self) {
+        if self.profile_replay.is_none() {
+            return;
+        }
+        self.release_profile_op_states()
+            .expect("profile operation state restoration failed");
+        self.cuda_stream
+            .synchronize()
+            .expect("profile replay synchronization failed");
+        self.release_all_bucket_cuda_graphs();
+        let session = self.profile_replay.take().unwrap();
+        self.hlir_buffers = session.saved_inputs;
+        self.hlir_host_mirrors = session.saved_mirrors;
+        self.external_buffers = session.saved_external;
+        self.output_ptr_registrations = session.saved_outputs;
+        self.invalidate_output_registration_resolution();
+        self.changed_hlir.extend(self.hlir_buffers.keys());
+        for bucket in &mut self.compiled_buckets {
+            bucket.hlir_synced = false;
+            bucket.materialization_fully_dirty = true;
+        }
+        self.cancel_search_profile();
+        // Slots drop only after graph releases and restoration of all bindings.
+    }
+
+    pub(crate) fn profile_case_indices(&self, bucket: usize) -> Option<Vec<usize>> {
+        self.profile_replay
+            .as_ref()
+            .map(|r| r.assigned[bucket].clone())
+    }
+    pub(crate) fn profile_case_dims(&self, case: usize) -> DynMap {
+        self.profile_workload.as_ref().unwrap().cases[case]
+            .dims
+            .clone()
+    }
+    pub(crate) fn activate_profile_case(&mut self, case: usize) -> anyhow::Result<()> {
+        self.profile_replay.as_mut().unwrap().active = Some(case);
+        self.restore_profile_inputs()
+    }
+    fn restore_profile_inputs(&mut self) -> anyhow::Result<()> {
+        let Some(session) = &mut self.profile_replay else {
+            return Ok(());
+        };
+        let Some(index) = session.active else {
+            return Ok(());
+        };
+        let inputs = &self.profile_workload.as_ref().unwrap().cases[index].inputs;
+        let groups = inputs.groups();
+        for (group, slot) in groups.iter().zip(&mut session.slots) {
+            if !group.0.is_empty() {
+                let mut destination = slot.slice_mut(..group.0.len());
+                if let Some(source) = session.snapshots.get(&(group.0.as_ptr() as usize)) {
+                    self.cuda_stream.memcpy_dtod(source, &mut destination)?;
+                } else {
+                    self.cuda_stream
+                        .memcpy_htod(group.0.as_ref(), &mut destination)?;
+                }
+            }
+        }
+        let bindings: Vec<_> = inputs
+            .bindings
+            .iter()
+            .map(|b| {
+                let group = groups
+                    .iter()
+                    .position(|g| Arc::ptr_eq(&g.0, &b.storage.0))
+                    .unwrap();
+                let ptr =
+                    session.slots[group].device_ptr(&self.cuda_stream).0 + b.range.start as u64;
+                (
+                    b.schema.id,
+                    ptr,
+                    b.range.len(),
+                    b.mirror.then(|| b.storage.0[b.range.clone()].to_vec()),
+                )
+            })
+            .collect();
+        for (id, ptr, len, mirror) in bindings {
+            unsafe {
+                self.set_device_ptr(id, ptr, len);
+            }
+            if let Some(bytes) = mirror {
+                self.hlir_host_mirrors.insert(id, bytes);
+            }
+        }
+        // End reset traffic before planning/timing (also supports borrowed streams).
+        self.cuda_stream.synchronize()?;
+        Ok(())
+    }
+
+    pub(crate) fn capture_profile_op_states(&mut self, llir: &LLIRGraph) -> anyhow::Result<()> {
+        for node in llir.node_weights() {
+            if let Some(host) = node.to_dialect::<dyn HostOp>() {
+                let state = host.capture_profile_state(&self.cuda_stream)?;
+                self.profile_replay
+                    .as_mut()
+                    .unwrap()
+                    .host_states
+                    .push(state);
+            }
+        }
+        Ok(())
+    }
+    pub(crate) fn release_profile_op_states(&mut self) -> anyhow::Result<()> {
+        let Some(session) = &mut self.profile_replay else {
+            return Ok(());
+        };
+        // Keep snapshots alive if restoration fails, so outer cleanup can retry.
+        for state in &session.host_states {
+            state.restore(&self.cuda_stream)?;
+        }
+        self.cuda_stream.synchronize()?;
+        session.host_states.clear();
+        Ok(())
+    }
+    pub(crate) fn restore_profile_trial(&mut self) -> anyhow::Result<()> {
+        if self.profile_replay.is_none() {
+            return Ok(());
+        }
+        self.restore_profile_inputs()?;
+        for state in &self.profile_replay.as_ref().unwrap().host_states {
+            state.restore(&self.cuda_stream)?;
+        }
+        self.cuda_stream.synchronize()?;
+        Ok(())
+    }
+
+    pub(crate) fn validate_profile_effects(&self, llir: &LLIRGraph) -> anyhow::Result<()> {
+        let workload = self.profile_workload.as_ref().unwrap();
+        let shared: FxHashSet<_> = workload.shared.iter().map(|s| s.id).collect();
+        // Follow declared storage aliases, not op names or graph patterns.
+        let incoming = |node| {
+            llir.edges_directed(node, Direction::Incoming)
+                .sorted_by_key(|e| e.id())
+                .map(|e| e.source())
+                .collect::<Vec<_>>()
+        };
+        let root = |mut node: NodeIndex| {
+            for _ in 0..=llir.node_count() {
+                if let Some(input) = llir[node].to_op::<Input>() {
+                    return Some(NodeIndex::new(input.node));
+                }
+                let alias = llir[node]
+                    .to_dialect::<dyn KernelOp>()?
+                    .output_aliases_input()?;
+                node = *incoming(node).get(alias)?;
+            }
+            None
+        };
+        for node in llir.node_indices() {
+            let writes = if let Some(kernel) = llir[node].to_dialect::<dyn KernelOp>() {
+                kernel
+                    .output_aliases_input()
+                    .filter(|_| kernel.mutates_aliased_input())
+                    .into_iter()
+                    .collect()
+            } else if let Some(host) = llir[node].to_dialect::<dyn HostOp>() {
+                host.profile_mutated_inputs()
+            } else {
+                vec![]
+            };
+            let inputs = incoming(node);
+            for write in writes {
+                let source = inputs
+                    .get(write)
+                    .ok_or_else(|| anyhow::anyhow!("invalid profile effect input index"))?;
+                let Some(id) = root(*source) else {
+                    continue;
+                };
+                anyhow::ensure!(
+                    !shared.contains(&id),
+                    "candidate writes shared read-only profile input {id:?}"
+                );
+                // Cross-input storage aliasing is invisible to e-graph exclusive-
+                // use proofs. Reject destructive alternatives that would change
+                // another input's logical value; ordinary out-of-place ops remain
+                // legal. Views of a single graph input retain normal alias proofs.
+                for case in &workload.cases {
+                    if let Some(b) = case.inputs.bindings.iter().find(|b| b.schema.id == id) {
+                        for other in &case.inputs.bindings {
+                            anyhow::ensure!(
+                                other.schema.id == id
+                                    || !Arc::ptr_eq(&b.storage.0, &other.storage.0)
+                                    || b.range.end <= other.range.start
+                                    || other.range.end <= b.range.start,
+                                "candidate writes overlapping profile input aliases"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn profile_timing_method(&self) -> luminal::op::TimingMethod {
+        self.profile_workload
+            .as_ref()
+            .map(|w| w.timing_method)
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn record_profile_evaluation(
+        &mut self,
+        bucket: usize,
+        cuda_graph: bool,
+        timings: &[(usize, Duration)],
+    ) -> anyhow::Result<Duration> {
+        let workload = self.profile_workload.as_ref().unwrap();
+        let total = workload.cases.iter().map(|c| c.weight).sum();
+        let values: Vec<_> = timings
+            .iter()
+            .map(|&(i, time)| (workload.cases[i].weight, time))
+            .collect();
+        let cost = weighted_profile_cost(&values, total)?;
+        self.profile_evaluations.push(ProfileEvaluation {
+            bucket,
+            cuda_graph,
+            timing_method: workload.timing_method,
+            weighted_cost: cost,
+            cases: timings
+                .iter()
+                .map(|&(i, duration)| {
+                    let c = &workload.cases[i];
+                    ProfileMeasurement {
+                        case_id: c.id.clone(),
+                        dims: c.dims.clone(),
+                        weight: c.weight,
+                        duration,
+                    }
+                })
+                .collect(),
+        });
+        Ok(cost)
+    }
+}
+
+#[cfg(test)]
+#[path = "profile_tests.rs"]
+mod tests;

--- a/crates/luminal_cuda_lite/src/profile.rs
+++ b/crates/luminal_cuda_lite/src/profile.rs
@@ -100,6 +100,22 @@ impl ProfileInputs {
         });
         self
     }
+    /// Select existing snapshots without copying their backing bytes.
+    pub fn select(&self, tensors: &[GraphTensor]) -> anyhow::Result<Self> {
+        let bindings = tensors
+            .iter()
+            .map(|tensor| {
+                self.bindings
+                    .iter()
+                    .find(|b| {
+                        b.schema.id == tensor.id && b.schema.graph == tensor.graph_ref as usize
+                    })
+                    .cloned()
+                    .ok_or_else(|| anyhow::anyhow!("missing snapshot input {:?}", tensor.id))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(Self { bindings })
+    }
     fn groups(&self) -> Vec<ProfileStorage> {
         let mut groups: Vec<ProfileStorage> = vec![];
         for b in self.bindings.iter().sorted_by_key(|b| b.schema.id) {
@@ -120,6 +136,7 @@ pub struct ProfileWorkload {
     shared: Vec<InputSchema>,
     timing_method: luminal::op::TimingMethod,
     device_snapshots: bool,
+    reused_inputs: ProfileInputs,
     space_token: Option<Arc<Box<dyn luminal::op::EgglogOp>>>,
 }
 impl ProfileWorkload {
@@ -136,9 +153,20 @@ impl ProfileWorkload {
     }
     /// Cache immutable sample backing on the device. Repeated resets use device
     /// copies instead of host transfers, at the cost of extra device memory.
-    /// Shared backing objects are uploaded once across all cases.
+    /// Only the active case's backing stays resident; shared backing objects
+    /// survive case switches. Uploads happen before candidate timing.
     pub fn device_snapshots(mut self, enabled: bool) -> Self {
         self.device_snapshots = enabled;
+        self
+    }
+    /// Replay selected inputs in their existing owned device allocations. These
+    /// inputs need no additional replay slots. `device_snapshots` also applies
+    /// to their trial resets. On exit (including candidate failure), restore the supplied
+    /// bytes and the original bindings. Capture `restore` immediately before
+    /// search to preserve current application state. Each selected input must
+    /// own a non-overlapping allocation and use a whole-storage snapshot.
+    pub fn reuse_input_buffers(mut self, restore: ProfileInputs) -> Self {
+        self.reused_inputs = restore;
         self
     }
     pub fn cases(&self) -> &[ProfileCase<ProfileInputs>] {
@@ -186,14 +214,39 @@ impl ProfileEvaluation {
 
 pub(super) struct ReplaySession {
     assigned: Vec<Vec<usize>>,
-    slots: Vec<CudaSlice<u8>>,
+    slots: Vec<Option<CudaSlice<u8>>>,
+    group_ptrs: Vec<Vec<u64>>,
+    reused: Vec<(u64, Binding)>,
     snapshots: FxHashMap<usize, CudaSlice<u8>>,
     active: Option<usize>,
     host_states: Vec<Box<dyn crate::host::ProfileState>>,
     saved_inputs: FxHashMap<NodeIndex, CudaInput>,
+    saved_prepared: FxHashMap<NodeIndex, PreparedInput>,
+    saved_prepared_unified: FxHashMap<NodeIndex, PreparedUnifiedOwner>,
     saved_mirrors: FxHashMap<NodeIndex, Vec<u8>>,
     saved_external: FxHashMap<NodeIndex, std::mem::ManuallyDrop<CudaSlice<u8>>>,
     saved_outputs: FxHashMap<NodeIndex, (u64, usize)>,
+}
+
+impl ReplaySession {
+    pub(super) fn managed_capacity(&self) -> usize {
+        self.saved_prepared_unified
+            .values()
+            .map(|o| o.buffer.len())
+            .fold(0usize, usize::saturating_add)
+    }
+    pub(super) fn owned_device_bytes(&self) -> usize {
+        self.saved_inputs
+            .values()
+            .filter_map(|input| match input {
+                CudaInput::Buffer { buf, .. } => Some(buf.len()),
+                CudaInput::Ptr(_) => None,
+            })
+            .chain(self.saved_prepared_unified.values().map(|o| o.buffer.len()))
+            .chain(self.slots.iter().flatten().map(CudaSlice::len))
+            .chain(self.snapshots.values().map(CudaSlice::len))
+            .fold(0usize, usize::saturating_add)
+    }
 }
 
 impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
@@ -231,6 +284,10 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             s.validate(graph)?;
             anyhow::ensure!(shared.insert(s.id), "duplicate shared profile input");
         }
+        anyhow::ensure!(
+            self.prepared_inputs.keys().all(|id| shared.contains(id)),
+            "prepared inputs must be shared by the representative workload"
+        );
         let mut ids = FxHashSet::default();
         for case in &workload.cases {
             anyhow::ensure!(
@@ -271,6 +328,9 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                 case.id
             );
         }
+        for b in &workload.reused_inputs.bindings {
+            b.schema.validate(graph)?;
+        }
         self.profile_workload = Some(workload);
         self.profile_evaluations.clear();
         Ok(())
@@ -295,6 +355,10 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         self.cuda_stream.synchronize()?;
         let mut ranges = vec![];
         for &tensor in tensors {
+            anyhow::ensure!(
+                !self.prepared_inputs.contains_key(&tensor.id),
+                "prepared inputs must be shared, not snapshotted"
+            );
             let (ptr, len) = self
                 .current_hlir_device_binding(tensor.id)
                 .ok_or_else(|| anyhow::anyhow!("missing capture input {:?}", tensor.id))?;
@@ -357,6 +421,58 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                 .is_some_and(|(a, b)| Arc::ptr_eq(a, b))),
             "profile workload belongs to another search space"
         );
+        anyhow::ensure!(
+            self.prepared_inputs
+                .keys()
+                .all(|id| workload.shared.iter().any(|s| s.id == *id)),
+            "prepared inputs must be shared by the representative workload"
+        );
+        let mut reused = vec![];
+        let mut reuse_ids = FxHashSet::default();
+        for b in &workload.reused_inputs.bindings {
+            let id = b.schema.id;
+            anyhow::ensure!(reuse_ids.insert(id), "duplicate reused input");
+            anyhow::ensure!(
+                !workload.shared.iter().any(|s| s.id == id),
+                "reused input cannot also be shared"
+            );
+            let Some(CudaInput::Buffer { buf, len }) = self.hlir_buffers.get(&id) else {
+                anyhow::bail!("reused input must have owned device storage");
+            };
+            anyhow::ensure!(
+                b.range == (0..b.storage.0.len()) && b.range.len() == *len,
+                "reused input restore snapshot must cover its whole logical binding"
+            );
+            let ptr = buf.device_ptr(&self.cuda_stream).0;
+            for &other in self.hlir_buffers.keys().filter(|&&other| other != id) {
+                if let Some((other_ptr, other_len)) = self.current_hlir_device_binding(other) {
+                    anyhow::ensure!(
+                        !device_ranges_overlap(ptr, buf.len(), other_ptr, other_len),
+                        "reused allocation overlaps another input"
+                    );
+                }
+            }
+            for case in &workload.cases {
+                let sample = case
+                    .inputs
+                    .bindings
+                    .iter()
+                    .find(|s| s.schema.id == id)
+                    .ok_or_else(|| anyhow::anyhow!("reused input missing from case"))?;
+                anyhow::ensure!(
+                    sample.range == (0..sample.storage.0.len())
+                        && sample.range.len() <= buf.len()
+                        && case
+                            .inputs
+                            .bindings
+                            .iter()
+                            .all(|other| other.schema.id == id
+                                || !Arc::ptr_eq(&other.storage.0, &sample.storage.0)),
+                    "reused case input must fit its owned allocation and have unaliased backing"
+                );
+            }
+            reused.push((ptr, b.clone()));
+        }
         let assigned = assign_profile_cases(&workload.cases, contexts)?;
         let mut capacities: Vec<usize> = vec![];
         for case in &workload.cases {
@@ -364,7 +480,11 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                 if capacities.len() <= i {
                     capacities.push(0);
                 }
-                capacities[i] = capacities[i].max(group.0.len().max(1));
+                if !case.inputs.bindings.iter().any(|b| {
+                    reuse_ids.contains(&b.schema.id) && Arc::ptr_eq(&b.storage.0, &group.0)
+                }) {
+                    capacities[i] = capacities[i].max(group.0.len().max(1));
+                }
             }
             for s in &workload.shared {
                 let (_, len) = self
@@ -389,7 +509,10 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             .into_iter()
             .enumerate()
             .map(|(i, n)| {
-                self.cuda_stream.alloc_zeros(n).map_err(|error| {
+                if n == 0 {
+                    return Ok(None);
+                }
+                self.cuda_stream.alloc_zeros(n).map(Some).map_err(|error| {
                     anyhow::anyhow!(
                         "profile replay slot {i} ({n} bytes): {error}; device free/total: {:?}",
                         self.cuda_stream.context().mem_get_info()
@@ -397,20 +520,35 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                 })
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
-        let mut snapshots = FxHashMap::default();
-        if workload.device_snapshots {
-            for case in &workload.cases {
-                for group in case.inputs.groups() {
-                    let key = group.0.as_ptr() as usize;
-                    if let std::collections::hash_map::Entry::Vacant(entry) = snapshots.entry(key) {
-                        let snapshot = self.cuda_stream.clone_htod(group.0.as_ref()).map_err(|error| {
-                            anyhow::anyhow!("profile snapshot for case {:?} ({} bytes): {error}; device free/total: {:?}", case.id, group.0.len(), self.cuda_stream.context().mem_get_info())
-                        })?;
-                        entry.insert(snapshot);
-                    }
-                }
-            }
-        }
+        let group_ptrs = workload
+            .cases
+            .iter()
+            .map(|case| {
+                case.inputs
+                    .groups()
+                    .iter()
+                    .enumerate()
+                    .map(|(index, group)| {
+                        reused
+                            .iter()
+                            .find(|(_, restored)| {
+                                case.inputs.bindings.iter().any(|b| {
+                                    b.schema.id == restored.schema.id
+                                        && Arc::ptr_eq(&b.storage.0, &group.0)
+                                })
+                            })
+                            .map(|(ptr, _)| *ptr)
+                            .unwrap_or_else(|| {
+                                slots[index]
+                                    .as_ref()
+                                    .unwrap()
+                                    .device_ptr(&self.cuda_stream)
+                                    .0
+                            })
+                    })
+                    .collect()
+            })
+            .collect();
         self.cuda_stream.synchronize()?;
         let shared_ids: Vec<_> = workload.shared.iter().map(|s| s.id).collect();
         self.release_all_bucket_cuda_graphs();
@@ -418,25 +556,38 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             .iter()
             .map(|&id| {
                 let (ptr, len) = self.current_hlir_device_binding(id).unwrap();
-                (id, ptr, len, self.hlir_host_mirrors.get(&id).cloned())
+                (
+                    id,
+                    ptr,
+                    len,
+                    self.hlir_host_mirrors.get(&id).cloned(),
+                    self.prepared_inputs.get(&id).copied(),
+                )
             })
             .collect();
         let session = ReplaySession {
             assigned,
+            group_ptrs,
+            reused,
             slots,
-            snapshots,
+            snapshots: FxHashMap::default(),
             active: None,
             host_states: vec![],
             saved_inputs: std::mem::take(&mut self.hlir_buffers),
+            saved_prepared: std::mem::take(&mut self.prepared_inputs),
+            saved_prepared_unified: std::mem::take(&mut self.prepared_unified_owners),
             saved_mirrors: std::mem::take(&mut self.hlir_host_mirrors),
             saved_external: std::mem::take(&mut self.external_buffers),
             saved_outputs: std::mem::take(&mut self.output_ptr_registrations),
         };
         self.invalidate_output_registration_resolution();
         self.profile_replay = Some(session);
-        for (id, ptr, len, mirror) in shared_bindings {
+        for (id, ptr, len, mirror, prepared) in shared_bindings {
             unsafe {
                 self.set_device_ptr(id, ptr, len);
+            }
+            if let Some(prepared) = prepared {
+                self.prepared_inputs.insert(id, prepared);
             }
             if let Some(bytes) = mirror {
                 self.hlir_host_mirrors.insert(id, bytes);
@@ -456,8 +607,17 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             .synchronize()
             .expect("profile replay synchronization failed");
         self.release_all_bucket_cuda_graphs();
+        // Owners are still retained by the session while restoring their bytes.
+        for (ptr, binding) in &self.profile_replay.as_ref().unwrap().reused {
+            if !binding.storage.0.is_empty() {
+                unsafe { result::memcpy_htod_sync(*ptr, binding.storage.0.as_ref()) }
+                    .expect("reused profile input restoration failed");
+            }
+        }
         let session = self.profile_replay.take().unwrap();
         self.hlir_buffers = session.saved_inputs;
+        self.prepared_inputs = session.saved_prepared;
+        self.prepared_unified_owners = session.saved_prepared_unified;
         self.hlir_host_mirrors = session.saved_mirrors;
         self.external_buffers = session.saved_external;
         self.output_ptr_registrations = session.saved_outputs;
@@ -482,7 +642,28 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             .clone()
     }
     pub(crate) fn activate_profile_case(&mut self, case: usize) -> anyhow::Result<()> {
-        self.profile_replay.as_mut().unwrap().active = Some(case);
+        let workload = self.profile_workload.as_ref().unwrap();
+        let session = self.profile_replay.as_mut().unwrap();
+        if workload.device_snapshots && session.active != Some(case) {
+            let sample = &workload.cases[case];
+            let groups = sample.inputs.groups();
+            let keys: FxHashSet<_> = groups.iter().map(|g| g.0.as_ptr() as usize).collect();
+            // Release inactive storage before allocating its replacement, so
+            // memory scales with the largest case rather than the case count.
+            session.snapshots.retain(|key, _| keys.contains(key));
+            for group in groups {
+                let key = group.0.as_ptr() as usize;
+                if let std::collections::hash_map::Entry::Vacant(entry) =
+                    session.snapshots.entry(key)
+                {
+                    let snapshot = self.cuda_stream.clone_htod(group.0.as_ref()).map_err(|error| {
+                        anyhow::anyhow!("profile snapshot for case {:?} ({} bytes): {error}; device free/total: {:?}", sample.id, group.0.len(), self.cuda_stream.context().mem_get_info())
+                    })?;
+                    entry.insert(snapshot);
+                }
+            }
+        }
+        session.active = Some(case);
         self.restore_profile_inputs()
     }
     fn restore_profile_inputs(&mut self) -> anyhow::Result<()> {
@@ -494,14 +675,17 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         };
         let inputs = &self.profile_workload.as_ref().unwrap().cases[index].inputs;
         let groups = inputs.groups();
-        for (group, slot) in groups.iter().zip(&mut session.slots) {
+        for (group, &ptr) in groups.iter().zip(&session.group_ptrs[index]) {
             if !group.0.is_empty() {
-                let mut destination = slot.slice_mut(..group.0.len());
+                let mut destination = std::mem::ManuallyDrop::new(unsafe {
+                    self.cuda_stream
+                        .upgrade_device_ptr::<u8>(ptr, group.0.len())
+                });
                 if let Some(source) = session.snapshots.get(&(group.0.as_ptr() as usize)) {
-                    self.cuda_stream.memcpy_dtod(source, &mut destination)?;
+                    self.cuda_stream.memcpy_dtod(source, &mut *destination)?;
                 } else {
                     self.cuda_stream
-                        .memcpy_htod(group.0.as_ref(), &mut destination)?;
+                        .memcpy_htod(group.0.as_ref(), &mut *destination)?;
                 }
             }
         }
@@ -513,8 +697,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                     .iter()
                     .position(|g| Arc::ptr_eq(&g.0, &b.storage.0))
                     .unwrap();
-                let ptr =
-                    session.slots[group].device_ptr(&self.cuda_stream).0 + b.range.start as u64;
+                let ptr = session.group_ptrs[index][group] + b.range.start as u64;
                 (
                     b.schema.id,
                     ptr,

--- a/crates/luminal_cuda_lite/src/profile_tests.rs
+++ b/crates/luminal_cuda_lite/src/profile_tests.rs
@@ -870,3 +870,150 @@ fn profile_replay_reclaims_previous_arena_and_rematerializes_original_program() 
     rt.execute(&graph.dyn_map);
     assert_eq!(rt.get_f32(output), vec![5.; 256]);
 }
+
+#[derive(Debug, Clone, Default)]
+struct WorkspaceCopy {
+    metadata: MetadataCopy,
+    cache: Arc<crate::host::workspace::WorkspaceCache>,
+    owners: Arc<Mutex<Vec<std::sync::Weak<crate::host::workspace::Workspace>>>>,
+}
+impl EgglogOp for WorkspaceCopy {
+    fn sort(&self) -> luminal::egglog_utils::api::SortDef {
+        luminal::egglog_utils::api::sort(luminal::egglog_utils::base::OP_KIND, "WorkspaceCopy", &[])
+    }
+    fn cleanup(&self) -> bool {
+        false
+    }
+    fn n_inputs(&self) -> usize {
+        2
+    }
+}
+impl CustomOp for WorkspaceCopy {
+    fn to_llir_op(&self) -> LLIROp {
+        LLIROp::new(Box::new(self.clone()) as Box<dyn HostOp>)
+    }
+}
+impl HostOp for WorkspaceCopy {
+    fn output_size(&self) -> Expression {
+        's'.into()
+    }
+    fn output_bytes(&self) -> Expression {
+        Expression::from('s') * 4
+    }
+    fn output_dtype(&self) -> DType {
+        DType::Int
+    }
+    fn cuda_graph_capture_arity(&self) -> Option<usize> {
+        Some(2)
+    }
+    fn cuda_graph_capture_dyn_dims(&self) -> Vec<Symbol> {
+        vec!['s'.into()]
+    }
+    fn prepare_cuda_graph_capture_resources(
+        &self,
+        capture: &Arc<CudaStream>,
+        execution: &Arc<CudaStream>,
+        node: NodeIndex,
+        inputs: &[NodeIndex],
+        buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
+        dims: &DynMap,
+    ) -> anyhow::Result<crate::host::CudaGraphCaptureResources> {
+        self.metadata
+            .prepare_cuda_graph_capture(capture, node, inputs, buffers, dims)?;
+        let owner = self
+            .cache
+            .acquire(capture, execution, dims[&'s'.into()] * 4)?;
+        self.owners.lock().unwrap().push(Arc::downgrade(&owner));
+        Ok(vec![owner])
+    }
+    fn execute(
+        &self,
+        stream: &Arc<CudaStream>,
+        node: NodeIndex,
+        inputs: &[NodeIndex],
+        buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
+        dims: &DynMap,
+    ) -> anyhow::Result<()> {
+        let bytes = dims[&'s'.into()] * 4;
+        let owner = if stream.capture_status()?
+            != cudarc::driver::sys::CUstreamCaptureStatus::CU_STREAM_CAPTURE_STATUS_NONE
+        {
+            self.cache.prepared(stream, bytes)?
+        } else {
+            self.cache.acquire(stream, stream, bytes)?
+        };
+        unsafe {
+            result::memcpy_dtod_async(
+                owner.ptr(),
+                buffers[&inputs[0]].ptr(),
+                bytes,
+                stream.cu_stream(),
+            )?;
+            result::memcpy_dtod_async(
+                buffers[&node].ptr(),
+                owner.ptr(),
+                bytes,
+                stream.cu_stream(),
+            )?;
+        }
+        Ok(())
+    }
+}
+
+#[test]
+fn captured_workspace_owners_follow_resident_graph_lifetimes() {
+    let mut graph = Graph::new();
+    let input = graph.tensor('s').as_dtype(DType::Int).persist();
+    let metadata = graph.tensor(1).as_dtype(DType::Int).persist();
+    let copy = WorkspaceCopy::default();
+    let owners = copy.owners.clone();
+    let output = graph
+        .custom_op(copy, (input.id, metadata.id), 's', DType::Int)
+        .output();
+    graph.set_dim('s', 1);
+    graph.build_search_space::<CudaRuntime>(
+        CompileOptions::default().dim_buckets('s', &[DimBucket::new(1, 8).representative(1)]),
+    );
+    let mut rt = runtime();
+    rt.set_data_with_capacity(input, vec![19i32; 1], 32);
+    rt.set_data_with_host_mirror(metadata, vec![1i32]);
+    rt = graph.search_with_rng(
+        rt,
+        CompileOptions::default().search_graph_limit(1).trials(1),
+        &mut SmallRng::seed_from_u64(221),
+    );
+    // Keep the generic output arena stable while the private workspace grows;
+    // arena relocation deliberately retires every resident graph generation.
+    rt.ensure_shared_arena_capacity(16 * 1024 * 1024);
+    rt.begin_cuda_graph_warmup(&['s'.into()]);
+    for s in [2, 7, 3, 2, 7, 3] {
+        graph.set_dim('s', s);
+        rt.set_data(input, vec![s as i32; s]);
+        rt.set_data_with_host_mirror(metadata, vec![s as i32]);
+        rt.execute(&graph.dyn_map);
+        assert_eq!(rt.get_i32(output), vec![s as i32; s]);
+    }
+    let live_allocations: FxHashSet<_> = owners
+        .lock()
+        .unwrap()
+        .iter()
+        .filter_map(std::sync::Weak::upgrade)
+        .map(|w| w.ptr())
+        .collect();
+    assert!(
+        live_allocations.len() >= 2,
+        "test must retain multiple allocation generations"
+    );
+    rt.release_all_bucket_cuda_graphs();
+    assert!(
+        owners.lock().unwrap().iter().all(|w| w.upgrade().is_none()),
+        "retired graphs retain workspace owners"
+    );
+    rt.execute(&graph.dyn_map);
+    assert_eq!(rt.get_i32(output), vec![3; 3]);
+    drop(rt);
+    assert!(
+        owners.lock().unwrap().iter().all(|w| w.upgrade().is_none()),
+        "dropping runtime retains workspace owners"
+    );
+}

--- a/crates/luminal_cuda_lite/src/profile_tests.rs
+++ b/crates/luminal_cuda_lite/src/profile_tests.rs
@@ -798,6 +798,71 @@ fn profile_capture_preparation_uses_exact_metadata() {
 }
 
 #[test]
+fn search_accepts_larger_equivalent_graph_after_small_candidate() {
+    let mut graph = Graph::new();
+    let input = graph.tensor('s').as_dtype(DType::Int).persist();
+    let metadata = graph.tensor(1).as_dtype(DType::Int).persist();
+    let output = graph
+        .custom_op(
+            MetadataCopy::default(),
+            (input.id, metadata.id),
+            's',
+            DType::Int,
+        )
+        .output();
+    graph.set_dim('s', 4);
+    graph.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let space = graph.search_space().unwrap();
+    let contexts = space.bucket_contexts(&graph.dyn_map);
+    let mut llir =
+        luminal::search::extract_one(space, &contexts[0], &mut SmallRng::seed_from_u64(17));
+    let copy = llir
+        .node_indices()
+        .find(|&n| {
+            llir[n]
+                .to_dialect::<dyn HostOp>()
+                .is_some_and(|op| op.as_any().is::<MetadataCopy>())
+        })
+        .unwrap();
+    let mut rt = runtime();
+    rt.set_data(input, vec![19i32; 4]);
+    rt.set_data_with_host_mirror(metadata, vec![4i32]);
+    drop(
+        rt.compile_and_validate_profile_candidate(&llir, &graph.dyn_map, &contexts[0])
+            .unwrap(),
+    );
+    let metadata_node = llir
+        .edges_directed(copy, petgraph::Direction::Incoming)
+        .max_by_key(|edge| edge.id())
+        .unwrap()
+        .source();
+    let consumers: Vec<_> = llir
+        .edges_directed(copy, petgraph::Direction::Outgoing)
+        .map(|edge| (edge.id(), edge.target()))
+        .collect();
+    let mut previous = copy;
+    // Identity copies keep the program's result unchanged while exercising a
+    // larger valid candidate, independent of the first candidate's node count.
+    for _ in 0..1025 {
+        let next = llir.add_node(llir[copy].clone());
+        llir.add_edge(previous, next, ());
+        llir.add_edge(metadata_node, next, ());
+        previous = next;
+    }
+    for (edge, target) in consumers {
+        llir.remove_edge(edge);
+        llir.add_edge(previous, target, ());
+    }
+    let compiled = rt
+        .compile_and_validate_profile_candidate(&llir, &graph.dyn_map, &contexts[0])
+        .expect("valid graph growth must not be rejected based on an earlier candidate's size");
+    rt.install_validated_bucket_set(&space.dim_buckets, compiled.buckets)
+        .unwrap();
+    rt.execute(&graph.dyn_map);
+    assert_eq!(rt.get_i32(output), vec![19; 4]);
+}
+
+#[test]
 fn synthetic_search_profiles_materialized_graphs() {
     let mut graph = Graph::new();
     let input = graph.tensor('s').as_dtype(DType::Int).persist();

--- a/crates/luminal_cuda_lite/src/profile_tests.rs
+++ b/crates/luminal_cuda_lite/src/profile_tests.rs
@@ -61,34 +61,27 @@ fn profile_dense_exact_cases_and_unseen_shapes() {
     );
     assert_eq!(rt.current_hlir_device_binding(input.id).unwrap(), original);
     assert!(!rt.profile_evaluations().is_empty());
-    for graph in [false, true] {
-        let evaluations: Vec<_> = rt
-            .profile_evaluations()
-            .iter()
-            .filter(|e| e.cuda_graph == graph)
-            .collect();
-        assert!(!evaluations.is_empty());
-        for evaluation in evaluations {
-            let expected = if evaluation.bucket == 0 {
-                vec![1, 4]
-            } else {
-                vec![7]
-            };
-            assert_eq!(
-                evaluation
-                    .cases
-                    .iter()
-                    .map(|c| c.dims[&'s'.into()])
-                    .collect::<Vec<_>>(),
-                expected
-            );
-            let score: f64 = evaluation
+    assert!(rt.profile_evaluations().iter().all(|e| e.cuda_graph));
+    for evaluation in rt.profile_evaluations() {
+        let expected = if evaluation.bucket == 0 {
+            vec![1, 4]
+        } else {
+            vec![7]
+        };
+        assert_eq!(
+            evaluation
                 .cases
                 .iter()
-                .map(|c| c.duration.as_secs_f64() * c.weight / 10.)
-                .sum();
-            assert!((evaluation.weighted_cost.as_secs_f64() - score).abs() < 1e-9);
-        }
+                .map(|c| c.dims[&'s'.into()])
+                .collect::<Vec<_>>(),
+            expected
+        );
+        let score: f64 = evaluation
+            .cases
+            .iter()
+            .map(|c| c.duration.as_secs_f64() * c.weight / 10.)
+            .sum();
+        assert!((evaluation.weighted_cost.as_secs_f64() - score).abs() < 1e-9);
     }
     rt.begin_cuda_graph_warmup(&[]);
     for s in [2, 8, 3, 6, 1] {
@@ -678,7 +671,9 @@ fn profile_bf16_strided_graph_uses_physical_input_abi() {
 }
 
 #[derive(Debug, Clone, Default)]
-struct MetadataCopy;
+struct MetadataCopy {
+    direct_launches: Arc<std::sync::atomic::AtomicUsize>,
+}
 impl EgglogOp for MetadataCopy {
     fn sort(&self) -> luminal::egglog_utils::api::SortDef {
         luminal::egglog_utils::api::sort(luminal::egglog_utils::base::OP_KIND, "MetadataCopy", &[])
@@ -740,6 +735,12 @@ impl HostOp for MetadataCopy {
         buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
         dims: &DynMap,
     ) -> anyhow::Result<()> {
+        if stream.capture_status()?
+            == cudarc::driver::sys::CUstreamCaptureStatus::CU_STREAM_CAPTURE_STATUS_NONE
+        {
+            self.direct_launches
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
         unsafe {
             result::memcpy_dtod_async(
                 buffers[&node].ptr(),
@@ -757,8 +758,10 @@ fn profile_capture_preparation_uses_exact_metadata() {
     let mut graph = Graph::new();
     let input = graph.tensor('s').as_dtype(DType::Int).persist();
     let metadata = graph.tensor(1).as_dtype(DType::Int).persist();
+    let copy = MetadataCopy::default();
+    let direct_launches = copy.direct_launches.clone();
     let output = graph
-        .custom_op(MetadataCopy, (input.id, metadata.id), 's', DType::Int)
+        .custom_op(copy, (input.id, metadata.id), 's', DType::Int)
         .output();
     graph.set_dim('s', 1);
     graph.build_search_space::<CudaRuntime>(
@@ -789,6 +792,32 @@ fn profile_capture_preparation_uses_exact_metadata() {
             .iter()
             .any(|e| e.cuda_graph && e.cases.len() == 2)
     );
+    assert_eq!(direct_launches.load(std::sync::atomic::Ordering::SeqCst), 0);
     rt.execute(&graph.dyn_map);
     assert_eq!(rt.get_i32(output), vec![19]);
+}
+
+#[test]
+fn synthetic_search_profiles_materialized_graphs() {
+    let mut graph = Graph::new();
+    let input = graph.tensor('s').as_dtype(DType::Int).persist();
+    let metadata = graph.tensor(1).as_dtype(DType::Int).persist();
+    let copy = MetadataCopy::default();
+    let direct_launches = copy.direct_launches.clone();
+    let output = graph
+        .custom_op(copy, (input.id, metadata.id), 's', DType::Int)
+        .output();
+    graph.set_dim('s', 4);
+    graph.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let mut rt = runtime();
+    rt.set_data(input, vec![19i32; 4]);
+    rt.set_data_with_host_mirror(metadata, vec![4i32]);
+    rt = graph.search_with_rng(
+        rt,
+        CompileOptions::default().search_graph_limit(1).trials(3),
+        &mut SmallRng::seed_from_u64(17),
+    );
+    assert_eq!(direct_launches.load(std::sync::atomic::Ordering::SeqCst), 0);
+    rt.execute(&graph.dyn_map);
+    assert_eq!(rt.get_i32(output), vec![19; 4]);
 }

--- a/crates/luminal_cuda_lite/src/profile_tests.rs
+++ b/crates/luminal_cuda_lite/src/profile_tests.rs
@@ -1584,14 +1584,25 @@ fn profile_storage_retains_owned_allocation_and_shared_alias_identity() {
 
 #[test]
 fn large_zero_capture_preserves_overlapping_views_after_device_mutation() {
+    check_large_capture_aliases(false);
+    check_large_capture_aliases(true);
+}
+
+fn check_large_capture_aliases(sparse: bool) {
     let mut graph = Graph::new();
-    let n = 256 * 1024;
+    let n = 512 * 1024;
     let a = graph.tensor(n).persist();
     let b = graph.tensor(n).persist();
     (a + b).output();
     graph.build_search_space::<CudaRuntime>(CompileOptions::default().search_log(false));
     let mut rt = runtime();
-    let mut backing = rt.cuda_stream.alloc_zeros::<f32>(n + 2).unwrap();
+    let mut expected = vec![0f32; n + 2];
+    if sparse {
+        for i in [0, 1, 16383, 16384, n, n + 1] {
+            expected[i] = i as f32 + 0.25;
+        }
+    }
+    let mut backing = rt.cuda_stream.clone_htod(&expected).unwrap();
     let ptr = backing.device_ptr(&rt.cuda_stream).0;
     unsafe {
         rt.set_device_ptr(a, ptr, n * 4);
@@ -1607,9 +1618,32 @@ fn large_zero_capture_preserves_overlapping_views_after_device_mutation() {
         .memcpy_htod(&vec![7.0f32; n + 2], &mut backing)
         .unwrap();
     rt.cuda_stream.synchronize().unwrap();
-    assert!(groups[0].0.iter().all(|&byte| byte == 0));
+    let expected: Vec<_> = expected.into_iter().flat_map(f32::to_ne_bytes).collect();
+    assert_eq!(groups[0].0.as_slice(), expected);
     assert!(Arc::ptr_eq(
         &captured.bindings[0].storage.0,
         &captured.bindings[1].storage.0
     ));
+}
+
+#[test]
+fn sparse_captured_storage_preserves_chunk_boundaries_and_dense_ownership() {
+    for len in [17, 1024 * 1024 + 7, 4 * 1024 * 1024 + 3] {
+        for dense in [false, true] {
+            let mut bytes = vec![if dense { 19 } else { 0 }; len];
+            for index in [0, 65535, 65536, 65537, len - 1] {
+                if index < len {
+                    bytes[index] = (index % 251 + 1) as u8;
+                }
+            }
+            let expected = bytes.clone();
+            let address = bytes.as_ptr();
+            let storage = ProfileStorage::captured(bytes);
+            assert_eq!(storage.0.as_slice(), expected);
+            if dense || len < 1024 * 1024 {
+                assert_eq!(storage.0.as_ptr(), address);
+            }
+            assert!(Arc::ptr_eq(&storage.0, &storage.clone().0));
+        }
+    }
 }

--- a/crates/luminal_cuda_lite/src/profile_tests.rs
+++ b/crates/luminal_cuda_lite/src/profile_tests.rs
@@ -15,6 +15,28 @@ fn dims(s: usize) -> DynMap {
 }
 
 #[test]
+fn profile_budget_never_substitutes_warmup_for_a_timed_trial() {
+    let mut cx = Graph::new();
+    let input = cx.tensor(4).persist();
+    let output = (input + 1.).output();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let space = cx.search_space().unwrap();
+    let contexts = space.bucket_contexts(&cx.dyn_map);
+    let llir = luminal::search::extract_one(space, &contexts[0], &mut SmallRng::seed_from_u64(73));
+    let mut rt = runtime();
+    rt.load_llir(&llir);
+    rt.set_data(input, vec![2f32; 4]);
+    let before = rt.next_execution_id;
+    rt.profile_loaded_cuda_graph(&llir, &cx.dyn_map, 3, Some(Duration::ZERO), None);
+    assert_eq!(
+        rt.next_execution_id - before,
+        2,
+        "even an exhausted profiling budget requires a warmup and one timed trial"
+    );
+    assert_eq!(rt.get_f32(output), vec![3f32; 4]);
+}
+
+#[test]
 fn profile_dense_exact_cases_and_unseen_shapes() {
     let mut cx = Graph::new();
     let input = cx.tensor(('s', 4)).persist();
@@ -129,8 +151,9 @@ fn profile_capture_aliases_and_restore_mirrors() {
         .unwrap()
         .bucket_contexts(&DynMap::default());
     rt.begin_profile_replay(&contexts).unwrap();
-    assert_eq!(rt.profile_replay.as_ref().unwrap().snapshots.len(), 2);
+    assert!(rt.profile_replay.as_ref().unwrap().snapshots.is_empty());
     rt.activate_profile_case(0).unwrap();
+    assert_eq!(rt.profile_replay.as_ref().unwrap().snapshots.len(), 2);
     let replay_a = rt.current_hlir_device_binding(a.id).unwrap().0;
     let replay_b = rt.current_hlir_device_binding(b.id).unwrap().0;
     assert_eq!(replay_b, replay_a + 8);
@@ -723,6 +746,7 @@ fn profile_bf16_strided_graph_uses_physical_input_abi() {
 #[derive(Debug, Clone, Default)]
 struct MetadataCopy {
     direct_launches: Arc<std::sync::atomic::AtomicUsize>,
+    preparation_delay: Duration,
 }
 impl EgglogOp for MetadataCopy {
     fn sort(&self) -> luminal::egglog_utils::api::SortDef {
@@ -775,6 +799,7 @@ impl HostOp for MetadataCopy {
             metadata[0] == rows as i32,
             "metadata disagrees with capture dimensions"
         );
+        std::thread::sleep(self.preparation_delay);
         Ok(())
     }
     fn execute(
@@ -800,6 +825,81 @@ impl HostOp for MetadataCopy {
             )?;
         }
         Ok(())
+    }
+}
+
+#[test]
+fn profile_budget_accepts_complete_workload_but_rejects_missing_cases() {
+    let mut graph = Graph::new();
+    let input = graph.tensor('s').as_dtype(DType::Int).persist();
+    let metadata = graph.tensor(1).as_dtype(DType::Int).persist();
+    let output = graph
+        .custom_op(
+            MetadataCopy {
+                preparation_delay: Duration::from_millis(100),
+                ..Default::default()
+            },
+            (input.id, metadata.id),
+            's',
+            DType::Int,
+        )
+        .output();
+    graph.set_dim('s', 4);
+    graph.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let space = graph.search_space().unwrap();
+    let contexts = space.bucket_contexts(&graph.dyn_map);
+    let llir = luminal::search::extract_one(space, &contexts[0], &mut SmallRng::seed_from_u64(17));
+    for cases in [1, 2] {
+        let mut rt = runtime();
+        rt.set_data(input, vec![19i32; 4]);
+        rt.set_data_with_host_mirror(metadata, vec![4i32]);
+        let mut workload = ProfileWorkload::new();
+        for case in 0..cases {
+            workload = workload.case(
+                format!("case-{case}"),
+                dims(4),
+                ProfileInputs::new()
+                    .input(input, vec![19i32; 4])
+                    .mirrored_input(metadata, vec![4i32]),
+                1.0,
+            );
+        }
+        rt.set_profile_workload(&graph, workload).unwrap();
+        rt.begin_profile_replay(&contexts).unwrap();
+        let before = rt.next_execution_id;
+        let result = rt.evaluate_profile_workload(
+            &llir,
+            &contexts[0],
+            &CompileOptions::default()
+                .trials(1)
+                .execution_timeout(Duration::from_millis(50)),
+            false,
+        );
+        assert_eq!(
+            rt.next_execution_id - before,
+            2,
+            "warmup and one full timed trial"
+        );
+        assert_eq!(rt.get_i32(output), vec![19; 4]);
+        if cases == 1 {
+            assert!(
+                result.is_ok(),
+                "completed workload must be rankable despite slow warmup: {result:?}"
+            );
+            assert_eq!(rt.profile_evaluations().len(), 1);
+        } else {
+            assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("before every case was measured")
+            );
+            assert!(
+                rt.profile_evaluations().is_empty(),
+                "incomplete workloads must not be ranked"
+            );
+        }
+        rt.finish_profile_replay();
     }
 }
 
@@ -975,8 +1075,9 @@ fn profile_replay_reclaims_previous_arena_and_rematerializes_original_program() 
         "previous arena overlaps replay storage"
     );
     assert!(!rt.cuda_graphs().any(CudaGraphOp::is_materialized));
-    assert_eq!(rt.profile_replay.as_ref().unwrap().snapshots.len(), 1);
+    assert!(rt.profile_replay.as_ref().unwrap().snapshots.is_empty());
     rt.activate_profile_case(0).unwrap();
+    assert_eq!(rt.profile_replay.as_ref().unwrap().snapshots.len(), 1);
     rt.execute(&graph.dyn_map);
     assert_eq!(rt.get_f32(output), vec![9.; 256]);
     rt.finish_profile_replay();
@@ -1131,4 +1232,335 @@ fn captured_workspace_owners_follow_resident_graph_lifetimes() {
         owners.lock().unwrap().iter().all(|w| w.upgrade().is_none()),
         "dropping runtime retains workspace owners"
     );
+}
+
+#[test]
+fn prepared_input_survives_replay_and_clears_on_ordinary_write() {
+    let mut graph = Graph::new();
+    let input = graph.tensor(4).persist();
+    let output = (input + 1.).output();
+    graph.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let mut rt = runtime();
+    let bytes: Vec<u8> = [2f32, 3., 4., 5., 99., 98., 97., 96.]
+        .into_iter()
+        .flat_map(f32::to_ne_bytes)
+        .collect();
+    let allocation = rt.cuda_stream.clone_htod(&bytes).unwrap();
+    rt.set_prepared_buffer(input, allocation, 16, "test.dual.v1");
+    let binding = rt.current_hlir_device_binding(input.id).unwrap();
+    let before = rt.current_resource_input_signature();
+    assert_eq!(before[&input.id].owned_capacity_bytes, Some(32));
+    assert!(rt.capture_profile_inputs(&[input], &graph.dyn_map).is_err());
+    assert!(
+        rt.set_profile_workload(
+            &graph,
+            ProfileWorkload::new().case(
+                "bad",
+                graph.dyn_map.clone(),
+                ProfileInputs::new().input(input, vec![0f32; 4]),
+                1.
+            )
+        )
+        .is_err()
+    );
+    rt.set_profile_workload(
+        &graph,
+        ProfileWorkload::new().shared_input(input).case(
+            "shared",
+            graph.dyn_map.clone(),
+            ProfileInputs::new(),
+            1.,
+        ),
+    )
+    .unwrap();
+    let contexts = graph
+        .search_space()
+        .unwrap()
+        .bucket_contexts(&graph.dyn_map);
+    rt.begin_profile_replay(&contexts).unwrap();
+    assert_eq!(rt.profile_replay.as_ref().unwrap().owned_device_bytes(), 32);
+    let view = CudaRuntime::input_device_buffer(
+        input.id,
+        &rt.cuda_stream,
+        &rt.hlir_buffers,
+        &rt.external_buffers,
+        &rt.prepared_inputs,
+    )
+    .unwrap();
+    assert_eq!(
+        (view.ptr(), view.len(), view.capacity(), view.input_format()),
+        (binding.0, 16, 32, Some("test.dual.v1"))
+    );
+    rt.finish_profile_replay();
+    assert_eq!(before, rt.current_resource_input_signature());
+    rt = graph.search_with_rng(
+        rt,
+        CompileOptions::default().search_graph_limit(2).trials(1),
+        &mut SmallRng::seed_from_u64(671),
+    );
+    rt.execute(&graph.dyn_map);
+    assert_eq!(rt.get_f32(output), vec![3., 4., 5., 6.]);
+    rt.set_data(input, vec![7f32; 4]);
+    assert!(!rt.prepared_inputs.contains_key(&input.id));
+    assert_eq!(rt.current_hlir_device_binding(input.id).unwrap(), binding);
+    assert_ne!(before, rt.current_resource_input_signature());
+    rt.execute(&graph.dyn_map);
+    assert_eq!(rt.get_f32(output), vec![8.; 4]);
+}
+
+#[test]
+fn prepared_input_rejects_writes_and_overlapping_output() {
+    let mut rt = runtime();
+    let input = NodeIndex::new(721);
+    let allocation = rt.cuda_stream.alloc_zeros::<u8>(64).unwrap();
+    let ptr = allocation.device_ptr(&rt.cuda_stream).0;
+    rt.set_prepared_buffer(input, allocation, 16, "test.dual.v1");
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+        rt.set_output_device_ptr(NodeIndex::new(722), ptr + 32, 4);
+    }));
+    assert!(result.is_err());
+    let mut llir = LLIRGraph::default();
+    let source = llir.add_node(LLIROp::new(Box::new(Input {
+        node: input.index(),
+        label: String::new(),
+        dtype: DType::Int,
+    })));
+    let op = llir.add_node(Probe::default().to_llir_op());
+    llir.add_edge(source, op, ());
+    llir.add_edge(source, op, ());
+    assert!(rt.validate_prepared_input_effects(&llir).is_err());
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        rt.copy_output_to_input(NodeIndex::new(722), input);
+    }));
+    assert!(result.is_err());
+}
+
+#[test]
+fn reused_replay_inputs_reset_each_trial_and_restore_after_failure() {
+    for fail in [false, true] {
+        let mut graph = Graph::new();
+        let state = graph.tensor(1).as_dtype(DType::Int).persist();
+        let meta = graph.tensor(1).as_dtype(DType::Int).persist();
+        let probe = Probe {
+            fail,
+            ..Probe::default()
+        };
+        graph
+            .custom_op(probe.clone(), (state.id, meta.id), 1, DType::F32)
+            .output();
+        graph.build_search_space::<CudaRuntime>(CompileOptions::default());
+        let mut rt = runtime();
+        rt.set_data(state, vec![101i32]);
+        rt.set_data_with_host_mirror(meta, vec![202i32]);
+        let original = rt.current_hlir_device_binding(state.id).unwrap();
+        let restore = rt.capture_profile_inputs(&[state], &graph.dyn_map).unwrap();
+        let workload = ProfileWorkload::new()
+            .device_snapshots(true)
+            .reuse_input_buffers(restore)
+            .case(
+                "a",
+                DynMap::default(),
+                ProfileInputs::new()
+                    .input(state, vec![7i32])
+                    .mirrored_input(meta, vec![11i32]),
+                1.,
+            )
+            .case(
+                "b",
+                DynMap::default(),
+                ProfileInputs::new()
+                    .input(state, vec![19i32])
+                    .mirrored_input(meta, vec![23i32]),
+                1.,
+            );
+        rt.set_profile_workload(&graph, workload).unwrap();
+        let space = graph.search_space().unwrap();
+        let contexts = space.bucket_contexts(&graph.dyn_map);
+        let llir =
+            luminal::search::extract_one(space, &contexts[0], &mut SmallRng::seed_from_u64(12));
+        rt.begin_profile_replay(&contexts).unwrap();
+        assert_eq!(
+            rt.profile_replay
+                .as_ref()
+                .unwrap()
+                .slots
+                .iter()
+                .flatten()
+                .count(),
+            1
+        );
+        assert!(rt.profile_replay.as_ref().unwrap().snapshots.is_empty());
+        rt.activate_profile_case(0).unwrap();
+        assert_eq!(rt.profile_replay.as_ref().unwrap().snapshots.len(), 2);
+        let first_keys: FxHashSet<_> = rt
+            .profile_replay
+            .as_ref()
+            .unwrap()
+            .snapshots
+            .keys()
+            .copied()
+            .collect();
+        rt.activate_profile_case(1).unwrap();
+        let second_keys: FxHashSet<_> = rt
+            .profile_replay
+            .as_ref()
+            .unwrap()
+            .snapshots
+            .keys()
+            .copied()
+            .collect();
+        assert_eq!(second_keys.len(), 2);
+        assert!(
+            first_keys.is_disjoint(&second_keys),
+            "inactive snapshots must be released"
+        );
+        rt.activate_profile_case(0).unwrap();
+        assert_eq!(rt.current_hlir_device_binding(state.id).unwrap(), original);
+        for _ in 0..2 {
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                rt.evaluate_profile_workload(
+                    &llir,
+                    &contexts[0],
+                    &CompileOptions::default().trials(3),
+                    false,
+                )
+            }));
+        }
+        rt.finish_profile_replay();
+        assert_eq!(rt.current_hlir_device_binding(state.id).unwrap(), original);
+        assert_eq!(rt.get_i32(state), vec![101]);
+        assert_eq!(rt.hlir_host_mirrors[&meta.id], 202i32.to_ne_bytes());
+        let seen = probe.seen.lock().unwrap();
+        assert!(!seen.is_empty());
+        assert!(
+            seen.iter().all(|v| *v == (7, 11, 0) || *v == (19, 23, 0)),
+            "{seen:?}"
+        );
+    }
+}
+
+#[test]
+fn reused_replay_rejects_external_aliases_and_oversized_cases() {
+    let mut graph = Graph::new();
+    let a = graph.tensor('s').persist();
+    let b = graph.tensor(1).persist();
+    (a * 2.).output();
+    b.output();
+    graph.set_dim('s', 1);
+    graph.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let mut rt = runtime();
+    rt.set_data(a, vec![3f32]);
+    rt.set_data(b, vec![4f32]);
+    let restore = rt.capture_profile_inputs(&[a], &graph.dyn_map).unwrap();
+    for oversized in [false, true] {
+        let ptr = rt.current_hlir_device_binding(a.id).unwrap().0;
+        if !oversized {
+            unsafe {
+                rt.set_device_ptr(b, ptr, 4);
+            }
+        } else {
+            rt.set_data(b, vec![4f32]);
+        }
+        rt.set_profile_workload(
+            &graph,
+            ProfileWorkload::new()
+                .reuse_input_buffers(restore.clone())
+                .shared_input(b)
+                .case(
+                    "bad",
+                    dims(if oversized { 2 } else { 1 }),
+                    ProfileInputs::new().input(a, vec![1f32; if oversized { 2 } else { 1 }]),
+                    1.,
+                ),
+        )
+        .unwrap();
+        let contexts = graph
+            .search_space()
+            .unwrap()
+            .bucket_contexts(&graph.dyn_map);
+        assert!(rt.begin_profile_replay(&contexts).is_err());
+        assert!(rt.profile_replay.is_none());
+        let mut actual = [0f32];
+        unsafe {
+            result::memcpy_dtoh_sync(&mut actual, ptr).unwrap();
+        }
+        assert_eq!(actual, [3.]);
+    }
+}
+
+#[test]
+fn prepared_unified_owner_survives_replay_and_releases_on_replacement() {
+    let mut graph = Graph::new();
+    let input = graph.tensor(4).persist();
+    let output = (input + 1.).output();
+    graph.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let mut rt = runtime();
+    let mut buffer = unsafe {
+        rt.cuda_stream
+            .context()
+            .alloc_unified::<u8>(32, true)
+            .unwrap()
+    };
+    let bytes: Vec<_> = [5f32; 8].iter().flat_map(|x| x.to_ne_bytes()).collect();
+    rt.cuda_stream.memcpy_htod(&bytes, &mut buffer).unwrap();
+    let ptr = buffer.device_ptr(&rt.cuda_stream).0;
+    rt.set_prepared_unified_buffer(input, buffer, 16, "test.dual.f32");
+    assert_eq!(rt.input_buffer(input).unwrap().capacity(), 32);
+    rt.set_profile_workload(
+        &graph,
+        ProfileWorkload::new().shared_input(input).case(
+            "shared",
+            DynMap::default(),
+            ProfileInputs::new(),
+            1.,
+        ),
+    )
+    .unwrap();
+    let contexts = graph
+        .search_space()
+        .unwrap()
+        .bucket_contexts(&graph.dyn_map);
+    let original_limits = rt.device_resource_limits;
+    rt.device_resource_limits
+        .as_mut()
+        .unwrap()
+        .max_candidate_memory_bytes = 16;
+    // The 32-byte managed owner is allowed to exceed the simulated physical
+    // budget. It must not eliminate room for non-evictable graph allocations.
+    assert_eq!(
+        rt.candidate_device_resource_limits()
+            .unwrap()
+            .max_candidate_memory_bytes,
+        16
+    );
+    let before = rt
+        .candidate_device_resource_limits()
+        .unwrap()
+        .max_candidate_memory_bytes;
+    rt.begin_profile_replay(&contexts).unwrap();
+    assert_eq!(
+        rt.candidate_device_resource_limits()
+            .unwrap()
+            .max_candidate_memory_bytes,
+        before
+    );
+    assert!(rt.prepared_unified_owners.is_empty());
+    assert_eq!(rt.profile_replay.as_ref().unwrap().owned_device_bytes(), 32);
+    rt.finish_profile_replay();
+    assert_eq!(rt.prepared_unified_owners.len(), 1);
+    rt.device_resource_limits = original_limits;
+    rt = graph.search_with_rng(
+        rt,
+        CompileOptions::default().search_graph_limit(1).trials(2),
+        &mut SmallRng::seed_from_u64(74),
+    );
+    assert_eq!(rt.input_buffer(input).unwrap().ptr(), ptr);
+    rt.execute(&graph.dyn_map);
+    assert_eq!(rt.get_f32(output), vec![6.; 4]);
+    rt.clear_profile_workload();
+    rt.set_data(input, vec![9f32; 4]);
+    assert!(rt.prepared_unified_owners.is_empty());
+    assert!(rt.prepared_inputs.is_empty());
+    rt.execute(&graph.dyn_map);
+    assert_eq!(rt.get_f32(output), vec![10.; 4]);
 }

--- a/crates/luminal_cuda_lite/src/profile_tests.rs
+++ b/crates/luminal_cuda_lite/src/profile_tests.rs
@@ -1,0 +1,794 @@
+use super::*;
+use luminal::op::{CustomOp, EgglogOp, LLIROp};
+use rand::{SeedableRng, rngs::SmallRng};
+use std::sync::Mutex;
+
+fn runtime() -> CudaRuntime {
+    CudaRuntime::initialize(
+        cudarc::driver::CudaContext::new(0)
+            .unwrap()
+            .default_stream(),
+    )
+}
+fn dims(s: usize) -> DynMap {
+    [(Symbol::from('s'), s)].into_iter().collect()
+}
+
+#[test]
+fn profile_dense_exact_cases_and_unseen_shapes() {
+    let mut cx = Graph::new();
+    let input = cx.tensor(('s', 4)).persist();
+    let bias = cx.tensor(4).persist();
+    let output = (input + bias.expand_dim(0, 's')).output();
+    cx.set_dim('s', 2);
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default().dim_buckets(
+        's',
+        &[
+            DimBucket::new(1, 4).representative(2),
+            DimBucket::new(5, 8).representative(6),
+        ],
+    ));
+    let mut rt = runtime();
+    rt.set_data(input, vec![9f32; 8]);
+    rt.set_data(bias, vec![1f32, 2., 3., 4.]);
+    let original = rt.current_hlir_device_binding(input.id).unwrap();
+    let workload = ProfileWorkload::new()
+        .device_snapshots(true)
+        .shared_input(bias)
+        .case(
+            "small",
+            dims(1),
+            ProfileInputs::new().input(input, vec![2f32; 4]),
+            1.,
+        )
+        .case(
+            "same-bucket",
+            dims(4),
+            ProfileInputs::new().input(input, vec![5f32; 16]),
+            8.,
+        )
+        .case(
+            "large",
+            dims(7),
+            ProfileInputs::new().input(input, vec![3f32; 28]),
+            1.,
+        );
+    rt.set_profile_workload(&cx, workload).unwrap();
+    rt = cx.search_with_rng(
+        rt,
+        CompileOptions::default().search_graph_limit(3).trials(2),
+        &mut SmallRng::seed_from_u64(43),
+    );
+    assert_eq!(rt.current_hlir_device_binding(input.id).unwrap(), original);
+    assert!(!rt.profile_evaluations().is_empty());
+    for graph in [false, true] {
+        let evaluations: Vec<_> = rt
+            .profile_evaluations()
+            .iter()
+            .filter(|e| e.cuda_graph == graph)
+            .collect();
+        assert!(!evaluations.is_empty());
+        for evaluation in evaluations {
+            let expected = if evaluation.bucket == 0 {
+                vec![1, 4]
+            } else {
+                vec![7]
+            };
+            assert_eq!(
+                evaluation
+                    .cases
+                    .iter()
+                    .map(|c| c.dims[&'s'.into()])
+                    .collect::<Vec<_>>(),
+                expected
+            );
+            let score: f64 = evaluation
+                .cases
+                .iter()
+                .map(|c| c.duration.as_secs_f64() * c.weight / 10.)
+                .sum();
+            assert!((evaluation.weighted_cost.as_secs_f64() - score).abs() < 1e-9);
+        }
+    }
+    rt.begin_cuda_graph_warmup(&[]);
+    for s in [2, 8, 3, 6, 1] {
+        cx.set_dim('s', s);
+        rt.set_data(input, vec![10f32; s * 4]);
+        rt.execute(&cx.dyn_map);
+        assert_eq!(rt.get_f32(output), [11., 12., 13., 14.].repeat(s));
+    }
+}
+
+#[test]
+fn profile_capture_aliases_and_restore_mirrors() {
+    let mut cx = Graph::new();
+    let a = cx.tensor(4).persist();
+    let b = cx.tensor(4).persist();
+    let meta = cx.tensor(1).as_dtype(DType::Int).persist();
+    (a + b).output();
+    meta.output();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let mut rt = runtime();
+    let backing = rt
+        .cuda_stream
+        .clone_htod(&[1f32, 2., 3., 4., 5., 6.])
+        .unwrap();
+    let ptr = backing.device_ptr(&rt.cuda_stream).0;
+    unsafe {
+        rt.set_device_ptr(a, ptr, 16);
+        rt.set_device_ptr(b, ptr + 8, 16);
+    }
+    rt.set_data_with_host_mirror(meta, vec![17i32]);
+    let inputs = rt
+        .capture_profile_inputs(&[a, b, meta], &DynMap::default())
+        .unwrap();
+    assert_eq!(inputs.groups().len(), 2);
+    rt.set_profile_workload(
+        &cx,
+        ProfileWorkload::new()
+            .device_snapshots(true)
+            .case("alias", DynMap::default(), inputs.clone(), 1.)
+            .case("alias-again", DynMap::default(), inputs, 1.),
+    )
+    .unwrap();
+    let contexts = cx
+        .search_space()
+        .unwrap()
+        .bucket_contexts(&DynMap::default());
+    rt.begin_profile_replay(&contexts).unwrap();
+    assert_eq!(rt.profile_replay.as_ref().unwrap().snapshots.len(), 2);
+    rt.activate_profile_case(0).unwrap();
+    let replay_a = rt.current_hlir_device_binding(a.id).unwrap().0;
+    let replay_b = rt.current_hlir_device_binding(b.id).unwrap().0;
+    assert_eq!(replay_b, replay_a + 8);
+    unsafe {
+        result::memcpy_htod_sync(replay_b, &[99f32; 4]).unwrap();
+    }
+    rt.hlir_host_mirrors.insert(meta.id, vec![0; 4]);
+    rt.restore_profile_inputs().unwrap();
+    let mut actual = [0f32; 6];
+    unsafe {
+        result::memcpy_dtoh_sync(&mut actual, replay_a).unwrap();
+    }
+    assert_eq!(actual, [1., 2., 3., 4., 5., 6.]);
+    assert_eq!(rt.hlir_host_mirrors[&meta.id], 17i32.to_ne_bytes());
+    rt.finish_profile_replay();
+    assert_eq!(rt.current_hlir_device_binding(a.id).unwrap().0, ptr);
+}
+
+#[derive(Debug, Clone, Default)]
+struct Probe {
+    seen: Arc<Mutex<Vec<(i32, i32, usize)>>>,
+    hidden: Arc<Mutex<usize>>,
+    fail: bool,
+}
+impl EgglogOp for Probe {
+    fn sort(&self) -> luminal::egglog_utils::api::SortDef {
+        luminal::egglog_utils::api::sort(luminal::egglog_utils::base::OP_KIND, "ReplayProbe", &[])
+    }
+    fn cleanup(&self) -> bool {
+        false
+    }
+    fn n_inputs(&self) -> usize {
+        2
+    }
+}
+impl CustomOp for Probe {
+    fn to_llir_op(&self) -> LLIROp {
+        LLIROp::new(Box::new(self.clone()) as Box<dyn HostOp>)
+    }
+}
+impl HostOp for Probe {
+    fn output_size(&self) -> Expression {
+        1.into()
+    }
+    fn output_bytes(&self) -> Expression {
+        4.into()
+    }
+    fn capture_profile_state(
+        &self,
+        _: &Arc<CudaStream>,
+    ) -> anyhow::Result<Box<dyn crate::host::ProfileState>> {
+        struct Snapshot(Arc<Mutex<usize>>, usize);
+        impl crate::host::ProfileState for Snapshot {
+            fn restore(&self, _: &Arc<CudaStream>) -> anyhow::Result<()> {
+                *self.0.lock().unwrap() = self.1;
+                Ok(())
+            }
+        }
+        Ok(Box::new(Snapshot(
+            self.hidden.clone(),
+            *self.hidden.lock().unwrap(),
+        )))
+    }
+    fn profile_mutated_inputs(&self) -> Vec<usize> {
+        vec![0]
+    }
+    fn execute(
+        &self,
+        stream: &Arc<CudaStream>,
+        node: NodeIndex,
+        inputs: &[NodeIndex],
+        buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
+        _: &DynMap,
+    ) -> anyhow::Result<()> {
+        stream.synchronize()?;
+        let mut state = [0i32];
+        let mut meta = [0i32];
+        unsafe {
+            result::memcpy_dtoh_sync(&mut state, buffers[&inputs[0]].ptr())?;
+            result::memcpy_dtoh_sync(&mut meta, buffers[&inputs[1]].ptr())?;
+        }
+        assert_eq!(
+            buffers[&inputs[1]].host_bytes().unwrap(),
+            meta[0].to_ne_bytes()
+        );
+        let mut hidden = self.hidden.lock().unwrap();
+        self.seen.lock().unwrap().push((state[0], meta[0], *hidden));
+        *hidden += 1;
+        unsafe {
+            result::memcpy_htod_sync(buffers[&inputs[0]].ptr(), &[state[0] + 1])?;
+            result::memcpy_htod_sync(buffers[&node].ptr(), &[state[0] as f32])?;
+        }
+        anyhow::ensure!(!self.fail, "deliberate probe failure after input mutation");
+        Ok(())
+    }
+}
+
+#[test]
+fn profile_custom_op_state_rng_and_candidate_order() {
+    let mut cx = Graph::new();
+    let state = cx.tensor(1).as_dtype(DType::Int).persist();
+    let meta = cx.tensor(1).as_dtype(DType::Int).persist();
+    let probe = Probe::default();
+    let out = cx
+        .custom_op(probe.clone(), (state.id, meta.id), 1, DType::F32)
+        .output();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let mut rt = runtime();
+    rt.set_data(state, vec![101i32]);
+    rt.set_data_with_host_mirror(meta, vec![202i32]);
+    let workload = ProfileWorkload::new()
+        .case(
+            "a",
+            DynMap::default(),
+            ProfileInputs::new()
+                .input(state, vec![7i32])
+                .mirrored_input(meta, vec![11i32]),
+            1.,
+        )
+        .case(
+            "b",
+            DynMap::default(),
+            ProfileInputs::new()
+                .input(state, vec![19i32])
+                .mirrored_input(meta, vec![23i32]),
+            3.,
+        );
+    rt.set_profile_workload(&cx, workload.clone()).unwrap();
+    rt = cx.search_with_rng(
+        rt,
+        CompileOptions::default().search_graph_limit(2).trials(3),
+        &mut SmallRng::seed_from_u64(1),
+    );
+    let seen = probe.seen.lock().unwrap().clone();
+    assert!(
+        seen.len() >= 16,
+        "warmup and trials in both execution modes"
+    );
+    assert!(
+        seen.iter().all(|v| *v == (7, 11, 0) || *v == (19, 23, 0)),
+        "{seen:?}"
+    );
+    probe.seen.lock().unwrap().clear();
+    let mut reversed = workload;
+    reversed.cases.reverse();
+    rt.set_profile_workload(&cx, reversed).unwrap();
+    rt = cx.search_with_rng(
+        rt,
+        CompileOptions::default().search_graph_limit(2).trials(3),
+        &mut SmallRng::seed_from_u64(2),
+    );
+    let seen = probe.seen.lock().unwrap().clone();
+    assert!(seen.iter().all(|v| *v == (7, 11, 0) || *v == (19, 23, 0)));
+    assert!(rt.profile_replay.is_none());
+    rt.execute(&DynMap::default());
+    assert_eq!(rt.get_f32(out), vec![101.]);
+}
+
+#[test]
+fn profile_rejects_invalid_bindings_and_uncovered_bucket() {
+    let mut cx = Graph::new();
+    let input = cx.tensor('s');
+    (input + input).output();
+    cx.set_dim('s', 1);
+    cx.build_search_space::<CudaRuntime>(
+        CompileOptions::default().dim_buckets('s', &[DimBucket::new(1, 4), DimBucket::new(5, 8)]),
+    );
+    let mut rt = runtime();
+    for (d, data, weight) in [
+        (dims(2), vec![1f32], 1.),
+        (DynMap::default(), vec![1f32], 1.),
+        (dims(1), vec![1f32], f64::NAN),
+    ] {
+        assert!(
+            rt.set_profile_workload(
+                &cx,
+                ProfileWorkload::new().case(
+                    "bad",
+                    d,
+                    ProfileInputs::new().input(input, data),
+                    weight
+                )
+            )
+            .is_err()
+        );
+    }
+    let storage = ProfileStorage::new(vec![0u8; 8]);
+    assert!(
+        rt.set_profile_workload(
+            &cx,
+            ProfileWorkload::new().case(
+                "unaligned",
+                dims(1),
+                ProfileInputs::new().view(input, &storage, 1..5, false),
+                1.
+            )
+        )
+        .is_err()
+    );
+    rt.set_profile_workload(
+        &cx,
+        ProfileWorkload::new().case(
+            "only",
+            dims(2),
+            ProfileInputs::new().input(input, vec![1f32; 2]),
+            1.,
+        ),
+    )
+    .unwrap();
+    let contexts = cx.search_space().unwrap().bucket_contexts(&cx.dyn_map);
+    assert!(rt.begin_profile_replay(&contexts).is_err());
+    assert!(rt.profile_replay.is_none());
+}
+
+// Two semantically identical test algorithms with deliberately different
+// data-dependent costs. Sleeping makes the ranking deterministic without relying
+// on a particular GPU kernel implementation or hardcoding a production winner.
+#[derive(Debug, Clone, Default)]
+struct Choice(usize);
+impl CustomOp for Choice {
+    fn to_llir_op(&self) -> LLIROp {
+        LLIROp::new(Box::new(self.clone()) as Box<dyn HostOp>)
+    }
+}
+impl EgglogOp for Choice {
+    fn sort(&self) -> luminal::egglog_utils::api::SortDef {
+        use luminal::egglog_utils::{
+            api::sort,
+            base::{I64, OP_KIND},
+        };
+        sort(OP_KIND, "ProfileChoice", &[("algorithm", I64)])
+    }
+    fn cleanup(&self) -> bool {
+        false
+    }
+    fn n_inputs(&self) -> usize {
+        1
+    }
+    fn rewrites(&self) -> Vec<luminal::egglog_utils::api::Rule> {
+        vec![luminal::egglog_utils::api::Rule::raw(
+            r#"
+            (rule ((= ?x (Op (CustomOpKind 0 (F32)) ?inputs)))
+                  ((union ?x (Op (ProfileChoice 0) ?inputs))
+                   (union ?x (Op (ProfileChoice 1) ?inputs))) :ruleset kernel_lower)
+        "#,
+        )]
+    }
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        children: &[&'a ENodeId],
+        inputs: Vec<&'a ENodeId>,
+        _: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        _: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        let algorithm = egraph.enodes[children[0]].0.parse().unwrap();
+        (Choice(algorithm).to_llir_op(), inputs)
+    }
+}
+impl HostOp for Choice {
+    fn output_size(&self) -> Expression {
+        1.into()
+    }
+    fn output_bytes(&self) -> Expression {
+        4.into()
+    }
+    fn execute(
+        &self,
+        stream: &Arc<CudaStream>,
+        node: NodeIndex,
+        inputs: &[NodeIndex],
+        buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
+        _: &DynMap,
+    ) -> anyhow::Result<()> {
+        stream.synchronize()?;
+        let mut data = [0f32; 4];
+        unsafe {
+            result::memcpy_dtoh_sync(&mut data, buffers[&inputs[0]].ptr())?;
+        }
+        let preferred = usize::from(data[0] != 0.);
+        std::thread::sleep(Duration::from_millis(if self.0 == preferred {
+            1
+        } else {
+            6
+        }));
+        unsafe {
+            result::memcpy_htod_sync(buffers[&node].ptr(), &[data.iter().sum::<f32>()])?;
+        }
+        Ok(())
+    }
+}
+
+#[test]
+fn profile_supplied_data_and_weights_change_search_winner() {
+    type TestRuntime = CudaRuntimeImpl<(DefaultCudaOps, Choice)>;
+    let mut cx = Graph::new();
+    let input = cx.tensor(4).persist();
+    let output = cx.custom_op(Choice(0), input, 1, DType::F32).output();
+    cx.build_search_space::<TestRuntime>(CompileOptions::default());
+    let mut rt = TestRuntime::initialize(
+        cudarc::driver::CudaContext::new(0)
+            .unwrap()
+            .default_stream(),
+    );
+    rt.set_data(input, vec![1f32, 2., 3., 4.]);
+    for (zero_weight, nonzero_weight, expected) in [(9., 1., 0), (1., 9., 1)] {
+        let workload = ProfileWorkload::new()
+            .timing_method(if expected == 0 {
+                luminal::op::TimingMethod::DeviceTimestamp
+            } else {
+                luminal::op::TimingMethod::WallClock
+            })
+            .case(
+                "zero",
+                DynMap::default(),
+                ProfileInputs::new().input(input, vec![0f32, 2., 3., 4.]),
+                zero_weight,
+            )
+            .case(
+                "nonzero",
+                DynMap::default(),
+                ProfileInputs::new().input(input, vec![1f32, 2., 3., 4.]),
+                nonzero_weight,
+            );
+        rt.set_profile_workload(&cx, workload).unwrap();
+        rt = cx.search_with_rng(
+            rt,
+            CompileOptions::default()
+                .search_graph_limit(8)
+                .trials(2)
+                .keep_best(8),
+            &mut SmallRng::seed_from_u64(17),
+        );
+        let choices: Vec<_> = rt.compiled_buckets[0]
+            .exec_graph
+            .node_weights()
+            .filter_map(|e| e.internal.as_any().downcast_ref::<Choice>())
+            .collect();
+        assert_eq!(choices.len(), 1);
+        assert_eq!(
+            choices[0].0, expected,
+            "supplied workload must drive selection"
+        );
+        assert!(rt.profile_evaluations().iter().all(|e| e.cases.len() == 2));
+        rt.execute(&DynMap::default());
+        assert_eq!(rt.get_f32(output), vec![10.]);
+    }
+}
+
+#[test]
+fn profile_failure_restores_caller_inputs_outputs_and_hidden_state() {
+    let mut cx = Graph::new();
+    let state = cx.tensor(1).as_dtype(DType::Int).persist();
+    let meta = cx.tensor(1).as_dtype(DType::Int).persist();
+    let probe = Probe {
+        fail: true,
+        ..Probe::default()
+    };
+    let output = cx
+        .custom_op(probe.clone(), (state, meta), 1, DType::F32)
+        .output();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let mut rt = runtime();
+    rt.set_data(state, vec![101i32]);
+    rt.set_data_with_host_mirror(meta, vec![202i32]);
+    let original = rt.current_hlir_device_binding(state.id).unwrap();
+    let output_buffer = rt.cuda_stream.clone_htod(&[42f32]).unwrap();
+    let output_ptr = output_buffer.device_ptr(&rt.cuda_stream).0;
+    unsafe {
+        rt.set_output_device_ptr(output, output_ptr, 4);
+    }
+    rt.set_profile_workload(
+        &cx,
+        ProfileWorkload::new().case(
+            "fails",
+            DynMap::default(),
+            ProfileInputs::new()
+                .input(state, vec![7i32])
+                .mirrored_input(meta, vec![11i32]),
+            1.,
+        ),
+    )
+    .unwrap();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // compile borrows the runtime so it remains available to inspect after
+        // search correctly reports that no executable candidate succeeded.
+        rt.compile(
+            cx.search_space().unwrap(),
+            &cx.dyn_map,
+            &CompileOptions::default().search_graph_limit(1),
+            &mut SmallRng::seed_from_u64(1),
+        );
+    }));
+    assert!(result.is_err());
+    assert!(rt.profile_replay.is_none());
+    assert!(!rt.profiling);
+    assert_eq!(rt.current_hlir_device_binding(state.id).unwrap(), original);
+    let mut state_bytes = [0i32];
+    unsafe {
+        result::memcpy_dtoh_sync(&mut state_bytes, original.0).unwrap();
+    }
+    assert_eq!(state_bytes, [101]);
+    assert_eq!(*probe.hidden.lock().unwrap(), 0);
+    assert_eq!(rt.output_ptr_registrations[&output.id], (output_ptr, 4));
+    assert_eq!(
+        rt.cuda_stream.clone_dtoh(&output_buffer).unwrap(),
+        vec![42f32]
+    );
+    assert_eq!(rt.hlir_host_mirrors[&meta.id], 202i32.to_ne_bytes());
+}
+
+#[test]
+fn profile_indexed_update_keeps_original_state() {
+    let mut cx = Graph::new();
+    let destination = cx.tensor(4).persist();
+    let indices = cx.tensor(2).as_dtype(DType::Int).persist();
+    let values = cx.tensor(2).persist();
+    let result = (destination.gather(indices) + values)
+        .scatter(indices, destination)
+        .output();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let mut rt = runtime();
+    rt.set_data(destination, vec![1f32, 2., 3., 4.]);
+    rt.set_data(indices, vec![1i32, 3]);
+    rt.set_data(values, vec![4f32, 5.]);
+    let samples = ProfileWorkload::new()
+        .case(
+            "indices-a",
+            DynMap::default(),
+            ProfileInputs::new()
+                .input(destination, vec![0f32; 4])
+                .input(indices, vec![1i32, 3])
+                .input(values, vec![4f32, 5.]),
+            1.,
+        )
+        .case(
+            "indices-b",
+            DynMap::default(),
+            ProfileInputs::new()
+                .input(destination, vec![10f32; 4])
+                .input(indices, vec![0i32, 2])
+                .input(values, vec![2f32, 3.]),
+            1.,
+        );
+    rt.set_profile_workload(&cx, samples).unwrap();
+    rt = cx.search_with_rng(
+        rt,
+        CompileOptions::default().search_graph_limit(5).trials(3),
+        &mut SmallRng::seed_from_u64(12),
+    );
+    rt.execute(&DynMap::default());
+    assert_eq!(rt.get_f32(result), vec![1., 6., 3., 9.]);
+}
+
+#[test]
+fn profile_rejects_shared_mutation_and_stale_search_space() {
+    let mut cx = Graph::new();
+    let state = cx.tensor(1).as_dtype(DType::Int);
+    let meta = cx.tensor(1).as_dtype(DType::Int);
+    let probe = Probe::default();
+    cx.custom_op(probe.clone(), (state, meta), 1, DType::F32)
+        .output();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let mut rt = runtime();
+    rt.set_data(state, vec![1i32]);
+    rt.set_profile_workload(
+        &cx,
+        ProfileWorkload::new().shared_input(state).case(
+            "readonly",
+            DynMap::default(),
+            ProfileInputs::new().mirrored_input(meta, vec![2i32]),
+            1.,
+        ),
+    )
+    .unwrap();
+    let mut llir = LLIRGraph::default();
+    let s = llir.add_node(LLIROp::new(Box::new(Input {
+        node: state.id.index(),
+        label: String::new(),
+        dtype: DType::Int,
+    })));
+    let m = llir.add_node(LLIROp::new(Box::new(Input {
+        node: meta.id.index(),
+        label: String::new(),
+        dtype: DType::Int,
+    })));
+    let op = llir.add_node(probe.to_llir_op());
+    llir.add_edge(s, op, ());
+    llir.add_edge(m, op, ());
+    assert!(
+        rt.validate_profile_effects(&llir)
+            .unwrap_err()
+            .to_string()
+            .contains("read-only")
+    );
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let contexts = cx.search_space().unwrap().bucket_contexts(&cx.dyn_map);
+    assert!(
+        rt.begin_profile_replay(&contexts)
+            .unwrap_err()
+            .to_string()
+            .contains("another search space")
+    );
+}
+
+#[test]
+fn profile_bf16_strided_graph_uses_physical_input_abi() {
+    let mut graph = Graph::new();
+    let input = graph.tensor((2, 3)).as_dtype(DType::Bf16).persist();
+    let output = input.permute((1, 0)).output();
+    graph.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let values: Vec<_> = (1..=6).map(|i| bf16::from_f32(i as f32)).collect();
+    let mut rt = runtime();
+    rt.set_data(input, values.clone());
+    rt.set_profile_workload(
+        &graph,
+        ProfileWorkload::new().case(
+            "bf16",
+            DynMap::default(),
+            ProfileInputs::new().input(input, values),
+            1.,
+        ),
+    )
+    .unwrap();
+    rt = graph.search_with_rng(
+        rt,
+        CompileOptions::default().search_graph_limit(2),
+        &mut SmallRng::seed_from_u64(5),
+    );
+    rt.execute(&DynMap::default());
+    assert_eq!(
+        rt.get_bf16(output)
+            .iter()
+            .map(|x| x.to_f32())
+            .collect::<Vec<_>>(),
+        vec![1., 4., 2., 5., 3., 6.]
+    );
+}
+
+#[derive(Debug, Clone, Default)]
+struct MetadataCopy;
+impl EgglogOp for MetadataCopy {
+    fn sort(&self) -> luminal::egglog_utils::api::SortDef {
+        luminal::egglog_utils::api::sort(luminal::egglog_utils::base::OP_KIND, "MetadataCopy", &[])
+    }
+    fn cleanup(&self) -> bool {
+        false
+    }
+    fn n_inputs(&self) -> usize {
+        2
+    }
+}
+impl CustomOp for MetadataCopy {
+    fn to_llir_op(&self) -> LLIROp {
+        LLIROp::new(Box::new(self.clone()) as Box<dyn HostOp>)
+    }
+}
+impl HostOp for MetadataCopy {
+    fn output_size(&self) -> Expression {
+        's'.into()
+    }
+    fn output_bytes(&self) -> Expression {
+        Expression::from('s') * 4
+    }
+    fn cuda_graph_capture_arity(&self) -> Option<usize> {
+        Some(2)
+    }
+    fn cuda_graph_capture_dyn_dims(&self) -> Vec<Symbol> {
+        vec!['s'.into()]
+    }
+    fn prepare_cuda_graph_capture(
+        &self,
+        stream: &Arc<CudaStream>,
+        _: NodeIndex,
+        inputs: &[NodeIndex],
+        buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
+        dims: &DynMap,
+    ) -> anyhow::Result<()> {
+        let rows = dims[&'s'.into()];
+        anyhow::ensure!(
+            buffers[&inputs[0]].len() == rows * 4,
+            "input length disagrees with capture dimensions"
+        );
+        stream.synchronize()?;
+        let mut metadata = [0i32];
+        unsafe {
+            result::memcpy_dtoh_sync(&mut metadata, buffers[&inputs[1]].ptr())?;
+        }
+        anyhow::ensure!(
+            metadata[0] == rows as i32,
+            "metadata disagrees with capture dimensions"
+        );
+        Ok(())
+    }
+    fn execute(
+        &self,
+        stream: &Arc<CudaStream>,
+        node: NodeIndex,
+        inputs: &[NodeIndex],
+        buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
+        dims: &DynMap,
+    ) -> anyhow::Result<()> {
+        unsafe {
+            result::memcpy_dtod_async(
+                buffers[&node].ptr(),
+                buffers[&inputs[0]].ptr(),
+                dims[&'s'.into()] * 4,
+                stream.cu_stream(),
+            )?;
+        }
+        Ok(())
+    }
+}
+
+#[test]
+fn profile_capture_preparation_uses_exact_metadata() {
+    let mut graph = Graph::new();
+    let input = graph.tensor('s').as_dtype(DType::Int).persist();
+    let metadata = graph.tensor(1).as_dtype(DType::Int).persist();
+    let output = graph
+        .custom_op(MetadataCopy, (input.id, metadata.id), 's', DType::Int)
+        .output();
+    graph.set_dim('s', 1);
+    graph.build_search_space::<CudaRuntime>(
+        CompileOptions::default().dim_buckets('s', &[DimBucket::new(1, 8).representative(8)]),
+    );
+    let mut rt = runtime();
+    rt.set_data(input, vec![19i32]);
+    rt.set_data_with_host_mirror(metadata, vec![1i32]);
+    let mut workload = ProfileWorkload::new();
+    for n in [2, 6] {
+        workload = workload.case(
+            format!("rows-{n}"),
+            dims(n),
+            ProfileInputs::new()
+                .input(input, vec![7i32; n])
+                .mirrored_input(metadata, vec![n as i32]),
+            1.,
+        );
+    }
+    rt.set_profile_workload(&graph, workload).unwrap();
+    rt = graph.search_with_rng(
+        rt,
+        CompileOptions::default().search_graph_limit(1),
+        &mut SmallRng::seed_from_u64(13),
+    );
+    assert!(
+        rt.profile_evaluations()
+            .iter()
+            .any(|e| e.cuda_graph && e.cases.len() == 2)
+    );
+    rt.execute(&graph.dyn_map);
+    assert_eq!(rt.get_i32(output), vec![19]);
+}

--- a/crates/luminal_cuda_lite/src/profile_tests.rs
+++ b/crates/luminal_cuda_lite/src/profile_tests.rs
@@ -821,3 +821,52 @@ fn synthetic_search_profiles_materialized_graphs() {
     rt.execute(&graph.dyn_map);
     assert_eq!(rt.get_i32(output), vec![19; 4]);
 }
+
+#[test]
+fn profile_replay_reclaims_previous_arena_and_rematerializes_original_program() {
+    let mut graph = Graph::new();
+    let input = graph.tensor(256).persist();
+    let output = (input + 2.0).output();
+    graph.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let mut rt = runtime();
+    rt.set_data(input, vec![3f32; 256]);
+    rt = graph.search_with_rng(
+        rt,
+        CompileOptions::default().search_graph_limit(2).trials(1),
+        &mut SmallRng::seed_from_u64(831),
+    );
+    rt.execute(&graph.dyn_map);
+    assert_eq!(rt.get_f32(output), vec![5.; 256]);
+    assert!(rt.shared_arena.is_some(), "test requires a resident arena");
+    assert!(rt.cuda_graphs().any(CudaGraphOp::is_materialized));
+    let original = rt.current_hlir_device_binding(input.id).unwrap();
+    rt.set_profile_workload(
+        &graph,
+        ProfileWorkload::new().device_snapshots(true).case(
+            "replacement",
+            DynMap::default(),
+            ProfileInputs::new().input(input, vec![7f32; 256]),
+            1.,
+        ),
+    )
+    .unwrap();
+    let contexts = graph
+        .search_space()
+        .unwrap()
+        .bucket_contexts(&graph.dyn_map);
+    rt.begin_profile_replay(&contexts).unwrap();
+    assert!(
+        rt.shared_arena.is_none(),
+        "previous arena overlaps replay storage"
+    );
+    assert!(!rt.cuda_graphs().any(CudaGraphOp::is_materialized));
+    assert_eq!(rt.profile_replay.as_ref().unwrap().snapshots.len(), 1);
+    rt.activate_profile_case(0).unwrap();
+    rt.execute(&graph.dyn_map);
+    assert_eq!(rt.get_f32(output), vec![9.; 256]);
+    rt.finish_profile_replay();
+    assert_eq!(rt.current_hlir_device_binding(input.id).unwrap(), original);
+    rt.clear_profile_workload();
+    rt.execute(&graph.dyn_map);
+    assert_eq!(rt.get_f32(output), vec![5.; 256]);
+}

--- a/crates/luminal_cuda_lite/src/profile_tests.rs
+++ b/crates/luminal_cuda_lite/src/profile_tests.rs
@@ -1564,3 +1564,52 @@ fn prepared_unified_owner_survives_replay_and_releases_on_replacement() {
     rt.execute(&graph.dyn_map);
     assert_eq!(rt.get_f32(output), vec![10.; 4]);
 }
+
+#[test]
+fn profile_storage_retains_owned_allocation_and_shared_alias_identity() {
+    let bytes = vec![0u8; 1024 * 1024];
+    let address = bytes.as_ptr();
+    let storage = ProfileStorage::new(bytes);
+    assert_eq!(
+        storage.0.as_ptr(),
+        address,
+        "moving a snapshot must not copy its bytes"
+    );
+    let alias = storage.clone();
+    assert!(Arc::ptr_eq(&storage.0, &alias.0));
+    assert_eq!(alias.0.len(), 1024 * 1024);
+    drop(storage);
+    assert!(alias.0.iter().all(|&b| b == 0));
+}
+
+#[test]
+fn large_zero_capture_preserves_overlapping_views_after_device_mutation() {
+    let mut graph = Graph::new();
+    let n = 256 * 1024;
+    let a = graph.tensor(n).persist();
+    let b = graph.tensor(n).persist();
+    (a + b).output();
+    graph.build_search_space::<CudaRuntime>(CompileOptions::default().search_log(false));
+    let mut rt = runtime();
+    let mut backing = rt.cuda_stream.alloc_zeros::<f32>(n + 2).unwrap();
+    let ptr = backing.device_ptr(&rt.cuda_stream).0;
+    unsafe {
+        rt.set_device_ptr(a, ptr, n * 4);
+        rt.set_device_ptr(b, ptr + 8, n * 4);
+    }
+    let captured = rt.capture_profile_inputs(&[a, b], &graph.dyn_map).unwrap();
+    let groups = captured.groups();
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0].0.len(), (n + 2) * 4);
+    assert_eq!(captured.bindings[0].range, 0..n * 4);
+    assert_eq!(captured.bindings[1].range, 8..(n + 2) * 4);
+    rt.cuda_stream
+        .memcpy_htod(&vec![7.0f32; n + 2], &mut backing)
+        .unwrap();
+    rt.cuda_stream.synchronize().unwrap();
+    assert!(groups[0].0.iter().all(|&byte| byte == 0));
+    assert!(Arc::ptr_eq(
+        &captured.bindings[0].storage.0,
+        &captured.bindings[1].storage.0
+    ));
+}

--- a/crates/luminal_cuda_lite/src/profile_tests.rs
+++ b/crates/luminal_cuda_lite/src/profile_tests.rs
@@ -849,11 +849,11 @@ fn profile_budget_accepts_complete_workload_but_rejects_missing_cases() {
     let space = graph.search_space().unwrap();
     let contexts = space.bucket_contexts(&graph.dyn_map);
     let llir = luminal::search::extract_one(space, &contexts[0], &mut SmallRng::seed_from_u64(17));
-    for cases in [1, 2] {
+    for (cases, warmups) in [(1, 1), (2, 1), (1, 3), (2, 3)] {
         let mut rt = runtime();
         rt.set_data(input, vec![19i32; 4]);
         rt.set_data_with_host_mirror(metadata, vec![4i32]);
-        let mut workload = ProfileWorkload::new();
+        let mut workload = ProfileWorkload::new().warmup_trials(warmups);
         for case in 0..cases {
             workload = workload.case(
                 format!("case-{case}"),
@@ -877,8 +877,8 @@ fn profile_budget_accepts_complete_workload_but_rejects_missing_cases() {
         );
         assert_eq!(
             rt.next_execution_id - before,
-            2,
-            "warmup and one full timed trial"
+            warmups as u64 + 1,
+            "configured warmups and one full timed trial"
         );
         assert_eq!(rt.get_i32(output), vec![19; 4]);
         if cases == 1 {

--- a/crates/luminal_cuda_lite/src/profile_tests.rs
+++ b/crates/luminal_cuda_lite/src/profile_tests.rs
@@ -15,6 +15,55 @@ fn dims(s: usize) -> DynMap {
 }
 
 #[test]
+fn boundary_counterfactual_restores_fixed_case_and_then_changed_inputs() {
+    let mut cx = Graph::new();
+    let input = cx.tensor(('s', 64)).persist();
+    let output = ((input + 1.).sin() * 3.).output();
+    cx.set_dim('s', 2);
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let mut rt = runtime();
+    rt.set_data(input, vec![2f32; 128]);
+    rt.set_profile_workload(
+        &cx,
+        ProfileWorkload::new().device_snapshots(true).case(
+            "actual",
+            dims(2),
+            ProfileInputs::new().input(input, vec![2f32; 128]),
+            1.,
+        ),
+    )
+    .unwrap();
+    let path = std::env::temp_dir().join(format!(
+        "luminal-counterfactual-{}.json",
+        std::process::id()
+    ));
+    rt.request_region_counterfactual(0, path.clone());
+    rt = cx.search_with_rng(
+        rt,
+        CompileOptions::default().search_graph_limit(1),
+        &mut SmallRng::seed_from_u64(43),
+    );
+    let report: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    assert!(report.get("error").is_none(), "{report}");
+    assert_eq!(report["measurements"].as_array().unwrap().len(), 6);
+    assert!(report["checked_output_count"].as_u64().unwrap() >= 1);
+    assert!(
+        report["measurements"][2]["replaced_operations"]
+            .as_u64()
+            .unwrap()
+            > 0,
+        "{report}"
+    );
+    rt.clear_profile_workload();
+    rt.set_data(input, vec![4f32; 128]);
+    rt.execute(&dims(2));
+    for value in rt.get_f32(output) {
+        assert!((value - 5f32.sin() * 3.).abs() < 1e-5);
+    }
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
 fn profile_budget_never_substitutes_warmup_for_a_timed_trial() {
     let mut cx = Graph::new();
     let input = cx.tensor(4).persist();

--- a/crates/luminal_cuda_lite/src/profile_tests.rs
+++ b/crates/luminal_cuda_lite/src/profile_tests.rs
@@ -481,6 +481,56 @@ fn profile_supplied_data_and_weights_change_search_winner() {
 }
 
 #[test]
+fn profile_research_remeasures_the_saved_program() {
+    let mut graph = Graph::new();
+    let input = graph.tensor(32).persist();
+    let output = (input.sin() * input + 1.0).output();
+    graph.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let mut rt = runtime();
+    rt.set_data(input, vec![2f32; 32]);
+    rt = graph.search_with_rng(
+        rt,
+        CompileOptions::default().search_graph_limit(8).trials(2),
+        &mut SmallRng::seed_from_u64(20260910),
+    );
+    let previous = serde_json::to_value(rt.selected_schedule.as_ref().unwrap()).unwrap();
+    rt.set_profile_workload(
+        &graph,
+        ProfileWorkload::new().case(
+            "new-input",
+            DynMap::default(),
+            ProfileInputs::new().input(input, vec![3f32; 32]),
+            1.,
+        ),
+    )
+    .unwrap();
+    rt = graph.search_with_rng(
+        rt,
+        CompileOptions::default().search_graph_limit(1).trials(2),
+        &mut SmallRng::seed_from_u64(9271),
+    );
+    assert_eq!(
+        serde_json::to_value(rt.selected_schedule.as_ref().unwrap()).unwrap(),
+        previous
+    );
+    let measurements = rt.profile_evaluations();
+    assert_eq!(
+        measurements.len(),
+        2,
+        "remeasure the seed and its deployment finalist"
+    );
+    assert!(measurements.iter().all(|m| m.cuda_graph
+        && m.cases.len() == 1
+        && m.cases[0].case_id == "new-input"
+        && m.cases[0].duration > Duration::ZERO));
+    rt.clear_profile_workload();
+    rt.execute(&DynMap::default());
+    for value in rt.get_f32(output) {
+        assert!((value - (2f32.sin() * 2. + 1.)).abs() < 1e-5);
+    }
+}
+
+#[test]
 fn profile_failure_restores_caller_inputs_outputs_and_hidden_state() {
     let mut cx = Graph::new();
     let state = cx.tensor(1).as_dtype(DType::Int).persist();

--- a/crates/luminal_cuda_lite/src/resource.rs
+++ b/crates/luminal_cuda_lite/src/resource.rs
@@ -235,10 +235,6 @@ impl CandidateResourcePlan {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResourceViolation {
-    CandidatePlanningNodes {
-        required: usize,
-        limit: usize,
-    },
     IntermediateMemory {
         required: usize,
         limit: usize,
@@ -307,10 +303,6 @@ pub enum ResourceViolation {
 impl std::fmt::Display for ResourceViolation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::CandidatePlanningNodes { required, limit } => write!(
-                f,
-                "candidate LLIR has {required} nodes, search planning limit is {limit} nodes"
-            ),
             Self::IntermediateMemory { required, limit } => write!(
                 f,
                 "intermediate memory requires {required} bytes, hard limit is {limit} bytes"

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -46,9 +46,12 @@ use std::{
 use tracing::{Level, span, trace};
 use uuid::Uuid;
 
+#[path = "prepared_input.rs"]
+mod prepared_input;
 #[path = "profile.rs"]
 mod profile;
 pub use crate::host::ProfileState;
+use prepared_input::{PreparedInput, PreparedUnifiedOwner, input_writes};
 pub use profile::{ProfileEvaluation, ProfileInputs, ProfileStorage, ProfileWorkload};
 
 const ARENA_ALIGNMENT: usize = 256;
@@ -116,6 +119,7 @@ pub enum CudaInput {
 /// the same logical length/capacity only requires refreshing launch bindings.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct ResourceInputFootprint {
+    prepared: Option<PreparedInput>,
     logical_bytes: Option<usize>,
     owned_capacity_bytes: Option<usize>,
 }
@@ -135,6 +139,7 @@ impl ResourceInputFootprint {
         Self {
             logical_bytes,
             owned_capacity_bytes: Some(capacity_bytes),
+            prepared: None,
         }
     }
 
@@ -142,6 +147,7 @@ impl ResourceInputFootprint {
         Self {
             logical_bytes: Some(logical_bytes),
             owned_capacity_bytes: None,
+            prepared: None,
         }
     }
 }
@@ -294,6 +300,7 @@ enum ResolvedOutputRegistration {
 /// Weights and the physical intermediate arena are shared by every bucket.
 pub(crate) struct CompiledBucket {
     pub(crate) exec_graph: StableGraph<ExecutableHostOp, (), Directed>,
+    input_writes: FxHashSet<NodeIndex>,
     /// One dynamic-dimension vector shared by CUDA graphs compiled with the
     /// same global ABI. Keeping this after `exec_graph` also guarantees graph
     /// executables are dropped before the pointer they capture.
@@ -358,6 +365,7 @@ impl CompiledBucket {
     fn new() -> Self {
         CompiledBucket {
             exec_graph: StableGraph::default(),
+            input_writes: FxHashSet::default(),
             shared_dyn_dims_buffer: None,
             shared_dyn_dims_order: Vec::new(),
             shared_dyn_dims_values: FxHashMap::default(),
@@ -453,6 +461,8 @@ pub struct CudaRuntimeImpl<O> {
     /// Opt-in host copies for small dynamic inputs consumed by HostOps. Large
     /// tensors are never mirrored implicitly.
     hlir_host_mirrors: FxHashMap<NodeIndex, Vec<u8>>,
+    prepared_inputs: FxHashMap<NodeIndex, PreparedInput>,
+    prepared_unified_owners: FxHashMap<NodeIndex, PreparedUnifiedOwner>,
     owned_stream: Arc<CudaStream>,
     cuda_stream: Arc<CudaStream>,
     changed_hlir: FxHashSet<NodeIndex>,
@@ -1123,10 +1133,11 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         buffer: DeviceBuffer,
     ) {
         let changed = bucket.cached_buffer_ptrs.get(&node) != Some(&buffer.ptr())
-            || bucket
-                .cached_device_buffers
-                .get(&node)
-                .is_none_or(|old| old.len() != buffer.len() || old.capacity() != buffer.capacity());
+            || bucket.cached_device_buffers.get(&node).is_none_or(|old| {
+                old.len() != buffer.len()
+                    || old.capacity() != buffer.capacity()
+                    || old.input_format() != buffer.input_format()
+            });
         if changed {
             bucket.materialization_dirty_nodes.insert(node);
         }
@@ -1187,6 +1198,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                 bucket,
                 &self.cuda_stream,
                 &self.hlir_buffers,
+                &self.prepared_inputs,
                 &self.external_buffers,
                 &self.external_output_buffers,
                 spec_node,
@@ -1247,6 +1259,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         bucket: &CompiledBucket,
         stream: &Arc<CudaStream>,
         hlir_buffers: &FxHashMap<NodeIndex, CudaInput>,
+        prepared_inputs: &FxHashMap<NodeIndex, PreparedInput>,
         external_buffers: &FxHashMap<NodeIndex, std::mem::ManuallyDrop<CudaSlice<u8>>>,
         external_output_buffers: &FxHashMap<NodeIndex, std::mem::ManuallyDrop<CudaSlice<u8>>>,
         mut node: NodeIndex,
@@ -1265,18 +1278,16 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                 return Some(buf);
             }
 
-            if let Some(hlir_node) = bucket.llir_to_hlir.get(&node) {
-                match hlir_buffers.get(hlir_node) {
-                    Some(CudaInput::Buffer { buf, len }) => {
-                        return Some(DeviceBuffer::new(buf.device_ptr(stream).0, *len));
-                    }
-                    Some(CudaInput::Ptr(_)) => {
-                        if let Some(ext) = external_buffers.get(hlir_node) {
-                            return Some(DeviceBuffer::new(ext.device_ptr(stream).0, ext.len()));
-                        }
-                    }
-                    None => {}
-                }
+            if let Some(hlir_node) = bucket.llir_to_hlir.get(&node)
+                && let Some(buffer) = Self::input_device_buffer(
+                    *hlir_node,
+                    stream,
+                    hlir_buffers,
+                    external_buffers,
+                    prepared_inputs,
+                )
+            {
+                return Some(buffer);
             }
 
             let alias_target = bucket.output_alias_map.get(&node)?;
@@ -1356,6 +1367,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                         "cannot load safetensor {label} dtype {tensor_dtype:?} into CUDA graph dtype {graph_dtype:?}"
                     ),
                 };
+                self.clear_prepared_input(node);
                 self.hlir_buffers.insert(node, dev);
             }
         }
@@ -1379,6 +1391,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
     }
 
     fn set_data_bytes(&mut self, id: NodeIndex, bytes: Vec<u8>, keep_host_mirror: bool) {
+        self.clear_prepared_input(id);
         if let Some(CudaInput::Buffer { buf, len }) = self.hlir_buffers.get_mut(&id)
             && bytes.len() <= buf.len()
         {
@@ -1421,6 +1434,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         capacity_bytes: usize,
     ) {
         let id = id.to_id();
+        self.clear_prepared_input(id);
         let bytes = data.into_cuda_bytes();
         assert!(
             capacity_bytes >= bytes.len(),
@@ -1439,8 +1453,18 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
     /// `set_data` with a host-side zero vector since it avoids the host allocation and H2D copy.
     pub fn set_zeros(&mut self, id: impl ToId, num_bytes: usize) {
         let id = id.to_id();
+        self.clear_prepared_input(id);
         self.hlir_host_mirrors.remove(&id);
-        let buf = self.cuda_stream.alloc_zeros(num_bytes).unwrap();
+        let buf = self
+            .cuda_stream
+            .alloc_zeros(num_bytes)
+            .unwrap_or_else(|error| {
+                panic!(
+                    "CUDA zeroed input allocation failed: node={id:?}, bytes={num_bytes}, \
+                 device free/total={:?}: {error}",
+                    self.cuda_stream.context().mem_get_info()
+                )
+            });
         self.hlir_buffers.insert(
             id,
             CudaInput::Buffer {
@@ -1463,6 +1487,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
     pub unsafe fn set_device_ptr(&mut self, id: impl ToId, device_ptr: u64, n_bytes: usize) {
         debug_assert!(device_ptr != 0, "set_device_ptr called with null pointer");
         let id = id.to_id();
+        self.clear_prepared_input(id);
         self.hlir_host_mirrors.remove(&id);
         let current_ptr = match self.hlir_buffers.get(&id) {
             Some(CudaInput::Ptr(ptr)) => Some(*ptr),
@@ -1496,6 +1521,15 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         debug_assert!(
             device_ptr != 0,
             "set_output_device_ptr called with null pointer"
+        );
+        assert!(
+            self.prepared_inputs.iter().all(|(&input, layout)| {
+                self.current_hlir_device_binding(input)
+                    .is_none_or(|(ptr, _)| {
+                        !device_ranges_overlap(ptr, layout.capacity, device_ptr, n_bytes)
+                    })
+            }),
+            "external output overlaps a prepared read-only input"
         );
         let id = id.to_id();
         if self.output_ptr_registrations.get(&id) == Some(&(device_ptr, n_bytes)) {
@@ -2005,6 +2039,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                 .copied();
             if let Some(hlir_node) = hlir_node {
                 self.hlir_host_mirrors.remove(&hlir_node);
+                self.clear_prepared_input(hlir_node);
                 match self
                     .hlir_buffers
                     .remove(&hlir_node)
@@ -2031,6 +2066,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                 .get(&lineage_node)
                 .expect("output_data_input lineage must reach an HLIR input node");
             self.hlir_host_mirrors.remove(&hlir_node);
+            self.clear_prepared_input(hlir_node);
 
             let output =
                 Self::bucket_buffer(&self.compiled_buckets[bi], &self.cuda_stream, &alias_node)
@@ -2055,6 +2091,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
     /// (just a pointer swap, no GPU memcpy).
     pub fn set_buffer(&mut self, id: impl ToId, buf: CudaSlice<u8>) {
         let id = id.to_id();
+        self.clear_prepared_input(id);
         self.hlir_host_mirrors.remove(&id);
         let len = buf.len();
         self.hlir_buffers.insert(id, CudaInput::Buffer { buf, len });
@@ -2067,6 +2104,10 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
     pub fn copy_output_to_input(&mut self, output: impl ToId, input: impl ToId) {
         let output = output.to_id();
         let input = input.to_id();
+        assert!(
+            !self.prepared_inputs.contains_key(&input),
+            "cannot commit state into a prepared read-only input"
+        );
         let data_node = self.resolve_data_node(output);
         if self.active().llir_to_hlir.get(&data_node) == Some(&input)
             && !self.external_output_buffers.contains_key(&data_node)
@@ -3354,25 +3395,18 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             let hlir_nodes = hlir_nodes.into_iter().unique().collect_vec();
             let collect_hlir_time = timer.elapsed();
             let timer = std::time::Instant::now();
-            let to_process: Vec<(NodeIndex, u64, usize)> = hlir_nodes
+            let to_process: Vec<(NodeIndex, DeviceBuffer)> = hlir_nodes
                 .iter()
-                .filter_map(|hlir_node| {
-                    bucket.hlir_to_all_llir.get(hlir_node)?;
-                    let input = self.hlir_buffers.get(hlir_node)?;
-                    let (ptr, len) = match input {
-                        CudaInput::Buffer { buf, len } => {
-                            (buf.device_ptr(&self.cuda_stream).0, *len)
-                        }
-                        CudaInput::Ptr(p) => {
-                            let len = self
-                                .external_buffers
-                                .get(hlir_node)
-                                .map(|buf| buf.len())
-                                .unwrap_or(0);
-                            (*p, len)
-                        }
-                    };
-                    Some((*hlir_node, ptr, len))
+                .filter_map(|&id| {
+                    bucket.hlir_to_all_llir.get(&id)?;
+                    Self::input_device_buffer(
+                        id,
+                        &self.cuda_stream,
+                        &self.hlir_buffers,
+                        &self.external_buffers,
+                        &self.prepared_inputs,
+                    )
+                    .map(|buffer| (id, buffer))
                 })
                 .collect();
             (
@@ -3386,14 +3420,14 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         let timer = std::time::Instant::now();
         let bucket = &mut self.compiled_buckets[bucket_idx];
         let to_process_count = to_process.len();
-        for (hlir_node, ptr, len) in to_process {
+        for (hlir_node, buffer) in to_process {
             let llir_nodes = bucket
                 .hlir_to_all_llir
                 .get(&hlir_node)
                 .cloned()
                 .unwrap_or_default();
             for llir_node in llir_nodes {
-                Self::cache_bucket_device_buffer(bucket, llir_node, DeviceBuffer::new(ptr, len));
+                Self::cache_bucket_device_buffer(bucket, llir_node, buffer);
             }
         }
         bucket.hlir_synced = true;
@@ -3475,6 +3509,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                     bucket,
                     &self.cuda_stream,
                     &self.hlir_buffers,
+                    &self.prepared_inputs,
                     &self.external_buffers,
                     &self.external_output_buffers,
                     exec_op.output,
@@ -3490,6 +3525,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                     bucket,
                     &self.cuda_stream,
                     &self.hlir_buffers,
+                    &self.prepared_inputs,
                     &self.external_buffers,
                     &self.external_output_buffers,
                     inp,
@@ -3519,6 +3555,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                 bucket,
                 &self.cuda_stream,
                 &self.hlir_buffers,
+                &self.prepared_inputs,
                 &self.external_buffers,
                 &self.external_output_buffers,
                 extra_node,
@@ -3556,6 +3593,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                     bucket,
                     &self.cuda_stream,
                     &self.hlir_buffers,
+                    &self.prepared_inputs,
                     &self.external_buffers,
                     &self.external_output_buffers,
                     node,
@@ -3645,6 +3683,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                             bucket,
                             &self.cuda_stream,
                             &self.hlir_buffers,
+                            &self.prepared_inputs,
                             &self.external_buffers,
                             &self.external_output_buffers,
                             node,
@@ -3863,7 +3902,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         input: &CudaInput,
     ) -> Option<ResourceInputFootprint> {
         let length_sensitive = self.resource_length_sensitive_hlir.contains(&node);
-        match input {
+        let mut footprint = match input {
             // Runtime-owned allocation capacity always contributes to the
             // device-memory limit. Its logical length matters only when an
             // attached HostOp explicitly consumes it during planning.
@@ -3875,14 +3914,18 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             // device-memory accounting: aliases/views could otherwise be
             // counted repeatedly. Retain only logical lengths that a HostOp
             // resource plan actually reads.
-            CudaInput::Ptr(_) if length_sensitive => Some(ResourceInputFootprint::external(
-                self.external_buffers
-                    .get(&node)
-                    .map(|buffer| buffer.len())
-                    .unwrap_or(0),
-            )),
+            CudaInput::Ptr(_) if length_sensitive || self.prepared_inputs.contains_key(&node) => {
+                Some(ResourceInputFootprint::external(
+                    self.external_buffers
+                        .get(&node)
+                        .map(|buffer| buffer.len())
+                        .unwrap_or(0),
+                ))
+            }
             CudaInput::Ptr(_) => None,
-        }
+        }?;
+        footprint.prepared = self.prepared_inputs.get(&node).copied();
+        Some(footprint)
     }
 
     fn current_resource_input_signature(&self) -> FxHashMap<NodeIndex, ResourceInputFootprint> {
@@ -4257,6 +4300,9 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         // Context state, allocator overhead/reservations, and unrelated device
         // allocations are also unknown, so this remains a necessary
         // planned-capacity check rather than an available-memory guarantee.
+        // Managed prepared storage can be evicted, so its entire allocation is
+        // not a lower bound on physical residency. Include migration in measured
+        // fitness; only non-evictable storage belongs in this capacity bound.
         let resident_owned_bytes = self
             .hlir_buffers
             .values()
@@ -4267,7 +4313,12 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             .fold(0usize, usize::saturating_add);
         limits.max_candidate_memory_bytes = limits
             .max_candidate_memory_bytes
-            .saturating_sub(resident_owned_bytes);
+            .saturating_sub(resident_owned_bytes)
+            .saturating_sub(self.profile_replay.as_ref().map_or(0, |session| {
+                session
+                    .owned_device_bytes()
+                    .saturating_sub(session.managed_capacity())
+            }));
         Some(limits)
     }
 
@@ -4286,7 +4337,22 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         {
             caps.max_intermediate_bytes = Some(bounded_search_intermediate_bytes(
                 caps.max_intermediate_bytes,
-                free,
+                // Managed prepared storage can release cold pages for a new
+                // arena. The separate total-capacity check still accounts for
+                // every owned byte; instantaneous free memory is not a hard
+                // ceiling when CUDA can evict these representations.
+                free.saturating_add(
+                    self.prepared_unified_owners
+                        .values()
+                        .map(|o| o.buffer.len())
+                        .fold(0usize, usize::saturating_add),
+                )
+                .saturating_add(
+                    self.profile_replay
+                        .as_ref()
+                        .map_or(0, profile::ReplaySession::managed_capacity),
+                )
+                .min(total),
                 total,
             ));
         }
@@ -4563,22 +4629,9 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         let warmup_duration = self
             .last_profile_duration
             .expect("profiled CUDA warmup did not record a duration");
-        // A warmup that already blew the whole profiling budget has proven
-        // the candidate slow; return it as the measurement instead of paying
-        // for a timed trial of the same magnitude. Bad candidates are the
-        // most expensive ones to run, so this halves their cost.
-        if timeout.is_some_and(|timeout| profile_start.elapsed() >= timeout) {
-            self.profiling = false;
-            self.profile_cuda_graphs = false;
-            if diagnostic {
-                eprintln!(
-                    "SEARCH_PROFILE_END graph={profile_cuda_graphs} warmups=1 trials=0 wall_ms={:.6} warmup_metric_ms={:.6} timed_metric_ms=0",
-                    profile_start.elapsed().as_secs_f64() * 1e3,
-                    warmup_duration.as_secs_f64() * 1e3
-                );
-            }
-            return (warmup_duration, format_duration_precise(&warmup_duration));
-        }
+        // Capture and first-use setup belong to warmup, not candidate fitness.
+        // Start the execution budget afterwards and always measure one trial.
+        let timed_trials_started = std::time::Instant::now();
         let mut durations = Vec::with_capacity(trials.max(1));
         for _ in 0..trials.max(1) {
             // Keep legacy synthetic profiling's forced plan refresh. Explicit
@@ -4592,7 +4645,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                 self.last_profile_duration
                     .expect("profiled CUDA trial did not record a duration"),
             );
-            if timeout.is_some_and(|timeout| profile_start.elapsed() >= timeout) {
+            if timeout.is_some_and(|timeout| timed_trials_started.elapsed() >= timeout) {
                 break;
             }
             // Early stop against the search's best-so-far: once this
@@ -4657,6 +4710,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
     }
 
     fn try_load_llir(&mut self, llir_graph: &LLIRGraph) -> anyhow::Result<()> {
+        self.validate_prepared_input_effects(llir_graph)?;
         validate_static_llir_semantics(llir_graph)
             .map_err(|violation| anyhow::anyhow!("invalid CUDA LLIR candidate: {violation}"))?;
 
@@ -4885,6 +4939,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         // loaded runtime. A bad later bucket must not discard a previously
         // usable graph after the earlier buckets have already compiled.
         for bucket in bucket_llirs {
+            self.validate_prepared_input_effects(bucket.llir)?;
             validate_static_llir_semantics(bucket.llir)
                 .map_err(|violation| anyhow::anyhow!("invalid CUDA LLIR bucket: {violation}"))?;
         }
@@ -5100,6 +5155,8 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
             selected_schedule: None,
             hlir_buffers: FxHashMap::default(),
             hlir_host_mirrors: FxHashMap::default(),
+            prepared_inputs: FxHashMap::default(),
+            prepared_unified_owners: FxHashMap::default(),
             owned_stream: Arc::clone(&stream),
             cuda_stream: stream,
             changed_hlir: FxHashSet::default(),
@@ -5763,6 +5820,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         prepared_kernel: Option<&PreparedKernelToHostPlan>,
     ) -> CompiledBucket {
         let mut bucket = CompiledBucket::new();
+        bucket.input_writes = input_writes(llir_graph).expect("invalid declared input effects");
         let mut exec_graph = StableGraph::default();
         let mut node_to_exec = FxHashMap::default();
 

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -4338,8 +4338,8 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             caps.max_intermediate_bytes = Some(bounded_search_intermediate_bytes(
                 caps.max_intermediate_bytes,
                 // Managed prepared storage can release cold pages for a new
-                // arena. The separate total-capacity check still accounts for
-                // every owned byte; instantaneous free memory is not a hard
+                // arena. The separate physical-capacity check accounts for
+                // non-evictable storage; instantaneous free memory is not a hard
                 // ceiling when CUDA can evict these representations.
                 free.saturating_add(
                     self.prepared_unified_owners

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -46,6 +46,8 @@ use std::{
 use tracing::{Level, span, trace};
 use uuid::Uuid;
 
+#[path = "counterfactual.rs"]
+mod counterfactual;
 #[path = "prepared_input.rs"]
 mod prepared_input;
 #[path = "profile.rs"]
@@ -476,6 +478,7 @@ pub struct CudaRuntimeImpl<O> {
     /// consumption (used during search/profile).
     profiling: bool,
     profile_workload: Option<ProfileWorkload>,
+    pub(crate) counterfactual_request: Option<(usize, std::path::PathBuf)>,
     profile_replay: Option<profile::ReplaySession>,
     profile_evaluations: Vec<ProfileEvaluation>,
     /// Selects the deployment CUDA-graph launch path while profiling. The
@@ -5134,6 +5137,9 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
         if ops.iter().any(|op| op.sort().name == "KernelScatterNoCopy") {
             passes.push(crate::kernel::other_ops::scatter_reuse_late_pass());
         }
+        if let Some(pass) = crate::temporary_fast_paths::pass(ops) {
+            passes.push(pass);
+        }
         passes
     }
 
@@ -5172,6 +5178,7 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
             region_source_cache: RegionSourceCache::default(),
             profiling: false,
             profile_workload: None,
+            counterfactual_request: None,
             profile_replay: None,
             profile_evaluations: vec![],
             profile_cuda_graphs: false,

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -4971,24 +4971,6 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         dyn_map: &DynMap,
         ctx: &luminal::search::BucketContext<'_>,
     ) -> Result<ValidatedProfileCandidate, String> {
-        self.compile_and_validate_profile_candidate_inner(llir_graph, dyn_map, ctx)
-    }
-
-    pub(crate) fn compile_and_validate_finalist_candidate(
-        &mut self,
-        llir_graph: &LLIRGraph,
-        dyn_map: &DynMap,
-        ctx: &luminal::search::BucketContext<'_>,
-    ) -> Result<ValidatedProfileCandidate, String> {
-        self.compile_and_validate_profile_candidate_inner(llir_graph, dyn_map, ctx)
-    }
-
-    fn compile_and_validate_profile_candidate_inner(
-        &mut self,
-        llir_graph: &LLIRGraph,
-        dyn_map: &DynMap,
-        ctx: &luminal::search::BucketContext<'_>,
-    ) -> Result<ValidatedProfileCandidate, String> {
         let allocation_dyn_map = Self::candidate_allocation_dyn_map(dyn_map, ctx);
         let caps = self.search_candidate_resource_caps();
         let static_plan = match prepare_static_llir_resources(

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -2075,8 +2075,20 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
     /// updates are free; copy-then-modify schedules copy into the existing
     /// allocation instead of allocating a new input on every iteration.
     pub fn copy_output_to_input(&mut self, output: impl ToId, input: impl ToId) {
-        let source = self.resolve_output_buffer(output);
+        let output = output.to_id();
         let input = input.to_id();
+        let data_node = self.resolve_data_node(output);
+        if self.active().llir_to_hlir.get(&data_node) == Some(&input)
+            && !self.external_output_buffers.contains_key(&data_node)
+            && matches!(self.hlir_buffers.get(&input), Some(CudaInput::Buffer { .. }))
+        {
+            // Identity follows proven storage aliases, not data lineage. Both
+            // sides are the same owned binding, so even acquiring managed CUDA
+            // pointers would only enqueue redundant read events and waits.
+            self.hlir_host_mirrors.remove(&input);
+            return;
+        }
+        let source = self.resolve_output_buffer(output);
         let CudaInput::Buffer { buf, len } = self
             .hlir_buffers
             .get(&input)
@@ -7268,5 +7280,38 @@ mod arena_plan_tests {
         planned[1].start = 0;
         CudaRuntime::assign_fixed_arena_slots(&mut overlapping, planned);
         assert_eq!(overlapping.arena_slots.len(), 2);
+    }
+}
+
+#[cfg(test)]
+mod recurrent_commit_tests {
+    use super::*;
+    use crate::kernel::cuda_graph::CudaGraphHandle;
+    use cudarc::driver::CudaContext;
+    use rand::{SeedableRng, rngs::StdRng};
+
+    #[test]
+    fn aliased_recurrent_commit_enqueues_no_device_work() {
+        let Ok(context) = CudaContext::new(0) else { return; };
+        let stream = context.new_stream().unwrap();
+        let mut graph = Graph::new();
+        let state = graph.tensor(4).persist().output();
+        let doubled = (state + state).output();
+        graph.build_search_space::<CudaRuntime>(CompileOptions::default());
+        let mut runtime = CudaRuntime::initialize(stream.clone());
+        runtime.set_data(state, vec![1.0f32;4]);
+        runtime = graph.search_with_rng(runtime, CompileOptions::default().search_graph_limit(3), &mut StdRng::seed_from_u64(19));
+        runtime.set_data_with_host_mirror(state, vec![1.0f32,2.0,3.0,4.0]);
+        runtime.execute(&graph.dyn_map);
+        assert!(runtime.hlir_host_mirrors.contains_key(&state.id));
+        CudaGraphHandle::begin_standalone_capture(&stream).unwrap();
+        runtime.copy_output_to_input(state, state);
+        let captured = CudaGraphHandle::end_standalone_capture(&stream).unwrap();
+        assert!(captured.nodes().unwrap().is_empty(), "alias commit must not add synchronization events");
+        assert!(!runtime.hlir_host_mirrors.contains_key(&state.id));
+        assert_eq!(runtime.get_f32(state), vec![1.0,2.0,3.0,4.0]);
+        // A distinct output must still copy into the existing state allocation.
+        runtime.copy_output_to_input(doubled, state);
+        assert_eq!(runtime.get_f32(state), vec![2.0,4.0,6.0,8.0]);
     }
 }

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -3213,7 +3213,8 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
     }
 
     fn prepare_bucket_buffers(&mut self, bucket_idx: usize, dyn_map: &DynMap) {
-        let profile_prepare = std::env::var_os("LUMINAL_CUDA_PROFILE_EXEC").is_some()
+        let profile_prepare = std::env::var_os("LUMINAL_CUDA_PROFILE_EXEC")
+            .is_some_and(|mode| mode != "search" || self.profiling)
             || std::env::var_os("LUMINAL_CUDA_PROFILE_RECAPTURE").is_some();
         let prepare_start = std::time::Instant::now();
         let changed_hlir_count = self.changed_hlir.len();
@@ -4622,13 +4623,16 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                 self.profile_timing_method()
             );
         }
-        // Warmup absorbs one-time costs (CUDA graph materialization, lazy
-        // allocations, cache warming) so the timed trials measure steady-state
-        // execution instead of folding setup noise into the candidate ranking.
-        self.execute(dyn_map);
-        let warmup_duration = self
-            .last_profile_duration
-            .expect("profiled CUDA warmup did not record a duration");
+        // The workload chooses the number of exact untimed replays. One graph
+        // execution need not settle lazy initialization or managed residency.
+        let warmups = self.profile_warmup_trials();
+        let mut warmup_duration = Duration::ZERO;
+        for _ in 0..warmups {
+            self.execute(dyn_map);
+            warmup_duration += self
+                .last_profile_duration
+                .expect("profiled CUDA warmup did not record a duration");
+        }
         // Capture and first-use setup belong to warmup, not candidate fitness.
         // Start the execution budget afterwards and always measure one trial.
         let timed_trials_started = std::time::Instant::now();
@@ -4667,7 +4671,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
 
         if diagnostic {
             eprintln!(
-                "SEARCH_PROFILE_END graph={profile_cuda_graphs} warmups=1 trials={} wall_ms={:.6} warmup_metric_ms={:.6} timed_metric_ms={:.6}",
+                "SEARCH_PROFILE_END graph={profile_cuda_graphs} warmups={warmups} trials={} wall_ms={:.6} warmup_metric_ms={:.6} timed_metric_ms={:.6}",
                 durations.len(),
                 profile_start.elapsed().as_secs_f64() * 1e3,
                 warmup_duration.as_secs_f64() * 1e3,
@@ -5256,7 +5260,8 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
         // `PROFILE_EXEC` measures only these coarse runtime phases. The older
         // `PROFILE_RECAPTURE` additionally instruments every CUDA-graph
         // materialization subphase and is intentionally more perturbative.
-        let profile_runtime = std::env::var_os("LUMINAL_CUDA_PROFILE_EXEC").is_some()
+        let profile_runtime = std::env::var_os("LUMINAL_CUDA_PROFILE_EXEC")
+            .is_some_and(|mode| mode != "search" || self.profiling)
             || std::env::var_os("LUMINAL_CUDA_PROFILE_RECAPTURE").is_some();
         let runtime_profile_start = std::time::Instant::now();
         let mut bucket_dispatch_time = Duration::ZERO;

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -46,6 +46,11 @@ use std::{
 use tracing::{Level, span, trace};
 use uuid::Uuid;
 
+#[path = "profile.rs"]
+mod profile;
+pub use crate::host::ProfileState;
+pub use profile::{ProfileEvaluation, ProfileInputs, ProfileStorage, ProfileWorkload};
+
 const ARENA_ALIGNMENT: usize = 256;
 const MIN_ARENA_ALLOCATION_BYTES: usize = 16 * 1024 * 1024;
 const MIN_SEARCH_DEVICE_HEADROOM_BYTES: usize = 512 * 1024 * 1024;
@@ -465,6 +470,9 @@ pub struct CudaRuntimeImpl<O> {
     /// When true, execute() records a device interval and skips input buffer
     /// consumption (used during search/profile).
     profiling: bool,
+    profile_workload: Option<ProfileWorkload>,
+    profile_replay: Option<profile::ReplaySession>,
+    profile_evaluations: Vec<ProfileEvaluation>,
     /// Selects the deployment CUDA-graph launch path while profiling. The
     /// broad genetic search leaves this false and cheaply times prepared
     /// steps; CUDA re-ranks its small finalist set with this true so the final
@@ -476,7 +484,7 @@ pub struct CudaRuntimeImpl<O> {
     /// from candidate ranking.
     profile_start_event: CudaEvent,
     profile_end_event: CudaEvent,
-    last_profile_device_duration: Option<Duration>,
+    last_profile_duration: Option<Duration>,
     /// Monotonic identifier passed to every HostOp in one `execute` call.
     /// Host-side planners use it to share immutable per-tick preparation
     /// without carrying dynamic metadata across executions.
@@ -4536,7 +4544,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
     pub(crate) fn cancel_search_profile(&mut self) {
         self.profiling = false;
         self.profile_cuda_graphs = false;
-        self.last_profile_device_duration = None;
+        self.last_profile_duration = None;
     }
 
     fn profile_loaded_llir_inner(
@@ -4551,13 +4559,21 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         self.profiling = true;
         self.profile_cuda_graphs = profile_cuda_graphs;
         let profile_start = std::time::Instant::now();
+        let diagnostic = std::env::var_os("LUMINAL_CUDA_PROFILE_EXEC").is_some();
+        if diagnostic {
+            eprintln!(
+                "SEARCH_PROFILE_BEGIN graph={profile_cuda_graphs} trials={} timing={:?} dyn={dyn_map:?}",
+                trials.max(1),
+                self.profile_timing_method()
+            );
+        }
         // Warmup absorbs one-time costs (CUDA graph materialization, lazy
         // allocations, cache warming) so the timed trials measure steady-state
         // execution instead of folding setup noise into the candidate ranking.
         self.execute(dyn_map);
         let warmup_duration = self
-            .last_profile_device_duration
-            .expect("profiled CUDA warmup did not record a device duration");
+            .last_profile_duration
+            .expect("profiled CUDA warmup did not record a duration");
         // A warmup that already blew the whole profiling budget has proven
         // the candidate slow; return it as the measurement instead of paying
         // for a timed trial of the same magnitude. Bad candidates are the
@@ -4565,20 +4581,27 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         if timeout.is_some_and(|timeout| profile_start.elapsed() >= timeout) {
             self.profiling = false;
             self.profile_cuda_graphs = false;
+            if diagnostic {
+                eprintln!(
+                    "SEARCH_PROFILE_END graph={profile_cuda_graphs} warmups=1 trials=0 wall_ms={:.6} warmup_metric_ms={:.6} timed_metric_ms=0",
+                    profile_start.elapsed().as_secs_f64() * 1e3,
+                    warmup_duration.as_secs_f64() * 1e3
+                );
+            }
             return (warmup_duration, format_duration_precise(&warmup_duration));
         }
         let mut durations = Vec::with_capacity(trials.max(1));
         for _ in 0..trials.max(1) {
-            // Deployment never executes the same dyn_map twice (decode's `c`
-            // is fresh every step), so mark dimensions stale before every
-            // trial. This refreshes any dimension-baked launch state before
-            // the start event; the metric itself remains strictly the
-            // resulting device execution interval.
-            self.assume_dyn_dims_stale();
+            // Keep legacy synthetic profiling's forced plan refresh. Explicit
+            // samples replay their exact dimensions; arbitrary tensor graphs do
+            // not necessarily change dimensions between invocations.
+            if self.profile_replay.is_none() {
+                self.assume_dyn_dims_stale();
+            }
             self.execute(dyn_map);
             durations.push(
-                self.last_profile_device_duration
-                    .expect("profiled CUDA trial did not record a device duration"),
+                self.last_profile_duration
+                    .expect("profiled CUDA trial did not record a duration"),
             );
             if timeout.is_some_and(|timeout| profile_start.elapsed() >= timeout) {
                 break;
@@ -4600,6 +4623,15 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         self.profile_cuda_graphs = false;
         let duration = durations.iter().sum::<std::time::Duration>() / durations.len() as u32;
 
+        if diagnostic {
+            eprintln!(
+                "SEARCH_PROFILE_END graph={profile_cuda_graphs} warmups=1 trials={} wall_ms={:.6} warmup_metric_ms={:.6} timed_metric_ms={:.6}",
+                durations.len(),
+                profile_start.elapsed().as_secs_f64() * 1e3,
+                warmup_duration.as_secs_f64() * 1e3,
+                durations.iter().sum::<Duration>().as_secs_f64() * 1e3
+            );
+        }
         let duration_str = format_duration_precise(&duration);
         let display = duration_str;
         let display = if std::env::var_os("LUMINAL_SEARCH_OP_NAMES").is_some() {
@@ -4807,7 +4839,12 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         // to call release_pooled_memory() itself, so on a memory-tight GPU the
         // arena allocation below would otherwise OOM against the pool residue.
         self.release_pooled_memory();
+        // Explicit replay binds exact sample metadata. A bucket representative
+        // need not describe that sample (or even a coherent set of its inputs).
+        // Capture lazily on the first exact invocation, including finalist
+        // reranking; resource validation still covers the full bucket domain.
         if prebuild_cuda_graphs
+            && self.profile_replay.is_none()
             && input_lengths_complete
             && let Some(representative_dyn_map) = representative_dyn_maps.get(self.active_bucket)
         {
@@ -5115,10 +5152,13 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
             compiled_function_resource_cache: CompiledFunctionResourceCache::default(),
             region_source_cache: RegionSourceCache::default(),
             profiling: false,
+            profile_workload: None,
+            profile_replay: None,
+            profile_evaluations: vec![],
             profile_cuda_graphs: false,
             profile_start_event,
             profile_end_event,
-            last_profile_device_duration: None,
+            last_profile_duration: None,
             next_execution_id: 0,
             max_intermediate_memory_bytes: None,
             max_kernel_source_bytes: Some(DEFAULT_MAX_KERNEL_SOURCE_BYTES),
@@ -5153,7 +5193,20 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
         options: &CompileOptions,
         rng: &mut dyn luminal::prelude::RngCore,
     ) {
-        self.search_and_load(space, dyn_map, options, rng);
+        assert!(
+            self.profile_workload.is_none() || options.profile_dims.is_empty(),
+            "profile_dims cannot override an explicit profile workload"
+        );
+        let contexts = space.bucket_contexts(dyn_map);
+        self.begin_profile_replay(&contexts)
+            .expect("invalid representative profile workload");
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            self.search_and_load(space, dyn_map, options, rng);
+        }));
+        self.finish_profile_replay();
+        if let Err(payload) = result {
+            std::panic::resume_unwind(payload);
+        }
     }
 
     fn selected_schedule(&self) -> Option<luminal::graph::SelectedSchedule> {
@@ -5175,6 +5228,15 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
 
     #[tracing::instrument(skip_all)]
     fn execute(&mut self, dyn_map: &DynMap) -> Self::ExecReturn {
+        let invocation_started = std::time::Instant::now();
+        if self.profiling {
+            self.restore_profile_trial()
+                .expect("profile state restoration failed");
+        }
+        let initial_restore_time = invocation_started.elapsed();
+        let profile_invocation_start = self.profiling.then(std::time::Instant::now);
+        let mut profile_reset_duration = Duration::ZERO;
+        let mut preparation_sync_time = Duration::ZERO;
         let execution_id = self.next_execution_id;
         self.next_execution_id = self.next_execution_id.wrapping_add(1);
         // `PROFILE_EXEC` measures only these coarse runtime phases. The older
@@ -5270,7 +5332,21 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
         }
         materialize_time += timer.elapsed();
         if self.profiling {
-            self.last_profile_device_duration = None;
+            // Preparation may warm a stateful library implementation. Reset
+            // again after preparation so the timed execution starts from the
+            // sample's state, even on the first graph materialization.
+            if self.profile_replay.is_some() {
+                let sync_started = std::time::Instant::now();
+                self.cuda_stream
+                    .synchronize()
+                    .expect("profile preparation synchronization failed");
+                preparation_sync_time = sync_started.elapsed();
+                let reset = std::time::Instant::now();
+                self.restore_profile_trial()
+                    .expect("profile state restoration failed");
+                profile_reset_duration = reset.elapsed();
+            }
+            self.last_profile_duration = None;
             self.profile_start_event
                 .record(&self.cuda_stream)
                 .expect("failed to record CUDA profiling start event");
@@ -5454,6 +5530,8 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
             self.cuda_stream.synchronize().unwrap();
         }
         sync_time += timer.elapsed();
+        let profile_invocation_duration = profile_invocation_start
+            .map(|start| start.elapsed().saturating_sub(profile_reset_duration));
         if std::env::var_os("LUMINAL_CUDA_PROFILE_GRAPH_STEPS").is_some() {
             for &exec_node in &bucket.exec_order {
                 let exec_op = &bucket.exec_graph[exec_node];
@@ -5493,8 +5571,12 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
                 .profile_start_event
                 .elapsed_ms(&self.profile_end_event)
                 .expect("failed to measure CUDA profiling events");
-            self.last_profile_device_duration =
-                Some(Duration::from_secs_f64(f64::from(elapsed_ms) / 1_000.0));
+            self.last_profile_duration = Some(match self.profile_timing_method() {
+                luminal::op::TimingMethod::DeviceTimestamp => {
+                    Duration::from_secs_f64(f64::from(elapsed_ms) / 1_000.0)
+                }
+                luminal::op::TimingMethod::WallClock => profile_invocation_duration.unwrap(),
+            });
         }
 
         // Populate last_kernel_stats from HostOps that report stats
@@ -5524,6 +5606,23 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
         // reinstall lifted weights. A later changed set_device_ptr call safely
         // replaces the retained non-owning view.
         if self.profiling {
+            if profile_runtime {
+                eprintln!(
+                    "SEARCH_EXEC graph={} wall_ms={:.6} initial_restore_ms={:.6} prepare_ms={:.6} materialize_ms={:.6} preparation_sync_ms={:.6} post_restore_ms={:.6} launch_sync_ms={:.6} stats_ms={:.6}",
+                    self.profile_cuda_graphs,
+                    invocation_started.elapsed().as_secs_f64() * 1e3,
+                    initial_restore_time.as_secs_f64() * 1e3,
+                    (bucket_dispatch_time + prepare_buffers_time + output_registration_time)
+                        .as_secs_f64()
+                        * 1e3,
+                    materialize_time.as_secs_f64() * 1e3,
+                    preparation_sync_time.as_secs_f64() * 1e3,
+                    profile_reset_duration.as_secs_f64() * 1e3,
+                    (graph_launch_time + host_op_time + sync_time + buffer_map_time).as_secs_f64()
+                        * 1e3,
+                    stats_time.as_secs_f64() * 1e3
+                );
+            }
             return;
         }
         let timer = std::time::Instant::now();

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -474,9 +474,8 @@ pub struct CudaRuntimeImpl<O> {
     profile_replay: Option<profile::ReplaySession>,
     profile_evaluations: Vec<ProfileEvaluation>,
     /// Selects the deployment CUDA-graph launch path while profiling. The
-    /// broad genetic search leaves this false and cheaply times prepared
-    /// steps; CUDA re-ranks its small finalist set with this true so the final
-    /// objective matches the executable installed for serving.
+    /// genetic search and finalist validation both use this path so their
+    /// fitness measures the executable installed for serving.
     profile_cuda_graphs: bool,
     /// Reused timing-enabled events bounding only the stream work launched by
     /// `execute`. Search profiling reads this interval instead of host wall
@@ -4523,27 +4522,11 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         }
     }
 
-    /// Every graph output gets a dedicated, statically-sized buffer before
-    /// profiling: candidate execution then includes its real output writes
-    /// (in-place families write through the alias, materializing families
-    /// write into the buffer via substitution), so the step cost the search
-    /// measures is the step cost deployment pays. User registrations take
-    /// precedence; scratch fills the rest and is reused across candidates.
-    pub(crate) fn profile_loaded_llir(
-        &mut self,
-        llir_graph: &LLIRGraph,
-        dyn_map: &DynMap,
-        trials: usize,
-        timeout: Option<std::time::Duration>,
-        early_stop: Option<(Duration, f64)>,
-    ) -> (Duration, String) {
-        self.profile_loaded_llir_inner(llir_graph, dyn_map, trials, timeout, early_stop, false)
-    }
-
-    /// Re-profile a loaded finalist through the same materialized CUDA-graph
-    /// launch path used by serving. Search uses this only for its bounded
-    /// finalist set; profiling every explored graph would retain excessive
-    /// driver graph state and spend most of the search budget on setup.
+    /// Score every search candidate through the materialized CUDA graph used
+    /// by deployment. Direct launches have different CPU gaps and GPU overlap,
+    /// so using them for genetic fitness can discard the best deployment graph
+    /// before finalist validation. Warmup excludes capture/setup from timing;
+    /// search releases each candidate's graph and arena before moving on.
     pub(crate) fn profile_loaded_cuda_graph(
         &mut self,
         llir_graph: &LLIRGraph,

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -2080,7 +2080,10 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         let data_node = self.resolve_data_node(output);
         if self.active().llir_to_hlir.get(&data_node) == Some(&input)
             && !self.external_output_buffers.contains_key(&data_node)
-            && matches!(self.hlir_buffers.get(&input), Some(CudaInput::Buffer { .. }))
+            && matches!(
+                self.hlir_buffers.get(&input),
+                Some(CudaInput::Buffer { .. })
+            )
         {
             // Identity follows proven storage aliases, not data lineage. Both
             // sides are the same owned binding, so even acquiring managed CUDA
@@ -7292,26 +7295,35 @@ mod recurrent_commit_tests {
 
     #[test]
     fn aliased_recurrent_commit_enqueues_no_device_work() {
-        let Ok(context) = CudaContext::new(0) else { return; };
+        let Ok(context) = CudaContext::new(0) else {
+            return;
+        };
         let stream = context.new_stream().unwrap();
         let mut graph = Graph::new();
         let state = graph.tensor(4).persist().output();
         let doubled = (state + state).output();
         graph.build_search_space::<CudaRuntime>(CompileOptions::default());
         let mut runtime = CudaRuntime::initialize(stream.clone());
-        runtime.set_data(state, vec![1.0f32;4]);
-        runtime = graph.search_with_rng(runtime, CompileOptions::default().search_graph_limit(3), &mut StdRng::seed_from_u64(19));
-        runtime.set_data_with_host_mirror(state, vec![1.0f32,2.0,3.0,4.0]);
+        runtime.set_data(state, vec![1.0f32; 4]);
+        runtime = graph.search_with_rng(
+            runtime,
+            CompileOptions::default().search_graph_limit(3),
+            &mut StdRng::seed_from_u64(19),
+        );
+        runtime.set_data_with_host_mirror(state, vec![1.0f32, 2.0, 3.0, 4.0]);
         runtime.execute(&graph.dyn_map);
         assert!(runtime.hlir_host_mirrors.contains_key(&state.id));
         CudaGraphHandle::begin_standalone_capture(&stream).unwrap();
         runtime.copy_output_to_input(state, state);
         let captured = CudaGraphHandle::end_standalone_capture(&stream).unwrap();
-        assert!(captured.nodes().unwrap().is_empty(), "alias commit must not add synchronization events");
+        assert!(
+            captured.nodes().unwrap().is_empty(),
+            "alias commit must not add synchronization events"
+        );
         assert!(!runtime.hlir_host_mirrors.contains_key(&state.id));
-        assert_eq!(runtime.get_f32(state), vec![1.0,2.0,3.0,4.0]);
+        assert_eq!(runtime.get_f32(state), vec![1.0, 2.0, 3.0, 4.0]);
         // A distinct output must still copy into the existing state allocation.
         runtime.copy_output_to_input(doubled, state);
-        assert_eq!(runtime.get_f32(state), vec![2.0,4.0,6.0,8.0]);
+        assert_eq!(runtime.get_f32(state), vec![2.0, 4.0, 6.0, 8.0]);
     }
 }

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -57,7 +57,6 @@ const MIN_SEARCH_DEVICE_HEADROOM_BYTES: usize = 512 * 1024 * 1024;
 const SEARCH_DEVICE_HEADROOM_DIVISOR: usize = 200;
 const MIN_SEARCH_CACHE_EVICTION_HEADROOM_BYTES: usize = 1024 * 1024 * 1024;
 const SEARCH_CACHE_EVICTION_HEADROOM_DIVISOR: usize = 50;
-const MIN_SEARCH_CANDIDATE_NODE_ALLOWANCE: usize = 1024;
 
 fn materialized_bucket_evictions(
     materialized: &[bool],
@@ -83,10 +82,6 @@ fn materialized_bucket_evictions(
         }
     }
     evictions
-}
-
-fn search_candidate_node_limit(baseline_nodes: usize) -> usize {
-    baseline_nodes.saturating_add(MIN_SEARCH_CANDIDATE_NODE_ALLOWANCE)
 }
 
 fn bounded_search_intermediate_bytes(
@@ -490,9 +485,6 @@ pub struct CudaRuntimeImpl<O> {
     next_execution_id: u64,
     max_intermediate_memory_bytes: Option<usize>,
     max_kernel_source_bytes: Option<usize>,
-    /// Cheap pre-codegen limit derived from the first viable candidate in the
-    /// current bucket. Reset together with bucket-local compilation state.
-    search_candidate_node_limit: Option<usize>,
     device_resource_limits: Option<CudaDeviceResourceLimits>,
     /// Resource-relevant input state covered by the most recent aggregate
     /// retained-bucket validation.
@@ -864,7 +856,6 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         let _ = self.cuda_stream.synchronize();
         self.release_all_arenas();
         self.compiled_buckets.clear();
-        self.search_candidate_node_limit = None;
         self.active_bucket = 0;
         self.validated_resource_signatures.clear();
         self.resource_length_sensitive_hlir.clear();
@@ -4980,7 +4971,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         dyn_map: &DynMap,
         ctx: &luminal::search::BucketContext<'_>,
     ) -> Result<ValidatedProfileCandidate, String> {
-        self.compile_and_validate_profile_candidate_inner(llir_graph, dyn_map, ctx, true)
+        self.compile_and_validate_profile_candidate_inner(llir_graph, dyn_map, ctx)
     }
 
     pub(crate) fn compile_and_validate_finalist_candidate(
@@ -4989,7 +4980,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         dyn_map: &DynMap,
         ctx: &luminal::search::BucketContext<'_>,
     ) -> Result<ValidatedProfileCandidate, String> {
-        self.compile_and_validate_profile_candidate_inner(llir_graph, dyn_map, ctx, false)
+        self.compile_and_validate_profile_candidate_inner(llir_graph, dyn_map, ctx)
     }
 
     fn compile_and_validate_profile_candidate_inner(
@@ -4997,16 +4988,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         llir_graph: &LLIRGraph,
         dyn_map: &DynMap,
         ctx: &luminal::search::BucketContext<'_>,
-        enforce_search_planning_limit: bool,
     ) -> Result<ValidatedProfileCandidate, String> {
-        if enforce_search_planning_limit && let Some(limit) = self.search_candidate_node_limit {
-            let required = llir_graph.node_count();
-            if required > limit {
-                let violation = ResourceViolation::CandidatePlanningNodes { required, limit };
-                luminal::mask_events::RESOURCE_REJECT.record_with(|| violation.to_string());
-                return Err(format!("resource reject: {violation}"));
-            }
-        }
         let allocation_dyn_map = Self::candidate_allocation_dyn_map(dyn_map, ctx);
         let caps = self.search_candidate_resource_caps();
         let static_plan = match prepare_static_llir_resources(
@@ -5082,10 +5064,6 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                 caps,
             )
             .map_err(|error| format!("resource reject: {error}"))?;
-        if enforce_search_planning_limit {
-            self.search_candidate_node_limit
-                .get_or_insert_with(|| search_candidate_node_limit(llir_graph.node_count()));
-        }
         let display = format!(
             "{}; generated CUDA source max {}, total {}; novel fusion compile {} / {}",
             format_memory_bytes(Self::peak_planned_arena_bytes(&validated.compiled_buckets)),
@@ -5160,7 +5138,6 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
             next_execution_id: 0,
             max_intermediate_memory_bytes: None,
             max_kernel_source_bytes: Some(DEFAULT_MAX_KERNEL_SOURCE_BYTES),
-            search_candidate_node_limit: None,
             device_resource_limits,
             last_resource_input_signature: FxHashMap::default(),
             synchronize_stream: true,
@@ -6564,13 +6541,6 @@ mod arena_plan_tests {
             materialized_bucket_evictions(&materialized, &lru, 1, 1),
             vec![0]
         );
-    }
-
-    #[test]
-    fn search_planning_node_limit_allows_growth_but_rejects_graph_explosion() {
-        assert_eq!(search_candidate_node_limit(3_500), 4_524);
-        assert!(10_311 > search_candidate_node_limit(3_500));
-        assert_eq!(search_candidate_node_limit(10), 1_034);
     }
 
     #[test]

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -164,11 +164,9 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         }
     }
 
-    /// Direct step launch is cheap enough for broad exploration, but serving
-    /// uses materialized CUDA graphs and can rank close schedules differently.
-    /// Re-extract the search's best parent-width set and measure that exact
-    /// deployment path before bucket-lattice selection. No schedule is named
-    /// or forced: both stages are ordered solely by measured device time.
+    /// Re-extract and remeasure the search's best parent-width set on the same
+    /// deployment graph path before bucket-lattice selection. No schedule is
+    /// named or forced: both stages are ordered solely by measured device time.
     fn rerank_cuda_graph_finalists<'a>(
         &mut self,
         ranked: Ranked<Duration>,

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -400,13 +400,13 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
 
 pub(crate) fn safe_fusion_late_pass() -> luminal::egglog_utils::LateEgglogPass {
     // Singleton elementwise regions already exist when this late pass runs.
-    // One Egglog round sees every materialized FE -> FS boundary in the DAG;
-    // the rule dissolves and subsumes those boundaries simultaneously, giving
-    // us maximal destructive fusion without enumerating fusion partitions.
+    // Matching-layout FE/FS boundaries are subsumed. Saturation also exposes
+    // cast conversions at strided reads, including chains of conversions;
+    // their materialized alternatives remain available to measured search.
     luminal::egglog_utils::LateEgglogPass::new(
         "",
         "(seq
-            fusion_inline_safe_late
+            (saturate fusion_inline_safe_late)
             (saturate expr)
             (saturate cleanup)
             (saturate post_cleanup)

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -33,7 +33,9 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             let bucket_started = Instant::now();
             let setup_started = Instant::now();
             let mut search = GeneticSearch::<Duration>::new(space, ctx, options, search_started_at);
-            if let Some(schedule) = &self.selected_schedule {
+            if options.seed_schedule.is_none()
+                && let Some(schedule) = &self.selected_schedule
+            {
                 search.seed_schedule(schedule);
             }
             log_search_phase(ctx.index, "graph-search", "search_init", setup_started);

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -272,7 +272,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                 .map_err(|e| e.to_string());
         }
         let candidate =
-            self.compile_and_validate_finalist_candidate(&pending.llir, &pending.dyn_map, ctx)?;
+            self.compile_and_validate_profile_candidate(&pending.llir, &pending.dyn_map, ctx)?;
         self.install_validated_bucket_set(ctx.dim_buckets(), candidate.buckets)
             .map_err(|error| format!("deployment CUDA-graph load reject: {error}"))?;
         let (metric, _) = self.profile_loaded_cuda_graph(
@@ -329,7 +329,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         let compile_started = Instant::now();
         if finalist {
             let prepared = self
-                .compile_and_validate_finalist_candidate(llir, &dims, ctx)
+                .compile_and_validate_profile_candidate(llir, &dims, ctx)
                 .map_err(anyhow::Error::msg)?;
             self.install_validated_bucket_set(ctx.dim_buckets(), prepared.buckets)?;
         } else {
@@ -385,11 +385,9 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         pending: &PendingFinalist<Duration>,
         ctx: &BucketContext<'_>,
     ) -> Result<(), String> {
-        // This genome was already compiled and timed during search. Re-run the
-        // exact CUDA/resource checks for deployment, but do not apply the
-        // cheap candidate-planning node guard: that guard bounds exploration
-        // work and is not a property of the measured graph.
-        self.compile_and_validate_finalist_candidate(&pending.llir, &pending.dyn_map, ctx)
+        // Revalidate the measured genome with the same CUDA/resource checks
+        // used during search before installing the deployment bucket set.
+        self.compile_and_validate_profile_candidate(&pending.llir, &pending.dyn_map, ctx)
             .map(|_| ())
     }
 }

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -30,6 +30,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         let contexts = space.bucket_contexts(dyn_map);
         let mut finalists = Vec::with_capacity(contexts.len());
         for ctx in &contexts {
+            let _image_cache = crate::search_image_cache::SearchImageCache::enter();
             let bucket_started = Instant::now();
             let setup_started = Instant::now();
             let mut search = GeneticSearch::<Duration>::new(space, ctx, options, search_started_at);

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -292,7 +292,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         Ok(metric)
     }
 
-    fn evaluate_profile_workload(
+    pub(crate) fn evaluate_profile_workload(
         &mut self,
         llir: &LLIRGraph,
         ctx: &BucketContext<'_>,
@@ -362,12 +362,10 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             let dims = self.profile_case_dims(index);
             let (duration, _) =
                 self.profile_loaded_cuda_graph(llir, &dims, options.trials, remaining, None);
-            anyhow::ensure!(
-                options
-                    .execution_timeout
-                    .is_none_or(|timeout| started.elapsed() < timeout),
-                "profile workload execution budget exhausted; partial measurements are not ranked"
-            );
+            // The profiler always finishes at least one timed trial. Exceeding
+            // the budget during warmup or that final trial does not invalidate
+            // a complete measurement. The next iteration rejects an incomplete
+            // multi-case workload if no budget remains for its other cases.
             timings.push((index, duration));
         }
         self.record_profile_evaluation(ctx.index, true, &timings)

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -121,7 +121,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             }));
             return match result {
                 Ok(Ok(metric)) => {
-                    Outcome::Measured(metric, format!("representative workload {metric:?}"))
+                    Outcome::Measured(metric, self.profile_evaluations().last().unwrap().display())
                 }
                 Ok(Err(reason)) => Outcome::Rejected(reason.to_string()),
                 Err(_) => {
@@ -233,9 +233,16 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             match profiled {
                 Ok(metric) => {
                     if options.search_log_enabled() {
-                        println!(
-                            "   Search  deployment finalist search={search_metric:?} graph={metric:?}"
-                        );
+                        if self.profile_case_indices(ctx.index).is_some() {
+                            println!(
+                                "   Search  deployment finalist search_score={search_metric:?}; {}",
+                                self.profile_evaluations().last().unwrap().display()
+                            );
+                        } else {
+                            println!(
+                                "   Search  deployment finalist search={search_metric:?} graph={metric:?}"
+                            );
+                        }
                     }
                     deployment_ranked.push((metric, genome.clone()));
                     if deployment_ranked.len() == target {

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -33,21 +33,21 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             let bucket_started = Instant::now();
             let setup_started = Instant::now();
             let mut search = GeneticSearch::<Duration>::new(space, ctx, options, search_started_at);
-            log_search_phase(ctx.index, "direct", "search_init", setup_started);
+            log_search_phase(ctx.index, "graph-search", "search_init", setup_started);
             loop {
                 let extract_started = Instant::now();
                 let candidate = search.next_candidate(rng);
-                log_search_phase(ctx.index, "direct", "extract", extract_started);
+                log_search_phase(ctx.index, "graph-search", "extract", extract_started);
                 let Some(mut candidate) = candidate else {
                     break;
                 };
                 let evaluate_started = Instant::now();
                 let outcome = self.evaluate_candidate(&mut candidate, ctx, options);
-                log_search_phase(ctx.index, "direct", "evaluate", evaluate_started);
+                log_search_phase(ctx.index, "graph-search", "evaluate", evaluate_started);
                 let cleanup_started = Instant::now();
                 search.report(candidate, outcome);
                 self.release_search_candidate_allocations();
-                log_search_phase(ctx.index, "direct", "report_release", cleanup_started);
+                log_search_phase(ctx.index, "graph-search", "report_release", cleanup_started);
             }
             let ranked = search.into_ranked();
             let bucket_finalists =
@@ -144,7 +144,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         };
         candidate.restart_timer();
         let profiled = catch_unwind(AssertUnwindSafe(|| {
-            self.profile_loaded_llir(
+            self.profile_loaded_cuda_graph(
                 &candidate.llir,
                 &candidate.profile_dyn_map,
                 options.trials,
@@ -180,13 +180,13 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         let target = options.keep_best.max(1).min(ranked.len());
         let mut deployment_ranked = Vec::with_capacity(target);
 
-        for (direct_metric, genome) in &ranked {
+        for (search_metric, genome) in &ranked {
             let extract_started = Instant::now();
             // Use Core's ordinary extractor on a one-genome ranked set. This
             // preserves the exact final extraction/unroll path the lattice
             // will use after the deployment metrics have been sorted.
             let mut extracted = Finalists::new(
-                vec![(*direct_metric, genome.clone())],
+                vec![(*search_metric, genome.clone())],
                 space,
                 ctx,
                 options,
@@ -231,7 +231,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                 Ok(metric) => {
                     if options.search_log_enabled() {
                         println!(
-                            "   Search  deployment finalist direct={direct_metric:?} graph={metric:?}"
+                            "   Search  deployment finalist search={search_metric:?} graph={metric:?}"
                         );
                     }
                     deployment_ranked.push((metric, genome.clone()));
@@ -287,11 +287,11 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         llir: &LLIRGraph,
         ctx: &BucketContext<'_>,
         options: &CompileOptions,
-        cuda_graph: bool,
+        finalist: bool,
     ) -> anyhow::Result<Duration> {
         let result = catch_unwind(AssertUnwindSafe(|| {
             self.capture_profile_op_states(llir)?;
-            self.evaluate_profile_workload_inner(llir, ctx, options, cuda_graph)
+            self.evaluate_profile_workload_inner(llir, ctx, options, finalist)
         }));
         self.release_profile_op_states()?;
         match result {
@@ -305,9 +305,13 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         llir: &LLIRGraph,
         ctx: &BucketContext<'_>,
         options: &CompileOptions,
-        cuda_graph: bool,
+        finalist: bool,
     ) -> anyhow::Result<Duration> {
-        let mode = if cuda_graph { "graph" } else { "direct" };
+        let mode = if finalist {
+            "graph-finalist"
+        } else {
+            "graph-search"
+        };
         if std::env::var_os("LUMINAL_CUDA_PROFILE_EXEC").is_some() {
             eprintln!("SEARCH_EVALUATION_BEGIN bucket={} mode={mode}", ctx.index);
         }
@@ -320,7 +324,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         self.restore_profile_trial()?;
         log_search_phase(ctx.index, mode, "initial_restore_validate", setup_started);
         let compile_started = Instant::now();
-        if cuda_graph {
+        if finalist {
             let prepared = self
                 .compile_and_validate_finalist_candidate(llir, &dims, ctx)
                 .map_err(anyhow::Error::msg)?;
@@ -346,11 +350,8 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             self.activate_profile_case(index)?;
             log_search_phase(ctx.index, mode, "case_activate", activate_started);
             let dims = self.profile_case_dims(index);
-            let (duration, _) = if cuda_graph {
-                self.profile_loaded_cuda_graph(llir, &dims, options.trials, remaining, None)
-            } else {
-                self.profile_loaded_llir(llir, &dims, options.trials, remaining, None)
-            };
+            let (duration, _) =
+                self.profile_loaded_cuda_graph(llir, &dims, options.trials, remaining, None);
             anyhow::ensure!(
                 options
                     .execution_timeout
@@ -359,7 +360,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             );
             timings.push((index, duration));
         }
-        self.record_profile_evaluation(ctx.index, cuda_graph, &timings)
+        self.record_profile_evaluation(ctx.index, true, &timings)
     }
 
     fn prepare_search_candidate(

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -33,6 +33,9 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             let bucket_started = Instant::now();
             let setup_started = Instant::now();
             let mut search = GeneticSearch::<Duration>::new(space, ctx, options, search_started_at);
+            if let Some(schedule) = &self.selected_schedule {
+                search.seed_schedule(schedule);
+            }
             log_search_phase(ctx.index, "graph-search", "search_init", setup_started);
             loop {
                 let extract_started = Instant::now();

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -30,17 +30,31 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         let contexts = space.bucket_contexts(dyn_map);
         let mut finalists = Vec::with_capacity(contexts.len());
         for ctx in &contexts {
+            let bucket_started = Instant::now();
+            let setup_started = Instant::now();
             let mut search = GeneticSearch::<Duration>::new(space, ctx, options, search_started_at);
-            while let Some(mut candidate) = search.next_candidate(rng) {
+            log_search_phase(ctx.index, "direct", "search_init", setup_started);
+            loop {
+                let extract_started = Instant::now();
+                let candidate = search.next_candidate(rng);
+                log_search_phase(ctx.index, "direct", "extract", extract_started);
+                let Some(mut candidate) = candidate else {
+                    break;
+                };
+                let evaluate_started = Instant::now();
                 let outcome = self.evaluate_candidate(&mut candidate, ctx, options);
+                log_search_phase(ctx.index, "direct", "evaluate", evaluate_started);
+                let cleanup_started = Instant::now();
                 search.report(candidate, outcome);
                 self.release_search_candidate_allocations();
+                log_search_phase(ctx.index, "direct", "report_release", cleanup_started);
             }
             let ranked = search.into_ranked();
             let bucket_finalists =
                 self.rerank_cuda_graph_finalists(ranked, space, ctx, options, search_started_at);
             self.discard_search_bucket_compilation_state();
             finalists.push(bucket_finalists);
+            log_search_phase(ctx.index, "all", "bucket_total", bucket_started);
         }
 
         let mut lattice = BucketLattice::new(
@@ -96,6 +110,21 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         ctx: &BucketContext<'_>,
         options: &CompileOptions,
     ) -> Outcome<Duration> {
+        if self.profile_case_indices(ctx.index).is_some() {
+            let result = catch_unwind(AssertUnwindSafe(|| {
+                self.evaluate_profile_workload(&candidate.llir, ctx, options, false)
+            }));
+            return match result {
+                Ok(Ok(metric)) => {
+                    Outcome::Measured(metric, format!("representative workload {metric:?}"))
+                }
+                Ok(Err(reason)) => Outcome::Rejected(reason.to_string()),
+                Err(_) => {
+                    self.cancel_search_profile();
+                    Outcome::Invalid("representative profiling panicked".into())
+                }
+            };
+        }
         // Snapshot before static preparation as well as execution: candidate
         // planning/codegen is synchronous and may itself be the phase that
         // needs post-mortem diagnosis.
@@ -152,6 +181,7 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         let mut deployment_ranked = Vec::with_capacity(target);
 
         for (direct_metric, genome) in &ranked {
+            let extract_started = Instant::now();
             // Use Core's ordinary extractor on a one-genome ranked set. This
             // preserves the exact final extraction/unroll path the lattice
             // will use after the deployment metrics have been sorted.
@@ -165,11 +195,15 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             let Some(pending) = extracted.extract_next() else {
                 continue;
             };
+            log_search_phase(ctx.index, "graph", "extract", extract_started);
             let candidate_started_at = Instant::now();
             let result = catch_unwind(AssertUnwindSafe(|| {
                 self.profile_finalist_cuda_graph(&pending, ctx, options)
             }));
+            log_search_phase(ctx.index, "graph", "evaluate", candidate_started_at);
+            let cleanup_started = Instant::now();
             self.release_search_candidate_allocations();
+            log_search_phase(ctx.index, "graph", "report_release", cleanup_started);
 
             let profiled = match result {
                 Ok(Ok(metric)) => Ok(metric),
@@ -229,6 +263,11 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
         ctx: &BucketContext<'_>,
         options: &CompileOptions,
     ) -> Result<Duration, String> {
+        if self.profile_case_indices(ctx.index).is_some() {
+            return self
+                .evaluate_profile_workload(&pending.llir, ctx, options, true)
+                .map_err(|e| e.to_string());
+        }
         let candidate =
             self.compile_and_validate_finalist_candidate(&pending.llir, &pending.dyn_map, ctx)?;
         self.install_validated_bucket_set(ctx.dim_buckets(), candidate.buckets)
@@ -241,6 +280,86 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             None,
         );
         Ok(metric)
+    }
+
+    fn evaluate_profile_workload(
+        &mut self,
+        llir: &LLIRGraph,
+        ctx: &BucketContext<'_>,
+        options: &CompileOptions,
+        cuda_graph: bool,
+    ) -> anyhow::Result<Duration> {
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            self.capture_profile_op_states(llir)?;
+            self.evaluate_profile_workload_inner(llir, ctx, options, cuda_graph)
+        }));
+        self.release_profile_op_states()?;
+        match result {
+            Ok(result) => result,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+    }
+
+    fn evaluate_profile_workload_inner(
+        &mut self,
+        llir: &LLIRGraph,
+        ctx: &BucketContext<'_>,
+        options: &CompileOptions,
+        cuda_graph: bool,
+    ) -> anyhow::Result<Duration> {
+        let mode = if cuda_graph { "graph" } else { "direct" };
+        if std::env::var_os("LUMINAL_CUDA_PROFILE_EXEC").is_some() {
+            eprintln!("SEARCH_EVALUATION_BEGIN bucket={} mode={mode}", ctx.index);
+        }
+        let setup_started = Instant::now();
+        let indices = self.profile_case_indices(ctx.index).unwrap();
+        self.validate_profile_effects(llir)?;
+        let first = indices[0];
+        let dims = self.profile_case_dims(first);
+        self.activate_profile_case(first)?;
+        self.restore_profile_trial()?;
+        log_search_phase(ctx.index, mode, "initial_restore_validate", setup_started);
+        let compile_started = Instant::now();
+        if cuda_graph {
+            let prepared = self
+                .compile_and_validate_finalist_candidate(llir, &dims, ctx)
+                .map_err(anyhow::Error::msg)?;
+            self.install_validated_bucket_set(ctx.dim_buckets(), prepared.buckets)?;
+        } else {
+            self.prepare_search_candidate(llir, &dims, ctx)
+                .map_err(anyhow::Error::msg)?;
+        }
+        log_search_phase(ctx.index, mode, "compile_install", compile_started);
+        let started = Instant::now();
+        let mut timings = Vec::with_capacity(indices.len());
+        // A single case cannot be early-stopped against an aggregate incumbent.
+        // Complete every case; execution/candidate budgets still bound the work.
+        for index in indices {
+            let remaining = if let Some(timeout) = options.execution_timeout {
+                Some(timeout.checked_sub(started.elapsed()).ok_or_else(|| {
+                    anyhow::anyhow!("workload timeout before every case was measured")
+                })?)
+            } else {
+                None
+            };
+            let activate_started = Instant::now();
+            self.activate_profile_case(index)?;
+            log_search_phase(ctx.index, mode, "case_activate", activate_started);
+            let dims = self.profile_case_dims(index);
+            let (duration, _) = if cuda_graph {
+                self.profile_loaded_cuda_graph(llir, &dims, options.trials, remaining, None)
+            } else {
+                self.profile_loaded_llir(llir, &dims, options.trials, remaining, None)
+            };
+            anyhow::ensure!(
+                options
+                    .execution_timeout
+                    .is_none_or(|timeout| started.elapsed() < timeout),
+                "profile workload execution budget exhausted; partial measurements are not ranked"
+            );
+            timings.push((index, duration));
+        }
+        self.record_profile_evaluation(ctx.index, cuda_graph, &timings)
     }
 
     fn prepare_search_candidate(
@@ -285,4 +404,14 @@ pub(crate) fn safe_fusion_late_pass() -> luminal::egglog_utils::LateEgglogPass {
             (saturate post_cleanup)
             (saturate base_cleanup))",
     )
+}
+
+/// Coarse search wall times, enabled with the existing execution diagnostic.
+fn log_search_phase(bucket: usize, mode: &str, phase: &str, started: Instant) {
+    if std::env::var_os("LUMINAL_CUDA_PROFILE_EXEC").is_some() {
+        eprintln!(
+            "SEARCH_PHASE bucket={bucket} mode={mode} phase={phase} ms={:.6}",
+            started.elapsed().as_secs_f64() * 1e3
+        );
+    }
 }

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -50,6 +50,18 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                 let evaluate_started = Instant::now();
                 let outcome = self.evaluate_candidate(&mut candidate, ctx, options);
                 log_search_phase(ctx.index, "graph-search", "evaluate", evaluate_started);
+                if matches!(outcome, Outcome::Measured(..))
+                    && self
+                        .counterfactual_request
+                        .as_ref()
+                        .is_some_and(|(bucket, _)| *bucket == ctx.index)
+                {
+                    let (_, path) = self.counterfactual_request.take().unwrap();
+                    let report = self
+                        .profile_region_counterfactuals(&candidate.llir, ctx.index)
+                        .unwrap_or_else(|error| serde_json::json!({"error": error.to_string()}));
+                    std::fs::write(path, serde_json::to_vec_pretty(&report).unwrap()).unwrap();
+                }
                 let cleanup_started = Instant::now();
                 search.report(candidate, outcome);
                 self.release_search_candidate_allocations();

--- a/crates/luminal_cuda_lite/src/search_image_cache.rs
+++ b/crates/luminal_cuda_lite/src/search_image_cache.rs
@@ -1,0 +1,165 @@
+//! Bucket-scoped compiled images survive GPU module eviction. The compilation
+//! environment is held fixed for a search bucket, as with its source-keyed
+//! CUDA module cache; this cache does not outlive that scope.
+use std::{
+    cell::RefCell,
+    collections::{HashMap, VecDeque},
+};
+
+#[derive(Default)]
+struct Images {
+    bytes: usize,
+    entries: HashMap<String, Vec<u8>>,
+    order: VecDeque<String>,
+}
+impl Images {
+    fn insert(&mut self, key: String, image: &[u8], limit: usize) {
+        if image.len() > limit || self.entries.contains_key(&key) {
+            return;
+        }
+        while self.bytes + image.len() > limit {
+            let old = self.order.pop_front().unwrap();
+            self.bytes -= self.entries.remove(&old).unwrap().len();
+        }
+        self.bytes += image.len();
+        self.order.push_back(key.clone());
+        self.entries.insert(key, image.to_vec());
+    }
+}
+thread_local! {
+    static IMAGES: RefCell<Option<Images>> = const { RefCell::new(None) };
+}
+/// Restores a surrounding scope even when candidate compilation panics.
+pub(crate) struct SearchImageCache(Option<Images>);
+impl SearchImageCache {
+    pub(crate) fn enter() -> Self {
+        Self(IMAGES.with(|cache| cache.replace(Some(Images::default()))))
+    }
+}
+impl Drop for SearchImageCache {
+    fn drop(&mut self) {
+        IMAGES.with(|cache| cache.replace(self.0.take()));
+    }
+}
+// Architecture and every compiler option are included. NVRTC is process-loaded
+// and cannot change within a bucket. A bucket never reuses another bucket's
+// images, and standalone/custom compilation outside search remains unchanged.
+pub(crate) fn key(source_key: &str, options: &[String]) -> String {
+    crate::artifact::module_key(&format!("{source_key}:{options:?}"))
+}
+pub(crate) fn lookup(key: &str) -> Option<Vec<u8>> {
+    IMAGES.with(|cache| cache.borrow().as_ref()?.entries.get(key).cloned())
+}
+pub(crate) fn record(key: String, image: &[u8]) {
+    IMAGES.with(|cache| {
+        if let Some(cache) = cache.borrow_mut().as_mut() {
+            cache.insert(key, image, 64 * 1024 * 1024);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn bounded_images_survive_handle_eviction_without_leaking_across_scopes() {
+        assert!(lookup("a").is_none());
+        {
+            let _scope = SearchImageCache::enter();
+            record("a".into(), &[1, 2, 3]);
+            assert_eq!(lookup("a"), Some(vec![1, 2, 3]));
+            let result = std::panic::catch_unwind(|| {
+                let _nested = SearchImageCache::enter();
+                assert!(lookup("a").is_none());
+                record("b".into(), &[4]);
+                panic!("failed candidate");
+            });
+            assert!(result.is_err());
+            assert_eq!(lookup("a"), Some(vec![1, 2, 3]));
+            assert!(lookup("b").is_none());
+        }
+        assert!(lookup("a").is_none());
+        let mut cache = Images::default();
+        cache.insert("a".into(), &[1, 2, 3], 5);
+        cache.insert("b".into(), &[4, 5, 6], 5);
+        cache.insert("large".into(), &[0; 6], 5);
+        assert_eq!(cache.bytes, 3);
+        assert_eq!(cache.entries.len(), 1);
+        assert_eq!(cache.entries["b"], [4, 5, 6]);
+    }
+    #[test]
+    fn compiler_options_and_source_identity_separate_images() {
+        let a = key("source-a", &["--gpu-architecture=sm_90".into()]);
+        assert_ne!(a, key("source-b", &["--gpu-architecture=sm_90".into()]));
+        assert_ne!(a, key("source-a", &["--gpu-architecture=sm_80".into()]));
+        assert_ne!(
+            a,
+            key(
+                "source-a",
+                &["--gpu-architecture=sm_90".into(), "--use_fast_math".into()]
+            )
+        );
+    }
+}
+
+#[cfg(test)]
+mod gpu_tests {
+    use super::*;
+    use cudarc::driver::{CudaContext, LaunchConfig, PushKernelArg};
+    #[test]
+    fn cached_images_recreate_released_modules_and_preserve_compile_guards() {
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+        let mut output = stream.alloc_zeros::<f32>(32).unwrap();
+        let src = "extern \"C\" __global__ void cached_image(float* out) { out[threadIdx.x] = threadIdx.x + 17.0f; }";
+        let _scope = SearchImageCache::enter();
+        let mut times = Vec::new();
+        for _ in 0..4 {
+            let start = std::time::Instant::now();
+            let image = crate::compile_module_image_for_current_device(&ctx, src).unwrap();
+            times.push(start.elapsed().as_secs_f64() * 1000.0);
+            let module = ctx.load_module(image).unwrap();
+            let function = module.load_function("cached_image").unwrap();
+            unsafe {
+                stream
+                    .launch_builder(&function)
+                    .arg(&mut output)
+                    .launch(LaunchConfig {
+                        grid_dim: (1, 1, 1),
+                        block_dim: (32, 1, 1),
+                        shared_mem_bytes: 0,
+                    })
+                    .unwrap();
+            }
+            stream.synchronize().unwrap();
+            // Both function and module owners are released before the next compile.
+        }
+        assert_eq!(
+            stream.clone_dtoh(&output).unwrap(),
+            (17..49).map(|x| x as f32).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            IMAGES.with(|cache| cache.borrow().as_ref().unwrap().entries.len()),
+            1
+        );
+        let failure = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            crate::with_kernel_source_limit(Some(1), || {
+                crate::compile_module_image_for_current_device(&ctx, src)
+            })
+            .unwrap();
+        }));
+        assert!(
+            failure.is_err(),
+            "a cached image cannot bypass the source budget"
+        );
+        let artifact = crate::artifact::module_artifact_session(&ctx, None).unwrap();
+        crate::artifact::finish_module_artifact_capture(&artifact);
+        crate::artifact::with_module_artifact_session(artifact, || {
+            assert!(
+                crate::compile_module_image_for_current_device(&ctx, src).is_err(),
+                "strict artifact misses cannot fall back to cached search images"
+            );
+        });
+        println!("source-to-image milliseconds after releasing module each time: {times:?}");
+    }
+}

--- a/crates/luminal_cuda_lite/src/temporary_fast_paths.rs
+++ b/crates/luminal_cuda_lite/src/temporary_fast_paths.rs
@@ -1,0 +1,98 @@
+//! Temporary performance campaign policy. Remove this module and its runtime
+//! hook after the fast complete programs have been demonstrated. Selection is
+//! still an egglog action, applied only within an already equivalent e-class.
+use luminal::{egglog_utils::LateEgglogPass, op::EgglogOp};
+use std::sync::Arc;
+
+pub(crate) fn pass(ops: &[Arc<Box<dyn EgglogOp>>]) -> Option<LateEgglogPass> {
+    if !ops.iter().any(|op| op.sort().name == "FlashAttention3") {
+        return None;
+    }
+    let mut program = String::from(
+        "(ruleset temporary_fast_path_classify)\n\
+         (ruleset temporary_fast_path_subsume)\n\
+         (relation temporary_fast_path_rank (OpKind i64))\n",
+    );
+    for op in ops {
+        let sort = op.sort();
+        if sort.class != "OpKind" {
+            continue;
+        }
+        let args = (0..sort.fields.len())
+            .map(|i| format!(" ?a{i}"))
+            .collect::<String>();
+        let rank = if sort.name == "FlashAttention3" { 0 } else { 1 };
+        program.push_str(&format!(
+            "(rule ((= ?kind ({}{})))\n\
+             ((temporary_fast_path_rank ?kind {rank}))\n\
+             :ruleset temporary_fast_path_classify)\n",
+            sort.name, args
+        ));
+    }
+    program.push_str(SUBSUME);
+    Some(LateEgglogPass::new(
+        program,
+        "(seq (saturate temporary_fast_path_classify)\n\
+         (saturate temporary_fast_path_subsume))",
+    ))
+}
+
+const SUBSUME: &str = "(rule\n\
+    ((= ?out (Op ?fast ?fast_inputs))\n\
+     (= ?out (Op ?slow ?slow_inputs))\n\
+     (temporary_fast_path_rank ?fast 0)\n\
+     (temporary_fast_path_rank ?slow 1))\n\
+    ((subsume (Op ?slow ?slow_inputs)))\n\
+    :ruleset temporary_fast_path_subsume\n\
+    :name \"temporary prefer proven FA3 over equivalent lowered attention\")";
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn subsumption_keeps_fast_variants_and_other_families() {
+        let mut graph = luminal::prelude::egglog::EGraph::default();
+        graph
+            .parse_and_run_program(
+                None,
+                &format!(
+                    r#"
+            (datatype OpKind (Fast i64) (Slow) (Other))
+            (datatype* (IR (Op OpKind IList)) (IList (INil)))
+            (ruleset temporary_fast_path_subsume)
+            (relation temporary_fast_path_rank (OpKind i64))
+            {}
+            (let a (Op (Fast 0) (INil)))
+            (let b (Op (Fast 1) (INil)))
+            (let slow (Op (Slow) (INil)))
+            (let other (Op (Other) (INil)))
+            (union a b) (union a slow)
+            (temporary_fast_path_rank (Fast 0) 0)
+            (temporary_fast_path_rank (Fast 1) 0)
+            (temporary_fast_path_rank (Slow) 1)
+            (temporary_fast_path_rank (Other) 1)
+            (run-schedule (saturate temporary_fast_path_subsume))
+            (check (= a (Op (Fast 0) (INil))))
+            (check (= a (Op (Fast 1) (INil))))
+        "#,
+                    super::SUBSUME
+                ),
+            )
+            .unwrap();
+        // Subsumption preserves equality/matching, but serialization marks the
+        // fallback unavailable to extraction (unlike delete, it cannot regrow).
+        let serialized = graph.serialize(luminal::prelude::egglog::SerializeConfig {
+            root_eclasses: vec![],
+            max_functions: None,
+            include_temporary_functions: false,
+            max_calls_per_function: None,
+        });
+        let ops: Vec<_> = serialized
+            .egraph
+            .nodes
+            .values()
+            .filter(|node| node.op == "Op")
+            .collect();
+        assert_eq!(ops.len(), 4);
+        assert_eq!(ops.iter().filter(|node| node.subsumed).count(), 1);
+    }
+}

--- a/crates/luminal_cuda_lite/src/tests/consumed_buffer_tests.rs
+++ b/crates/luminal_cuda_lite/src/tests/consumed_buffer_tests.rs
@@ -397,6 +397,130 @@ fn test_scatter_nocopy_not_selected_for_expanded_dest_layout() {
 
 /// Actually execute the scatter and verify every selected implementation.
 #[test]
+fn scatter_copy_preserves_strided_and_broadcast_destinations_across_sizes() {
+    for broadcast in [false, true] {
+        let mut cx = Graph::new();
+        let dest = if broadcast {
+            cx.tensor(3)
+        } else {
+            cx.tensor(('d', 3))
+        }
+        .persist();
+        let src = if broadcast {
+            cx.tensor(2)
+        } else {
+            cx.tensor(('u', 2))
+        }
+        .persist();
+        let indexes = cx.tensor(('u', 2)).as_dtype(DType::Int).persist();
+        let dest_view = if broadcast {
+            dest.expand_dim(0, 'd')
+        } else {
+            dest
+        }
+        .permute((1, 0));
+        let src_view = if broadcast {
+            src.expand_dim(0, 'u')
+        } else {
+            src
+        }
+        .permute((1, 0));
+        let result = src_view
+            .scatter(indexes.permute((1, 0)), dest_view)
+            .output();
+        dest.output();
+        cx.set_dim('d', 17);
+        cx.set_dim('u', 3);
+        cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+        let llir = extract_forced_kernel_llir(&cx, "KernelScatter", "Scatter");
+        let mut rt = CudaRuntime::initialize(CudaContext::new(0).unwrap().default_stream());
+        rt.load_llir(&llir);
+        for (d, u) in [
+            (17, 3),
+            (1023, 5),
+            (1025, 33),
+            (8193, 257),
+            (65537, 4097),
+            (17, 3),
+        ] {
+            cx.set_dim('d', d);
+            cx.set_dim('u', u);
+            let original: Vec<f32> = (0..if broadcast { 3 } else { d * 3 })
+                .map(|i| (i % 10000) as f32)
+                .collect();
+            let updates: Vec<f32> = (0..if broadcast { 2 } else { u * 2 })
+                .map(|i| -(i as f32) - 1.)
+                .collect();
+            let mut indices = vec![0i32; u * 2];
+            let mut expected: Vec<f32> = (0..d * 3)
+                .map(|z| original[if broadcast { z / d } else { z % d * 3 + z / d }])
+                .collect();
+            for z in 0..u * 2 {
+                let physical = z % u * 2 + z / u;
+                let index = match z {
+                    0 => -1,
+                    1 => (d * 3) as i32,
+                    _ => ((z * 13 + 7) % (d * 3)) as i32,
+                };
+                indices[physical] = index;
+                if index >= 0 && (index as usize) < expected.len() {
+                    expected[index as usize] = updates[if broadcast { z / u } else { physical }];
+                }
+            }
+            rt.set_data(dest, original.clone());
+            rt.set_data(src, updates);
+            rt.set_data(indexes, indices);
+            rt.execute(&cx.dyn_map);
+            assert_eq!(
+                rt.get_f32(result),
+                expected,
+                "broadcast={broadcast}, d={d}, u={u}"
+            );
+            assert_eq!(
+                rt.get_f32(dest),
+                original,
+                "scatter must preserve the observed destination"
+            );
+        }
+    }
+}
+
+#[test]
+#[ignore = "CUDA performance comparison; run explicitly before and after kernel changes"]
+fn scatter_large_destination_profile() {
+    let mut cx = Graph::new();
+    let elements = 32 * 1024 * 1024;
+    let dest = cx.tensor(elements).persist();
+    let src = cx.tensor('u').persist();
+    let indexes = cx.tensor('u').as_dtype(DType::Int).persist();
+    let result = src.scatter(indexes, dest).output();
+    dest.output();
+    cx.set_dim('u', 1024);
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let llir = extract_forced_kernel_llir(&cx, "KernelScatter", "Scatter");
+    let mut rt = CudaRuntime::initialize(CudaContext::new(0).unwrap().default_stream());
+    rt.load_llir(&llir);
+    for updates in [1024, 1024 * 1024] {
+        cx.set_dim('u', updates);
+        rt.set_data(dest, vec![0.125f32; elements]);
+        rt.set_data(src, vec![2f32; updates]);
+        let positions: Vec<i32> = (0..updates).map(|i| (i * 17 % elements) as i32).collect();
+        rt.set_data(indexes, positions.clone());
+        let (duration, _) = rt.profile_loaded_cuda_graph(&llir, &cx.dyn_map, 3, None, None);
+        let mut expected = vec![0.125f32; elements];
+        for i in positions {
+            expected[i as usize] = 2.;
+        }
+        assert_eq!(rt.get_f32(result), expected);
+        assert!(rt.get_f32(dest).iter().all(|x| *x == 0.125));
+        println!(
+            "SCATTER_BENCH elements={elements} updates={updates} wall_ms={:.6}",
+            duration.as_secs_f64() * 1000.
+        );
+    }
+}
+
+#[test]
 fn test_scatter_execution_correctness() {
     let ctx = CudaContext::new(0).unwrap();
     ctx.bind_to_thread().unwrap();

--- a/crates/luminal_cuda_lite/src/tests/cublaslt_rewrite_tests.rs
+++ b/crates/luminal_cuda_lite/src/tests/cublaslt_rewrite_tests.rs
@@ -4356,3 +4356,197 @@ fn cublaslt_c_d_layout_matches(llir: &LLIRGraph) -> Vec<bool> {
         .filter_map(|host_op| cublaslt_c_d_layouts_match(host_op.as_ref().as_ref()))
         .collect()
 }
+
+#[test]
+fn cublaslt_mixed_affine_matches_single_round_reference_across_layouts() {
+    let stream = get_cuda_stream().expect("CUDA required for mixed-precision regression");
+    for (dtype, delta) in [(DType::Bf16, 1.0 / 256.0), (DType::F16, 1.0 / 2048.0)] {
+        for layout in LAYOUT_CASES {
+            for bias_enabled in [false, true] {
+                let (m, n, k) = (4, 64, 64);
+                let mut cx = Graph::new();
+                let a = cx
+                    .tensor(if layout.a_col_major { (k, m) } else { (m, k) })
+                    .as_dtype(dtype)
+                    .persist();
+                let b = cx
+                    .tensor(if layout.b_col_major { (n, k) } else { (k, n) })
+                    .as_dtype(dtype)
+                    .persist();
+                let bias = cx.tensor(n).as_dtype(dtype).persist();
+                let a32 = a.cast(DType::F32);
+                let b32 = b.cast(DType::F32);
+                let product = (if layout.a_col_major { a32.t() } else { a32 })
+                    .matmul(if layout.b_col_major { b32.t() } else { b32 });
+                let result = if bias_enabled {
+                    product + bias.cast(DType::F32).expand_dim(0, m)
+                } else {
+                    product
+                };
+                let out = result.cast(dtype).cast(DType::F32).output();
+                cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+                let llir = try_extract_forced_op_llir_where(
+                    &cx,
+                    &["cublaslt"],
+                    ForcedExtractionConfig::new(0x00C0_B1A5).attempts_per_node(16),
+                    |llir| {
+                        cublaslt_type_tuples(llir).contains(&(
+                            dtype,
+                            dtype,
+                            dtype,
+                            dtype,
+                            "32F",
+                            DType::F32,
+                        )) && cublaslt_epilogues(llir).contains(&if bias_enabled {
+                            "BIAS"
+                        } else {
+                            "DEFAULT"
+                        })
+                    },
+                )
+                .unwrap_or_else(|err| panic!("{dtype:?} {layout:?} bias={bias_enabled}: {err}"));
+                let encode = |values: Vec<f32>| -> Vec<u8> {
+                    values
+                        .into_iter()
+                        .flat_map(|v| match dtype {
+                            DType::Bf16 => half::bf16::from_f32(v).to_bits().to_le_bytes(),
+                            _ => half::f16::from_f32(v).to_bits().to_le_bytes(),
+                        })
+                        .collect()
+                };
+                let av = (0..m * k)
+                    .map(|i| {
+                        let col = if layout.a_col_major { i / m } else { i % k };
+                        match col {
+                            0 => 1.0,
+                            1 => delta,
+                            _ => 0.0,
+                        }
+                    })
+                    .collect();
+                let bv = (0..k * n)
+                    .map(|i| {
+                        let row = if layout.b_col_major { i % k } else { i / n };
+                        if row < 2 { 1.0 } else { 0.0 }
+                    })
+                    .collect();
+                let mut rt = CudaRuntime::initialize(stream.clone());
+                rt.load_llir(&llir);
+                rt.set_data(a, encode(av));
+                rt.set_data(b, encode(bv));
+                rt.set_data(bias, encode(vec![-1.0; n]));
+                for _ in 0..3 {
+                    rt.execute(&cx.dyn_map);
+                    // The exact product is 1+delta. Round after adding -1.
+                    assert_eq!(
+                        rt.get_f32(out),
+                        vec![if bias_enabled { delta } else { 1.0 }; m * n],
+                        "{dtype:?} {layout:?}"
+                    );
+                }
+
+                if !bias_enabled {
+                    // Widening also preserves subnormal operands. Their product
+                    // here is normal, so flushing them would be observable.
+                    let (tiny, large) = match dtype {
+                        DType::Bf16 => (half::bf16::from_bits(1).to_f32(), 2.0f32.powi(120)),
+                        _ => (half::f16::from_bits(1).to_f32(), 2.0f32.powi(15)),
+                    };
+                    for (av, bv) in [(tiny, large), (large, tiny)] {
+                        rt.set_data(a, encode(vec![av; m * k]));
+                        rt.set_data(b, encode(vec![bv; k * n]));
+                        rt.execute(&cx.dyn_map);
+                        assert_eq!(rt.get_f32(out), vec![tiny * large * k as f32; m * n]);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn cublaslt_mixed_affine_keeps_unconverted_f32_bias_and_partial_output() {
+    for partial in [false, true] {
+        let mut cx = Graph::new();
+        let a = cx.tensor((4, 64)).as_dtype(DType::Bf16);
+        let b = cx.tensor((64, 64)).as_dtype(DType::Bf16);
+        let bias = cx.tensor(64);
+        let product = a.cast(DType::F32).matmul(b.cast(DType::F32));
+        let value = if partial {
+            product.slice((.., ..32))
+        } else {
+            product + bias.expand_dim(0, 4)
+        };
+        value.cast(DType::Bf16).output();
+        assert_no_cublaslt_llir_where(
+            &mut cx,
+            "mixed cast must preserve bias dtype and view extent",
+            |llir| {
+                cublaslt_type_tuples(llir)
+                    .iter()
+                    .any(|t| t.3 == DType::Bf16)
+            },
+        );
+    }
+}
+
+#[test]
+fn cublaslt_mixed_affine_batched_dynamic_f32_output() {
+    let stream = get_cuda_stream().expect("CUDA required for mixed-precision regression");
+    let (batch, n, k) = (3, 64, 64);
+    let mut cx = Graph::new();
+    let a = cx.tensor((batch, 'm', k)).as_dtype(DType::Bf16);
+    let b = cx.tensor((batch, k, n)).as_dtype(DType::Bf16).persist();
+    // F32 bias must retain its original precision and storage type.
+    let bias = cx.tensor(n).persist();
+    let product = a.cast(DType::F32).matmul(b.cast(DType::F32));
+    let out =
+        (product + bias.expand_lhs([Expression::from(batch), Expression::from('m')])).output();
+    cx.set_dim('m', 4);
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    let llir = try_extract_forced_op_llir_where(
+        &cx,
+        &["cublaslt"],
+        ForcedExtractionConfig::new(0x00C0_B1A5).attempts_per_node(16),
+        |llir| {
+            cublaslt_type_tuples(llir).contains(&(
+                DType::Bf16,
+                DType::Bf16,
+                DType::F32,
+                DType::F32,
+                "32F",
+                DType::F32,
+            )) && cublaslt_epilogues(llir).contains(&"BIAS")
+        },
+    )
+    .expect("batched mixed affine should be extractable");
+    let mut rt = CudaRuntime::initialize(stream);
+    rt.load_llir(&llir);
+    rt.set_data(
+        b,
+        (0..batch * k * n)
+            .map(|i| half::bf16::from_f32(if (i / n) % k < 2 { 1.0 } else { 0.0 }))
+            .collect::<Vec<_>>(),
+    );
+    rt.set_data(bias, vec![-1.0 + 1.0 / 65536.0; n]);
+    for m in [4, 1, 8, 4] {
+        cx.set_dim('m', m);
+        rt.set_data(
+            a,
+            (0..batch * m * k)
+                .map(|i| {
+                    half::bf16::from_f32(match i % k {
+                        0 => 1.0,
+                        1 => 1.0 / 256.0,
+                        _ => 0.0,
+                    })
+                })
+                .collect::<Vec<_>>(),
+        );
+        rt.execute(&cx.dyn_map);
+        assert_eq!(
+            rt.get_f32(out),
+            vec![1.0 / 256.0 + 1.0 / 65536.0; batch * m * n]
+        );
+    }
+}

--- a/crates/luminal_cuda_lite/src/tests/cublaslt_rewrite_tests.rs
+++ b/crates/luminal_cuda_lite/src/tests/cublaslt_rewrite_tests.rs
@@ -2887,10 +2887,16 @@ fn cublaslt_postops_do_not_remove_low_precision_rounding() {
                 build_batched_scaled_alpha_beta_graph(LAYOUT_CASES[1], dtype, commuted),
                 build_batched_matmul_plus_column_bias_graph(LAYOUT_CASES[1], dtype, commuted),
             ] {
-                assert_no_cublaslt_llir_where(&mut graph, "postops must retain low-precision rounding", |llir| {
-                    cublaslt_epilogues(llir).contains(&"BIAS")
-                        || cublaslt_scale_value_tuples(llir).iter().any(|&(alpha,beta)| alpha != 1.0 || beta != 0.0)
-                });
+                assert_no_cublaslt_llir_where(
+                    &mut graph,
+                    "postops must retain low-precision rounding",
+                    |llir| {
+                        cublaslt_epilogues(llir).contains(&"BIAS")
+                            || cublaslt_scale_value_tuples(llir)
+                                .iter()
+                                .any(|&(alpha, beta)| alpha != 1.0 || beta != 0.0)
+                    },
+                );
             }
         }
     }
@@ -2901,31 +2907,54 @@ fn cublaslt_postops_do_not_remove_low_precision_rounding() {
 /// library bias epilogue rounds(dot + bias) to a nonzero value.
 #[test]
 fn cublaslt_bias_preserves_low_precision_matmul_rounding() {
-    let Some(stream) = get_cuda_stream() else { return; };
+    let Some(stream) = get_cuda_stream() else {
+        return;
+    };
     for (dtype, delta) in [(DType::Bf16, 1.0 / 512.0), (DType::F16, 1.0 / 4096.0)] {
         let (m, n, k) = (16, 64, 64);
         let mut cx = Graph::new();
-        let a = cx.tensor((m,k)).as_dtype(dtype);
-        let b = cx.tensor((n,k)).as_dtype(dtype);
+        let a = cx.tensor((m, k)).as_dtype(dtype);
+        let b = cx.tensor((n, k)).as_dtype(dtype);
         let bias = cx.tensor(n).as_dtype(dtype);
-        let out = (a.matmul(b.t()) + bias.expand_dim(0,m)).cast(DType::F32).output();
-        assert_no_cublaslt_llir_where(&mut cx, "bias must retain low-precision rounding", |llir| cublaslt_epilogues(llir).contains(&"BIAS"));
-        let llir = extract_forced_cublaslt_llir_where(&mut cx, "rounded matmul then bias", |llir| cublaslt_epilogues(llir).contains(&"DEFAULT"));
+        let out = (a.matmul(b.t()) + bias.expand_dim(0, m))
+            .cast(DType::F32)
+            .output();
+        assert_no_cublaslt_llir_where(&mut cx, "bias must retain low-precision rounding", |llir| {
+            cublaslt_epilogues(llir).contains(&"BIAS")
+        });
+        let llir =
+            extract_forced_cublaslt_llir_where(&mut cx, "rounded matmul then bias", |llir| {
+                cublaslt_epilogues(llir).contains(&"DEFAULT")
+            });
         let mut rt = CudaRuntime::initialize(stream.clone());
         rt.load_llir(&llir);
-        let values: Vec<f32> = (0..m*k).map(|i| match i%k {0=>1.0, 1=>delta, _=>0.0}).collect();
-        let weights: Vec<f32> = (0..n*k).map(|i| if i%k<2 {1.0} else {0.0}).collect();
+        let values: Vec<f32> = (0..m * k)
+            .map(|i| match i % k {
+                0 => 1.0,
+                1 => delta,
+                _ => 0.0,
+            })
+            .collect();
+        let weights: Vec<f32> = (0..n * k)
+            .map(|i| if i % k < 2 { 1.0 } else { 0.0 })
+            .collect();
         let encode = |data: Vec<f32>| -> Vec<u8> {
-            data.into_iter().flat_map(|x| match dtype {
-                DType::Bf16 => half::bf16::from_f32(x).to_bits().to_le_bytes(),
-                _ => half::f16::from_f32(x).to_bits().to_le_bytes(),
-            }).collect()
+            data.into_iter()
+                .flat_map(|x| match dtype {
+                    DType::Bf16 => half::bf16::from_f32(x).to_bits().to_le_bytes(),
+                    _ => half::f16::from_f32(x).to_bits().to_le_bytes(),
+                })
+                .collect()
         };
         rt.set_data(a, encode(values));
         rt.set_data(b, encode(weights));
-        rt.set_data(bias, encode(vec![-1.0;n]));
+        rt.set_data(bias, encode(vec![-1.0; n]));
         rt.execute(&cx.dyn_map);
-        assert_eq!(rt.get_f32(out), vec![0.0;m*n], "{dtype:?} rounding before bias");
+        assert_eq!(
+            rt.get_f32(out),
+            vec![0.0; m * n],
+            "{dtype:?} rounding before bias"
+        );
     }
 }
 

--- a/crates/luminal_cuda_lite/src/tests/cublaslt_rewrite_tests.rs
+++ b/crates/luminal_cuda_lite/src/tests/cublaslt_rewrite_tests.rs
@@ -2879,6 +2879,57 @@ fn cublaslt_scaled_alpha_beta_candidate_executes_batched_matmul_plus_c() {
 }
 
 #[test]
+fn cublaslt_postops_do_not_remove_low_precision_rounding() {
+    for dtype in [DType::Bf16, DType::F16] {
+        for commuted in [false, true] {
+            for mut graph in [
+                build_2d_scaled_alpha_beta_graph(LAYOUT_CASES[0], dtype, commuted),
+                build_batched_scaled_alpha_beta_graph(LAYOUT_CASES[1], dtype, commuted),
+                build_batched_matmul_plus_column_bias_graph(LAYOUT_CASES[1], dtype, commuted),
+            ] {
+                assert_no_cublaslt_llir_where(&mut graph, "postops must retain low-precision rounding", |llir| {
+                    cublaslt_epilogues(llir).contains(&"BIAS")
+                        || cublaslt_scale_value_tuples(llir).iter().any(|&(alpha,beta)| alpha != 1.0 || beta != 0.0)
+                });
+            }
+        }
+    }
+}
+
+/// The low-precision matmul is an observable rounding boundary. For this
+/// exactly representable dot product, round(dot) + bias is zero while the
+/// library bias epilogue rounds(dot + bias) to a nonzero value.
+#[test]
+fn cublaslt_bias_preserves_low_precision_matmul_rounding() {
+    let Some(stream) = get_cuda_stream() else { return; };
+    for (dtype, delta) in [(DType::Bf16, 1.0 / 512.0), (DType::F16, 1.0 / 4096.0)] {
+        let (m, n, k) = (16, 64, 64);
+        let mut cx = Graph::new();
+        let a = cx.tensor((m,k)).as_dtype(dtype);
+        let b = cx.tensor((n,k)).as_dtype(dtype);
+        let bias = cx.tensor(n).as_dtype(dtype);
+        let out = (a.matmul(b.t()) + bias.expand_dim(0,m)).cast(DType::F32).output();
+        assert_no_cublaslt_llir_where(&mut cx, "bias must retain low-precision rounding", |llir| cublaslt_epilogues(llir).contains(&"BIAS"));
+        let llir = extract_forced_cublaslt_llir_where(&mut cx, "rounded matmul then bias", |llir| cublaslt_epilogues(llir).contains(&"DEFAULT"));
+        let mut rt = CudaRuntime::initialize(stream.clone());
+        rt.load_llir(&llir);
+        let values: Vec<f32> = (0..m*k).map(|i| match i%k {0=>1.0, 1=>delta, _=>0.0}).collect();
+        let weights: Vec<f32> = (0..n*k).map(|i| if i%k<2 {1.0} else {0.0}).collect();
+        let encode = |data: Vec<f32>| -> Vec<u8> {
+            data.into_iter().flat_map(|x| match dtype {
+                DType::Bf16 => half::bf16::from_f32(x).to_bits().to_le_bytes(),
+                _ => half::f16::from_f32(x).to_bits().to_le_bytes(),
+            }).collect()
+        };
+        rt.set_data(a, encode(values));
+        rt.set_data(b, encode(weights));
+        rt.set_data(bias, encode(vec![-1.0;n]));
+        rt.execute(&cx.dyn_map);
+        assert_eq!(rt.get_f32(out), vec![0.0;m*n], "{dtype:?} rounding before bias");
+    }
+}
+
+#[test]
 #[ignore = "expensive CUDA functional candidate sweep; run with cargo test -p luminal_cuda_lite -- --ignored"]
 fn cublaslt_bias_epilogue_candidate_executes_2d_matmul_plus_column_bias() {
     let Some(stream) = get_cuda_stream() else {

--- a/crates/luminal_cuda_lite/src/tests/fusion.rs
+++ b/crates/luminal_cuda_lite/src/tests/fusion.rs
@@ -1413,3 +1413,90 @@ fn test_cast_fusion_preserves_output() {
         tol,
     );
 }
+
+#[test]
+fn strided_cast_read_fuses_broadcast_and_preserves_fanout() {
+    use luminal::dtype::DType;
+    for fanout in [false, true] {
+        let mut cx = Graph::new();
+        let x = cx.tensor(('s', 7));
+        let bias = cx.tensor(7).cast(DType::Bf16).cast(DType::F32);
+        if fanout {
+            bias.output();
+        }
+        (x + bias.expand_dim(0, 's')).output();
+        cx.set_dim('s', 3);
+        let regions = extract_fused_regions_with_options(
+            &mut cx,
+            CompileOptions::default().dim_buckets('s', &[DimBucket::new(2, 8)]),
+        );
+        let expected = sorted_names(&["FusedAdd", "FusedCast", "FusedCast"]);
+        assert!(
+            regions
+                .iter()
+                .any(|r| r.internal_ops_sorted == expected && r.start_count == 2),
+            "fanout={fanout}: {regions:#?}"
+        );
+        let egraph = cx.egraph().unwrap();
+        assert!(
+            egraph.eclasses.keys().any(|class| {
+                eclass_has_op_kind(egraph, class, "FusionStart")
+                    && eclass_has_op_kind(egraph, class, "CudaUnaryElementwise")
+            }),
+            "materialized and inline cast reads must both remain searchable"
+        );
+    }
+}
+
+#[test]
+fn strided_cast_read_preserves_transposed_values() {
+    test_unary_cuda::<f32>(
+        (3, 7),
+        |a| {
+            a.cast(luminal::dtype::DType::Bf16)
+                .cast(luminal::dtype::DType::F32)
+                .permute((1, 0))
+                .sin()
+        },
+        |a| {
+            a.to_dtype(candle_core::DType::BF16)
+                .unwrap()
+                .to_dtype(candle_core::DType::F32)
+                .unwrap()
+                .permute((1, 0))
+                .unwrap()
+                .sin()
+                .unwrap()
+        },
+        |n, seed| random_f32_vec(n, seed, -2., 2.),
+        0xCA57_051D,
+    );
+}
+
+#[test]
+fn strided_cast_read_preserves_broadcast_rounding() {
+    test_binary_cuda::<f32>(
+        (3, 7),
+        7,
+        |a, b| {
+            a + b
+                .cast(luminal::dtype::DType::Bf16)
+                .cast(luminal::dtype::DType::F32)
+                .expand_dim(0, 3)
+        },
+        |a, b| {
+            a.broadcast_add(
+                &b.to_dtype(candle_core::DType::BF16)
+                    .unwrap()
+                    .to_dtype(candle_core::DType::F32)
+                    .unwrap(),
+            )
+            .unwrap()
+        },
+        |n, seed| random_f32_vec(n, seed, -2., 2.),
+        |n, seed| random_f32_vec(n, seed, -2., 2.),
+        0xCA57_051E,
+        1e-6,
+        1e-6,
+    );
+}

--- a/crates/luminal_cuda_lite/src/tests/fusion.rs
+++ b/crates/luminal_cuda_lite/src/tests/fusion.rs
@@ -500,7 +500,11 @@ struct FusedRegion {
 /// Helper: collect every distinct fused region reachable across many random
 /// extractions of the search space.
 fn extract_all_fused_regions(cx: &mut Graph) -> Vec<FusedRegion> {
-    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    extract_fused_regions_with_options(cx, CompileOptions::default())
+}
+
+fn extract_fused_regions_with_options(cx: &mut Graph, options: CompileOptions) -> Vec<FusedRegion> {
+    cx.build_search_space::<CudaRuntime>(options);
     let egraph = cx.egraph().expect("egraph not built");
     let ops = cx.egglog_ops().expect("ops not built");
     let custom_ops = &cx.custom_ops;
@@ -1172,6 +1176,118 @@ extern "C" __global__ void fused_k(float* out, const float* a, const float* b, l
 // =========================================================================
 // Cast fusion: explicit HLIR Casts are the only dtype changes inside a region.
 // =========================================================================
+
+#[test]
+fn cast_roundtrip_fusion_with_dynamic_rows_and_fanout() {
+    use luminal::dtype::DType;
+    for dynamic in [false, true] {
+        for fanout in [false, true] {
+            let mut cx = Graph::new();
+            let a = if dynamic {
+                cx.tensor(('s', 2880))
+            } else {
+                cx.tensor((8, 2880))
+            }
+            .as_dtype(DType::Bf16);
+            cx.set_dim('s', 8);
+            let wide = a.cast(DType::F32);
+            if fanout {
+                wide.output();
+            }
+            wide.cast(DType::Bf16).output();
+            let regions = extract_fused_regions_with_options(
+                &mut cx,
+                CompileOptions::default().dim_buckets('s', &[DimBucket::new(2, 8)]),
+            );
+            assert!(
+                regions
+                    .iter()
+                    .any(|r| r.internal_ops_sorted == ["FusedCast", "FusedCast"]
+                        && r.start_count == 1
+                        && r.end_count == 1),
+                "dynamic={dynamic} fanout={fanout}: {regions:#?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn matrix_cast_and_elementwise_chain_fuses_across_flat_cast_shape() {
+    use luminal::dtype::DType;
+    for (dynamic, rank) in [(false, 2), (true, 2), (false, 3), (true, 3)] {
+        let mut cx = Graph::new();
+        let first = if dynamic { expr('s') } else { expr(8) };
+        let a = if rank == 2 {
+            cx.tensor([first, expr(2880)])
+        } else {
+            cx.tensor([first, expr(5), expr(7)])
+        };
+        cx.set_dim('s', 8);
+        a.sin().cast(DType::Bf16).cast(DType::F32).sqrt().output();
+        let regions = extract_fused_regions_with_options(
+            &mut cx,
+            CompileOptions::default().dim_buckets('s', &[DimBucket::new(2, 8)]),
+        );
+        let expected = sorted_names(&["FusedSin", "FusedCast", "FusedCast", "FusedSqrt"]);
+        assert!(
+            regions.iter().any(|r| r.internal_ops_sorted == expected
+                && r.start_count == 1
+                && r.end_count == 1),
+            "dynamic={dynamic} rank={rank}: {regions:#?}"
+        );
+    }
+}
+
+#[test]
+fn cast_grid_does_not_bridge_a_transpose() {
+    let mut cx = Graph::new();
+    cx.tensor((3, 7))
+        .sin()
+        .permute((1, 0))
+        .cast(luminal::dtype::DType::Bf16)
+        .cast(luminal::dtype::DType::F32)
+        .sqrt()
+        .output();
+    for r in extract_all_fused_regions(&mut cx) {
+        assert!(
+            !(r.internal_ops_sorted.contains(&"FusedSin".to_string())
+                && r.internal_ops_sorted.contains(&"FusedSqrt".to_string())),
+            "{r:#?}"
+        );
+    }
+}
+
+#[test]
+fn matrix_cast_fusion_preserves_rounding_and_layout() {
+    for permuted in [false, true] {
+        test_unary_cuda::<f32>(
+            (3, 5, 7),
+            |a| {
+                let a = a.sin();
+                let a = if permuted { a.permute((2, 0, 1)) } else { a };
+                a.cast(luminal::dtype::DType::Bf16)
+                    .cast(luminal::dtype::DType::F32)
+                    .sqrt()
+            },
+            |a| {
+                let a = a.sin().unwrap();
+                let a = if permuted {
+                    a.permute((2, 0, 1)).unwrap()
+                } else {
+                    a
+                };
+                a.to_dtype(candle_core::DType::BF16)
+                    .unwrap()
+                    .to_dtype(candle_core::DType::F32)
+                    .unwrap()
+                    .sqrt()
+                    .unwrap()
+            },
+            |n, seed| random_f32_vec(n, seed, 0.1, 0.9),
+            0xCA57_601D,
+        );
+    }
+}
 
 #[test]
 fn test_cast_after_unary_fuses() {

--- a/src/egglog_utils/base.rs
+++ b/src/egglog_utils/base.rs
@@ -742,6 +742,7 @@ fn base_expression_egglog_impl(use_interval_analysis: bool) -> String {
             .ruleset("expr"),
     );
     p.add_rule(rewrite("div-one", div(v("a"), num(i64(1))), v("a")).ruleset("expr"));
+    p.add_rule(rewrite("mod-one", modd(v("a"), num(i64(1))), num(i64(0))).ruleset("expr"));
     p.add_rule(
         rewrite(
             "mod-mul-self",
@@ -1494,4 +1495,26 @@ pub fn base_cleanup_egglog() -> String {
     }
 
     p.to_egglog_string()
+}
+
+#[cfg(test)]
+mod normalization_tests {
+    #[test]
+    fn singleton_axis_index_matches_its_constant_folded_spelling() {
+        let mut egraph = egglog::EGraph::default();
+        let program = format!(
+            "{}\n{}",
+            super::base_expression_egglog(),
+            r#"
+            (let outer (MDiv (MIter) (MNum 2880)))
+            (let folded (MAdd (MNum 1) (MMul outer (MNum 5760))))
+            (let full (MAdd (MAdd (MNum 1)
+                (MMul (MMod outer (MNum 1)) (MNum 5760)))
+                (MMul outer (MNum 5760))))
+            (run-schedule (saturate expr))
+            (check (= full folded))
+        "#
+        );
+        egraph.parse_and_run_program(None, &program).unwrap();
+    }
 }

--- a/src/egglog_utils/base.rs
+++ b/src/egglog_utils/base.rs
@@ -808,6 +808,34 @@ fn base_expression_egglog_impl(use_interval_analysis: bool) -> String {
 
     if use_interval_analysis {
         // ---- Interval analysis and interval-guarded simplifications ----
+        for (name, bound) in [
+            ("lower", interval_lower as fn(Term) -> Term),
+            ("upper", interval_upper as fn(Term) -> Term),
+        ] {
+            p.add_rule(
+                Rule::new()
+                    .facts(vec![
+                        peq(v("?e"), mul(v("?a"), v("?b"))),
+                        peq(v("?a_bound"), bound(v("?a"))),
+                        peq(v("?b_bound"), bound(v("?b"))),
+                        peq(v("?a_min"), interval_lower(v("?a"))),
+                        peq(v("?b_min"), interval_lower(v("?b"))),
+                        pgte(v("?a_min"), i64(0)),
+                        pgte(v("?b_min"), i64(0)),
+                        pgte(v("?a_bound"), i64(0)),
+                        pgte(v("?b_bound"), i64(0)),
+                        // The divisor stays nonzero even before other guards
+                        // are evaluated. Multiply only after proving no overflow.
+                        pgte(
+                            pdiv(i64(i64::MAX), pmax(v("?a_bound"), i64(1))),
+                            v("?b_bound"),
+                        ),
+                    ])
+                    .set(bound(v("?e")), pmul(v("?a_bound"), v("?b_bound")))
+                    .ruleset("interval_expr")
+                    .name(&format!("interval-mul-{name}-nonnegative")),
+            );
+        }
         p.add_rule(
             Rule::new()
                 .fact(peq(v("?e"), num(v("?n"))))

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -2,7 +2,7 @@ use colored::Colorize;
 use egglog::{ast::Span, prelude::RustSpan, var};
 use itertools::Itertools;
 use petgraph::{Direction, graph::NodeIndex};
-use rand::Rng;
+use rand::{Rng, seq::SliceRandom};
 use rustc_hash::FxHashSet;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -2379,11 +2379,18 @@ impl<'a> LlirExtractor<'a> {
                     continue;
                 }
                 let pool = match target {
-                    CoverageTarget::Constructor(family) => self.mutation_nodes[class as usize]
-                        .as_ref()
-                        .unwrap()
-                        .families[family]
-                        .clone(),
+                    CoverageTarget::Constructor(family) => {
+                        let nodes = self.indexed_classes[class as usize].nodes;
+                        nearest_constructor_alternatives(
+                            self.egraph,
+                            &nodes[choices.choices[class as usize] as usize],
+                            &self.mutation_nodes[class as usize]
+                                .as_ref()
+                                .unwrap()
+                                .families[family],
+                            |slot| &nodes[slot as usize],
+                        )
+                    }
                     // Parents can change while a pass is pending. Recompute
                     // neighbors so companion changes remain minimal for this parent.
                     CoverageTarget::Argument(argument) => {
@@ -2423,6 +2430,10 @@ impl<'a> LlirExtractor<'a> {
                     }
                 }
             }
+            // Keep complete-pass coverage, but avoid favoring serialized class
+            // IDs when the caller stops before a whole pass. The supplied RNG
+            // makes the order reproducible.
+            self.covered_alternatives.shuffle(rng);
         }
         None
     }
@@ -3179,12 +3190,14 @@ fn non_marker_enode_indices(egraph: &SerializedEGraph, enodes: &[NodeId]) -> Vec
 
 // Compare existing terms, without inventing parameter combinations. For the
 // generic Op wrapper, require identical inputs and an unambiguous OpKind so a
-// constructor-argument proposal cannot silently change its data dependencies.
-fn changed_constructor_arguments(
-    egraph: &SerializedEGraph,
+// tuning-preserving proposal cannot silently change its data dependencies.
+type ConstructorTerm = (String, Vec<ClassId>);
+
+fn comparable_constructor_terms<'a>(
+    egraph: &'a SerializedEGraph,
     before: &NodeId,
     after: &NodeId,
-) -> Option<Vec<(usize, ClassId)>> {
+) -> Option<(&'a ConstructorTerm, &'a ConstructorTerm)> {
     let (mut left, mut right) = (&egraph.enodes[before], &egraph.enodes[after]);
     if left.0 == "Op" && right.0 == "Op" {
         if left.1.get(1..) != right.1.get(1..) {
@@ -3202,6 +3215,44 @@ fn changed_constructor_arguments(
         left = &egraph.enodes[&left_kinds[0]];
         right = &egraph.enodes[&right_kinds[0]];
     }
+    Some((left, right))
+}
+
+// On the systematic constructor pass, preserve as many existing argument
+// classes as possible. Extra arguments are free to vary. Only existing enodes
+// participate; the random half still samples every configuration in the family.
+fn nearest_constructor_alternatives<'a, T: Copy>(
+    egraph: &'a SerializedEGraph,
+    current: &NodeId,
+    pool: &[T],
+    node: impl Fn(T) -> &'a NodeId,
+) -> Vec<T> {
+    let mut nearest = Vec::new();
+    let mut best = usize::MAX;
+    for &candidate in pool {
+        let distance = comparable_constructor_terms(egraph, current, node(candidate))
+            .map(|(left, right)| {
+                left.1.len().abs_diff(right.1.len())
+                    + left.1.iter().zip(&right.1).filter(|(a, b)| a != b).count()
+            })
+            .unwrap_or(usize::MAX);
+        if distance < best {
+            best = distance;
+            nearest.clear();
+        }
+        if distance == best {
+            nearest.push(candidate);
+        }
+    }
+    nearest
+}
+
+fn changed_constructor_arguments(
+    egraph: &SerializedEGraph,
+    before: &NodeId,
+    after: &NodeId,
+) -> Option<Vec<(usize, ClassId)>> {
+    let (left, right) = comparable_constructor_terms(egraph, before, after)?;
     if left.0 != right.0 || left.1.len() != right.1.len() {
         return None;
     }

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -2434,6 +2434,37 @@ impl<'a> LlirExtractor<'a> {
             // IDs when the caller stops before a whole pass. The supplied RNG
             // makes the order reproducible.
             self.covered_alternatives.shuffle(rng);
+            if !arguments {
+                // Cover distinct algorithm transitions before revisiting their
+                // sites. Otherwise hundreds of repeated elementwise choices
+                // can exhaust a budget before one expensive fusion is offered.
+                // Round-robin ordering retains every site and every family;
+                // backend names and static cost guesses have no preference.
+                let mut visits = FxHashMap::default();
+                self.covered_alternatives
+                    .sort_by_cached_key(|&(class, ref target)| {
+                        let CoverageTarget::Constructor(family) = *target else {
+                            unreachable!()
+                        };
+                        let nodes = self.indexed_classes[class as usize].nodes;
+                        let destination = self.mutation_nodes[class as usize]
+                            .as_ref()
+                            .unwrap()
+                            .families[family][0];
+                        let key = (
+                            proposal_family_key(
+                                self.egraph,
+                                &nodes[choices.choices[class as usize] as usize],
+                            ),
+                            proposal_family_key(self.egraph, &nodes[destination as usize]),
+                        );
+                        let visit = visits.entry(key).or_insert(0usize);
+                        let round = *visit;
+                        *visit += 1;
+                        round
+                    });
+                self.covered_alternatives.reverse(); // pop the first round first
+            }
         }
         None
     }
@@ -3279,18 +3310,7 @@ fn proposal_families<'a, T: Copy>(
     let mut indices = FxHashMap::default();
     let mut families: Vec<Vec<T>> = Vec::new();
     for &choice in pool {
-        let (head, children) = &egraph.enodes[node(choice)];
-        let mut key = vec![head.as_str()];
-        if head == "Op"
-            && let Some((kind_sort, kinds)) = children.first().and_then(|c| egraph.eclasses.get(c))
-            && kind_sort == "OpKind"
-        {
-            let mut constructors: Vec<_> =
-                kinds.iter().map(|k| egraph.enodes[k].0.as_str()).collect();
-            constructors.sort_unstable();
-            constructors.dedup();
-            key.extend(constructors);
-        }
+        let key = proposal_family_key(egraph, node(choice));
         let index = *indices.entry(key).or_insert_with(|| {
             families.push(Vec::new());
             families.len() - 1
@@ -3298,6 +3318,21 @@ fn proposal_families<'a, T: Copy>(
         families[index].push(choice);
     }
     families
+}
+
+fn proposal_family_key<'a>(egraph: &'a SerializedEGraph, node: &NodeId) -> Vec<&'a str> {
+    let (head, children) = &egraph.enodes[node];
+    let mut key = vec![head.as_str()];
+    if head == "Op"
+        && let Some((kind_sort, kinds)) = children.first().and_then(|c| egraph.eclasses.get(c))
+        && kind_sort == "OpKind"
+    {
+        let mut constructors: Vec<_> = kinds.iter().map(|k| egraph.enodes[k].0.as_str()).collect();
+        constructors.sort_unstable();
+        constructors.dedup();
+        key.extend(constructors);
+    }
+    key
 }
 
 pub fn random_initial_choice<'a>(

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -2313,6 +2313,9 @@ impl<'a> LlirExtractor<'a> {
         mutable_classes
     }
 
+    // For each argument value, keep existing alternatives requiring the fewest
+    // companion changes. Independent knobs still move alone; coupled legal
+    // configurations remain reachable without inventing invalid combinations.
     fn argument_pools(
         &mut self,
         choices: &IndexedChoiceSet,
@@ -2321,13 +2324,28 @@ impl<'a> LlirExtractor<'a> {
         let pool = self.mutation_pool(class).to_vec();
         let nodes = self.indexed_classes[class as usize].nodes;
         let current = &nodes[choices.choices[class as usize] as usize];
-        let mut arguments = std::collections::BTreeMap::<_, Vec<_>>::new();
+        let mut nearest = std::collections::BTreeMap::<_, (usize, Vec<_>)>::new();
         for slot in pool {
-            if let Some(argument) =
-                single_argument_change(self.egraph, current, &nodes[slot as usize])
-            {
-                arguments.entry(argument).or_default().push(slot);
+            let Some(changes) =
+                changed_constructor_arguments(self.egraph, current, &nodes[slot as usize])
+            else {
+                continue;
+            };
+            let distance = changes.len();
+            for target in changes {
+                let (best, candidates) = nearest.entry(target).or_insert((distance, Vec::new()));
+                if distance < *best {
+                    *best = distance;
+                    candidates.clear();
+                }
+                if distance == *best {
+                    candidates.push(slot);
+                }
             }
+        }
+        let mut arguments = std::collections::BTreeMap::<_, Vec<_>>::new();
+        for ((argument, _), (_, candidates)) in nearest {
+            arguments.entry(argument).or_default().extend(candidates);
         }
         arguments
     }
@@ -2352,7 +2370,7 @@ impl<'a> LlirExtractor<'a> {
                         .families[family]
                         .clone(),
                     // Parents can change while a pass is pending. Recompute
-                    // neighbors so the proposal still changes exactly one argument.
+                    // neighbors so companion changes remain minimal for this parent.
                     CoverageTarget::Argument(argument) => {
                         let Some(pool) = self.argument_pools(choices, class).remove(&argument)
                         else {
@@ -3147,11 +3165,11 @@ fn non_marker_enode_indices(egraph: &SerializedEGraph, enodes: &[NodeId]) -> Vec
 // Compare existing terms, without inventing parameter combinations. For the
 // generic Op wrapper, require identical inputs and an unambiguous OpKind so a
 // constructor-argument proposal cannot silently change its data dependencies.
-fn single_argument_change(
+fn changed_constructor_arguments(
     egraph: &SerializedEGraph,
     before: &NodeId,
     after: &NodeId,
-) -> Option<usize> {
+) -> Option<Vec<(usize, ClassId)>> {
     let (mut left, mut right) = (&egraph.enodes[before], &egraph.enodes[after]);
     if left.0 == "Op" && right.0 == "Op" {
         if left.1.get(1..) != right.1.get(1..) {
@@ -3172,16 +3190,15 @@ fn single_argument_change(
     if left.0 != right.0 || left.1.len() != right.1.len() {
         return None;
     }
-    let mut changed = None;
-    for (index, (a, b)) in left.1.iter().zip(&right.1).enumerate() {
-        if a != b {
-            if changed.is_some() {
-                return None;
-            }
-            changed = Some(index);
-        }
-    }
-    changed
+    Some(
+        left.1
+            .iter()
+            .zip(&right.1)
+            .enumerate()
+            .filter(|(_, (a, b))| a != b)
+            .map(|(index, (_, value))| (index, value.clone()))
+            .collect(),
+    )
 }
 
 /// Group legal proposals by constructor before sampling tuning variants. The

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -1966,12 +1966,17 @@ pub struct LlirExtractor<'a> {
     class_to_index: FxHashMap<&'a ClassId, DenseIndex>,
     root_index: DenseIndex,
     indexed_extractions: Vec<Vec<(DenseIndex, Vec<CachedIndexedExtraction>)>>,
-    mutation_nodes: Vec<Option<Vec<DenseIndex>>>,
+    mutation_nodes: Vec<Option<MutationChoices>>,
     visit_epoch: u32,
     visited: Vec<u32>,
     reachable: Vec<DenseNode>,
     reachability_stack: Vec<DenseNode>,
     graph_nodes: Vec<(u32, usize)>,
+}
+
+struct MutationChoices {
+    nodes: Vec<DenseIndex>,
+    families: Vec<Vec<DenseIndex>>,
 }
 
 #[derive(Clone, Copy)]
@@ -2179,9 +2184,14 @@ impl<'a> LlirExtractor<'a> {
             } else {
                 all()
             };
-            self.mutation_nodes[class as usize] = Some(pool);
+            let nodes = class_info.nodes;
+            let families = proposal_families(self.egraph, &pool, |slot| &nodes[slot as usize]);
+            self.mutation_nodes[class as usize] = Some(MutationChoices {
+                nodes: pool,
+                families,
+            });
         }
-        self.mutation_nodes[class as usize].as_deref().unwrap()
+        &self.mutation_nodes[class as usize].as_ref().unwrap().nodes
     }
 
     pub fn index_choice_set(&self, choices: &EGraphChoiceSet<'a>) -> IndexedChoiceSet {
@@ -2313,8 +2323,13 @@ impl<'a> LlirExtractor<'a> {
             for _ in 0..mutation_count {
                 let class = mutable_classes[rng.random_range(0..mutable_classes.len())];
                 let new_node = {
-                    let pool = self.mutation_pool(class);
-                    pool[rng.random_range(0..pool.len())]
+                    self.mutation_pool(class);
+                    let families = &self.mutation_nodes[class as usize]
+                        .as_ref()
+                        .unwrap()
+                        .families;
+                    let family = &families[rng.random_range(0..families.len())];
+                    family[rng.random_range(0..family.len())]
                 };
                 let old_node = std::mem::replace(&mut child.choices[class as usize], new_node);
                 let class_info = &self.indexed_classes[class as usize];
@@ -2987,6 +3002,39 @@ fn non_marker_enode_indices(egraph: &SerializedEGraph, enodes: &[NodeId]) -> Vec
         .collect()
 }
 
+/// Group legal proposals by constructor before sampling tuning variants. The
+/// generic IR `Op` wrapper carries its constructor in the OpKind child; no
+/// backend names, tensor dimensions, or preferred implementations enter the
+/// proposal policy. Pool filtering and measured fitness remain unchanged.
+fn proposal_families<'a, T: Copy>(
+    egraph: &'a SerializedEGraph,
+    pool: &[T],
+    node: impl Fn(T) -> &'a NodeId,
+) -> Vec<Vec<T>> {
+    let mut indices = FxHashMap::default();
+    let mut families: Vec<Vec<T>> = Vec::new();
+    for &choice in pool {
+        let (head, children) = &egraph.enodes[node(choice)];
+        let mut key = vec![head.as_str()];
+        if head == "Op"
+            && let Some((kind_sort, kinds)) = children.first().and_then(|c| egraph.eclasses.get(c))
+            && kind_sort == "OpKind"
+        {
+            let mut constructors: Vec<_> =
+                kinds.iter().map(|k| egraph.enodes[k].0.as_str()).collect();
+            constructors.sort_unstable();
+            constructors.dedup();
+            key.extend(constructors);
+        }
+        let index = *indices.entry(key).or_insert_with(|| {
+            families.push(Vec::new());
+            families.len() - 1
+        });
+        families[index].push(choice);
+    }
+    families
+}
+
 pub fn random_initial_choice<'a>(
     egraph: &'a SerializedEGraph,
     rng: &mut (impl Rng + ?Sized),
@@ -3039,15 +3087,18 @@ pub fn random_initial_choice<'a>(
         };
         let consistent_opkind_indices = restrict(consistent_opkind_indices);
         let synth_indices = restrict(synth_indices);
-        let pick_idx = if !consistent_opkind_indices.is_empty() {
-            consistent_opkind_indices[rng.random_range(0..consistent_opkind_indices.len())]
+        let pool = if !consistent_opkind_indices.is_empty() {
+            consistent_opkind_indices
         } else if !synth_indices.is_empty() {
-            synth_indices[rng.random_range(0..synth_indices.len())]
+            synth_indices
         } else if !marker_free.is_empty() {
-            marker_free[rng.random_range(0..marker_free.len())]
+            marker_free
         } else {
-            rng.random_range(0..enodes.len())
+            (0..enodes.len()).collect()
         };
+        let families = proposal_families(egraph, &pool, |index| &enodes[index]);
+        let family = &families[rng.random_range(0..families.len())];
+        let pick_idx = family[rng.random_range(0..family.len())];
         choices.insert(eclass, &enodes[pick_idx]);
     }
     repair_choice_cycles(egraph, &mut choices, rng);
@@ -3644,6 +3695,9 @@ fn egglog_to_llir_from_root_cached<'a>(
     // before it is loaded into the runtime.
     graph
 }
+
+#[cfg(test)]
+mod proposal_tests;
 
 #[cfg(test)]
 mod tests {

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -3361,7 +3361,7 @@ fn proposal_families<'a, T: Copy>(
         // Changing an Op's input dependencies is an implementation change,
         // even when its backend constructor is unchanged (e.g. cast absorption).
         // Keep tuning variants with identical inputs together. Across sites,
-        // transition ordering still uses constructor names, not unique class IDs.
+        // transition ordering uses constructor/dtype values, not unique class IDs.
         let inputs = if head == "Op" { &children[1..] } else { &[] };
         let key = (proposal_family_key(egraph, selected), inputs);
         let index = *indices.entry(key).or_insert_with(|| {
@@ -3380,10 +3380,32 @@ fn proposal_family_key<'a>(egraph: &'a SerializedEGraph, node: &NodeId) -> Vec<&
         && let Some((kind_sort, kinds)) = children.first().and_then(|c| egraph.eclasses.get(c))
         && kind_sort == "OpKind"
     {
-        let mut constructors: Vec<_> = kinds.iter().map(|k| egraph.enodes[k].0.as_str()).collect();
+        let mut constructors: Vec<_> = kinds
+            .iter()
+            .map(|kind| proposal_family_key(egraph, kind))
+            .collect();
         constructors.sort_unstable();
         constructors.dedup();
-        key.extend(constructors);
+        key.extend(constructors.into_iter().flatten());
+    } else {
+        // Storage and accumulation dtypes distinguish implementations, even
+        // when constructor names coincide. Use dtype values, never site IDs,
+        // so repeated sites share a transition while numeric tuning variants
+        // remain together. Empty separators preserve argument positions.
+        for child in children {
+            key.push("");
+            if let Some((sort, variants)) = egraph.eclasses.get(child)
+                && sort == "DType"
+            {
+                let mut dtypes: Vec<_> = variants
+                    .iter()
+                    .map(|variant| egraph.enodes[variant].0.as_str())
+                    .collect();
+                dtypes.sort_unstable();
+                dtypes.dedup();
+                key.extend(dtypes);
+            }
+        }
     }
     key
 }

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -2485,11 +2485,57 @@ impl<'a> LlirExtractor<'a> {
             let family = &families[rng.random_range(0..families.len())];
             family[rng.random_range(0..family.len())]
         });
+        self.set_indexed_choice(child, class, new_node)
+    }
+
+    fn set_indexed_choice(
+        &self,
+        child: &mut IndexedChoiceSet,
+        class: DenseIndex,
+        new_node: DenseIndex,
+    ) -> bool {
         let old_node = std::mem::replace(&mut child.choices[class as usize], new_node);
         let class_info = &self.indexed_classes[class as usize];
         child.hash ^= hash_choice_entry(class_info.id, &class_info.nodes[old_node as usize]);
         child.hash ^= hash_choice_entry(class_info.id, &class_info.nodes[new_node as usize]);
         old_node != new_node
+    }
+
+    /// Offer each differing active choice from a donor independently. Newly
+    /// exposed dependencies inherit its choices too, while already-active
+    /// shared choices stay with the receiver. These are ordinary e-graph
+    /// genomes: extraction, validation and measured fitness still decide.
+    pub fn recombine_reachable_choices(
+        &mut self,
+        receiver: &IndexedChoiceSet,
+        donor: &IndexedChoiceSet,
+        prev_selected: &mut FxHashSet<u64>,
+    ) -> Vec<IndexedChoiceSet> {
+        let active = self.reachable_mutation_classes(receiver);
+        let mut offspring = Vec::new();
+        for &class in &active {
+            let choice = donor.choices[class as usize];
+            if receiver.choices[class as usize] == choice {
+                continue;
+            }
+            let mut child = receiver.clone();
+            // No random initialization: preserve the donor's tested branch.
+            self.set_indexed_choice(&mut child, class, choice);
+            let mut initialized: FxHashSet<_> = active.iter().copied().collect();
+            loop {
+                let reachable = self.reachable_mutation_classes(&child);
+                let Some(new_class) = reachable.into_iter().find(|c| !initialized.contains(c))
+                else {
+                    break;
+                };
+                initialized.insert(new_class);
+                self.set_indexed_choice(&mut child, new_class, donor.choices[new_class as usize]);
+            }
+            if prev_selected.insert(child.hash) {
+                offspring.push(child);
+            }
+        }
+        offspring
     }
 
     pub fn extract_reachable_indexed_generation(

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -41,10 +41,9 @@ const EGGLOG_RULESETS: &[&str] = &[
     "fusion_pair",
     "fusion_grow",
     "fusion_merge",
-    // One-shot structural fusion rules (large joins), run once in the
-    // dedicated "fuse late" phase instead of inside the saturating main
-    // cycles. The _pre ruleset holds producer stages (e.g. the RoPE angle
-    // relation) consumed by rules in the main late ruleset.
+    // Structural fusion markers converge in a dedicated late phase, after
+    // dtype/shape facts are available and before cleanup removes proof nodes.
+    // The _pre rulesets seed facts consumed by the main late ruleset.
     "kernel_fuse_late_pre_rms",
     "kernel_fuse_late_pre_topk",
     "kernel_fuse_late_pre_rope",
@@ -200,7 +199,7 @@ pub struct OpTextParts {
     /// Backend-provided egglog text (see [`crate::op::Runtime::extra_egglog`]),
     /// spliced after `op_defs` and `op_declarations`, before the rewrite rules.
     /// Empty for core / the reference backend.
-    extra_egglog: String,
+    pub(crate) extra_egglog: String,
     cleanups: String,
     /// Names of op kinds that are eligible for cleanup (cleanup() == true).
     /// Used by the Rust post-processing pass to safely strip HLIR ops only
@@ -321,19 +320,12 @@ fn egglog_main_cycle_phases(cycle: usize, use_interval_analysis: bool) -> Vec<Eg
 
 fn egglog_final_phases(use_interval_analysis: bool) -> Vec<EgglogSchedulePhase> {
     vec![
-        // One-shot structural fusion rules with large joins. Running them
-        // once here (dtype facts present, raw HLIR rows not yet deleted by
-        // the cleanup phases) instead of inside the saturating main cycles
-        // avoids re-evaluating tens-of-seconds joins on every iteration.
-        // `seq` so each ruleset's join runs exactly once: producer stages
-        // first, then the consumer rules.
+        // Establish producer facts, converge the structural markers, then
+        // materialize consumers while the original HLIR proof nodes exist.
         EgglogSchedulePhase {
             name: "fuse late".to_string(),
-            // The second `kernel_fuse_late` run consumes relation facts the
-            // first run produced (e.g. rope_rotated); semi-naive evaluation
-            // makes it a cheap delta join.
-            // Depth = the longest relation cascade: invf(pre) → angles →
-            // rotation → concat each consume the previous run's facts.
+            // Marker rules may have arbitrary dependency depth. Reach their
+            // fixed point before consumers materialize the fused operations.
             schedule: "(seq
                 kernel_fuse_late_pre_rms
                 kernel_fuse_late_pre_topk
@@ -343,9 +335,7 @@ fn egglog_final_phases(use_interval_analysis: bool) -> Vec<EgglogSchedulePhase> 
                 kernel_fuse_late_pre_sink_attention_past
                 kernel_fuse_late_pre_sink_attention_finish
                 kernel_fuse_late_pre_flashinfer
-                kernel_fuse_late
-                kernel_fuse_late
-                kernel_fuse_late
+                (saturate kernel_fuse_late)
                 kernel_fuse_late2_rope
                 kernel_fuse_late2_sink_attention
                 kernel_fuse_late2_flashinfer_value
@@ -1330,7 +1320,7 @@ pub fn run_egglog_with_report_parts(
     )
 }
 
-fn run_egglog_with_report_parts_impl(
+pub(crate) fn run_egglog_with_report_parts_impl(
     program: &str,
     root: &str,
     op_parts: &OpTextParts,
@@ -1424,6 +1414,21 @@ fn run_egglog_with_report_parts_impl(
     }
     let full_report = stage_report(&egraph, full_start.elapsed());
     trace_stage_report("---- Egglog Rule Matches ----", &full_report);
+    if log && egglog_debug() {
+        let report = egraph.get_overall_run_report();
+        eprintln!("---- Egglog Overall Run Report ----\n{report}");
+        // Keep complete rule names and precise timings for cross-bucket analysis.
+        eprintln!(
+            "EGGLOG_RUN_REPORT_JSON {}",
+            serde_json::json!({
+                "search_and_apply_time_per_rule": report.search_and_apply_time_per_rule,
+                "num_matches_per_rule": report.num_matches_per_rule,
+                "search_and_apply_time_per_ruleset": report.search_and_apply_time_per_ruleset,
+                "merge_time_per_ruleset": report.merge_time_per_ruleset,
+                "rebuild_time_per_ruleset": report.rebuild_time_per_ruleset,
+            })
+        );
+    }
 
     let run_report = EgglogRunReport {
         full: full_report,
@@ -3871,6 +3876,38 @@ mod tests {
                 "seed {seed} retained a reachable cycle"
             );
         }
+    }
+
+    #[test]
+    fn late_fusion_markers_reach_a_fixed_point() {
+        let ops = <HLIROps as IntoEgglogOp>::into_vec();
+        let egraph = super::run_egglog_with_late_passes_interval_analysis_and_log(
+            "(let t0 (Input 0 \"\" (F32))) (let t1 (Output t0 0 false))",
+            "t1",
+            &ops,
+            false,
+            &[],
+            r#"
+            (relation test_late_marker (i64 IR))
+            (rule ((= ?x (Input ?id ?name ?dtype)))
+                  ((test_late_marker 0 ?x)) :ruleset kernel_fuse_late)
+            (rule ((test_late_marker ?step ?x) (< ?step 7))
+                  ((test_late_marker (+ ?step 1) ?x)) :ruleset kernel_fuse_late)
+            (rule ((test_late_marker 7 ?x) (= ?out (Output ?x ?id ?persist)))
+                  ((union ?out ?x)) :ruleset kernel_fuse_late)
+            "#,
+            false,
+            false,
+        )
+        .unwrap();
+        let root = &egraph.roots[0];
+        assert!(
+            egraph.eclasses[root]
+                .1
+                .iter()
+                .any(|node| egraph.enodes[node].0 == "Input"),
+            "the consumer must see markers deeper than the old three-run limit"
+        );
     }
 
     #[test]

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -1968,7 +1968,7 @@ pub struct LlirExtractor<'a> {
     indexed_extractions: Vec<Vec<(DenseIndex, Vec<CachedIndexedExtraction>)>>,
     mutation_nodes: Vec<Option<MutationChoices>>,
     cover_next_proposal: bool,
-    covered_alternatives: Vec<(DenseIndex, CoverageTarget)>,
+    covered_alternatives: [Vec<(DenseIndex, CoverageTarget)>; 2],
     cover_arguments_next: bool,
     visit_epoch: u32,
     visited: Vec<u32>,
@@ -2063,7 +2063,7 @@ impl<'a> LlirExtractor<'a> {
             indexed_extractions,
             mutation_nodes,
             cover_next_proposal: true,
-            covered_alternatives: Vec::new(),
+            covered_alternatives: [Vec::new(), Vec::new()],
             cover_arguments_next: false,
             visit_epoch: 0,
             visited: vec![0; indexed_class_count],
@@ -2371,99 +2371,102 @@ impl<'a> LlirExtractor<'a> {
         active_classes: &[DenseIndex],
         rng: &mut (impl Rng + ?Sized),
     ) -> Option<(DenseIndex, DenseIndex)> {
-        // Alternate full constructor and argument passes. Starting with the
-        // constructor pass preserves coverage before revisiting tuning variants.
-        for refill in 0..=2 {
-            while let Some((class, target)) = self.covered_alternatives.pop() {
-                if !active_classes.contains(&class) {
-                    continue;
-                }
-                let pool = match target {
-                    CoverageTarget::Constructor(family) => {
-                        let nodes = self.indexed_classes[class as usize].nodes;
-                        nearest_constructor_alternatives(
-                            self.egraph,
-                            &nodes[choices.choices[class as usize] as usize],
-                            &self.mutation_nodes[class as usize]
+        // Independent queues: a long constructor/site pass must not delay all
+        // argument exploration (or vice versa). Random proposals remain intact.
+        let requested = usize::from(self.cover_arguments_next);
+        self.cover_arguments_next = !self.cover_arguments_next;
+        for queue in [requested, 1 - requested] {
+            for refill in 0..=1 {
+                while let Some((class, target)) = self.covered_alternatives[queue].pop() {
+                    if !active_classes.contains(&class) {
+                        continue;
+                    }
+                    let pool = match target {
+                        CoverageTarget::Constructor(family) => {
+                            let nodes = self.indexed_classes[class as usize].nodes;
+                            let family = &self.mutation_nodes[class as usize]
                                 .as_ref()
                                 .unwrap()
-                                .families[family],
-                            |slot| &nodes[slot as usize],
-                        )
-                    }
-                    // Parents can change while a pass is pending. Recompute
-                    // neighbors so companion changes remain minimal for this parent.
-                    CoverageTarget::Argument(argument) => {
-                        let Some(pool) = self.argument_pools(choices, class).remove(&argument)
-                        else {
-                            continue;
-                        };
-                        pool
-                    }
-                };
-                return Some((class, pool[rng.random_range(0..pool.len())]));
-            }
-            if refill == 2 {
-                break;
-            }
-            let arguments = self.cover_arguments_next;
-            self.cover_arguments_next = !arguments;
-            let mut classes = active_classes.to_vec();
-            classes.sort_unstable();
-            for class in classes.into_iter().rev() {
-                if arguments {
-                    for argument in self.argument_pools(choices, class).into_keys().rev() {
-                        self.covered_alternatives
-                            .push((class, CoverageTarget::Argument(argument)));
-                    }
-                } else {
-                    self.mutation_pool(class);
-                    let families = &self.mutation_nodes[class as usize]
-                        .as_ref()
-                        .unwrap()
-                        .families;
-                    for (index, family) in families.iter().enumerate().rev() {
-                        if !family.contains(&choices.choices[class as usize]) {
-                            self.covered_alternatives
-                                .push((class, CoverageTarget::Constructor(index)));
+                                .families[family];
+                            if family.contains(&choices.choices[class as usize]) {
+                                continue;
+                            }
+                            nearest_constructor_alternatives(
+                                self.egraph,
+                                &nodes[choices.choices[class as usize] as usize],
+                                family,
+                                |slot| &nodes[slot as usize],
+                            )
+                        }
+                        CoverageTarget::Argument(argument) => {
+                            // A changed parent may need different companion
+                            // changes. Only existing legal alternatives enter.
+                            let Some(pool) = self.argument_pools(choices, class).remove(&argument)
+                            else {
+                                continue;
+                            };
+                            pool
+                        }
+                    };
+                    return Some((class, pool[rng.random_range(0..pool.len())]));
+                }
+                if refill == 1 {
+                    break;
+                }
+                let mut pending = Vec::new();
+                let mut classes = active_classes.to_vec();
+                classes.sort_unstable();
+                for class in classes.into_iter().rev() {
+                    if queue == 1 {
+                        for argument in self.argument_pools(choices, class).into_keys().rev() {
+                            pending.push((class, CoverageTarget::Argument(argument)));
+                        }
+                    } else {
+                        self.mutation_pool(class);
+                        let families = &self.mutation_nodes[class as usize]
+                            .as_ref()
+                            .unwrap()
+                            .families;
+                        for (index, family) in families.iter().enumerate().rev() {
+                            if !family.contains(&choices.choices[class as usize]) {
+                                pending.push((class, CoverageTarget::Constructor(index)));
+                            }
                         }
                     }
                 }
-            }
-            // Keep complete-pass coverage, but avoid favoring serialized class
-            // IDs when the caller stops before a whole pass. The supplied RNG
-            // makes the order reproducible.
-            self.covered_alternatives.shuffle(rng);
-            if !arguments {
-                // Cover distinct algorithm transitions before revisiting their
-                // sites. Otherwise hundreds of repeated elementwise choices
-                // can exhaust a budget before one expensive fusion is offered.
-                // Round-robin ordering retains every site and every family;
-                // backend names and static cost guesses have no preference.
+                pending.shuffle(rng);
+                // Visit distinct implementation transitions / argument positions
+                // before repeated sites. Neither backend names nor class IDs
+                // determine priority, and every queued site remains reachable.
                 let mut visits = FxHashMap::default();
-                self.covered_alternatives
-                    .sort_by_cached_key(|&(class, ref target)| {
-                        let CoverageTarget::Constructor(family) = *target else {
-                            unreachable!()
-                        };
-                        let nodes = self.indexed_classes[class as usize].nodes;
-                        let destination = self.mutation_nodes[class as usize]
-                            .as_ref()
-                            .unwrap()
-                            .families[family][0];
-                        let key = (
-                            proposal_family_key(
-                                self.egraph,
-                                &nodes[choices.choices[class as usize] as usize],
-                            ),
-                            proposal_family_key(self.egraph, &nodes[destination as usize]),
-                        );
-                        let visit = visits.entry(key).or_insert(0usize);
-                        let round = *visit;
-                        *visit += 1;
-                        round
-                    });
-                self.covered_alternatives.reverse(); // pop the first round first
+                pending.sort_by_cached_key(|&(class, ref target)| {
+                    let nodes = self.indexed_classes[class as usize].nodes;
+                    let source = proposal_family_key(
+                        self.egraph,
+                        &nodes[choices.choices[class as usize] as usize],
+                    );
+                    let (destination, argument) = match *target {
+                        CoverageTarget::Constructor(family) => {
+                            let slot = self.mutation_nodes[class as usize]
+                                .as_ref()
+                                .unwrap()
+                                .families[family][0];
+                            (
+                                proposal_family_key(self.egraph, &nodes[slot as usize]),
+                                None,
+                            )
+                        }
+                        CoverageTarget::Argument(argument) => (Vec::new(), Some(argument)),
+                    };
+                    let visit = visits
+                        .entry((source, destination, argument))
+                        .or_insert(0usize);
+                    let round = *visit;
+                    *visit += 1;
+                    round
+                });
+                pending.reverse();
+                self.covered_alternatives[queue] = pending;
             }
         }
         None

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -3356,7 +3356,14 @@ fn proposal_families<'a, T: Copy>(
     let mut indices = FxHashMap::default();
     let mut families: Vec<Vec<T>> = Vec::new();
     for &choice in pool {
-        let key = proposal_family_key(egraph, node(choice));
+        let selected = node(choice);
+        let (head, children) = &egraph.enodes[selected];
+        // Changing an Op's input dependencies is an implementation change,
+        // even when its backend constructor is unchanged (e.g. cast absorption).
+        // Keep tuning variants with identical inputs together. Across sites,
+        // transition ordering still uses constructor names, not unique class IDs.
+        let inputs = if head == "Op" { &children[1..] } else { &[] };
+        let key = (proposal_family_key(egraph, selected), inputs);
         let index = *indices.entry(key).or_insert_with(|| {
             families.push(Vec::new());
             families.len() - 1

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -1958,6 +1958,7 @@ pub struct LlirExtractor<'a> {
     egraph: &'a SerializedEGraph,
     ops: &'a [Arc<Box<dyn EgglogOp>>],
     op_by_name: FxHashMap<String, usize>,
+    constructor_fields: FxHashMap<String, Vec<(String, String)>>,
     list_cache: FxHashMap<&'a NodeId, Vec<Expression>>,
     expr_cache: FxHashMap<&'a NodeId, Expression>,
     indexed_classes: Vec<IndexedEClass<'a>>,
@@ -2009,6 +2010,16 @@ impl<'a> LlirExtractor<'a> {
             .enumerate()
             .map(|(index, op)| (op.sort().name, index))
             .collect();
+        let constructor_fields = ops
+            .iter()
+            .map(|op| {
+                let sort = op.sort();
+                (
+                    sort.name,
+                    sort.fields.into_iter().map(|f| (f.name, f.sort)).collect(),
+                )
+            })
+            .collect();
 
         let mut classes = egraph.eclasses.keys().collect::<Vec<_>>();
         classes.sort_unstable_by(|left, right| left.as_ref().cmp(right.as_ref()));
@@ -2054,6 +2065,7 @@ impl<'a> LlirExtractor<'a> {
             egraph,
             ops,
             op_by_name,
+            constructor_fields,
             list_cache: FxHashMap::default(),
             expr_cache: FxHashMap::default(),
             indexed_classes,
@@ -2395,6 +2407,7 @@ impl<'a> LlirExtractor<'a> {
                             }
                             nearest_constructor_alternatives(
                                 self.egraph,
+                                &self.constructor_fields,
                                 &nodes[choices.choices[class as usize] as usize],
                                 family,
                                 |slot| &nodes[slot as usize],
@@ -3383,12 +3396,13 @@ fn comparable_constructor_terms<'a>(
     Some((left, right))
 }
 
-// Preserve argument positions only within the same constructor. Different
-// constructors can assign unrelated meanings to the same position (e.g. a
-// thread count versus a row tile); their variants must not inherit that bias.
-// Only existing enodes participate; random proposals retain every variant.
+// Across constructors, align only uniquely named fields with the same declared
+// sort. This is a proposal heuristic over existing equivalent enodes, not a
+// proof that two fields have identical semantics. Positions alone are meaningful
+// only within a constructor. Unmatched fields and random proposals remain free.
 fn nearest_constructor_alternatives<'a, T: Copy>(
     egraph: &'a SerializedEGraph,
+    fields: &FxHashMap<String, Vec<(String, String)>>,
     current: &NodeId,
     pool: &[T],
     node: impl Fn(T) -> &'a NodeId,
@@ -3397,10 +3411,32 @@ fn nearest_constructor_alternatives<'a, T: Copy>(
     let mut best = usize::MAX;
     for &candidate in pool {
         let distance = comparable_constructor_terms(egraph, current, node(candidate))
-            .filter(|(left, right)| left.0 == right.0)
             .map(|(left, right)| {
-                left.1.len().abs_diff(right.1.len())
-                    + left.1.iter().zip(&right.1).filter(|(a, b)| a != b).count()
+                if left.0 == right.0 {
+                    return left.1.len().abs_diff(right.1.len())
+                        + left.1.iter().zip(&right.1).filter(|(a, b)| a != b).count();
+                }
+                let Some(lf) = fields.get(&left.0).filter(|f| f.len() == left.1.len()) else {
+                    return usize::MAX;
+                };
+                let Some(rf) = fields.get(&right.0).filter(|f| f.len() == right.1.len()) else {
+                    return usize::MAX;
+                };
+                let mut compared = 0;
+                let mut changed = 0;
+                for (i, field) in lf.iter().enumerate() {
+                    if lf.iter().filter(|f| *f == field).count() != 1 {
+                        continue;
+                    }
+                    let mut matches = rf.iter().enumerate().filter(|(_, f)| *f == field);
+                    if let Some((j, _)) = matches.next()
+                        && matches.next().is_none()
+                    {
+                        compared += 1;
+                        changed += usize::from(left.1[i] != right.1[j]);
+                    }
+                }
+                if compared == 0 { usize::MAX } else { changed }
             })
             .unwrap_or(usize::MAX);
         if distance < best {

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -1968,8 +1968,8 @@ pub struct LlirExtractor<'a> {
     indexed_extractions: Vec<Vec<(DenseIndex, Vec<CachedIndexedExtraction>)>>,
     mutation_nodes: Vec<Option<MutationChoices>>,
     cover_next_proposal: bool,
-    covered_alternatives: [Vec<(DenseIndex, CoverageTarget)>; 2],
-    cover_arguments_next: bool,
+    covered_alternatives: [Vec<(DenseIndex, CoverageTarget)>; 3],
+    cover_queue: usize,
     visit_epoch: u32,
     visited: Vec<u32>,
     reachable: Vec<DenseNode>,
@@ -1980,6 +1980,7 @@ pub struct LlirExtractor<'a> {
 enum CoverageTarget {
     Constructor(usize),
     Argument(usize),
+    FamilyArgument(DenseIndex, usize),
 }
 
 struct MutationChoices {
@@ -2063,8 +2064,8 @@ impl<'a> LlirExtractor<'a> {
             indexed_extractions,
             mutation_nodes,
             cover_next_proposal: true,
-            covered_alternatives: [Vec::new(), Vec::new()],
-            cover_arguments_next: false,
+            covered_alternatives: [Vec::new(), Vec::new(), Vec::new()],
+            cover_queue: 0,
             visit_epoch: 0,
             visited: vec![0; indexed_class_count],
             reachable: Vec::new(),
@@ -2371,11 +2372,12 @@ impl<'a> LlirExtractor<'a> {
         active_classes: &[DenseIndex],
         rng: &mut (impl Rng + ?Sized),
     ) -> Option<(DenseIndex, DenseIndex)> {
-        // Independent queues: a long constructor/site pass must not delay all
-        // argument exploration (or vice versa). Random proposals remain intact.
-        let requested = usize::from(self.cover_arguments_next);
-        self.cover_arguments_next = !self.cover_arguments_next;
-        for queue in [requested, 1 - requested] {
+        // Share coverage among implementation transitions, incumbent arguments,
+        // and the tuning neighborhoods of newly proposed implementations. A
+        // losing initial configuration must not suppress its whole family.
+        let requested = self.cover_queue;
+        self.cover_queue = (self.cover_queue + 1) % 3;
+        for queue in (0..3).map(|offset| (requested + offset) % 3) {
             for refill in 0..=1 {
                 while let Some((class, target)) = self.covered_alternatives[queue].pop() {
                     if !active_classes.contains(&class) {
@@ -2398,6 +2400,16 @@ impl<'a> LlirExtractor<'a> {
                                 |slot| &nodes[slot as usize],
                             )
                         }
+                        CoverageTarget::FamilyArgument(anchor, argument) => {
+                            let mut anchored = choices.clone();
+                            self.set_indexed_choice(&mut anchored, class, anchor);
+                            let Some(pool) =
+                                self.argument_pools(&anchored, class).remove(&argument)
+                            else {
+                                continue;
+                            };
+                            pool
+                        }
                         CoverageTarget::Argument(argument) => {
                             // A changed parent may need different companion
                             // changes. Only existing legal alternatives enter.
@@ -2408,9 +2420,23 @@ impl<'a> LlirExtractor<'a> {
                             pool
                         }
                     };
-                    return Some((class, pool[rng.random_range(0..pool.len())]));
+                    let selected = pool[rng.random_range(0..pool.len())];
+                    if matches!(target, CoverageTarget::Constructor(_)) {
+                        let mut anchored = choices.clone();
+                        self.set_indexed_choice(&mut anchored, class, selected);
+                        let mut arguments: Vec<_> =
+                            self.argument_pools(&anchored, class).into_keys().collect();
+                        arguments.shuffle(rng);
+                        for argument in arguments {
+                            self.covered_alternatives[2].insert(
+                                0,
+                                (class, CoverageTarget::FamilyArgument(selected, argument)),
+                            );
+                        }
+                    }
+                    return Some((class, selected));
                 }
-                if refill == 1 {
+                if refill == 1 || queue == 2 {
                     break;
                 }
                 let mut pending = Vec::new();
@@ -2457,6 +2483,9 @@ impl<'a> LlirExtractor<'a> {
                             )
                         }
                         CoverageTarget::Argument(argument) => (Vec::new(), Some(argument)),
+                        CoverageTarget::FamilyArgument(..) => {
+                            unreachable!("local neighborhoods are queued at proposal time")
+                        }
                     };
                     let visit = visits
                         .entry((source, destination, argument))
@@ -3298,9 +3327,10 @@ fn comparable_constructor_terms<'a>(
     Some((left, right))
 }
 
-// On the systematic constructor pass, preserve as many existing argument
-// classes as possible. Extra arguments are free to vary. Only existing enodes
-// participate; the random half still samples every configuration in the family.
+// Preserve argument positions only within the same constructor. Different
+// constructors can assign unrelated meanings to the same position (e.g. a
+// thread count versus a row tile); their variants must not inherit that bias.
+// Only existing enodes participate; random proposals retain every variant.
 fn nearest_constructor_alternatives<'a, T: Copy>(
     egraph: &'a SerializedEGraph,
     current: &NodeId,
@@ -3311,6 +3341,7 @@ fn nearest_constructor_alternatives<'a, T: Copy>(
     let mut best = usize::MAX;
     for &candidate in pool {
         let distance = comparable_constructor_terms(egraph, current, node(candidate))
+            .filter(|(left, right)| left.0 == right.0)
             .map(|(left, right)| {
                 left.1.len().abs_diff(right.1.len())
                     + left.1.iter().zip(&right.1).filter(|(a, b)| a != b).count()

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -2271,14 +2271,7 @@ impl<'a> LlirExtractor<'a> {
         generation
     }
 
-    pub fn extract_reachable_indexed_generation(
-        &mut self,
-        base: &IndexedChoiceSet,
-        generation_size: usize,
-        mutations_per_generation: usize,
-        prev_selected: &mut FxHashSet<u64>,
-        rng: &mut (impl Rng + ?Sized),
-    ) -> Vec<IndexedChoiceSet> {
+    fn reachable_mutation_classes(&mut self, choices: &IndexedChoiceSet) -> Vec<DenseIndex> {
         let mut seen_nodes = FxHashSet::default();
         let mut seen_classes = FxHashSet::default();
         let mut mutable_classes = Vec::new();
@@ -2288,7 +2281,7 @@ impl<'a> LlirExtractor<'a> {
             seen_classes.insert(root);
             mutable_classes.push(root);
         }
-        let mut stack = vec![self.indexed_selected(base, root)];
+        let mut stack = vec![self.indexed_selected(choices, root)];
         while let Some(node) = stack.pop() {
             if !seen_nodes.insert(node) {
                 continue;
@@ -2302,9 +2295,22 @@ impl<'a> LlirExtractor<'a> {
                 if class.nodes.len() > 1 && seen_classes.insert(child_class) {
                     mutable_classes.push(child_class);
                 }
-                stack.push(self.indexed_selected(base, child_class));
+                stack.push(self.indexed_selected(choices, child_class));
             }
         }
+
+        mutable_classes
+    }
+
+    pub fn extract_reachable_indexed_generation(
+        &mut self,
+        base: &IndexedChoiceSet,
+        generation_size: usize,
+        mutations_per_generation: usize,
+        prev_selected: &mut FxHashSet<u64>,
+        rng: &mut (impl Rng + ?Sized),
+    ) -> Vec<IndexedChoiceSet> {
+        let mutable_classes = self.reachable_mutation_classes(base);
 
         if mutable_classes.is_empty() {
             if prev_selected.insert(base.hash) {
@@ -2319,9 +2325,10 @@ impl<'a> LlirExtractor<'a> {
         while offspring.len() < generation_size && attempts < max_attempts {
             attempts += 1;
             let mut child = base.clone();
+            let mut active_classes = mutable_classes.clone();
             let mutation_count = rng.random_range(1..=mutations_per_generation.max(1));
-            for _ in 0..mutation_count {
-                let class = mutable_classes[rng.random_range(0..mutable_classes.len())];
+            for mutation in 0..mutation_count {
+                let class = active_classes[rng.random_range(0..active_classes.len())];
                 let new_node = {
                     self.mutation_pool(class);
                     let families = &self.mutation_nodes[class as usize]
@@ -2337,6 +2344,15 @@ impl<'a> LlirExtractor<'a> {
                     hash_choice_entry(class_info.id, &class_info.nodes[old_node as usize]);
                 child.hash ^=
                     hash_choice_entry(class_info.id, &class_info.nodes[new_node as usize]);
+                // A different implementation can expose previously inactive
+                // inputs. Later mutations must see the child's current graph,
+                // allowing a structural choice and its tuning to change together.
+                if old_node != new_node && mutation + 1 < mutation_count {
+                    active_classes = self.reachable_mutation_classes(&child);
+                    if active_classes.is_empty() {
+                        break;
+                    }
+                }
             }
             if prev_selected.insert(child.hash) {
                 offspring.push(child);

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -2302,6 +2302,26 @@ impl<'a> LlirExtractor<'a> {
         mutable_classes
     }
 
+    fn mutate_choice(
+        &mut self,
+        child: &mut IndexedChoiceSet,
+        class: DenseIndex,
+        rng: &mut (impl Rng + ?Sized),
+    ) -> bool {
+        self.mutation_pool(class);
+        let families = &self.mutation_nodes[class as usize]
+            .as_ref()
+            .unwrap()
+            .families;
+        let family = &families[rng.random_range(0..families.len())];
+        let new_node = family[rng.random_range(0..family.len())];
+        let old_node = std::mem::replace(&mut child.choices[class as usize], new_node);
+        let class_info = &self.indexed_classes[class as usize];
+        child.hash ^= hash_choice_entry(class_info.id, &class_info.nodes[old_node as usize]);
+        child.hash ^= hash_choice_entry(class_info.id, &class_info.nodes[new_node as usize]);
+        old_node != new_node
+    }
+
     pub fn extract_reachable_indexed_generation(
         &mut self,
         base: &IndexedChoiceSet,
@@ -2327,28 +2347,27 @@ impl<'a> LlirExtractor<'a> {
             let mut child = base.clone();
             let mut active_classes = mutable_classes.clone();
             let mutation_count = rng.random_range(1..=mutations_per_generation.max(1));
-            for mutation in 0..mutation_count {
+            for _ in 0..mutation_count {
                 let class = active_classes[rng.random_range(0..active_classes.len())];
-                let new_node = {
-                    self.mutation_pool(class);
-                    let families = &self.mutation_nodes[class as usize]
-                        .as_ref()
-                        .unwrap()
-                        .families;
-                    let family = &families[rng.random_range(0..families.len())];
-                    family[rng.random_range(0..family.len())]
-                };
-                let old_node = std::mem::replace(&mut child.choices[class as usize], new_node);
-                let class_info = &self.indexed_classes[class as usize];
-                child.hash ^=
-                    hash_choice_entry(class_info.id, &class_info.nodes[old_node as usize]);
-                child.hash ^=
-                    hash_choice_entry(class_info.id, &class_info.nodes[new_node as usize]);
-                // A different implementation can expose previously inactive
-                // inputs. Later mutations must see the child's current graph,
-                // allowing a structural choice and its tuning to change together.
-                if old_node != new_node && mutation + 1 < mutation_count {
-                    active_classes = self.reachable_mutation_classes(&child);
+                if self.mutate_choice(&mut child, class, rng) {
+                    // A structural choice can expose dormant genes left at an
+                    // unrelated implementation by an earlier genome. Initialize
+                    // the newly active subgraph in this same proposal, so a
+                    // wrapper change need not survive as a slower intermediate
+                    // parent before its underlying implementation can change.
+                    let mut initialized: FxHashSet<_> = active_classes.iter().copied().collect();
+                    loop {
+                        active_classes = self.reachable_mutation_classes(&child);
+                        let Some(new_class) = active_classes
+                            .iter()
+                            .find(|c| !initialized.contains(c))
+                            .copied()
+                        else {
+                            break;
+                        };
+                        initialized.insert(new_class);
+                        self.mutate_choice(&mut child, new_class, rng);
+                    }
                     if active_classes.is_empty() {
                         break;
                     }

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -2263,6 +2263,21 @@ impl<'a> LlirExtractor<'a> {
         self.index_choice_set(&choices)
     }
 
+    /// Complete dormant genes introduced after a saved incumbent was created.
+    /// Existing bindings remain exact; callers verify the extracted incumbent.
+    pub(crate) fn index_seed_choices(&mut self, choices: &[(String, String)]) -> IndexedChoiceSet {
+        let mut genome = self.index_named_choices(choices);
+        for index in 0..self.indexed_classes.len() {
+            if self.indexed_classes[index].searchable && genome.choices[index] == NO_DENSE_INDEX {
+                let slot = self.mutation_pool(index as DenseIndex)[0];
+                let class = &self.indexed_classes[index];
+                genome.choices[index] = slot;
+                genome.hash ^= hash_choice_entry(class.id, &class.nodes[slot as usize]);
+            }
+        }
+        genome
+    }
+
     pub fn random_indexed_generation(
         &self,
         generation_size: usize,

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -444,7 +444,7 @@ use crate::{
 use egglog::{ArcSort, CommandOutput, EGraph, Value};
 use egglog_reports::ReportLevel;
 
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 ///  This is snapshot of an EGraph with Rust native hash maps and sets for enabling more native traversal / algorithm writing.
 ///  The name comes from the serialize egraph crates, which returns a ETermDAG, which caused issues, so this is a homebrew semi-static egraph
 pub struct SerializedEGraph {

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -2533,6 +2533,62 @@ impl<'a> LlirExtractor<'a> {
         old_node != new_node
     }
 
+    /// Active implementation families that differ from the incumbent. Family
+    /// identities include input dependencies and dtypes, not tuning values.
+    pub(crate) fn alternate_families(
+        &mut self,
+        choices: &IndexedChoiceSet,
+        incumbent: &IndexedChoiceSet,
+    ) -> Vec<(u32, usize)> {
+        let incumbent_active = self.reachable_mutation_classes(incumbent);
+        let active = self.reachable_mutation_classes(choices);
+        let mut result = Vec::new();
+        for class in active {
+            if !incumbent_active.contains(&class) {
+                continue;
+            }
+            self.mutation_pool(class);
+            let families = &self.mutation_nodes[class as usize]
+                .as_ref()
+                .unwrap()
+                .families;
+            for (family, slots) in families.iter().enumerate() {
+                if slots.contains(&choices.choices[class as usize])
+                    && !slots.contains(&incumbent.choices[class as usize])
+                {
+                    result.push((class, family));
+                }
+            }
+        }
+        result
+    }
+
+    /// Existing nearest legal neighbors, preserving the candidate's other
+    /// choices. A family can climb through improving configurations even while
+    /// every intermediate configuration remains slower than another family.
+    pub(crate) fn argument_neighbors(
+        &mut self,
+        choices: &IndexedChoiceSet,
+        class: u32,
+        seen: &mut FxHashSet<u64>,
+    ) -> Vec<IndexedChoiceSet> {
+        let mut slots: Vec<_> = self
+            .argument_pools(choices, class)
+            .into_values()
+            .flatten()
+            .collect();
+        slots.sort_unstable();
+        slots.dedup();
+        slots
+            .into_iter()
+            .filter_map(|slot| {
+                let mut child = choices.clone();
+                self.set_indexed_choice(&mut child, class, slot);
+                seen.insert(child.hash).then_some(child)
+            })
+            .collect()
+    }
+
     /// Offer each differing active choice from a donor independently. Newly
     /// exposed dependencies inherit its choices too, while already-active
     /// shared choices stay with the receiver. These are ordinary e-graph
@@ -4106,7 +4162,7 @@ fn egglog_to_llir_from_root_cached<'a>(
 }
 
 #[cfg(test)]
-mod proposal_tests;
+pub(crate) mod proposal_tests;
 
 #[cfg(test)]
 mod tests {

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -1967,6 +1967,8 @@ pub struct LlirExtractor<'a> {
     root_index: DenseIndex,
     indexed_extractions: Vec<Vec<(DenseIndex, Vec<CachedIndexedExtraction>)>>,
     mutation_nodes: Vec<Option<MutationChoices>>,
+    cover_next_proposal: bool,
+    constructor_alternatives: Vec<(DenseIndex, usize)>,
     visit_epoch: u32,
     visited: Vec<u32>,
     reachable: Vec<DenseNode>,
@@ -2054,6 +2056,8 @@ impl<'a> LlirExtractor<'a> {
             root_index,
             indexed_extractions,
             mutation_nodes,
+            cover_next_proposal: true,
+            constructor_alternatives: Vec::new(),
             visit_epoch: 0,
             visited: vec![0; indexed_class_count],
             reachable: Vec::new(),
@@ -2302,10 +2306,41 @@ impl<'a> LlirExtractor<'a> {
         mutable_classes
     }
 
+    fn next_constructor_alternative(
+        &mut self,
+        choices: &IndexedChoiceSet,
+        active_classes: &[DenseIndex],
+    ) -> Option<(DenseIndex, usize)> {
+        while let Some(alternative) = self.constructor_alternatives.pop() {
+            if active_classes.contains(&alternative.0) {
+                return Some(alternative);
+            }
+        }
+        // One cycle offers each other constructor at every active site. Avoid
+        // spending this coverage budget revisiting the incumbent constructor's
+        // tuning variants; random proposals continue to explore those variants.
+        let mut classes = active_classes.to_vec();
+        classes.sort_unstable();
+        for class in classes.into_iter().rev() {
+            self.mutation_pool(class);
+            let families = &self.mutation_nodes[class as usize]
+                .as_ref()
+                .unwrap()
+                .families;
+            for (index, family) in families.iter().enumerate().rev() {
+                if !family.contains(&choices.choices[class as usize]) {
+                    self.constructor_alternatives.push((class, index));
+                }
+            }
+        }
+        self.constructor_alternatives.pop()
+    }
+
     fn mutate_choice(
         &mut self,
         child: &mut IndexedChoiceSet,
         class: DenseIndex,
+        family_index: Option<usize>,
         rng: &mut (impl Rng + ?Sized),
     ) -> bool {
         self.mutation_pool(class);
@@ -2313,7 +2348,8 @@ impl<'a> LlirExtractor<'a> {
             .as_ref()
             .unwrap()
             .families;
-        let family = &families[rng.random_range(0..families.len())];
+        let family_index = family_index.unwrap_or_else(|| rng.random_range(0..families.len()));
+        let family = &families[family_index];
         let new_node = family[rng.random_range(0..family.len())];
         let old_node = std::mem::replace(&mut child.choices[class as usize], new_node);
         let class_info = &self.indexed_classes[class as usize];
@@ -2345,11 +2381,28 @@ impl<'a> LlirExtractor<'a> {
         while offspring.len() < generation_size && attempts < max_attempts {
             attempts += 1;
             let mut child = base.clone();
+            let cover_constructor = self.cover_next_proposal;
+            self.cover_next_proposal = !self.cover_next_proposal;
             let mut active_classes = mutable_classes.clone();
             let mutation_count = rng.random_range(1..=mutations_per_generation.max(1));
+            // Measure direct alternatives independently; the random half keeps
+            // the caller's full joint-mutation budget for escaping local minima.
+            let mutation_count = if cover_constructor { 1 } else { mutation_count };
             for _ in 0..mutation_count {
-                let class = active_classes[rng.random_range(0..active_classes.len())];
-                if self.mutate_choice(&mut child, class, rng) {
+                // Cover alternate constructors between unrestricted random
+                // proposals, which continue exploring every tuning/joint choice.
+                let alternative = cover_constructor
+                    .then(|| self.next_constructor_alternative(&child, &active_classes))
+                    .flatten();
+                let class = alternative
+                    .map(|(class, _)| class)
+                    .unwrap_or_else(|| active_classes[rng.random_range(0..active_classes.len())]);
+                if self.mutate_choice(
+                    &mut child,
+                    class,
+                    alternative.map(|(_, family)| family),
+                    rng,
+                ) {
                     // A structural choice can expose dormant genes left at an
                     // unrelated implementation by an earlier genome. Initialize
                     // the newly active subgraph in this same proposal, so a
@@ -2366,7 +2419,7 @@ impl<'a> LlirExtractor<'a> {
                             break;
                         };
                         initialized.insert(new_class);
-                        self.mutate_choice(&mut child, new_class, rng);
+                        self.mutate_choice(&mut child, new_class, None, rng);
                     }
                     if active_classes.is_empty() {
                         break;

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -1968,12 +1968,18 @@ pub struct LlirExtractor<'a> {
     indexed_extractions: Vec<Vec<(DenseIndex, Vec<CachedIndexedExtraction>)>>,
     mutation_nodes: Vec<Option<MutationChoices>>,
     cover_next_proposal: bool,
-    constructor_alternatives: Vec<(DenseIndex, usize)>,
+    covered_alternatives: Vec<(DenseIndex, CoverageTarget)>,
+    cover_arguments_next: bool,
     visit_epoch: u32,
     visited: Vec<u32>,
     reachable: Vec<DenseNode>,
     reachability_stack: Vec<DenseNode>,
     graph_nodes: Vec<(u32, usize)>,
+}
+
+enum CoverageTarget {
+    Constructor(usize),
+    Argument(usize),
 }
 
 struct MutationChoices {
@@ -2057,7 +2063,8 @@ impl<'a> LlirExtractor<'a> {
             indexed_extractions,
             mutation_nodes,
             cover_next_proposal: true,
-            constructor_alternatives: Vec::new(),
+            covered_alternatives: Vec::new(),
+            cover_arguments_next: false,
             visit_epoch: 0,
             visited: vec![0; indexed_class_count],
             reachable: Vec::new(),
@@ -2306,51 +2313,103 @@ impl<'a> LlirExtractor<'a> {
         mutable_classes
     }
 
-    fn next_constructor_alternative(
+    fn argument_pools(
+        &mut self,
+        choices: &IndexedChoiceSet,
+        class: DenseIndex,
+    ) -> std::collections::BTreeMap<usize, Vec<DenseIndex>> {
+        let pool = self.mutation_pool(class).to_vec();
+        let nodes = self.indexed_classes[class as usize].nodes;
+        let current = &nodes[choices.choices[class as usize] as usize];
+        let mut arguments = std::collections::BTreeMap::<_, Vec<_>>::new();
+        for slot in pool {
+            if let Some(argument) =
+                single_argument_change(self.egraph, current, &nodes[slot as usize])
+            {
+                arguments.entry(argument).or_default().push(slot);
+            }
+        }
+        arguments
+    }
+
+    fn next_covered_choice(
         &mut self,
         choices: &IndexedChoiceSet,
         active_classes: &[DenseIndex],
-    ) -> Option<(DenseIndex, usize)> {
-        while let Some(alternative) = self.constructor_alternatives.pop() {
-            if active_classes.contains(&alternative.0) {
-                return Some(alternative);
+        rng: &mut (impl Rng + ?Sized),
+    ) -> Option<(DenseIndex, DenseIndex)> {
+        // Alternate full constructor and argument passes. Starting with the
+        // constructor pass preserves coverage before revisiting tuning variants.
+        for refill in 0..=2 {
+            while let Some((class, target)) = self.covered_alternatives.pop() {
+                if !active_classes.contains(&class) {
+                    continue;
+                }
+                let pool = match target {
+                    CoverageTarget::Constructor(family) => self.mutation_nodes[class as usize]
+                        .as_ref()
+                        .unwrap()
+                        .families[family]
+                        .clone(),
+                    // Parents can change while a pass is pending. Recompute
+                    // neighbors so the proposal still changes exactly one argument.
+                    CoverageTarget::Argument(argument) => {
+                        let Some(pool) = self.argument_pools(choices, class).remove(&argument)
+                        else {
+                            continue;
+                        };
+                        pool
+                    }
+                };
+                return Some((class, pool[rng.random_range(0..pool.len())]));
             }
-        }
-        // One cycle offers each other constructor at every active site. Avoid
-        // spending this coverage budget revisiting the incumbent constructor's
-        // tuning variants; random proposals continue to explore those variants.
-        let mut classes = active_classes.to_vec();
-        classes.sort_unstable();
-        for class in classes.into_iter().rev() {
-            self.mutation_pool(class);
-            let families = &self.mutation_nodes[class as usize]
-                .as_ref()
-                .unwrap()
-                .families;
-            for (index, family) in families.iter().enumerate().rev() {
-                if !family.contains(&choices.choices[class as usize]) {
-                    self.constructor_alternatives.push((class, index));
+            if refill == 2 {
+                break;
+            }
+            let arguments = self.cover_arguments_next;
+            self.cover_arguments_next = !arguments;
+            let mut classes = active_classes.to_vec();
+            classes.sort_unstable();
+            for class in classes.into_iter().rev() {
+                if arguments {
+                    for argument in self.argument_pools(choices, class).into_keys().rev() {
+                        self.covered_alternatives
+                            .push((class, CoverageTarget::Argument(argument)));
+                    }
+                } else {
+                    self.mutation_pool(class);
+                    let families = &self.mutation_nodes[class as usize]
+                        .as_ref()
+                        .unwrap()
+                        .families;
+                    for (index, family) in families.iter().enumerate().rev() {
+                        if !family.contains(&choices.choices[class as usize]) {
+                            self.covered_alternatives
+                                .push((class, CoverageTarget::Constructor(index)));
+                        }
+                    }
                 }
             }
         }
-        self.constructor_alternatives.pop()
+        None
     }
 
     fn mutate_choice(
         &mut self,
         child: &mut IndexedChoiceSet,
         class: DenseIndex,
-        family_index: Option<usize>,
+        selected: Option<DenseIndex>,
         rng: &mut (impl Rng + ?Sized),
     ) -> bool {
-        self.mutation_pool(class);
-        let families = &self.mutation_nodes[class as usize]
-            .as_ref()
-            .unwrap()
-            .families;
-        let family_index = family_index.unwrap_or_else(|| rng.random_range(0..families.len()));
-        let family = &families[family_index];
-        let new_node = family[rng.random_range(0..family.len())];
+        let new_node = selected.unwrap_or_else(|| {
+            self.mutation_pool(class);
+            let families = &self.mutation_nodes[class as usize]
+                .as_ref()
+                .unwrap()
+                .families;
+            let family = &families[rng.random_range(0..families.len())];
+            family[rng.random_range(0..family.len())]
+        });
         let old_node = std::mem::replace(&mut child.choices[class as usize], new_node);
         let class_info = &self.indexed_classes[class as usize];
         child.hash ^= hash_choice_entry(class_info.id, &class_info.nodes[old_node as usize]);
@@ -2381,28 +2440,23 @@ impl<'a> LlirExtractor<'a> {
         while offspring.len() < generation_size && attempts < max_attempts {
             attempts += 1;
             let mut child = base.clone();
-            let cover_constructor = self.cover_next_proposal;
+            let cover_proposal = self.cover_next_proposal;
             self.cover_next_proposal = !self.cover_next_proposal;
             let mut active_classes = mutable_classes.clone();
             let mutation_count = rng.random_range(1..=mutations_per_generation.max(1));
             // Measure direct alternatives independently; the random half keeps
             // the caller's full joint-mutation budget for escaping local minima.
-            let mutation_count = if cover_constructor { 1 } else { mutation_count };
+            let mutation_count = if cover_proposal { 1 } else { mutation_count };
             for _ in 0..mutation_count {
                 // Cover alternate constructors between unrestricted random
                 // proposals, which continue exploring every tuning/joint choice.
-                let alternative = cover_constructor
-                    .then(|| self.next_constructor_alternative(&child, &active_classes))
+                let alternative = cover_proposal
+                    .then(|| self.next_covered_choice(&child, &active_classes, rng))
                     .flatten();
                 let class = alternative
                     .map(|(class, _)| class)
                     .unwrap_or_else(|| active_classes[rng.random_range(0..active_classes.len())]);
-                if self.mutate_choice(
-                    &mut child,
-                    class,
-                    alternative.map(|(_, family)| family),
-                    rng,
-                ) {
+                if self.mutate_choice(&mut child, class, alternative.map(|(_, node)| node), rng) {
                     // A structural choice can expose dormant genes left at an
                     // unrelated implementation by an earlier genome. Initialize
                     // the newly active subgraph in this same proposal, so a
@@ -3088,6 +3142,46 @@ fn non_marker_enode_indices(egraph: &SerializedEGraph, enodes: &[NodeId]) -> Vec
         .filter(|(_, n)| !enode_is_loop_input_marker(egraph, n))
         .map(|(i, _)| i)
         .collect()
+}
+
+// Compare existing terms, without inventing parameter combinations. For the
+// generic Op wrapper, require identical inputs and an unambiguous OpKind so a
+// constructor-argument proposal cannot silently change its data dependencies.
+fn single_argument_change(
+    egraph: &SerializedEGraph,
+    before: &NodeId,
+    after: &NodeId,
+) -> Option<usize> {
+    let (mut left, mut right) = (&egraph.enodes[before], &egraph.enodes[after]);
+    if left.0 == "Op" && right.0 == "Op" {
+        if left.1.get(1..) != right.1.get(1..) {
+            return None;
+        }
+        let (left_sort, left_kinds) = &egraph.eclasses[left.1.first()?];
+        let (right_sort, right_kinds) = &egraph.eclasses[right.1.first()?];
+        if left_sort != "OpKind"
+            || right_sort != "OpKind"
+            || left_kinds.len() != 1
+            || right_kinds.len() != 1
+        {
+            return None;
+        }
+        left = &egraph.enodes[&left_kinds[0]];
+        right = &egraph.enodes[&right_kinds[0]];
+    }
+    if left.0 != right.0 || left.1.len() != right.1.len() {
+        return None;
+    }
+    let mut changed = None;
+    for (index, (a, b)) in left.1.iter().zip(&right.1).enumerate() {
+        if a != b {
+            if changed.is_some() {
+                return None;
+            }
+            changed = Some(index);
+        }
+    }
+    changed
 }
 
 /// Group legal proposals by constructor before sampling tuning variants. The

--- a/src/egglog_utils/proposal_tests.rs
+++ b/src/egglog_utils/proposal_tests.rs
@@ -312,6 +312,50 @@ fn independent_choices_fixture(
 }
 
 #[test]
+fn constructor_coverage_is_not_diluted_by_repeated_operation_sites() {
+    let (mut graph, roots) = independent_choices_fixture(129, 70);
+    let rare = roots.last().unwrap();
+    let alternative = graph.eclasses[rare].1[0].clone();
+    let kind = ClassId::from("rare-kind");
+    let kind_node = NodeId::from("rare-kind-node");
+    graph
+        .enodes
+        .insert(kind_node.clone(), ("RareAlgorithm".into(), vec![]));
+    graph.node_to_class.insert(kind_node.clone(), kind.clone());
+    graph
+        .eclasses
+        .insert(kind.clone(), ("OpKind".into(), vec![kind_node]));
+    graph.enodes.get_mut(&alternative).unwrap().1[0] = kind;
+
+    for seed in 0..16 {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let mut choices = random_initial_choice(&graph, &mut rng);
+        for root in &roots {
+            let (class, (_, nodes)) = graph.eclasses.get_key_value(root).unwrap();
+            choices.insert(class, &nodes[1]);
+        }
+        let mut extractor = LlirExtractor::new(&graph, &[]);
+        let base = extractor.index_choice_set(&choices);
+        let mut seen = FxHashSet::default();
+        let mut covered = false;
+        // Two distinct constructor transitions: cover both before spending
+        // more proposals on the 128 repeated sites. Random proposals alternate.
+        for _ in 0..4 {
+            let child = extractor
+                .extract_reachable_indexed_generation(&base, 1, 1, &mut seen, &mut rng)
+                .pop()
+                .unwrap();
+            let node = extractor.indexed_selected(&child, extractor.class_to_index[rare]);
+            covered |= extractor.indexed_node_id(node) == &alternative;
+        }
+        assert!(
+            covered,
+            "rare constructor transition starved for seed {seed}"
+        );
+    }
+}
+
+#[test]
 fn mutation_covers_each_active_constructor_within_bounded_proposals() {
     const CLASSES: usize = 48;
     let (graph, roots) = independent_choices_fixture(CLASSES, 70);

--- a/src/egglog_utils/proposal_tests.rs
+++ b/src/egglog_utils/proposal_tests.rs
@@ -104,8 +104,8 @@ fn reachable_mutation_balances_families_and_preserves_every_variant() {
 }
 
 // A direct implementation hides the input of an equivalent wrapped form.
-// Switching to the wrapper must permit later mutations in this same child
-// to tune the newly activated input, without first retaining a worse parent.
+// Switching to the wrapper must initialize its newly activated input in the
+// same proposal, without first retaining a worse intermediate parent.
 fn activated_input_fixture() -> SerializedEGraph {
     let mut graph = SerializedEGraph {
         enodes: FxHashMap::default(),
@@ -159,41 +159,78 @@ fn activated_input_fixture() -> SerializedEGraph {
 }
 
 #[test]
-fn mutation_can_tune_an_input_activated_by_an_earlier_mutation() {
-    let graph = activated_input_fixture();
+fn structural_mutation_initializes_newly_exposed_choices() {
+    check_activated_input_mutation(false);
+}
+
+#[test]
+fn structural_mutation_preserves_already_active_shared_choices() {
+    check_activated_input_mutation(true);
+}
+
+fn check_activated_input_mutation(already_active: bool) {
+    let mut graph = activated_input_fixture();
     let root = ClassId::from("root");
     let hidden = ClassId::from("hidden");
+    if already_active {
+        let join = ClassId::from("join");
+        let node = NodeId::from("join-node");
+        graph.enodes.insert(
+            node.clone(),
+            ("OutputJoin".into(), vec![root.clone(), hidden.clone()]),
+        );
+        graph.node_to_class.insert(node.clone(), join.clone());
+        graph
+            .eclasses
+            .insert(join.clone(), ("IR".into(), vec![node]));
+        graph.roots = vec![join];
+    }
     let mut rng = StdRng::seed_from_u64(1827);
     let mut choices = random_initial_choice(&graph, &mut rng);
-    choices.insert(&graph.roots[0], &graph.eclasses[&root].1[0]);
+    choices.insert(
+        graph.eclasses.get_key_value(&root).unwrap().0,
+        &graph.eclasses[&root].1[0],
+    );
     choices.insert(
         graph.eclasses.get_key_value(&hidden).unwrap().0,
         &graph.eclasses[&hidden].1[0],
     );
     let mut extractor = LlirExtractor::new(&graph, &[]);
     let base = extractor.index_choice_set(&choices);
+    let mut wrapped = 0;
     let mut composed = 0;
     for _ in 0..1024 {
         let children = extractor.extract_reachable_indexed_generation(
             &base,
             1,
-            8,
+            1,
             &mut FxHashSet::default(),
             &mut rng,
         );
         assert_eq!(children.len(), 1);
         let named = extractor.named_choices(&children[0]);
         assert_eq!(extractor.index_named_choices(&named).hash, children[0].hash);
-        if named.contains(&("root".into(), "wrapped".into()))
-            && named.contains(&("hidden".into(), "fast".into()))
-        {
-            composed += 1;
+        if named.contains(&("root".into(), "wrapped".into())) {
+            wrapped += 1;
+            if named.contains(&("hidden".into(), "fast".into())) {
+                composed += 1;
+            }
         }
     }
-    assert!(
-        composed > 0,
-        "no child could tune an input exposed by its earlier mutation"
+    assert!(wrapped > 0, "structural alternatives remain searchable");
+    if already_active {
+        assert_eq!(
+            composed, 0,
+            "initializing a newly exposed branch must preserve already-active shared choices"
+        );
+    } else {
+        assert!(
+            composed > 0,
+            "a structural proposal must initialize the newly exposed input without retaining an intermediate parent"
+        );
+    }
+    assert_eq!(
+        base.choices[extractor.class_to_index[&hidden] as usize], 0,
+        "parent is immutable"
     );
-    // Parents are immutable while children explore implementation changes.
-    assert_eq!(base.choices[extractor.class_to_index[&hidden] as usize], 0);
 }

--- a/src/egglog_utils/proposal_tests.rs
+++ b/src/egglog_utils/proposal_tests.rs
@@ -897,3 +897,55 @@ fn coverage_separates_changed_inputs_from_tunings_of_the_same_constructor() {
         );
     }
 }
+
+#[test]
+fn dtype_transitions_are_not_starved_by_repeated_constructor_transitions() {
+    let (mut graph, roots) = independent_choices_fixture(129, 1);
+    for dtype in ["F32", "Bf16"] {
+        let class = ClassId::from(dtype);
+        let node = NodeId::from(format!("dtype-{dtype}"));
+        graph.enodes.insert(node.clone(), (dtype.into(), vec![]));
+        graph.node_to_class.insert(node.clone(), class.clone());
+        graph.eclasses.insert(class, ("DType".into(), vec![node]));
+    }
+    for i in 0..=1 {
+        graph
+            .enodes
+            .get_mut(&NodeId::from(format!("kind-node-{i}")))
+            .unwrap()
+            .1
+            .push(ClassId::from("F32"));
+    }
+    let rare = roots.last().unwrap();
+    let alternative = graph.eclasses[rare].1[0].clone();
+    let kind = ClassId::from("mixed-kind");
+    let kind_node = NodeId::from("mixed-kind-node");
+    let mut term = graph.enodes[&NodeId::from("kind-node-0")].clone();
+    *term.1.last_mut().unwrap() = ClassId::from("Bf16");
+    graph.enodes.insert(kind_node.clone(), term);
+    graph.node_to_class.insert(kind_node.clone(), kind.clone());
+    graph
+        .eclasses
+        .insert(kind.clone(), ("OpKind".into(), vec![kind_node]));
+    graph.enodes.get_mut(&alternative).unwrap().1[0] = kind;
+    for seed in 0..32 {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let mut extractor = LlirExtractor::new(&graph, &[]);
+        let bindings = roots
+            .iter()
+            .map(|r| (r.to_string(), graph.eclasses[r].1[1].to_string()))
+            .collect::<Vec<_>>();
+        let parent = extractor.index_seed_choices(&bindings);
+        let mut seen = FxHashSet::default();
+        let mut covered = false;
+        for _ in 0..4 {
+            let child = extractor
+                .extract_reachable_indexed_generation(&parent, 1, 1, &mut seen, &mut rng)
+                .pop()
+                .unwrap();
+            let choice = extractor.indexed_selected(&child, extractor.class_to_index[rare]);
+            covered |= extractor.indexed_node_id(choice) == &alternative;
+        }
+        assert!(covered, "dtype-changing transition starved for seed {seed}");
+    }
+}

--- a/src/egglog_utils/proposal_tests.rs
+++ b/src/egglog_utils/proposal_tests.rs
@@ -3,7 +3,7 @@ use rand::{SeedableRng, rngs::StdRng};
 
 // Two arbitrary implementations of a value: one untuned and one with many
 // configurations. This fixture has no backend, shape, or model policy.
-fn choices_fixture(variants: usize) -> SerializedEGraph {
+pub(crate) fn choices_fixture(variants: usize) -> SerializedEGraph {
     let root = ClassId::from("root");
     let mut graph = SerializedEGraph {
         enodes: FxHashMap::default(),
@@ -548,7 +548,7 @@ fn constructor_coverage_tests_direct_alternatives_with_large_mutation_limits() {
     }
 }
 
-fn paired_arguments_fixture(width: usize, coupled: bool) -> SerializedEGraph {
+pub(crate) fn paired_arguments_fixture(width: usize, coupled: bool) -> SerializedEGraph {
     let mut graph = choices_fixture(0);
     graph.enodes.remove(&NodeId::from("op-0"));
     graph.node_to_class.remove(&NodeId::from("op-0"));

--- a/src/egglog_utils/proposal_tests.rs
+++ b/src/egglog_utils/proposal_tests.rs
@@ -570,3 +570,152 @@ fn argument_coverage_proposes_required_companion_changes() {
         );
     }
 }
+
+#[test]
+fn constructor_coverage_preserves_existing_arguments_without_pruning_variants() {
+    let mut graph = paired_arguments_fixture(4, false);
+    let root = graph.roots[0].clone();
+    let before = NodeId::from("pair-2-3");
+    let original = graph.eclasses[&root].1.clone();
+    for node in original {
+        let (_, inputs) = &graph.enodes[&node];
+        let kind = &graph.eclasses[&inputs[0]].1[0];
+        let (_, arguments) = &graph.enodes[kind];
+        let arguments = arguments.clone();
+        for extra in 0..4 {
+            let class = ClassId::from(format!("extended-{node}-{extra}"));
+            let kind = NodeId::from(format!("extended-kind-{node}-{extra}"));
+            let mut args = arguments.clone();
+            args.push(ClassId::from(format!("knob-{extra}")));
+            graph.enodes.insert(kind.clone(), ("Extended".into(), args));
+            graph.node_to_class.insert(kind.clone(), class.clone());
+            graph
+                .eclasses
+                .insert(class.clone(), ("OpKind".into(), vec![kind]));
+            let op = NodeId::from(format!("extended-op-{node}-{extra}"));
+            graph.enodes.insert(
+                op.clone(),
+                ("Op".into(), vec![class, ClassId::from("sources")]),
+            );
+            graph.node_to_class.insert(op.clone(), root.clone());
+            graph.eclasses.get_mut(&root).unwrap().1.push(op);
+        }
+    }
+    let mut rng = StdRng::seed_from_u64(971);
+    let mut choices = random_initial_choice(&graph, &mut rng);
+    choices.insert(&root, &before);
+    let mut extractor = LlirExtractor::new(&graph, &[]);
+    let base = extractor.index_choice_set(&choices);
+    let mut reached = FxHashSet::default();
+    let mut covered_extra = FxHashSet::default();
+    for proposal in 0..4096 {
+        let child = extractor
+            .extract_reachable_indexed_generation(&base, 1, 1, &mut FxHashSet::default(), &mut rng)
+            .pop()
+            .unwrap();
+        let selected = extractor.indexed_selected(&child, extractor.root_index);
+        let node = extractor.indexed_node_id(selected);
+        reached.insert(node.clone());
+        let (_, term) = comparable_constructor_terms(&graph, &before, node).unwrap();
+        if proposal % 2 == 0 && term.0 == "Extended" {
+            assert_eq!(
+                term.1[..2],
+                [ClassId::from("knob-2"), ClassId::from("knob-3")]
+            );
+            covered_extra.insert(term.1[2].clone());
+        }
+    }
+    assert_eq!(
+        covered_extra.len(),
+        4,
+        "new arguments must remain free to vary"
+    );
+    assert_eq!(
+        reached.len(),
+        80,
+        "random exploration must retain every configuration"
+    );
+}
+
+#[test]
+fn short_coverage_passes_do_not_always_start_at_the_same_class() {
+    let (graph, roots) = independent_choices_fixture(48, 1);
+    let mut first_classes = FxHashSet::default();
+    for seed in 0..32 {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let mut choices = random_initial_choice(&graph, &mut rng);
+        for root in &roots {
+            let (class, (_, nodes)) = graph.eclasses.get_key_value(root).unwrap();
+            choices.insert(class, &nodes[1]);
+        }
+        let mut extractor = LlirExtractor::new(&graph, &[]);
+        let base = extractor.index_choice_set(&choices);
+        let child = extractor
+            .extract_reachable_indexed_generation(&base, 1, 1, &mut FxHashSet::default(), &mut rng)
+            .pop()
+            .unwrap();
+        for root in &roots {
+            let class = extractor.class_to_index[root];
+            if extractor.indexed_selected(&child, class) != extractor.indexed_selected(&base, class)
+            {
+                first_classes.insert(root);
+            }
+        }
+    }
+    assert!(
+        first_classes.len() > 8,
+        "short runs must not always cover the same class first"
+    );
+}
+
+/// CPU-only proposal inspection. It holds each saved parent fixed; this is not
+/// a substitute for measured search, parent selection, or backend validation.
+#[test]
+#[ignore = "requires a saved schedule and an output path"]
+fn saved_schedule_constructor_transition_diagnostic() {
+    let schedule: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(std::env::var("LUMINAL_PROPOSAL_SCHEDULE").unwrap()).unwrap(),
+    )
+    .unwrap();
+    let limit = std::env::var("LUMINAL_PROPOSAL_LIMIT")
+        .unwrap_or("80".into())
+        .parse::<usize>()
+        .unwrap();
+    let mut report = Vec::new();
+    for (bucket, data) in schedule["buckets"].as_array().unwrap().iter().enumerate() {
+        let graph: SerializedEGraph = serde_json::from_value(data["egraph"].clone()).unwrap();
+        let bindings: Vec<(String, String)> =
+            serde_json::from_value(data["choices"].clone()).unwrap();
+        let mut extractor = LlirExtractor::new(&graph, &[]);
+        let base = extractor.index_named_choices(&bindings);
+        let active = extractor.reachable_mutation_classes(&base);
+        let mut rng = StdRng::seed_from_u64(0x1A11_CE5E_ED5E_ED01);
+        let mut seen = FxHashSet::default();
+        for proposal in 0..limit {
+            let child = extractor
+                .extract_reachable_indexed_generation(&base, 1, 1, &mut seen, &mut rng)
+                .pop()
+                .unwrap();
+            for &class in &active {
+                let old = extractor.indexed_node_id(extractor.indexed_selected(&base, class));
+                let new = extractor.indexed_node_id(extractor.indexed_selected(&child, class));
+                if old == new {
+                    continue;
+                }
+                let terms = comparable_constructor_terms(&graph, old, new);
+                report.push(serde_json::json!({
+                    "bucket": bucket, "proposal": proposal,
+                    "class": extractor.indexed_classes[class as usize].id,
+                    "old": old, "new": new,
+                    "comparable_terms": terms,
+                    "changed_shared_arguments": terms.map(|(a,b)| a.1.iter().zip(&b.1).filter(|(a,b)|a!=b).count()),
+                }));
+            }
+        }
+    }
+    std::fs::write(
+        std::env::var("LUMINAL_PROPOSAL_REPORT").unwrap(),
+        serde_json::to_vec(&report).unwrap(),
+    )
+    .unwrap();
+}

--- a/src/egglog_utils/proposal_tests.rs
+++ b/src/egglog_utils/proposal_tests.rs
@@ -276,7 +276,7 @@ fn check_activated_input_mutation(already_active: bool) {
     );
 }
 
-fn independent_choices_fixture(
+pub(crate) fn independent_choices_fixture(
     classes: usize,
     variants: usize,
 ) -> (SerializedEGraph, Vec<ClassId>) {

--- a/src/egglog_utils/proposal_tests.rs
+++ b/src/egglog_utils/proposal_tests.rs
@@ -701,11 +701,9 @@ fn argument_coverage_proposes_required_companion_changes() {
     }
 }
 
-#[test]
-fn constructor_coverage_does_not_align_unrelated_argument_positions() {
+fn extended_arguments_fixture() -> SerializedEGraph {
     let mut graph = paired_arguments_fixture(4, false);
     let root = graph.roots[0].clone();
-    let before = NodeId::from("pair-2-3");
     let original = graph.eclasses[&root].1.clone();
     for node in original {
         let (_, inputs) = &graph.enodes[&node];
@@ -731,6 +729,14 @@ fn constructor_coverage_does_not_align_unrelated_argument_positions() {
             graph.eclasses.get_mut(&root).unwrap().1.push(op);
         }
     }
+    graph
+}
+
+#[test]
+fn constructor_coverage_does_not_align_unrelated_argument_positions() {
+    let graph = extended_arguments_fixture();
+    let root = graph.roots[0].clone();
+    let before = NodeId::from("pair-2-3");
     let mut rng = StdRng::seed_from_u64(971);
     let mut choices = random_initial_choice(&graph, &mut rng);
     choices.insert(&root, &before);
@@ -1029,4 +1035,87 @@ fn losing_constructor_proposals_still_receive_tuning_neighbors() {
         proposal_family_key(&graph, &nodes[first.1 as usize]),
         proposal_family_key(&graph, &nodes[next.1 as usize])
     );
+}
+
+#[test]
+fn constructor_coverage_transfers_named_fields_across_reordered_schemas() {
+    let graph = extended_arguments_fixture();
+    let fields: FxHashMap<_, _> = [
+        (
+            "Tunable".into(),
+            vec![("x".into(), "i64".into()), ("y".into(), "i64".into())],
+        ),
+        (
+            "Extended".into(),
+            vec![
+                ("y".into(), "i64".into()),
+                ("x".into(), "i64".into()),
+                ("new".into(), "i64".into()),
+            ],
+        ),
+    ]
+    .into_iter()
+    .collect();
+    let root = &graph.roots[0];
+    let before = NodeId::from("pair-2-3");
+    let mut extras = FxHashSet::default();
+    for seed in 0..64 {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let mut choices = random_initial_choice(&graph, &mut rng);
+        choices.insert(root, &before);
+        let mut extractor = LlirExtractor::new(&graph, &[]);
+        extractor.constructor_fields = fields.clone();
+        let base = extractor.index_choice_set(&choices);
+        let child = extractor
+            .extract_reachable_indexed_generation(&base, 1, 1, &mut FxHashSet::default(), &mut rng)
+            .pop()
+            .unwrap();
+        let selected = extractor.indexed_selected(&child, extractor.root_index);
+        let node = extractor.indexed_node_id(selected);
+        let (_, term) = comparable_constructor_terms(&graph, &before, node).unwrap();
+        assert_eq!(term.0, "Extended");
+        assert_eq!(
+            term.1[..2],
+            [ClassId::from("knob-3"), ClassId::from("knob-2")]
+        );
+        extras.insert(term.1[2].clone());
+    }
+    assert_eq!(extras.len(), 4, "new fields remain free to vary");
+}
+
+#[test]
+fn named_constructor_alignment_requires_matching_sorts_and_unique_fields() {
+    let graph = extended_arguments_fixture();
+    let before = NodeId::from("pair-2-3");
+    let pool = graph.eclasses[&graph.roots[0]]
+        .1
+        .iter()
+        .filter(|n| n.as_ref().starts_with("extended-op-"))
+        .collect::<Vec<_>>();
+    for extended in [
+        vec![
+            ("x".into(), "Expression".into()),
+            ("unrelated".into(), "i64".into()),
+            ("new".into(), "i64".into()),
+        ],
+        vec![
+            ("x".into(), "i64".into()),
+            ("x".into(), "i64".into()),
+            ("new".into(), "i64".into()),
+        ],
+    ] {
+        let fields = [
+            (
+                "Tunable".into(),
+                vec![("x".into(), "i64".into()), ("y".into(), "i64".into())],
+            ),
+            ("Extended".into(), extended),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            nearest_constructor_alternatives(&graph, &fields, &before, &pool, |n| n).len(),
+            pool.len()
+        );
+    }
 }

--- a/src/egglog_utils/proposal_tests.rs
+++ b/src/egglog_utils/proposal_tests.rs
@@ -422,8 +422,9 @@ fn constructor_coverage_is_not_diluted_by_repeated_operation_sites() {
         let mut seen = FxHashSet::default();
         let mut covered = false;
         // Two distinct constructor transitions: cover both before spending
-        // more proposals on the 128 repeated sites. Random proposals alternate.
-        for _ in 0..4 {
+        // more constructor proposals on repeated sites. Argument and random
+        // proposals each retain their independent share of the budget.
+        for _ in 0..8 {
             let child = extractor
                 .extract_reachable_indexed_generation(&base, 1, 1, &mut seen, &mut rng)
                 .pop()
@@ -451,7 +452,9 @@ fn mutation_covers_each_active_constructor_within_bounded_proposals() {
     let mut extractor = LlirExtractor::new(&graph, &[]);
     let base = extractor.index_choice_set(&choices);
     let mut covered = FxHashSet::default();
-    for _ in 0..CLASSES * 2 {
+    // One constructor proposal per four proposals: argument coverage and
+    // unrestricted random exploration also receive a bounded share.
+    for _ in 0..CLASSES * 4 {
         let child = extractor
             .extract_reachable_indexed_generation(&base, 1, 1, &mut FxHashSet::default(), &mut rng)
             .pop()
@@ -947,5 +950,52 @@ fn dtype_transitions_are_not_starved_by_repeated_constructor_transitions() {
             covered |= extractor.indexed_node_id(choice) == &alternative;
         }
         assert!(covered, "dtype-changing transition starved for seed {seed}");
+    }
+}
+
+#[test]
+fn constructor_and_argument_coverage_do_not_starve_each_other() {
+    for rare_argument in [true, false] {
+        let (mut graph, roots) = independent_choices_fixture(129, 1);
+        let kind = ClassId::from("same-constructor-new-argument");
+        let node = NodeId::from("same-constructor-new-argument-node");
+        graph.enodes.insert(
+            node.clone(),
+            ("Tuned".into(), vec![ClassId::from("parameter-0")]),
+        );
+        graph.node_to_class.insert(node.clone(), kind.clone());
+        graph
+            .eclasses
+            .insert(kind.clone(), ("OpKind".into(), vec![node]));
+        for (index, root) in roots.iter().enumerate() {
+            if (index == roots.len() - 1) == rare_argument {
+                let alternative = graph.eclasses[root].1[0].clone();
+                graph.enodes.get_mut(&alternative).unwrap().1[0] = kind.clone();
+            }
+        }
+        let rare = roots.last().unwrap();
+        for seed in 0..32 {
+            let mut extractor = LlirExtractor::new(&graph, &[]);
+            let bindings = roots
+                .iter()
+                .map(|r| (r.to_string(), graph.eclasses[r].1[1].to_string()))
+                .collect::<Vec<_>>();
+            let parent = extractor.index_seed_choices(&bindings);
+            let mut rng = StdRng::seed_from_u64(seed);
+            let mut seen = FxHashSet::default();
+            let mut covered = false;
+            for _ in 0..4 {
+                let child = extractor
+                    .extract_reachable_indexed_generation(&parent, 1, 1, &mut seen, &mut rng)
+                    .pop()
+                    .unwrap();
+                let choice = extractor.indexed_selected(&child, extractor.class_to_index[rare]);
+                covered |= extractor.indexed_node_id(choice) == &graph.eclasses[rare].1[0];
+            }
+            assert!(
+                covered,
+                "rare_argument={rare_argument}, seed={seed}: one coverage queue starved the other"
+            );
+        }
     }
 }

--- a/src/egglog_utils/proposal_tests.rs
+++ b/src/egglog_utils/proposal_tests.rs
@@ -382,3 +382,126 @@ fn constructor_coverage_tests_direct_alternatives_with_large_mutation_limits() {
         }
     }
 }
+
+fn paired_arguments_fixture(width: usize, coupled: bool) -> SerializedEGraph {
+    let mut graph = choices_fixture(0);
+    graph.enodes.remove(&NodeId::from("op-0"));
+    graph.node_to_class.remove(&NodeId::from("op-0"));
+    let mut parameters = Vec::new();
+    for i in 0..width {
+        let class = ClassId::from(format!("knob-{i}"));
+        let node = NodeId::from(format!("knob-node-{i}"));
+        graph.enodes.insert(node.clone(), (i.to_string(), vec![]));
+        graph.node_to_class.insert(node.clone(), class.clone());
+        graph
+            .eclasses
+            .insert(class.clone(), ("i64".into(), vec![node]));
+        parameters.push(class);
+    }
+    let root = ClassId::from("root");
+    let mut alternatives = Vec::new();
+    for x in 0..width {
+        for y in 0..width {
+            if coupled && x != y {
+                continue;
+            }
+            let class = ClassId::from(format!("pair-kind-{x}-{y}"));
+            let kind = NodeId::from(format!("pair-kind-node-{x}-{y}"));
+            graph.enodes.insert(
+                kind.clone(),
+                (
+                    "Tunable".into(),
+                    vec![parameters[x].clone(), parameters[y].clone()],
+                ),
+            );
+            graph.node_to_class.insert(kind.clone(), class.clone());
+            graph
+                .eclasses
+                .insert(class.clone(), ("OpKind".into(), vec![kind]));
+            let node = NodeId::from(format!("pair-{x}-{y}"));
+            graph.enodes.insert(
+                node.clone(),
+                ("Op".into(), vec![class, ClassId::from("sources")]),
+            );
+            graph.node_to_class.insert(node.clone(), root.clone());
+            alternatives.push(node);
+        }
+    }
+    graph.eclasses.insert(root, ("IR".into(), alternatives));
+    graph
+}
+
+#[test]
+fn coverage_explores_each_constructor_argument_independently() {
+    let graph = paired_arguments_fixture(16, false);
+    let mut rng = StdRng::seed_from_u64(967);
+    let root = &graph.roots[0];
+    let mut choices = random_initial_choice(&graph, &mut rng);
+    choices.insert(root, &graph.eclasses[root].1[0]);
+    let mut extractor = LlirExtractor::new(&graph, &[]);
+    let base = extractor.index_choice_set(&choices);
+    let arguments = |node: &NodeId| {
+        let kind_class = &graph.enodes[node].1[0];
+        &graph.enodes[&graph.eclasses[kind_class].1[0]].1
+    };
+    let original = arguments(&graph.eclasses[root].1[0]);
+    let mut covered = FxHashSet::default();
+    for proposal in 0..4 {
+        let child = extractor
+            .extract_reachable_indexed_generation(&base, 1, 8, &mut FxHashSet::default(), &mut rng)
+            .pop()
+            .unwrap();
+        if proposal % 2 == 0 {
+            let node =
+                extractor.indexed_node_id(extractor.indexed_selected(&child, extractor.root_index));
+            let changed: Vec<_> = arguments(node)
+                .iter()
+                .zip(original)
+                .enumerate()
+                .filter(|(_, (a, b))| a != b)
+                .map(|(i, _)| i)
+                .collect();
+            assert_eq!(
+                changed.len(),
+                1,
+                "tuning coverage must isolate one constructor argument"
+            );
+            covered.insert(changed[0]);
+        }
+    }
+    assert_eq!(
+        covered.len(),
+        2,
+        "every independently mutable argument gets a proposal"
+    );
+}
+
+#[test]
+fn argument_coverage_retains_coupled_tuning_choices() {
+    for coupled in [false, true] {
+        let graph = paired_arguments_fixture(16, coupled);
+        let mut rng = StdRng::seed_from_u64(971);
+        let root = &graph.roots[0];
+        let mut choices = random_initial_choice(&graph, &mut rng);
+        choices.insert(root, &graph.eclasses[root].1[0]);
+        let mut extractor = LlirExtractor::new(&graph, &[]);
+        let base = extractor.index_choice_set(&choices);
+        assert!(
+            (0..8192).any(|_| {
+                let child = extractor
+                    .extract_reachable_indexed_generation(
+                        &base,
+                        1,
+                        1,
+                        &mut FxHashSet::default(),
+                        &mut rng,
+                    )
+                    .pop()
+                    .unwrap();
+                extractor.indexed_node_id(extractor.indexed_selected(&child, extractor.root_index))
+                    == &NodeId::from("pair-15-15")
+            }),
+            "valid coupled choices remain reachable, including when no single-argument neighbor exists"
+        );
+    }
+}

--- a/src/egglog_utils/proposal_tests.rs
+++ b/src/egglog_utils/proposal_tests.rs
@@ -109,6 +109,41 @@ fn reachable_mutation_balances_families_and_preserves_every_variant() {
     }
 }
 
+#[test]
+fn saved_incumbent_can_mutate_into_new_searchable_classes() {
+    let old = choices_fixture(0);
+    let mut rng = StdRng::seed_from_u64(937);
+    let old_extractor = LlirExtractor::new(&old, &[]);
+    let bindings = old_extractor.named_choices(&old_extractor.random_indexed_choice(&mut rng));
+    let expanded = choices_fixture(16);
+    let mut extractor = LlirExtractor::new(&expanded, &[]);
+    let seed = extractor.index_seed_choices(&bindings);
+    let completed = extractor.named_choices(&seed);
+    assert!(bindings.iter().all(|binding| completed.contains(binding)));
+    assert_eq!(seed.hash, extractor.index_named_choices(&completed).hash);
+    let mut reached = FxHashSet::default();
+    for _ in 0..1024 {
+        for child in extractor.extract_reachable_indexed_generation(
+            &seed,
+            1,
+            2,
+            &mut FxHashSet::default(),
+            &mut rng,
+        ) {
+            let selected = extractor.indexed_selected(&child, extractor.root_index);
+            reached.insert(extractor.indexed_node_id(selected).clone());
+            extractor.reachable_mutation_classes(&child);
+            let named = extractor.named_choices(&child);
+            assert_eq!(child.hash, extractor.index_named_choices(&named).hash);
+        }
+    }
+    assert_eq!(
+        reached.len(),
+        17,
+        "every added implementation stays searchable"
+    );
+}
+
 // A direct implementation hides the input of an equivalent wrapped form.
 // Switching to the wrapper must initialize its newly activated input in the
 // same proposal, without first retaining a worse intermediate parent.

--- a/src/egglog_utils/proposal_tests.rs
+++ b/src/egglog_utils/proposal_tests.rs
@@ -846,3 +846,54 @@ fn saved_schedule_constructor_transition_diagnostic() {
     )
     .unwrap();
 }
+
+#[test]
+fn coverage_separates_changed_inputs_from_tunings_of_the_same_constructor() {
+    let mut graph = choices_fixture(70);
+    // Every alternative uses the same operation constructor. One reads a
+    // different existing input, as with an absorbed cast or a fused operand.
+    for i in 0..=70 {
+        graph
+            .enodes
+            .get_mut(&NodeId::from(format!("kind-node-{i}")))
+            .unwrap()
+            .0 = "SameOp".into();
+    }
+    let source = ClassId::from("source");
+    let source_node = NodeId::from("source-value");
+    graph
+        .enodes
+        .insert(source_node.clone(), ("Leaf".into(), vec![]));
+    graph
+        .node_to_class
+        .insert(source_node.clone(), source.clone());
+    graph
+        .eclasses
+        .insert(source.clone(), ("IR".into(), vec![source_node]));
+    let inputs = ClassId::from("different-inputs");
+    let list = NodeId::from("different-inputs-node");
+    graph.enodes.insert(
+        list.clone(),
+        ("ICons".into(), vec![source, ClassId::from("sources")]),
+    );
+    graph.node_to_class.insert(list.clone(), inputs.clone());
+    graph
+        .eclasses
+        .insert(inputs.clone(), ("IList".into(), vec![list]));
+    graph.enodes.get_mut(&NodeId::from("op-70")).unwrap().1[1] = inputs;
+    for seed in 0..32 {
+        let mut extractor = LlirExtractor::new(&graph, &[]);
+        let base = extractor.index_seed_choices(&[("root".into(), "op-0".into())]);
+        let mut rng = StdRng::seed_from_u64(seed);
+        let child = extractor
+            .extract_reachable_indexed_generation(&base, 1, 1, &mut FxHashSet::default(), &mut rng)
+            .pop()
+            .unwrap();
+        let selected = extractor.indexed_selected(&child, extractor.root_index);
+        assert_eq!(
+            extractor.indexed_node_id(selected),
+            &NodeId::from("op-70"),
+            "seed {seed}: input-changing implementation must receive systematic coverage"
+        );
+    }
+}

--- a/src/egglog_utils/proposal_tests.rs
+++ b/src/egglog_utils/proposal_tests.rs
@@ -505,3 +505,33 @@ fn argument_coverage_retains_coupled_tuning_choices() {
         );
     }
 }
+
+#[test]
+fn argument_coverage_proposes_required_companion_changes() {
+    let graph = paired_arguments_fixture(3, true);
+    let root = &graph.roots[0];
+    let mut rng = StdRng::seed_from_u64(977);
+    let mut choices = random_initial_choice(&graph, &mut rng);
+    choices.insert(root, &graph.eclasses[root].1[0]);
+    let mut extractor = LlirExtractor::new(&graph, &[]);
+    let base = extractor.index_choice_set(&choices);
+    let pools = extractor.argument_pools(&base, extractor.root_index);
+    assert_eq!(
+        pools.len(),
+        2,
+        "both coupled arguments need direct coverage"
+    );
+    for pool in pools.values() {
+        let nodes = extractor.indexed_classes[extractor.root_index as usize].nodes;
+        let selected: FxHashSet<_> = pool
+            .iter()
+            .map(|&slot| nodes[slot as usize].clone())
+            .collect();
+        assert_eq!(
+            selected,
+            [NodeId::from("pair-1-1"), NodeId::from("pair-2-2")]
+                .into_iter()
+                .collect()
+        );
+    }
+}

--- a/src/egglog_utils/proposal_tests.rs
+++ b/src/egglog_utils/proposal_tests.rs
@@ -51,10 +51,14 @@ fn choices_fixture(variants: usize) -> SerializedEGraph {
     graph
 }
 
-fn check_distribution(counts: &FxHashMap<NodeId, usize>, variants: usize) {
+fn check_distribution(
+    counts: &FxHashMap<NodeId, usize>,
+    variants: usize,
+    range: std::ops::Range<usize>,
+) {
     let untuned = counts[&NodeId::from("op-0")];
     assert!(
-        (1800..2300).contains(&untuned),
+        range.contains(&untuned),
         "untuned proposals: {untuned}/4096"
     );
     // Balancing must not remove any of the tuning configurations.
@@ -71,7 +75,7 @@ fn initial_proposals_balance_families_independent_of_tuning_cardinality() {
             let choices = random_initial_choice(&graph, &mut rng);
             *counts.entry(choices[&graph.roots[0]].clone()).or_default() += 1;
         }
-        check_distribution(&counts, variants);
+        check_distribution(&counts, variants, 1800..2300);
     }
 }
 
@@ -99,7 +103,9 @@ fn reachable_mutation_balances_families_and_preserves_every_variant() {
                 .entry(extractor.indexed_node_id(selected).clone())
                 .or_default() += 1;
         }
-        check_distribution(&counts, variants);
+        // Coverage proposes the alternate family; the random half still
+        // selects both families equally, independently of variant cardinality.
+        check_distribution(&counts, variants, 850..1200);
     }
 }
 
@@ -233,4 +239,146 @@ fn check_activated_input_mutation(already_active: bool) {
         base.choices[extractor.class_to_index[&hidden] as usize], 0,
         "parent is immutable"
     );
+}
+
+fn independent_choices_fixture(
+    classes: usize,
+    variants: usize,
+) -> (SerializedEGraph, Vec<ClassId>) {
+    let mut graph = choices_fixture(variants);
+    let template = graph.eclasses[&ClassId::from("root")].1.clone();
+    let mut roots = Vec::new();
+    for i in 0..classes {
+        let class = ClassId::from(format!("value-class-{i}"));
+        let nodes: Vec<_> = template
+            .iter()
+            .enumerate()
+            .map(|(j, node)| {
+                let id = NodeId::from(format!("value-{i}-variant-{j}"));
+                graph.enodes.insert(id.clone(), graph.enodes[node].clone());
+                graph.node_to_class.insert(id.clone(), class.clone());
+                id
+            })
+            .collect();
+        graph.eclasses.insert(class.clone(), ("IR".into(), nodes));
+        roots.push(class);
+    }
+    let join = ClassId::from("joined-values");
+    let node = NodeId::from("joined-values-node");
+    graph
+        .enodes
+        .insert(node.clone(), ("OutputJoin".into(), roots.clone()));
+    graph.node_to_class.insert(node.clone(), join.clone());
+    graph
+        .eclasses
+        .insert(join.clone(), ("IR".into(), vec![node]));
+    graph.roots = vec![join];
+    (graph, roots)
+}
+
+#[test]
+fn mutation_covers_each_active_constructor_within_bounded_proposals() {
+    const CLASSES: usize = 48;
+    let (graph, roots) = independent_choices_fixture(CLASSES, 70);
+    let mut rng = StdRng::seed_from_u64(937);
+    let mut choices = random_initial_choice(&graph, &mut rng);
+    for root in &roots {
+        let (class, (_, nodes)) = graph.eclasses.get_key_value(root).unwrap();
+        choices.insert(class, &nodes[1]);
+    }
+    let mut extractor = LlirExtractor::new(&graph, &[]);
+    let base = extractor.index_choice_set(&choices);
+    let mut covered = FxHashSet::default();
+    for _ in 0..CLASSES * 2 {
+        let child = extractor
+            .extract_reachable_indexed_generation(&base, 1, 1, &mut FxHashSet::default(), &mut rng)
+            .pop()
+            .unwrap();
+        for root in &roots {
+            let selected = extractor.indexed_selected(&child, extractor.class_to_index[root]);
+            if extractor.indexed_node_id(selected) == &graph.eclasses[root].1[0] {
+                covered.insert(root);
+            }
+        }
+    }
+    assert_eq!(
+        covered.len(),
+        CLASSES,
+        "every active value must be offered its alternate constructor within one coverage cycle"
+    );
+}
+
+#[test]
+fn coverage_preserves_nonadjacent_joint_mutations() {
+    let (graph, roots) = independent_choices_fixture(4, 1);
+    let mut rng = StdRng::seed_from_u64(947);
+    let mut choices = random_initial_choice(&graph, &mut rng);
+    for root in &roots {
+        let (class, (_, nodes)) = graph.eclasses.get_key_value(root).unwrap();
+        choices.insert(class, &nodes[1]);
+    }
+    let mut extractor = LlirExtractor::new(&graph, &[]);
+    let base = extractor.index_choice_set(&choices);
+    let mut classes: Vec<_> = roots
+        .iter()
+        .map(|root| extractor.class_to_index[root])
+        .collect();
+    classes.sort_unstable();
+    let targets = [classes[0], classes[2]];
+    assert!(
+        (0..1024).any(|_| {
+            let child = extractor
+                .extract_reachable_indexed_generation(
+                    &base,
+                    1,
+                    2,
+                    &mut FxHashSet::default(),
+                    &mut rng,
+                )
+                .pop()
+                .unwrap();
+            targets.iter().all(|&class| {
+                let selected = extractor.indexed_selected(&child, class);
+                let root = roots
+                    .iter()
+                    .find(|root| extractor.class_to_index[*root] == class)
+                    .unwrap();
+                extractor.indexed_node_id(selected) == &graph.eclasses[root].1[0]
+            })
+        }),
+        "coverage must retain random proposals that jointly mutate nonadjacent active values"
+    );
+}
+
+#[test]
+fn constructor_coverage_tests_direct_alternatives_with_large_mutation_limits() {
+    let (graph, roots) = independent_choices_fixture(8, 1);
+    let mut rng = StdRng::seed_from_u64(953);
+    let mut choices = random_initial_choice(&graph, &mut rng);
+    for root in &roots {
+        let (class, (_, nodes)) = graph.eclasses.get_key_value(root).unwrap();
+        choices.insert(class, &nodes[1]);
+    }
+    let mut extractor = LlirExtractor::new(&graph, &[]);
+    let base = extractor.index_choice_set(&choices);
+    for proposal in 0..32 {
+        let child = extractor
+            .extract_reachable_indexed_generation(&base, 1, 8, &mut FxHashSet::default(), &mut rng)
+            .pop()
+            .unwrap();
+        if proposal % 2 == 0 {
+            let changed = roots
+                .iter()
+                .filter(|root| {
+                    let class = extractor.class_to_index[*root];
+                    extractor.indexed_selected(&child, class)
+                        != extractor.indexed_selected(&base, class)
+                })
+                .count();
+            assert_eq!(
+                changed, 1,
+                "coverage must evaluate a direct alternative without unrelated active-site mutations"
+            );
+        }
+    }
 }

--- a/src/egglog_utils/proposal_tests.rs
+++ b/src/egglog_utils/proposal_tests.rs
@@ -452,9 +452,9 @@ fn mutation_covers_each_active_constructor_within_bounded_proposals() {
     let mut extractor = LlirExtractor::new(&graph, &[]);
     let base = extractor.index_choice_set(&choices);
     let mut covered = FxHashSet::default();
-    // One constructor proposal per four proposals: argument coverage and
-    // unrestricted random exploration also receive a bounded share.
-    for _ in 0..CLASSES * 4 {
+    // One constructor proposal per six proposals: incumbent/local argument
+    // coverage and random exploration also receive a bounded share.
+    for _ in 0..CLASSES * 6 {
         let child = extractor
             .extract_reachable_indexed_generation(&base, 1, 1, &mut FxHashSet::default(), &mut rng)
             .pop()
@@ -702,7 +702,7 @@ fn argument_coverage_proposes_required_companion_changes() {
 }
 
 #[test]
-fn constructor_coverage_preserves_existing_arguments_without_pruning_variants() {
+fn constructor_coverage_does_not_align_unrelated_argument_positions() {
     let mut graph = paired_arguments_fixture(4, false);
     let root = graph.roots[0].clone();
     let before = NodeId::from("pair-2-3");
@@ -738,6 +738,7 @@ fn constructor_coverage_preserves_existing_arguments_without_pruning_variants() 
     let base = extractor.index_choice_set(&choices);
     let mut reached = FxHashSet::default();
     let mut covered_extra = FxHashSet::default();
+    let mut covered_prefix = FxHashSet::default();
     for proposal in 0..4096 {
         let child = extractor
             .extract_reachable_indexed_generation(&base, 1, 1, &mut FxHashSet::default(), &mut rng)
@@ -748,13 +749,15 @@ fn constructor_coverage_preserves_existing_arguments_without_pruning_variants() 
         reached.insert(node.clone());
         let (_, term) = comparable_constructor_terms(&graph, &before, node).unwrap();
         if proposal % 2 == 0 && term.0 == "Extended" {
-            assert_eq!(
-                term.1[..2],
-                [ClassId::from("knob-2"), ClassId::from("knob-3")]
-            );
+            covered_prefix.insert(term.1[..2].to_vec());
             covered_extra.insert(term.1[2].clone());
         }
     }
+    assert_eq!(
+        covered_prefix.len(),
+        16,
+        "unrelated positional values must not bias the new constructor"
+    );
     assert_eq!(
         covered_extra.len(),
         4,
@@ -998,4 +1001,32 @@ fn constructor_and_argument_coverage_do_not_starve_each_other() {
             );
         }
     }
+}
+
+#[test]
+fn losing_constructor_proposals_still_receive_tuning_neighbors() {
+    let graph = choices_fixture(16);
+    let mut extractor = LlirExtractor::new(&graph, &[]);
+    let base = extractor.index_seed_choices(&[("root".into(), "op-0".into())]);
+    let active = extractor.reachable_mutation_classes(&base);
+    let mut rng = StdRng::seed_from_u64(991);
+    let first = extractor
+        .next_covered_choice(&base, &active, &mut rng)
+        .unwrap();
+    assert_ne!(first.1, base.choices[first.0 as usize]);
+    assert!(!extractor.covered_alternatives[2].is_empty());
+    extractor.cover_queue = 2;
+    let next = extractor
+        .next_covered_choice(&base, &active, &mut rng)
+        .unwrap();
+    assert_eq!(first.0, next.0);
+    assert_ne!(
+        first.1, next.1,
+        "explore another tuning even though the base retained the old family"
+    );
+    let nodes = extractor.indexed_classes[first.0 as usize].nodes;
+    assert_eq!(
+        proposal_family_key(&graph, &nodes[first.1 as usize]),
+        proposal_family_key(&graph, &nodes[next.1 as usize])
+    );
 }

--- a/src/egglog_utils/proposal_tests.rs
+++ b/src/egglog_utils/proposal_tests.rs
@@ -102,3 +102,98 @@ fn reachable_mutation_balances_families_and_preserves_every_variant() {
         check_distribution(&counts, variants);
     }
 }
+
+// A direct implementation hides the input of an equivalent wrapped form.
+// Switching to the wrapper must permit later mutations in this same child
+// to tune the newly activated input, without first retaining a worse parent.
+fn activated_input_fixture() -> SerializedEGraph {
+    let mut graph = SerializedEGraph {
+        enodes: FxHashMap::default(),
+        eclasses: FxHashMap::default(),
+        node_to_class: FxHashMap::default(),
+        roots: vec![ClassId::from("root")],
+    };
+    let mut add = |class: &str, sort: &str, nodes: &[(&str, &str, &[&str])]| {
+        let class = ClassId::from(class);
+        let mut ids = Vec::new();
+        for &(id, head, children) in nodes {
+            let id = NodeId::from(id);
+            graph.enodes.insert(
+                id.clone(),
+                (
+                    head.into(),
+                    children.iter().map(|&c| ClassId::from(c)).collect(),
+                ),
+            );
+            graph.node_to_class.insert(id.clone(), class.clone());
+            ids.push(id);
+        }
+        graph.eclasses.insert(class, (sort.into(), ids));
+    };
+    add("nil", "IList", &[("nil-node", "INil", &[])]);
+    add(
+        "inputs",
+        "IList",
+        &[("inputs-node", "ICons", &["hidden", "nil"])],
+    );
+    for name in ["Direct", "Wrapped", "Slow", "Fast"] {
+        add(name, "OpKind", &[(name, name, &[])]);
+    }
+    add(
+        "hidden",
+        "IR",
+        &[
+            ("slow", "Op", &["Slow", "nil"]),
+            ("fast", "Op", &["Fast", "nil"]),
+        ],
+    );
+    add(
+        "root",
+        "IR",
+        &[
+            ("direct", "Op", &["Direct", "nil"]),
+            ("wrapped", "Op", &["Wrapped", "inputs"]),
+        ],
+    );
+    graph
+}
+
+#[test]
+fn mutation_can_tune_an_input_activated_by_an_earlier_mutation() {
+    let graph = activated_input_fixture();
+    let root = ClassId::from("root");
+    let hidden = ClassId::from("hidden");
+    let mut rng = StdRng::seed_from_u64(1827);
+    let mut choices = random_initial_choice(&graph, &mut rng);
+    choices.insert(&graph.roots[0], &graph.eclasses[&root].1[0]);
+    choices.insert(
+        graph.eclasses.get_key_value(&hidden).unwrap().0,
+        &graph.eclasses[&hidden].1[0],
+    );
+    let mut extractor = LlirExtractor::new(&graph, &[]);
+    let base = extractor.index_choice_set(&choices);
+    let mut composed = 0;
+    for _ in 0..1024 {
+        let children = extractor.extract_reachable_indexed_generation(
+            &base,
+            1,
+            8,
+            &mut FxHashSet::default(),
+            &mut rng,
+        );
+        assert_eq!(children.len(), 1);
+        let named = extractor.named_choices(&children[0]);
+        assert_eq!(extractor.index_named_choices(&named).hash, children[0].hash);
+        if named.contains(&("root".into(), "wrapped".into()))
+            && named.contains(&("hidden".into(), "fast".into()))
+        {
+            composed += 1;
+        }
+    }
+    assert!(
+        composed > 0,
+        "no child could tune an input exposed by its earlier mutation"
+    );
+    // Parents are immutable while children explore implementation changes.
+    assert_eq!(base.choices[extractor.class_to_index[&hidden] as usize], 0);
+}

--- a/src/egglog_utils/proposal_tests.rs
+++ b/src/egglog_utils/proposal_tests.rs
@@ -1,0 +1,104 @@
+use super::*;
+use rand::{SeedableRng, rngs::StdRng};
+
+// Two arbitrary implementations of a value: one untuned and one with many
+// configurations. This fixture has no backend, shape, or model policy.
+fn choices_fixture(variants: usize) -> SerializedEGraph {
+    let root = ClassId::from("root");
+    let mut graph = SerializedEGraph {
+        enodes: FxHashMap::default(),
+        eclasses: FxHashMap::default(),
+        node_to_class: FxHashMap::default(),
+        roots: vec![root.clone()],
+    };
+    let nil_class = ClassId::from("sources");
+    let nil = NodeId::from("nil");
+    graph.enodes.insert(nil.clone(), ("INil".into(), vec![]));
+    graph.node_to_class.insert(nil.clone(), nil_class.clone());
+    graph
+        .eclasses
+        .insert(nil_class.clone(), ("IList".into(), vec![nil]));
+    let mut alternatives = Vec::new();
+    for i in 0..=variants {
+        let parameter = ClassId::from(format!("parameter-{i}"));
+        let value = NodeId::from(format!("value-{i}"));
+        graph.enodes.insert(value.clone(), (i.to_string(), vec![]));
+        graph.node_to_class.insert(value.clone(), parameter.clone());
+        graph
+            .eclasses
+            .insert(parameter.clone(), ("i64".into(), vec![value]));
+        let kind = ClassId::from(format!("kind-{i}"));
+        let node = NodeId::from(format!("kind-node-{i}"));
+        graph.enodes.insert(
+            node.clone(),
+            (
+                if i == 0 { "Untuned" } else { "Tuned" }.into(),
+                vec![parameter],
+            ),
+        );
+        graph.node_to_class.insert(node.clone(), kind.clone());
+        graph
+            .eclasses
+            .insert(kind.clone(), ("OpKind".into(), vec![node]));
+        let op = NodeId::from(format!("op-{i}"));
+        graph
+            .enodes
+            .insert(op.clone(), ("Op".into(), vec![kind, nil_class.clone()]));
+        graph.node_to_class.insert(op.clone(), root.clone());
+        alternatives.push(op);
+    }
+    graph.eclasses.insert(root, ("IR".into(), alternatives));
+    graph
+}
+
+fn check_distribution(counts: &FxHashMap<NodeId, usize>, variants: usize) {
+    let untuned = counts[&NodeId::from("op-0")];
+    assert!(
+        (1800..2300).contains(&untuned),
+        "untuned proposals: {untuned}/4096"
+    );
+    // Balancing must not remove any of the tuning configurations.
+    assert_eq!(counts.len(), variants + 1);
+}
+
+#[test]
+fn initial_proposals_balance_families_independent_of_tuning_cardinality() {
+    for variants in [1, 70] {
+        let graph = choices_fixture(variants);
+        let mut rng = StdRng::seed_from_u64(937);
+        let mut counts = FxHashMap::default();
+        for _ in 0..4096 {
+            let choices = random_initial_choice(&graph, &mut rng);
+            *counts.entry(choices[&graph.roots[0]].clone()).or_default() += 1;
+        }
+        check_distribution(&counts, variants);
+    }
+}
+
+#[test]
+fn reachable_mutation_balances_families_and_preserves_every_variant() {
+    for variants in [1, 70] {
+        let graph = choices_fixture(variants);
+        let mut rng = StdRng::seed_from_u64(937);
+        let mut choices = random_initial_choice(&graph, &mut rng);
+        choices.insert(&graph.roots[0], &graph.eclasses[&graph.roots[0]].1[0]);
+        let mut extractor = LlirExtractor::new(&graph, &[]);
+        let base = extractor.index_choice_set(&choices);
+        let mut counts = FxHashMap::default();
+        for _ in 0..4096 {
+            let children = extractor.extract_reachable_indexed_generation(
+                &base,
+                1,
+                1,
+                &mut FxHashSet::default(),
+                &mut rng,
+            );
+            assert_eq!(children.len(), 1);
+            let selected = extractor.indexed_selected(&children[0], extractor.root_index);
+            *counts
+                .entry(extractor.indexed_node_id(selected).clone())
+                .or_default() += 1;
+        }
+        check_distribution(&counts, variants);
+    }
+}

--- a/src/egglog_utils/proposal_tests.rs
+++ b/src/egglog_utils/proposal_tests.rs
@@ -312,6 +312,89 @@ fn independent_choices_fixture(
 }
 
 #[test]
+fn recombination_combines_independent_parent_improvements() {
+    let (graph, roots) = independent_choices_fixture(3, 1);
+    let mut extractor = LlirExtractor::new(&graph, &[]);
+    let parent = |variants: [usize; 3]| {
+        roots
+            .iter()
+            .zip(variants)
+            .map(|(class, variant)| {
+                (
+                    class.to_string(),
+                    graph.eclasses[class].1[variant].to_string(),
+                )
+            })
+            .collect::<Vec<_>>()
+    };
+    let receiver = extractor.index_seed_choices(&parent([0, 1, 1]));
+    let donor = extractor.index_seed_choices(&parent([1, 0, 1]));
+    let target = extractor.index_seed_choices(&parent([0, 0, 1]));
+    let mut seen = FxHashSet::from_iter([receiver.hash, donor.hash]);
+    let children = extractor.recombine_reachable_choices(&receiver, &donor, &mut seen);
+    assert!(children.iter().any(|child| child.hash == target.hash));
+    for child in &children {
+        assert_eq!(
+            extractor
+                .index_named_choices(&extractor.named_choices(child))
+                .hash,
+            child.hash
+        );
+        let c = extractor.class_to_index[&roots[2]];
+        assert_eq!(child.choices[c as usize], receiver.choices[c as usize]);
+    }
+    assert!(
+        extractor
+            .recombine_reachable_choices(&receiver, &donor, &mut seen)
+            .is_empty()
+    );
+    assert_eq!(
+        receiver.hash,
+        extractor.index_seed_choices(&parent([0, 1, 1])).hash
+    );
+}
+
+#[test]
+fn recombination_inherits_new_dependencies_but_preserves_shared_active_choices() {
+    for shared in [false, true] {
+        let mut graph = activated_input_fixture();
+        if shared {
+            let class = ClassId::from("join");
+            let node = NodeId::from("join-node");
+            graph.enodes.insert(
+                node.clone(),
+                (
+                    "OutputJoin".into(),
+                    vec![ClassId::from("root"), ClassId::from("hidden")],
+                ),
+            );
+            graph.node_to_class.insert(node.clone(), class.clone());
+            graph
+                .eclasses
+                .insert(class.clone(), ("IR".into(), vec![node]));
+            graph.roots = vec![class];
+        }
+        let mut extractor = LlirExtractor::new(&graph, &[]);
+        let receiver = extractor.index_seed_choices(&[
+            ("root".into(), "direct".into()),
+            ("hidden".into(), "slow".into()),
+        ]);
+        let donor = extractor.index_seed_choices(&[
+            ("root".into(), "wrapped".into()),
+            ("hidden".into(), "fast".into()),
+        ]);
+        let children =
+            extractor.recombine_reachable_choices(&receiver, &donor, &mut FxHashSet::default());
+        let choices = children
+            .iter()
+            .map(|child| extractor.named_choices(child))
+            .find(|choices| choices.contains(&("root".into(), "wrapped".into())))
+            .unwrap();
+        assert!(choices.contains(&("hidden".into(), if shared { "slow" } else { "fast" }.into())));
+    }
+}
+
+#[test]
 fn constructor_coverage_is_not_diluted_by_repeated_operation_sites() {
     let (mut graph, roots) = independent_choices_fixture(129, 70);
     let rare = roots.last().unwrap();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -159,6 +159,9 @@ impl DimBucket {
 /// ```
 #[derive(Debug, Clone)]
 pub struct CompileOptions {
+    /// Optional previously selected schedule to revalidate and remeasure as the
+    /// first candidate. Incompatible buckets fall back to ordinary search.
+    pub seed_schedule: Option<std::sync::Arc<SelectedSchedule>>,
     /// Maximum number of graphs to evaluate during search.
     pub limit: usize,
     /// Maximum wall-clock time to spend searching.
@@ -226,6 +229,12 @@ fn checked_dim(dimension: impl Into<Symbol>) -> Symbol {
 }
 
 impl CompileOptions {
+    /// Start search from a compatible prior program without reusing its timing.
+    pub fn seed_schedule(mut self, schedule: std::sync::Arc<SelectedSchedule>) -> Self {
+        self.seed_schedule = Some(schedule);
+        self
+    }
+
     /// Set the maximum number of graphs to evaluate during search.
     pub fn search_graph_limit(mut self, limit: usize) -> Self {
         self.limit = limit;
@@ -355,6 +364,7 @@ impl CompileOptions {
 impl Default for CompileOptions {
     fn default() -> Self {
         Self {
+            seed_schedule: None,
             limit: 100,
             search_time_limit: std::time::Duration::MAX,
             generation_size: 10,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -168,7 +168,8 @@ pub struct CompileOptions {
     pub search_time_limit: std::time::Duration,
     /// Number of offspring per generation (default: 10)
     pub generation_size: usize,
-    /// Number of mutations applied to each offspring (default: 10)
+    /// Maximum active-choice mutations per offspring (default: 10). Newly
+    /// exposed subgraphs are initialized within the same structural proposal.
     pub mutations: usize,
     /// Number of profiling trials per candidate (default: 3)
     pub trials: usize,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,5 +1,5 @@
 use crate::egglog_utils::{
-    hlir_to_egglog, log_channel_enabled, run_egglog_with_late_passes_interval_analysis_and_log,
+    OpTextParts, hlir_to_egglog, log_channel_enabled, run_egglog_with_report_parts_impl,
 };
 pub use crate::search::unroll::{collapse_loops_to_first_iter, unroll_loops_in_llir};
 use crate::search::{BucketSearchSpace, SearchSpace, bucket_index_combinations};
@@ -21,6 +21,7 @@ use std::{
 use tracing;
 
 mod artifact;
+mod parallel;
 
 pub use artifact::{ScheduleBucket, SelectedSchedule};
 
@@ -1601,30 +1602,43 @@ impl Graph {
         let extra_egglog = Rt::extra_egglog();
 
         let (program, root) = hlir_to_egglog(self);
-        let buckets = bucket_index_combinations(&dim_buckets)
+        // Materialize op-owned text before crossing thread boundaries: backend
+        // op trait objects need not be Send/Sync. Each bucket owns its EGraph.
+        let mut parts = OpTextParts::new_with_late_passes(&ops, Rt::CLEANUP_HLIR, &late_passes);
+        parts.extra_egglog = extra_egglog;
+        let jobs: Vec<_> = bucket_index_combinations(&dim_buckets)
             .into_iter()
             .map(|bucket_indices| {
                 let intervals = self.bucket_intervals(&dim_buckets, &bucket_indices);
                 let (contextual_program, use_interval_analysis) =
                     self.egglog_program_with_interval_facts(&program, &intervals);
-                let egraph = run_egglog_with_late_passes_interval_analysis_and_log(
-                    &contextual_program,
-                    &root,
-                    &ops,
-                    Rt::CLEANUP_HLIR,
-                    &late_passes,
-                    &extra_egglog,
+                (
+                    bucket_indices,
+                    intervals,
+                    contextual_program,
                     use_interval_analysis,
-                    options.egglog_log_enabled(),
+                )
+            })
+            .collect();
+        let log = options.egglog_log_enabled();
+        let buckets = parallel::map_buckets(
+            &jobs,
+            |(bucket_indices, intervals, contextual_program, use_interval_analysis)| {
+                let (egraph, _) = run_egglog_with_report_parts_impl(
+                    contextual_program,
+                    &root,
+                    &parts,
+                    *use_interval_analysis,
+                    log,
                 )
                 .unwrap();
                 BucketSearchSpace {
                     egraph,
-                    bucket_indices,
-                    intervals,
+                    bucket_indices: bucket_indices.clone(),
+                    intervals: intervals.clone(),
                 }
-            })
-            .collect();
+            },
+        );
         let custom_ops = self.custom_ops.iter().map(|op| op.to_llir_op()).collect();
         self.search_space = Some(SearchSpace {
             buckets,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -164,6 +164,10 @@ pub struct CompileOptions {
     pub seed_schedule: Option<std::sync::Arc<SelectedSchedule>>,
     /// Maximum number of graphs to evaluate during search.
     pub limit: usize,
+    /// Candidate-budget overrides by zero-based SearchSpace bucket index.
+    /// Unspecified buckets use `limit`; every bucket still needs a viable,
+    /// freshly measured candidate, including when seeded from a prior schedule.
+    pub bucket_limits: FxHashMap<usize, usize>,
     /// Maximum wall-clock time to spend searching.
     pub search_time_limit: std::time::Duration,
     /// Number of offspring per generation (default: 10)
@@ -239,6 +243,13 @@ impl CompileOptions {
     /// Set the maximum number of graphs to evaluate during search.
     pub fn search_graph_limit(mut self, limit: usize) -> Self {
         self.limit = limit;
+        self
+    }
+
+    /// Override the candidate budget for one SearchSpace bucket. With a viable
+    /// seed, a limit of one revalidates and remeasures only that incumbent.
+    pub fn bucket_search_graph_limit(mut self, bucket: usize, limit: usize) -> Self {
+        self.bucket_limits.insert(bucket, limit);
         self
     }
 
@@ -367,6 +378,7 @@ impl Default for CompileOptions {
         Self {
             seed_schedule: None,
             limit: 100,
+            bucket_limits: FxHashMap::default(),
             search_time_limit: std::time::Duration::MAX,
             generation_size: 10,
             mutations: 10,

--- a/src/graph/artifact.rs
+++ b/src/graph/artifact.rs
@@ -14,7 +14,7 @@ use rustc_hash::FxHashMap;
 use super::{DimBucket, Graph, LLIRGraph};
 use crate::{
     dtype::DType,
-    egglog_utils::{LlirExtractor, SerializedEGraph},
+    egglog_utils::{ClassId, LlirExtractor, NodeId, SerializedEGraph},
     hlir::HLIROps,
     op::{IntoEgglogOp, Runtime},
     search::{SearchSpace, SelectedProgram, unroll_packed_llir},
@@ -88,8 +88,100 @@ pub struct SelectedSchedule {
     buckets: Vec<ScheduleBucket>,
 }
 
+// E-graph IDs are local to a saturation run. Recover their correspondence by
+// congruence (sort, constructor, ordered child classes), never by op preference.
+// Conservatively reject changed/ambiguous class structure; the extracted LLIR
+// fingerprint below also guards changes to lowering implementations.
+fn remap_choices(
+    source: &SerializedEGraph,
+    target: &SerializedEGraph,
+    choices: &[(String, String)],
+) -> Option<Vec<(String, String)>> {
+    let mut target_nodes = FxHashMap::default();
+    for (node, (op, children)) in &target.enodes {
+        let class = target.node_to_class.get(node)?;
+        let key = (
+            target.eclasses.get(class)?.0.clone(),
+            op.clone(),
+            children.clone(),
+        );
+        if let Some((previous, _)) = target_nodes.insert(key, (class, node))
+            && previous != class
+        {
+            return None;
+        }
+    }
+    let mut classes: FxHashMap<ClassId, ClassId> = FxHashMap::default();
+    let mut pending: Vec<_> = source
+        .enodes
+        .iter()
+        .map(|(node, (op, children))| (node, (op, children)))
+        .collect();
+    loop {
+        let before = classes.len();
+        let mut unresolved = Vec::new();
+        for (node, (op, children)) in pending {
+            let Some(children) = children
+                .iter()
+                .map(|c| classes.get(c).cloned())
+                .collect::<Option<Vec<_>>>()
+            else {
+                unresolved.push((node, (op, children)));
+                continue;
+            };
+            let class = source.node_to_class.get(node)?;
+            let key = (source.eclasses.get(class)?.0.clone(), op.clone(), children);
+            if let Some((target_class, _)) = target_nodes.get(&key)
+                && let Some(previous) = classes.insert(class.clone(), (*target_class).clone())
+                && previous != **target_class
+            {
+                return None;
+            }
+        }
+        pending = unresolved;
+        if classes.len() == before {
+            break;
+        }
+    }
+    // A complete bijection avoids importing incomplete genomes when a rewrite
+    // changes the search-space structure. New choices may still exist in the
+    // corresponding classes and remain available to ordinary mutation.
+    let mapped: rustc_hash::FxHashSet<_> = classes.values().collect();
+    if classes.len() != source.eclasses.len()
+        || mapped.len() != target.eclasses.len()
+        || classes.len() != mapped.len()
+        || source
+            .roots
+            .iter()
+            .map(|r| classes.get(r))
+            .collect::<Option<Vec<_>>>()?
+            != target.roots.iter().collect::<Vec<_>>()
+    {
+        return None;
+    }
+    choices
+        .iter()
+        .map(|(class, node)| {
+            let class = ClassId::from(class.as_str());
+            let node = NodeId::from(node.as_str());
+            if source.node_to_class.get(&node)? != &class {
+                return None;
+            }
+            let (op, children) = source.enodes.get(&node)?;
+            let children = children
+                .iter()
+                .map(|c| classes.get(c).cloned())
+                .collect::<Option<Vec<_>>>()?;
+            let key = (source.eclasses.get(&class)?.0.clone(), op.clone(), children);
+            let (target_class, target_node) = target_nodes.get(&key)?;
+            (classes.get(&class)? == *target_class)
+                .then(|| (target_class.to_string(), target_node.to_string()))
+        })
+        .collect()
+}
+
 impl SelectedSchedule {
-    /// Recover an incumbent only for the identical saturated search space.
+    /// Recover an incumbent across equivalent saturated spaces, including ID renumbering.
     /// The caller must revalidate and remeasure it under the current workload.
     pub(crate) fn seed_for_bucket(
         &self,
@@ -98,11 +190,17 @@ impl SelectedSchedule {
         if !ctx.space.custom_ops.is_empty() || self.dim_buckets != ctx.space.dim_buckets {
             return None;
         }
-        let bucket = self.buckets.iter().find(|bucket| {
-            bucket.bucket_indices == *ctx.bucket_indices() && bucket.egraph == *ctx.egraph()
-        })?;
+        let bucket = self
+            .buckets
+            .iter()
+            .find(|bucket| bucket.bucket_indices == *ctx.bucket_indices())?;
         let mut extractor = LlirExtractor::new(ctx.egraph(), &ctx.space.ops);
-        let genome = extractor.index_named_choices(&bucket.choices);
+        let choices = if bucket.egraph == *ctx.egraph() {
+            bucket.choices.clone()
+        } else {
+            remap_choices(&bucket.egraph, ctx.egraph(), &bucket.choices)?
+        };
+        let genome = extractor.index_named_choices(&choices);
         let llir = unroll_packed_llir(extractor.extract_indexed_packed(&genome, &[]));
         (fingerprint_llir(&llir) == bucket.unrolled_llir_fingerprint).then_some(genome)
     }
@@ -245,6 +343,88 @@ mod tests {
         };
         let schedule = SelectedSchedule::from_search(space, &[selected]).unwrap();
         (graph, schedule)
+    }
+
+    #[test]
+    fn search_seed_survives_egraph_renumbering_but_rejects_changed_structure() {
+        let (graph, mut schedule) = selected_schedule();
+        let bucket = &mut schedule.buckets[0];
+        let old = &bucket.egraph;
+        let classes: FxHashMap<_, _> = old
+            .eclasses
+            .keys()
+            .enumerate()
+            .map(|(i, c)| (c.clone(), ClassId::from(format!("renamed-class-{i}"))))
+            .collect();
+        let nodes: FxHashMap<_, _> = old
+            .enodes
+            .keys()
+            .enumerate()
+            .map(|(i, n)| (n.clone(), NodeId::from(format!("renamed-node-{i}"))))
+            .collect();
+        bucket.choices = bucket
+            .choices
+            .iter()
+            .map(|(c, n)| {
+                (
+                    classes[&ClassId::from(c.as_str())].to_string(),
+                    nodes[&NodeId::from(n.as_str())].to_string(),
+                )
+            })
+            .collect();
+        bucket.egraph = SerializedEGraph {
+            enodes: old
+                .enodes
+                .iter()
+                .map(|(n, (op, cs))| {
+                    (
+                        nodes[n].clone(),
+                        (op.clone(), cs.iter().map(|c| classes[c].clone()).collect()),
+                    )
+                })
+                .collect(),
+            eclasses: old
+                .eclasses
+                .iter()
+                .map(|(c, (sort, ns))| {
+                    (
+                        classes[c].clone(),
+                        (
+                            sort.clone(),
+                            ns.iter().rev().map(|n| nodes[n].clone()).collect(),
+                        ),
+                    )
+                })
+                .collect(),
+            node_to_class: old
+                .node_to_class
+                .iter()
+                .map(|(n, c)| (nodes[n].clone(), classes[c].clone()))
+                .collect(),
+            roots: old.roots.iter().map(|c| classes[c].clone()).collect(),
+        };
+        let contexts = graph
+            .search_space()
+            .unwrap()
+            .bucket_contexts(&graph.dyn_map);
+        assert_ne!(schedule.buckets[0].egraph, *contexts[0].egraph());
+        assert!(schedule.seed_for_bucket(&contexts[0]).is_some());
+        for change_sort in [false, true] {
+            let mut changed = schedule.clone();
+            let egraph = &mut changed.buckets[0].egraph;
+            if change_sort {
+                for (sort, _) in egraph.eclasses.values_mut() {
+                    *sort = format!("different-sort-{sort}");
+                }
+            } else {
+                for (op, children) in egraph.enodes.values_mut() {
+                    if children.is_empty() {
+                        *op = format!("different-leaf-{op}");
+                    }
+                }
+            }
+            assert!(changed.seed_for_bucket(&contexts[0]).is_none());
+        }
     }
 
     #[test]

--- a/src/graph/artifact.rs
+++ b/src/graph/artifact.rs
@@ -143,12 +143,11 @@ fn remap_choices(
             break;
         }
     }
-    // A complete bijection avoids importing incomplete genomes when a rewrite
-    // changes the search-space structure. New choices may still exist in the
-    // corresponding classes and remain available to ordinary mutation.
+    // Embed every old class injectively, while allowing new target classes
+    // introduced by additional alternatives. The old choices still define a
+    // complete incumbent; extraction below verifies its exact LLIR fingerprint.
     let mapped: rustc_hash::FxHashSet<_> = classes.values().collect();
     if classes.len() != source.eclasses.len()
-        || mapped.len() != target.eclasses.len()
         || classes.len() != mapped.len()
         || source
             .roots
@@ -425,6 +424,62 @@ mod tests {
             }
             assert!(changed.seed_for_bucket(&contexts[0]).is_none());
         }
+    }
+
+    #[test]
+    fn search_seed_survives_new_equivalent_alternatives_with_new_classes() {
+        let (mut graph, schedule) = selected_schedule();
+        let egraph = &mut graph.search_space.as_mut().unwrap().buckets[0].egraph;
+        let four = egraph
+            .enodes
+            .iter()
+            .find_map(|(node, (op, children))| {
+                (op == "MNum"
+                    && egraph.eclasses[&children[0]]
+                        .1
+                        .iter()
+                        .any(|n| egraph.enodes[n].0 == "4"))
+                .then(|| egraph.node_to_class[node].clone())
+            })
+            .expect("the input extent is four");
+        let mut expressions = Vec::new();
+        for value in [127, 123] {
+            let literal = ClassId::from(format!("new-i64-{value}"));
+            let expression = ClassId::from(format!("new-expression-{value}"));
+            for (class, sort, op, children) in [
+                (literal.clone(), "i64", value.to_string(), vec![]),
+                (
+                    expression.clone(),
+                    "Expression",
+                    "MNum".to_string(),
+                    vec![literal],
+                ),
+            ] {
+                let node = NodeId::from(format!("node-{class}"));
+                assert!(egraph.enodes.insert(node.clone(), (op, children)).is_none());
+                egraph.node_to_class.insert(node.clone(), class.clone());
+                egraph
+                    .eclasses
+                    .insert(class, (sort.to_string(), vec![node]));
+            }
+            expressions.push(expression);
+        }
+        // The old program remains selectable; the new spelling needs classes
+        // which did not exist when the incumbent was saved.
+        let node = NodeId::from("new-equivalent-subtraction");
+        egraph
+            .enodes
+            .insert(node.clone(), ("MSub".to_string(), expressions));
+        egraph.node_to_class.insert(node.clone(), four.clone());
+        egraph.eclasses.get_mut(&four).unwrap().1.push(node);
+        let contexts = graph
+            .search_space()
+            .unwrap()
+            .bucket_contexts(&graph.dyn_map);
+        assert!(
+            schedule.seed_for_bucket(&contexts[0]).is_some(),
+            "additional legal alternatives must not invalidate an unchanged incumbent"
+        );
     }
 
     #[test]

--- a/src/graph/artifact.rs
+++ b/src/graph/artifact.rs
@@ -199,7 +199,7 @@ impl SelectedSchedule {
         } else {
             remap_choices(&bucket.egraph, ctx.egraph(), &bucket.choices)?
         };
-        let genome = extractor.index_named_choices(&choices);
+        let genome = extractor.index_seed_choices(&choices);
         let llir = unroll_packed_llir(extractor.extract_indexed_packed(&genome, &[]));
         (fingerprint_llir(&llir) == bucket.unrolled_llir_fingerprint).then_some(genome)
     }

--- a/src/graph/artifact.rs
+++ b/src/graph/artifact.rs
@@ -89,6 +89,24 @@ pub struct SelectedSchedule {
 }
 
 impl SelectedSchedule {
+    /// Recover an incumbent only for the identical saturated search space.
+    /// The caller must revalidate and remeasure it under the current workload.
+    pub(crate) fn seed_for_bucket(
+        &self,
+        ctx: &crate::search::BucketContext<'_>,
+    ) -> Option<crate::egglog_utils::IndexedChoiceSet> {
+        if !ctx.space.custom_ops.is_empty() || self.dim_buckets != ctx.space.dim_buckets {
+            return None;
+        }
+        let bucket = self.buckets.iter().find(|bucket| {
+            bucket.bucket_indices == *ctx.bucket_indices() && bucket.egraph == *ctx.egraph()
+        })?;
+        let mut extractor = LlirExtractor::new(ctx.egraph(), &ctx.space.ops);
+        let genome = extractor.index_named_choices(&bucket.choices);
+        let llir = unroll_packed_llir(extractor.extract_indexed_packed(&genome, &[]));
+        (fingerprint_llir(&llir) == bucket.unrolled_llir_fingerprint).then_some(genome)
+    }
+
     #[doc(hidden)]
     pub fn from_search(space: &SearchSpace, selected: &[SelectedProgram]) -> Option<Self> {
         if !space.custom_ops.is_empty() || selected.len() != space.buckets.len() {
@@ -248,11 +266,72 @@ mod tests {
     fn selected_schedule_rejects_changed_llir() {
         let (graph, mut schedule) = selected_schedule();
         schedule.buckets[0].unrolled_llir_fingerprint.0 ^= 1;
+        assert!(
+            schedule
+                .seed_for_bucket(
+                    &graph
+                        .search_space()
+                        .unwrap()
+                        .bucket_contexts(&graph.dyn_map)[0]
+                )
+                .is_none(),
+            "search seeding must also reject changed extraction semantics"
+        );
         let loaded = Graph::from_selected_schedule(graph.dyn_map, graph.input_meta, schedule);
         let error = loaded
             .load_selected_schedule(&mut ReferenceRuntime::initialize(()))
             .unwrap_err();
         assert!(error.contains("fingerprint mismatch"), "{error}");
+    }
+
+    #[test]
+    fn search_seeds_require_matching_bucket_contracts_and_egraphs() {
+        use rand::SeedableRng;
+        let mut graph = Graph::new();
+        let _ = graph.tensor('s').sin().output();
+        graph.build_search_space::<ReferenceRuntime>(CompileOptions::default().dim_buckets(
+            's',
+            &[DimBucket::new(1, 1), DimBucket::new(2, 8).representative(4)],
+        ));
+        let space = graph.search_space().unwrap();
+        let contexts = space.bucket_contexts(&graph.dyn_map);
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0xB0C0_2026);
+        let selected: Vec<_> = contexts
+            .iter()
+            .map(|ctx| {
+                let mut extractor = LlirExtractor::new(ctx.egraph(), &space.ops);
+                let genome = extractor.random_indexed_choice(&mut rng);
+                let llir = unroll_packed_llir(extractor.extract_indexed_packed(&genome, &[]));
+                SelectedProgram {
+                    bucket_indices: ctx.bucket_indices().clone(),
+                    representative_dyn_map: ctx.representative_dyn_map.clone(),
+                    genome,
+                    llir,
+                }
+            })
+            .collect();
+        let mut schedule = SelectedSchedule::from_search(space, &selected).unwrap();
+        schedule.buckets.reverse();
+        for ctx in &contexts {
+            assert!(schedule.seed_for_bucket(ctx).is_some());
+            let mut current = ctx.clone();
+            current
+                .representative_dyn_map
+                .insert('s'.into(), if ctx.index == 0 { 1 } else { 7 });
+            assert!(
+                schedule.seed_for_bucket(&current).is_some(),
+                "current tensor dimensions are reprofiled"
+            );
+        }
+        let mut changed = schedule.clone();
+        changed.dim_buckets.get_mut(&'s'.into()).unwrap()[1] = DimBucket::new(2, 16);
+        assert!(changed.seed_for_bucket(&contexts[1]).is_none());
+        let mut changed = schedule.clone();
+        for bucket in &mut changed.buckets {
+            bucket.egraph.roots.clear();
+        }
+        assert!(changed.seed_for_bucket(&contexts[0]).is_none());
+        assert!(changed.seed_for_bucket(&contexts[1]).is_none());
     }
 
     #[test]

--- a/src/graph/parallel.rs
+++ b/src/graph/parallel.rs
@@ -1,0 +1,120 @@
+//! Bounded independent e-graph construction. Nested egglog work stays in
+//! each worker's Rayon pool; completed buckets retain their original order.
+
+pub(super) fn map_buckets<T: Sync, R: Send>(jobs: &[T], run: impl Fn(&T) -> R + Sync) -> Vec<R> {
+    let budget = rayon::current_num_threads();
+    let workers = jobs.len().min(budget);
+    // Empty/single-worker builds can reuse the caller's Rayon context.
+    if workers <= 1 {
+        return jobs.iter().map(run).collect();
+    }
+    let threads = budget / workers;
+    let mut results = std::thread::scope(|scope| {
+        let handles: Vec<_> = (0..workers)
+            .map(|worker| {
+                let run = &run;
+                scope.spawn(move || {
+                    let pool = rayon::ThreadPoolBuilder::new()
+                        .num_threads(threads)
+                        .build()
+                        .expect("create egglog worker pool");
+                    pool.install(|| {
+                        jobs.iter()
+                            .enumerate()
+                            .skip(worker)
+                            .step_by(workers)
+                            .map(|(index, job)| (index, run(job)))
+                            .collect::<Vec<_>>()
+                    })
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .flat_map(|h| {
+                h.join()
+                    .unwrap_or_else(|panic| std::panic::resume_unwind(panic))
+            })
+            .collect::<Vec<_>>()
+    });
+    results.sort_unstable_by_key(|(index, _)| *index);
+    results.into_iter().map(|(_, result)| result).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::map_buckets;
+    use crate::egglog_utils::{
+        OpTextParts, base::interval_facts_egglog, run_egglog_with_report_parts_impl,
+    };
+    use crate::hlir::HLIROps;
+    use crate::op::IntoEgglogOp;
+    use crate::shape::{DimInterval, DynDimIntervals, sym};
+
+    #[test]
+    fn parallel_buckets_preserve_order_and_interval_proofs() {
+        let ops = HLIROps::into_vec();
+        let parts = OpTextParts::new(&ops, false);
+        let jobs: Vec<_> = [(1, 3), (4, 7), (2, 2), (8, 16)]
+            .into_iter()
+            .map(|(min, max)| {
+                let intervals =
+                    DynDimIntervals::from_iter([(sym("s"), DimInterval::new(min, max))]);
+                format!(
+                    "{} (let root (MLt (MVar \"s\") (MNum 4)))",
+                    interval_facts_egglog(&intervals, [])
+                )
+            })
+            .collect();
+        for budget in [1, 2, 4, 8] {
+            let pool = rayon::ThreadPoolBuilder::new()
+                .num_threads(budget)
+                .build()
+                .unwrap();
+            let values = pool.install(|| {
+                map_buckets(&jobs, |program| {
+                    assert_eq!(
+                        rayon::current_num_threads(),
+                        budget / jobs.len().min(budget)
+                    );
+                    let (graph, _) =
+                        run_egglog_with_report_parts_impl(program, "root", &parts, true, false)
+                            .unwrap();
+                    let constants: Vec<_> = graph.eclasses[&graph.roots[0]]
+                        .1
+                        .iter()
+                        .filter_map(|node| {
+                            let (label, children) = &graph.enodes[node];
+                            (label == "MNum").then(|| {
+                                let literal = &graph.eclasses[&children[0]].1[0];
+                                graph.enodes[literal].0.clone()
+                            })
+                        })
+                        .collect();
+                    assert_eq!(constants.len(), 1, "conflicting bucket interval proofs");
+                    constants[0].clone()
+                })
+            });
+            assert_eq!(values, ["1", "0", "1", "0"]);
+        }
+    }
+
+    #[test]
+    fn worker_failures_propagate_without_returning_partial_buckets() {
+        assert!(
+            std::panic::catch_unwind(|| {
+                let pool = rayon::ThreadPoolBuilder::new()
+                    .num_threads(2)
+                    .build()
+                    .unwrap();
+                pool.install(|| {
+                    map_buckets(&[0, 1, 2], |n| {
+                        assert_ne!(*n, 1, "failed saturation");
+                        *n
+                    })
+                })
+            })
+            .is_err()
+        );
+    }
+}

--- a/src/search/diagnostics.rs
+++ b/src/search/diagnostics.rs
@@ -310,3 +310,21 @@ pub fn log_best_llir(llir: &LLIRGraph, context: &str) {
     }
     println!("LLIR_BEST_END");
 }
+
+/// Exact generic search choices, including rejected candidates. Construct records
+/// only when requested; writing happens after evaluation and outside its metric.
+pub(super) fn log_candidate_choices(record: impl FnOnce() -> serde_json::Value) {
+    static PATH: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+    let Some(path) = PATH.get_or_init(|| std::env::var("LUMINAL_SEARCH_CHOICE_TRACE").ok()) else {
+        return;
+    };
+    let mut line = serde_json::to_vec(&record()).expect("serialize search choice trace");
+    line.push(b'\n');
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .expect("open requested search choice trace");
+    file.write_all(&line)
+        .expect("write requested search choice trace");
+}

--- a/src/search/genetic.rs
+++ b/src/search/genetic.rs
@@ -112,6 +112,7 @@ pub struct GeneticSearch<'a, M> {
     outstanding: Option<(CandidateId, IndexedChoiceSet)>,
 
     // Initial phase.
+    initial_seed: Option<IndexedChoiceSet>,
     invalid_attempts: usize,
     filter_fails: usize,
     max_filter_fails: usize,
@@ -179,6 +180,7 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
             phase: Phase::Initial,
             next_id: 0,
             outstanding: None,
+            initial_seed: None,
             invalid_attempts: 0,
             filter_fails: 0,
             max_filter_fails,
@@ -202,6 +204,24 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
 
     pub fn bucket_context(&self) -> &'a BucketContext<'a> {
         self.ctx
+    }
+
+    /// Start from a previously selected program when its e-graph and bucket
+    /// contracts match. It enters the ordinary validation/profiling path and
+    /// consumes one measured-candidate slot; no old fitness is reused. A
+    /// rejected seed falls back to random initialization, and mutation remains
+    /// free to replace any of its choices.
+    pub fn seed_schedule(&mut self, schedule: &crate::graph::SelectedSchedule) -> bool {
+        assert!(
+            self.phase == Phase::Initial
+                && self.outstanding.is_none()
+                && self.initial_seed.is_none()
+                && self.invalid_attempts == 0
+                && self.filter_fails == 0,
+            "seed a search only before requesting its first candidate"
+        );
+        self.initial_seed = schedule.seed_for_bucket(self.ctx);
+        self.initial_seed.is_some()
     }
 
     /// Dyn values candidates should be evaluated with.
@@ -235,10 +255,12 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
             match self.phase {
                 Phase::Done => return None,
                 Phase::Initial => {
-                    let mut generation =
+                    let genome = self.initial_seed.take().or_else(|| {
                         self.extractor
-                            .random_indexed_generation(1, &mut self.prev_selected, rng);
-                    let Some(genome) = generation.pop() else {
+                            .random_indexed_generation(1, &mut self.prev_selected, rng)
+                            .pop()
+                    });
+                    let Some(genome) = genome else {
                         panic_initial_filter_limit(
                             self.filter_fails,
                             self.last_filter_rejection.as_deref(),

--- a/src/search/genetic.rs
+++ b/src/search/genetic.rs
@@ -122,6 +122,8 @@ pub struct GeneticSearch<'a, M> {
 
     // Evolving phase.
     pending: VecDeque<IndexedChoiceSet>,
+    refinements: VecDeque<((u32, usize), VecDeque<IndexedChoiceSet>)>,
+    prefer_refinement: bool,
     generation_open: bool,
     ranked: Ranked<M>,
     parents: Vec<(M, IndexedChoiceSet)>,
@@ -208,6 +210,8 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
             n_timed_out: 0,
             n_invalid_profile: 0,
             pending: VecDeque::new(),
+            refinements: VecDeque::new(),
+            prefer_refinement: false,
             generation_open: false,
             ranked: Vec::new(),
             parents: Vec::new(),
@@ -311,12 +315,14 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
                         self.finish();
                         return None;
                     }
-                    if self.pending.is_empty() {
+                    if self.pending.is_empty()
+                        && (!self.prefer_refinement || self.refinements.is_empty())
+                    {
                         if self.generation_open {
                             self.close_generation();
                         }
                         self.breed(rng);
-                        if self.pending.is_empty() {
+                        if self.pending.is_empty() && self.refinements.is_empty() {
                             self.finish();
                             return None;
                         }
@@ -327,7 +333,7 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
                         self.finish();
                         return None;
                     }
-                    let genome = self.pending.pop_front().unwrap();
+                    let genome = self.take_pending().unwrap();
                     match self.extract(&genome) {
                         Ok(Some((pre_collapse, llir))) => {
                             return Some(self.hand_out(genome, llir, pre_collapse));
@@ -342,6 +348,25 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
                     }
                 }
             }
+        }
+    }
+
+    // Alternate exploration with refinement. A continually improving losing
+    // family must not delay every other constructor until its lattice is spent.
+    // Within refinement, visit families round-robin while prioritizing each
+    // family's newest measured improvement. Every proposal uses the same budget.
+    fn take_pending(&mut self) -> Option<IndexedChoiceSet> {
+        if !self.refinements.is_empty() && (self.prefer_refinement || self.pending.is_empty()) {
+            self.prefer_refinement = false;
+            let (key, mut queue) = self.refinements.pop_front().unwrap();
+            let genome = queue.pop_front();
+            if !queue.is_empty() {
+                self.refinements.push_back((key, queue));
+            }
+            genome
+        } else {
+            self.prefer_refinement = true;
+            self.pending.pop_front()
         }
     }
 
@@ -563,13 +588,21 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
                     .is_none_or(|best| new_metric.lt(best));
                 if improved {
                     self.family_best.insert(family, new_metric.clone());
-                    for neighbor in self
-                        .extractor
-                        .argument_neighbors(&genome, family.0, &mut self.prev_selected)
-                        .into_iter()
-                        .rev()
-                    {
-                        self.pending.push_front(neighbor);
+                    let neighbors = self.extractor.argument_neighbors(
+                        &genome,
+                        family.0,
+                        &mut self.prev_selected,
+                    );
+                    if !neighbors.is_empty() {
+                        if let Some((_, queue)) =
+                            self.refinements.iter_mut().find(|(key, _)| *key == family)
+                        {
+                            for neighbor in neighbors.into_iter().rev() {
+                                queue.push_front(neighbor);
+                            }
+                        } else {
+                            self.refinements.push_back((family, neighbors.into()));
+                        }
                     }
                 }
             }
@@ -722,10 +755,9 @@ mod family_tests {
     use crate::search::BucketSearchSpace;
     use rand::SeedableRng;
 
-    #[test]
-    fn losing_family_climbs_multiple_arguments_within_candidate_budget() {
-        let mut graph = paired_arguments_fixture(2, false);
-        let old = choices_fixture(0);
+    fn family_space(width: usize, variants: usize) -> SearchSpace {
+        let mut graph = paired_arguments_fixture(width, false);
+        let old = choices_fixture(variants);
         let root = graph.roots[0].clone();
         graph
             .eclasses
@@ -740,7 +772,7 @@ mod family_tests {
                 graph.eclasses.insert(class, value);
             }
         }
-        let space = SearchSpace {
+        SearchSpace {
             buckets: vec![BucketSearchSpace {
                 egraph: graph,
                 bucket_indices: Default::default(),
@@ -749,7 +781,12 @@ mod family_tests {
             ops: vec![],
             custom_ops: vec![],
             dim_buckets: Default::default(),
-        };
+        }
+    }
+
+    #[test]
+    fn losing_family_climbs_multiple_arguments_within_candidate_budget() {
+        let space = family_space(2, 0);
         let ctx = BucketContext {
             space: &space,
             index: 0,
@@ -792,8 +829,15 @@ mod family_tests {
         let candidate = search.hand_out(seed, LLIRGraph::default(), None);
         search.report(candidate, Outcome::Measured(120, "new family".into()));
         assert_eq!(search.best(), Some(&100));
-        assert_eq!(search.pending.len(), 2);
-        while let Some(genome) = search.pending.pop_front() {
+        assert_eq!(
+            search
+                .refinements
+                .iter()
+                .map(|(_, q)| q.len())
+                .sum::<usize>(),
+            2
+        );
+        while let Some(genome) = search.take_pending() {
             let named = search.extractor.named_choices(&genome);
             let node = &named.iter().find(|(class, _)| class == "root").unwrap().1;
             let metric = if node == "pair-0-0" { 80 } else { 110 };
@@ -816,5 +860,74 @@ mod family_tests {
             5,
             "family exploration consumes the ordinary budget"
         );
+    }
+
+    #[test]
+    fn improving_losing_family_does_not_starve_queued_algorithms() {
+        let space = family_space(16, 3);
+        let ctx = BucketContext {
+            space: &space,
+            index: 0,
+            representative_dyn_map: Default::default(),
+        };
+        let options = CompileOptions::default()
+            .search_log(false)
+            .search_graph_limit(8);
+        let mut search = GeneticSearch::<usize>::new(&space, &ctx, &options, Instant::now());
+        let incumbent = search
+            .extractor
+            .index_seed_choices(&[("root".into(), "op-0".into())]);
+        let candidate = search.hand_out(incumbent, LLIRGraph::default(), None);
+        search.report(candidate, Outcome::Measured(100, "incumbent".into()));
+        let family = search
+            .extractor
+            .index_seed_choices(&[("root".into(), "pair-15-15".into())]);
+        let candidate = search.hand_out(family, LLIRGraph::default(), None);
+        search.report(candidate, Outcome::Measured(200, "losing family".into()));
+        // These proposals were already generated before refinement began. Only
+        // the last is a winner; improvements within the large losing family
+        // must leave enough of the same eight-evaluation budget to discover it.
+        for i in 1..=3 {
+            let genome = search
+                .extractor
+                .index_seed_choices(&[("root".into(), format!("op-{i}"))]);
+            search.pending.push_back(genome);
+        }
+        let mut tried = Vec::new();
+        while search.measured() < 8 {
+            let genome = search.take_pending().expect("unmeasured proposals remain");
+            let named = search.extractor.named_choices(&genome);
+            let node = named
+                .iter()
+                .find(|(class, _)| class == "root")
+                .unwrap()
+                .1
+                .clone();
+            // Every visited family refinement improves, but still loses to the
+            // incumbent. This reproduced exhaustion of the serving search budget.
+            let metric = if node == "op-3" {
+                80
+            } else {
+                200 - search.measured()
+            };
+            tried.push(node);
+            let candidate = search.hand_out(genome, LLIRGraph::default(), None);
+            search.report(candidate, Outcome::Measured(metric, metric.to_string()));
+        }
+        assert!(
+            tried.iter().any(|node| node.starts_with("pair-")),
+            "refinement remains useful"
+        );
+        assert_eq!(
+            search.best(),
+            Some(&80),
+            "queued algorithms must be tested before the budget is exhausted: {tried:?}"
+        );
+        assert!(
+            search
+                .next_candidate(&mut rand::rngs::StdRng::seed_from_u64(993))
+                .is_none()
+        );
+        assert_eq!(search.measured(), 8);
     }
 }

--- a/src/search/genetic.rs
+++ b/src/search/genetic.rs
@@ -163,6 +163,21 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
             .saturating_mul(options.generation_size.max(1))
             .saturating_mul(100)
             .max(10_000);
+        let initial_seed = options
+            .seed_schedule
+            .as_ref()
+            .and_then(|schedule| schedule.seed_for_bucket(ctx));
+        if search_log && options.seed_schedule.is_some() {
+            println!(
+                "Search seed bucket {}: {}",
+                ctx.index,
+                if initial_seed.is_some() {
+                    "accepted; revalidating and remeasuring"
+                } else {
+                    "incompatible; ordinary initialization"
+                }
+            );
+        }
         Self {
             space,
             ctx,
@@ -180,7 +195,7 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
             phase: Phase::Initial,
             next_id: 0,
             outstanding: None,
-            initial_seed: None,
+            initial_seed,
             invalid_attempts: 0,
             filter_fails: 0,
             max_filter_fails,

--- a/src/search/genetic.rs
+++ b/src/search/genetic.rs
@@ -157,8 +157,12 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
                 );
             }
         }
-        let max_filter_fails = options
-            .limit
+        let limit = options
+            .bucket_limits
+            .get(&ctx.index)
+            .copied()
+            .unwrap_or(options.limit);
+        let max_filter_fails = limit
             .max(1)
             .saturating_mul(options.generation_size.max(1))
             .saturating_mul(100)
@@ -184,7 +188,7 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
             options,
             extractor: LlirExtractor::new(ctx.egraph(), &space.ops),
             profile_dyn_map: ctx.profile_dyn_map(options),
-            search_limit: count_choice_sets_up_to(ctx.egraph(), options.limit),
+            search_limit: count_choice_sets_up_to(ctx.egraph(), limit),
             started_at: Instant::now(),
             search_started_at,
             search_log,

--- a/src/search/genetic.rs
+++ b/src/search/genetic.rs
@@ -16,7 +16,7 @@ use std::time::Instant;
 
 use colored::Colorize;
 use rand::RngCore;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::diagnostics::{
     ProgressBars, log_best_llir, log_candidate_ops, panic_initial_filter_limit,
@@ -126,6 +126,7 @@ pub struct GeneticSearch<'a, M> {
     ranked: Ranked<M>,
     parents: Vec<(M, IndexedChoiceSet)>,
     best_metric: Option<M>,
+    family_best: FxHashMap<(u32, usize), M>,
     n_graphs: usize,
     resample_generation: bool,
     stagnant_generations: usize,
@@ -211,6 +212,7 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
             ranked: Vec::new(),
             parents: Vec::new(),
             best_metric: None,
+            family_best: FxHashMap::default(),
             n_graphs: 0,
             resample_generation: false,
             stagnant_generations: 0,
@@ -550,6 +552,29 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
         self.ranked
             .insert(rank, (new_metric.clone(), genome.clone()));
 
+        if !new_best {
+            for family in self
+                .extractor
+                .alternate_families(&genome, &self.ranked[0].1)
+            {
+                let improved = self
+                    .family_best
+                    .get(&family)
+                    .is_none_or(|best| new_metric.lt(best));
+                if improved {
+                    self.family_best.insert(family, new_metric.clone());
+                    for neighbor in self
+                        .extractor
+                        .argument_neighbors(&genome, family.0, &mut self.prev_selected)
+                        .into_iter()
+                        .rev()
+                    {
+                        self.pending.push_front(neighbor);
+                    }
+                }
+            }
+        }
+
         // Update parents list (keep top-N for next generation)
         let dominated_by_all = self.parents.len() >= self.options.keep_best
             && !self.parents.last().unwrap().0.gt(&new_metric);
@@ -687,5 +712,109 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
         }
         self.finish();
         std::mem::take(&mut self.ranked)
+    }
+}
+
+#[cfg(test)]
+mod family_tests {
+    use super::*;
+    use crate::egglog_utils::proposal_tests::{choices_fixture, paired_arguments_fixture};
+    use crate::search::BucketSearchSpace;
+    use rand::SeedableRng;
+
+    #[test]
+    fn losing_family_climbs_multiple_arguments_within_candidate_budget() {
+        let mut graph = paired_arguments_fixture(2, false);
+        let old = choices_fixture(0);
+        let root = graph.roots[0].clone();
+        graph
+            .eclasses
+            .get_mut(&root)
+            .unwrap()
+            .1
+            .extend(old.eclasses[&root].1.clone());
+        graph.enodes.extend(old.enodes);
+        graph.node_to_class.extend(old.node_to_class);
+        for (class, value) in old.eclasses {
+            if class != root {
+                graph.eclasses.insert(class, value);
+            }
+        }
+        let space = SearchSpace {
+            buckets: vec![BucketSearchSpace {
+                egraph: graph,
+                bucket_indices: Default::default(),
+                intervals: Default::default(),
+            }],
+            ops: vec![],
+            custom_ops: vec![],
+            dim_buckets: Default::default(),
+        };
+        let ctx = BucketContext {
+            space: &space,
+            index: 0,
+            representative_dyn_map: Default::default(),
+        };
+        let options = CompileOptions::default()
+            .search_log(false)
+            .search_graph_limit(5);
+        let mut search = GeneticSearch::<usize>::new(&space, &ctx, &options, Instant::now());
+        // Extraction is irrelevant to this state-machine test. Each fake
+        // evaluation reports the metric for an ordinary legal genome.
+        let incumbent = search
+            .extractor
+            .index_seed_choices(&[("root".into(), "op-0".into())]);
+        fn mark_seen(search: &mut GeneticSearch<usize>, genome: &IndexedChoiceSet) {
+            let bindings: Vec<_> = search
+                .extractor
+                .named_choices(genome)
+                .into_iter()
+                .map(|(c, n)| {
+                    (
+                        egraph_serialize::ClassId::from(c),
+                        egraph_serialize::NodeId::from(n),
+                    )
+                })
+                .collect();
+            search
+                .prev_selected
+                .insert(crate::egglog_utils::hash_choice_set(
+                    &bindings.iter().map(|(c, n)| (c, n)).collect(),
+                ));
+        }
+        mark_seen(&mut search, &incumbent);
+        let candidate = search.hand_out(incumbent, LLIRGraph::default(), None);
+        search.report(candidate, Outcome::Measured(100, "incumbent".into()));
+        let seed = search
+            .extractor
+            .index_seed_choices(&[("root".into(), "pair-1-1".into())]);
+        mark_seen(&mut search, &seed);
+        let candidate = search.hand_out(seed, LLIRGraph::default(), None);
+        search.report(candidate, Outcome::Measured(120, "new family".into()));
+        assert_eq!(search.best(), Some(&100));
+        assert_eq!(search.pending.len(), 2);
+        while let Some(genome) = search.pending.pop_front() {
+            let named = search.extractor.named_choices(&genome);
+            let node = &named.iter().find(|(class, _)| class == "root").unwrap().1;
+            let metric = if node == "pair-0-0" { 80 } else { 110 };
+            let candidate = search.hand_out(genome, LLIRGraph::default(), None);
+            search.report(candidate, Outcome::Measured(metric, metric.to_string()));
+        }
+        assert_eq!(
+            search.best(),
+            Some(&80),
+            "two individually losing changes must compose"
+        );
+        assert_eq!(search.measured(), 5);
+        assert!(
+            search
+                .next_candidate(&mut rand::rngs::StdRng::seed_from_u64(993))
+                .is_none()
+        );
+        assert_eq!(
+            search.measured(),
+            5,
+            "family exploration consumes the ordinary budget"
+        );
     }
 }

--- a/src/search/genetic.rs
+++ b/src/search/genetic.rs
@@ -300,13 +300,18 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
                     }
                 }
                 Phase::Evolving => {
-                    if self.pending.is_empty() {
+                    // Recombination can add proposals during a generation.
+                    // The measured-candidate budget applies before every handout.
+                    if self.n_graphs >= self.search_limit || self.time_limit_reached() {
                         if self.generation_open {
                             self.close_generation();
                         }
-                        if self.n_graphs >= self.search_limit || self.time_limit_reached() {
-                            self.finish();
-                            return None;
+                        self.finish();
+                        return None;
+                    }
+                    if self.pending.is_empty() {
+                        if self.generation_open {
+                            self.close_generation();
                         }
                         self.breed(rng);
                         if self.pending.is_empty() {
@@ -515,6 +520,24 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
             }
         };
 
+        let new_best = self
+            .best_metric
+            .as_ref()
+            .is_some_and(|best| best.gt(&new_metric));
+        if new_best {
+            // A winner may descend from an older parent and lose independent
+            // improvements in the previous incumbent. Test their combinations
+            // immediately instead of waiting for mutation to rediscover them.
+            let combinations = self.extractor.recombine_reachable_choices(
+                &genome,
+                &self.ranked[0].1,
+                &mut self.prev_selected,
+            );
+            for child in combinations.into_iter().rev() {
+                self.pending.push_front(child);
+            }
+        }
+
         let rank = self
             .ranked
             .iter()
@@ -550,10 +573,6 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
             &candidate.llir,
             &format!("cand={} {display_metric}", self.n_graphs),
         );
-        let new_best = self
-            .best_metric
-            .as_ref()
-            .is_some_and(|best| best.gt(&new_metric));
         if new_best {
             self.generation_found_new_best = true;
             self.best_metric = Some(new_metric);

--- a/src/search/genetic.rs
+++ b/src/search/genetic.rs
@@ -410,6 +410,17 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
             .options
             .candidate_timeout
             .is_some_and(|timeout| candidate.timer.elapsed() >= timeout);
+        super::diagnostics::log_candidate_choices(|| {
+            serde_json::json!({
+                "search_started": format!("{:?}", self.search_started_at),
+                "bucket": self.ctx.index,
+                "candidate": candidate.id.0,
+                "candidate_seconds": candidate.timer.elapsed().as_secs_f64(),
+                "timed_out": timed_out,
+                "outcome": format!("{outcome:?}"),
+                "choices": self.extractor.named_choices(&genome),
+            })
+        });
         match self.phase {
             Phase::Initial => self.report_initial(genome, candidate, outcome, timed_out),
             Phase::Evolving => self.report_evolving(genome, candidate, outcome, timed_out),

--- a/src/search/genetic.rs
+++ b/src/search/genetic.rs
@@ -92,6 +92,12 @@ enum Phase {
 
 const MAX_INVALID_INITIAL_ATTEMPTS: usize = 100;
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Refinement {
+    Family(u32, usize),
+    Recombination,
+}
+
 pub struct GeneticSearch<'a, M> {
     space: &'a SearchSpace,
     ctx: &'a BucketContext<'a>,
@@ -122,7 +128,7 @@ pub struct GeneticSearch<'a, M> {
 
     // Evolving phase.
     pending: VecDeque<IndexedChoiceSet>,
-    refinements: VecDeque<((u32, usize), VecDeque<IndexedChoiceSet>)>,
+    refinements: VecDeque<(Refinement, VecDeque<IndexedChoiceSet>)>,
     prefer_refinement: bool,
     generation_open: bool,
     ranked: Ranked<M>,
@@ -352,7 +358,7 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
     }
 
     // Alternate exploration with refinement. A continually improving losing
-    // family must not delay every other constructor until its lattice is spent.
+    // family or winner recombination must not delay every other constructor.
     // Within refinement, visit families round-robin while prioritizing each
     // family's newest measured improvement. Every proposal uses the same budget.
     fn take_pending(&mut self) -> Option<IndexedChoiceSet> {
@@ -367,6 +373,19 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
         } else {
             self.prefer_refinement = true;
             self.pending.pop_front()
+        }
+    }
+
+    fn queue_refinement(&mut self, key: Refinement, neighbors: Vec<IndexedChoiceSet>) {
+        if neighbors.is_empty() {
+            return;
+        }
+        if let Some((_, queue)) = self.refinements.iter_mut().find(|(k, _)| *k == key) {
+            for neighbor in neighbors.into_iter().rev() {
+                queue.push_front(neighbor);
+            }
+        } else {
+            self.refinements.push_back((key, neighbors.into()));
         }
     }
 
@@ -560,9 +579,7 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
                 &self.ranked[0].1,
                 &mut self.prev_selected,
             );
-            for child in combinations.into_iter().rev() {
-                self.pending.push_front(child);
-            }
+            self.queue_refinement(Refinement::Recombination, combinations);
         }
 
         let rank = self
@@ -593,17 +610,7 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
                         family.0,
                         &mut self.prev_selected,
                     );
-                    if !neighbors.is_empty() {
-                        if let Some((_, queue)) =
-                            self.refinements.iter_mut().find(|(key, _)| *key == family)
-                        {
-                            for neighbor in neighbors.into_iter().rev() {
-                                queue.push_front(neighbor);
-                            }
-                        } else {
-                            self.refinements.push_back((family, neighbors.into()));
-                        }
-                    }
+                    self.queue_refinement(Refinement::Family(family.0, family.1), neighbors);
                 }
             }
         }
@@ -751,7 +758,9 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
 #[cfg(test)]
 mod family_tests {
     use super::*;
-    use crate::egglog_utils::proposal_tests::{choices_fixture, paired_arguments_fixture};
+    use crate::egglog_utils::proposal_tests::{
+        choices_fixture, independent_choices_fixture, paired_arguments_fixture,
+    };
     use crate::search::BucketSearchSpace;
     use rand::SeedableRng;
 
@@ -929,5 +938,80 @@ mod family_tests {
                 .is_none()
         );
         assert_eq!(search.measured(), 8);
+    }
+
+    #[test]
+    fn winner_recombination_does_not_starve_queued_algorithms() {
+        let (graph, roots) = independent_choices_fixture(8, 1);
+        let space = SearchSpace {
+            buckets: vec![BucketSearchSpace {
+                egraph: graph,
+                bucket_indices: Default::default(),
+                intervals: Default::default(),
+            }],
+            ops: vec![],
+            custom_ops: vec![],
+            dim_buckets: Default::default(),
+        };
+        let ctx = BucketContext {
+            space: &space,
+            index: 0,
+            representative_dyn_map: Default::default(),
+        };
+        let options = CompileOptions::default()
+            .search_log(false)
+            .search_graph_limit(4);
+        let mut search = GeneticSearch::<usize>::new(&space, &ctx, &options, Instant::now());
+        let bindings = |which: fn(usize) -> bool| {
+            roots
+                .iter()
+                .enumerate()
+                .map(|(i, c)| {
+                    (
+                        c.to_string(),
+                        format!("value-{i}-variant-{}", usize::from(which(i))),
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+        let incumbent = search.extractor.index_seed_choices(&bindings(|i| i < 4));
+        let candidate = search.hand_out(incumbent, LLIRGraph::default(), None);
+        search.report(candidate, Outcome::Measured(100, "incumbent".into()));
+        let probe = search.extractor.index_seed_choices(&bindings(|_| true));
+        search.pending.push_back(probe);
+        let winner = search.extractor.index_seed_choices(&bindings(|i| i >= 4));
+        let candidate = search.hand_out(winner, LLIRGraph::default(), None);
+        search.report(
+            candidate,
+            Outcome::Measured(90, "independent improvements".into()),
+        );
+        // The two parents disagree at eight sites, generating more combinations
+        // than the remaining budget. The queued all-improved program must still
+        // be evaluated, while combination proposals retain a share of the work.
+        let mut combinations = 0;
+        while search.measured() < 4 {
+            let genome = search.take_pending().unwrap();
+            let all_improved = search
+                .extractor
+                .named_choices(&genome)
+                .iter()
+                .filter(|(class, node)| {
+                    class.starts_with("value-class-") && node.ends_with("variant-1")
+                })
+                .count()
+                == 8;
+            combinations += usize::from(!all_improved);
+            let cost = if all_improved { 1 } else { 95 };
+            let candidate = search.hand_out(genome, LLIRGraph::default(), None);
+            search.report(candidate, Outcome::Measured(cost, cost.to_string()));
+        }
+        assert_eq!(search.best(), Some(&1));
+        assert_eq!(combinations, 1);
+        assert!(
+            search
+                .next_candidate(&mut rand::rngs::StdRng::seed_from_u64(997))
+                .is_none()
+        );
+        assert_eq!(search.measured(), 4);
     }
 }

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -24,6 +24,8 @@ pub mod finalist;
 pub mod genetic;
 pub mod lattice;
 pub mod packed;
+pub mod profile;
+pub use profile::{ProfileCase, ProfileMeasurement, assign_profile_cases, weighted_profile_cost};
 #[cfg(test)]
 mod tests;
 pub mod unroll;

--- a/src/search/profile.rs
+++ b/src/search/profile.rs
@@ -1,0 +1,168 @@
+//! Backend-independent metadata and scoring for replayable graph workloads.
+use super::BucketContext;
+use crate::shape::DynMap;
+use std::time::Duration;
+
+/// One fixed workload example. `inputs` is owned by the backend, not the e-graph.
+#[derive(Clone, Debug)]
+pub struct ProfileCase<T> {
+    pub id: String,
+    pub dims: DynMap,
+    /// Relative invocation frequency across the *whole* workload.
+    pub weight: f64,
+    pub inputs: T,
+}
+
+impl<T> ProfileCase<T> {
+    pub fn new(id: impl Into<String>, dims: DynMap, inputs: T, weight: f64) -> Self {
+        Self {
+            id: id.into(),
+            dims,
+            weight,
+            inputs,
+        }
+    }
+}
+
+/// Assign exact examples without changing the semantic bucket domains. Explicit
+/// workloads must cover every compiled bucket; no synthetic fallback is implied.
+pub fn assign_profile_cases<T>(
+    cases: &[ProfileCase<T>],
+    contexts: &[BucketContext<'_>],
+) -> anyhow::Result<Vec<Vec<usize>>> {
+    anyhow::ensure!(!cases.is_empty(), "profile workload has no cases");
+    let mut assigned = vec![vec![]; contexts.len()];
+    let mut ids = std::collections::HashSet::new();
+    let total: f64 = cases.iter().map(|c| c.weight).sum();
+    anyhow::ensure!(
+        total.is_finite() && total > 0.,
+        "invalid total profile weight"
+    );
+    for (i, case) in cases.iter().enumerate() {
+        anyhow::ensure!(
+            !case.id.is_empty() && ids.insert(&case.id),
+            "empty or duplicate profile case ID: {}",
+            case.id
+        );
+        anyhow::ensure!(
+            case.weight.is_finite() && case.weight > 0.,
+            "invalid weight for {}",
+            case.id
+        );
+        let matches: Vec<_> = contexts
+            .iter()
+            .filter(|ctx| {
+                ctx.representative_dyn_map
+                    .keys()
+                    .all(|dim| case.dims.contains_key(dim))
+                    && ctx.bucket().intervals.iter().all(|(dim, interval)| {
+                        case.dims.get(dim).is_some_and(|&v| {
+                            i64::try_from(v).is_ok_and(|v| interval.min <= v && v <= interval.max)
+                        })
+                    })
+                    && ctx.bucket_indices().iter().all(|(dim, &index)| {
+                        let b = &ctx.dim_buckets()[dim][index];
+                        case.dims
+                            .get(dim)
+                            .is_some_and(|&v| b.min <= v && v <= b.max)
+                    })
+            })
+            .collect();
+        anyhow::ensure!(
+            matches.len() == 1,
+            "case {} has missing dimensions or matches {} buckets",
+            case.id,
+            matches.len()
+        );
+        assigned[matches[0].index].push(i);
+    }
+    for (index, group) in assigned.iter().enumerate() {
+        anyhow::ensure!(
+            !group.is_empty(),
+            "profile workload does not cover bucket {index}"
+        );
+    }
+    Ok(assigned)
+}
+
+/// Global weighted contribution of a bucket. Summing bucket contributions gives
+/// expected workload latency; normalizing each bucket separately would change
+/// the objective when selecting a resource-constrained set of programs.
+pub fn weighted_profile_cost(
+    samples: &[(f64, Duration)],
+    total_weight: f64,
+) -> anyhow::Result<Duration> {
+    anyhow::ensure!(
+        total_weight.is_finite() && total_weight > 0.,
+        "invalid total profile weight"
+    );
+    let mut seconds = 0.;
+    for &(weight, duration) in samples {
+        anyhow::ensure!(weight.is_finite() && weight > 0., "invalid profile weight");
+        seconds += (weight / total_weight) * duration.as_secs_f64();
+    }
+    Duration::try_from_secs_f64(seconds).map_err(Into::into)
+}
+
+/// Per-case measurements remain available even though genetic search uses a
+/// scalar score. Duration excludes sample restoration and includes the selected
+/// backend's timing protocol.
+#[derive(Clone, Debug)]
+pub struct ProfileMeasurement {
+    pub case_id: String,
+    pub dims: DynMap,
+    pub weight: f64,
+    pub duration: Duration,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn global_weights_preserve_bucket_tradeoffs() {
+        let a = weighted_profile_cost(&[(9., Duration::from_millis(10))], 10.).unwrap();
+        let b = weighted_profile_cost(&[(1., Duration::from_millis(100))], 10.).unwrap();
+        assert_eq!(a + b, Duration::from_millis(19));
+        assert!(weighted_profile_cost(&[(f64::NAN, Duration::ZERO)], 1.).is_err());
+        assert!(weighted_profile_cost(&[(1., Duration::ZERO)], 0.).is_err());
+    }
+    #[test]
+    fn exact_cases_cover_buckets_without_representative_clamping() {
+        use crate::prelude::*;
+        let mut graph = Graph::new();
+        let a = graph.tensor('s');
+        (a + a).output();
+        graph.set_dim('s', 2);
+        graph.build_search_space::<ReferenceRuntime>(CompileOptions::default().dim_buckets(
+            's',
+            &[
+                DimBucket::new(1, 4).representative(2),
+                DimBucket::new(5, 8).representative(6),
+            ],
+        ));
+        let contexts = graph
+            .search_space()
+            .unwrap()
+            .bucket_contexts(&graph.dyn_map);
+        let case =
+            |id, n| ProfileCase::new(id, [(Symbol::from('s'), n)].into_iter().collect(), (), 1.);
+        let cases = vec![case("low", 1), case("high", 4), case("next", 8)];
+        assert_eq!(
+            assign_profile_cases(&cases, &contexts).unwrap(),
+            vec![vec![0, 1], vec![2]]
+        );
+        assert_eq!(cases[1].dims[&'s'.into()], 4);
+        assert!(assign_profile_cases(&cases[..2], &contexts).is_err());
+        assert!(assign_profile_cases(&[case("outside", 9)], &contexts).is_err());
+        assert!(
+            assign_profile_cases(&[case("duplicate", 1), case("duplicate", 8)], &contexts).is_err()
+        );
+        assert!(
+            assign_profile_cases(
+                &[ProfileCase::new("missing", DynMap::default(), (), 1.)],
+                &contexts
+            )
+            .is_err()
+        );
+    }
+}

--- a/src/search/tests.rs
+++ b/src/search/tests.rs
@@ -1469,3 +1469,28 @@ fn seeded_search_remeasures_and_can_replace_or_reject_the_incumbent() {
     );
     assert!(search.next_candidate(&mut rng).is_some());
 }
+
+#[test]
+fn bucket_candidate_budgets_override_only_the_requested_bucket() {
+    let mut graph = Graph::new();
+    let _ = graph.tensor('s').sin().sin().sin().output();
+    let options = CompileOptions::default()
+        .dim_buckets('s', &[DimBucket::new(1, 1), DimBucket::new(2, 2)])
+        .search_graph_limit(2)
+        .bucket_search_graph_limit(1, 1)
+        .search_log(false);
+    graph.build_search_space::<ExplicitLoopRuntime>(options.clone());
+    let space = graph.search_space().unwrap();
+    let contexts = space.bucket_contexts(&graph.dyn_map);
+    assert_eq!(contexts.len(), 2);
+    let mut rng = rand::rngs::StdRng::seed_from_u64(0xB0D6E7);
+    for (ctx, expected) in contexts.iter().zip([2, 1]) {
+        let mut search =
+            super::GeneticSearch::<usize>::new(space, ctx, &options, std::time::Instant::now());
+        while let Some(candidate) = search.next_candidate(&mut rng) {
+            search.report(candidate, Outcome::Measured(1, "measured".into()));
+        }
+        assert_eq!(search.measured(), expected);
+        assert!(!search.into_ranked().is_empty());
+    }
+}

--- a/src/search/tests.rs
+++ b/src/search/tests.rs
@@ -1471,6 +1471,39 @@ fn seeded_search_remeasures_and_can_replace_or_reject_the_incumbent() {
 }
 
 #[test]
+fn recombination_proposals_do_not_extend_the_measured_candidate_budget() {
+    let mut graph = Graph::new();
+    // Distinct shapes keep these choices independent of loop-body sharing.
+    for n in 8..14 {
+        graph.tensor(n).sin().output();
+    }
+    let options = CompileOptions::default()
+        .search_graph_limit(5)
+        .generation_size(4)
+        .mutations(3)
+        .search_log(false);
+    graph.build_search_space::<ExplicitLoopRuntime>(options.clone());
+    let space = graph.search_space().unwrap();
+    let contexts = space.bucket_contexts(&graph.dyn_map);
+    for seed in 0..16 {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+        let mut search = super::GeneticSearch::<usize>::new(
+            space,
+            &contexts[0],
+            &options,
+            std::time::Instant::now(),
+        );
+        while let Some(candidate) = search.next_candidate(&mut rng) {
+            // Every report triggers incumbent recombination, including reports
+            // made with otherwise-full or almost-exhausted generation queues.
+            let cost = 100usize.saturating_sub(search.measured());
+            search.report(candidate, Outcome::Measured(cost, "improvement".into()));
+        }
+        assert_eq!(search.measured(), 5, "seed {seed}");
+    }
+}
+
+#[test]
 fn bucket_candidate_budgets_override_only_the_requested_bucket() {
     let mut graph = Graph::new();
     let _ = graph.tensor('s').sin().sin().sin().output();

--- a/src/search/tests.rs
+++ b/src/search/tests.rs
@@ -1417,9 +1417,11 @@ fn seeded_search_remeasures_and_can_replace_or_reject_the_incumbent() {
     )
     .unwrap();
     for reject in [false, true] {
+        let options = options
+            .clone()
+            .seed_schedule(std::sync::Arc::new(schedule.clone()));
         let mut search =
             super::GeneticSearch::<usize>::new(space, ctx, &options, std::time::Instant::now());
-        assert!(search.seed_schedule(&schedule));
         assert_eq!(search.best(), None, "prior fitness must not be reused");
         assert_eq!(search.measured(), 0);
         let candidate = search.next_candidate(&mut rng).unwrap();

--- a/src/search/tests.rs
+++ b/src/search/tests.rs
@@ -1387,3 +1387,83 @@ fn reported_candidate_must_be_outstanding() {
     assert_eq!(search.measured(), 1);
     assert_eq!(search.best(), Some(&1));
 }
+
+#[test]
+fn seeded_search_remeasures_and_can_replace_or_reject_the_incumbent() {
+    let mut graph = Graph::new();
+    let _ = graph.tensor(8).sin().sin().sin().output();
+    graph.build_search_space::<ExplicitLoopRuntime>(CompileOptions::default());
+    let space = graph.search_space().unwrap();
+    let contexts = space.bucket_contexts(&graph.dyn_map);
+    let ctx = &contexts[0];
+    let options = CompileOptions::default()
+        .search_graph_limit(16)
+        .generation_size(4)
+        .mutations(2)
+        .search_log(false);
+    let mut rng = rand::rngs::StdRng::seed_from_u64(0x5EED_2026);
+    let mut extractor = super::LlirExtractor::new(ctx.egraph(), &space.ops);
+    let genome = extractor.random_indexed_choice(&mut rng);
+    let llir = super::unroll_packed_llir(extractor.extract_indexed_packed(&genome, &[]));
+    let expected = format!("{llir:?}");
+    let schedule = crate::graph::SelectedSchedule::from_search(
+        space,
+        &[super::SelectedProgram {
+            bucket_indices: ctx.bucket_indices().clone(),
+            representative_dyn_map: ctx.representative_dyn_map.clone(),
+            genome,
+            llir,
+        }],
+    )
+    .unwrap();
+    for reject in [false, true] {
+        let mut search =
+            super::GeneticSearch::<usize>::new(space, ctx, &options, std::time::Instant::now());
+        assert!(search.seed_schedule(&schedule));
+        assert_eq!(search.best(), None, "prior fitness must not be reused");
+        assert_eq!(search.measured(), 0);
+        let candidate = search.next_candidate(&mut rng).unwrap();
+        assert_eq!(format!("{:?}", candidate.llir), expected);
+        search.report(
+            candidate,
+            if reject {
+                Outcome::Rejected("current resource contract rejects the old program".into())
+            } else {
+                Outcome::Measured(1_000, "new workload makes the incumbent slow".into())
+            },
+        );
+        assert_eq!(search.measured(), usize::from(!reject));
+        let mut alternatives = 0;
+        while let Some(candidate) = search.next_candidate(&mut rng) {
+            assert_ne!(format!("{:?}", candidate.llir), expected, "program dedup");
+            alternatives += 1;
+            search.report(candidate, Outcome::Measured(1, "faster replacement".into()));
+        }
+        assert!(alternatives > 0);
+        assert_eq!(search.measured(), alternatives + usize::from(!reject));
+        assert!(search.measured() <= 16);
+        let ranked = search.into_ranked();
+        assert_eq!(ranked[0].0, 1);
+        assert_eq!(
+            ranked.iter().filter(|(cost, _)| *cost == 1_000).count(),
+            usize::from(!reject)
+        );
+    }
+
+    let mut different_graph = Graph::new();
+    let _ = different_graph.tensor(9).sin().output();
+    different_graph.build_search_space::<ExplicitLoopRuntime>(CompileOptions::default());
+    let different_space = different_graph.search_space().unwrap();
+    let contexts = different_space.bucket_contexts(&different_graph.dyn_map);
+    let mut search = super::GeneticSearch::<usize>::new(
+        different_space,
+        &contexts[0],
+        &options,
+        std::time::Instant::now(),
+    );
+    assert!(
+        !search.seed_schedule(&schedule),
+        "different graph must not inherit indexed choices"
+    );
+    assert!(search.next_candidate(&mut rng).is_some());
+}

--- a/src/shape/expression.rs
+++ b/src/shape/expression.rs
@@ -1407,6 +1407,44 @@ mod tests {
     }
 
     #[test]
+    fn test_product_interval_proofs_require_nonnegative_safe_bounds() {
+        let product = expr('s') * expr('t');
+        let intervals = [
+            (sym("s"), DimInterval::new(2, 8)),
+            (sym("t"), DimInterval::new(3, 9)),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(product.max(1).simplify_with_intervals(&intervals), product);
+        assert_eq!(product.lt(73).simplify_with_intervals(&intervals), expr(1));
+        assert_eq!(product.lt(6).simplify_with_intervals(&intervals), expr(0));
+
+        // Positive upper endpoints do not establish a product upper bound
+        // when both operands can also be negative: (-9)*(-7) exceeds 8*4.
+        let signed = [
+            (sym("s"), DimInterval::new(-9, 8)),
+            (sym("t"), DimInterval::new(-7, 4)),
+        ]
+        .into_iter()
+        .collect();
+        assert_ne!(product.lt(33).simplify_with_intervals(&signed), expr(1));
+        let overflow = [
+            (sym("s"), DimInterval::new(i64::MAX / 2 + 1, i64::MAX)),
+            (sym("t"), DimInterval::new(2, 3)),
+        ]
+        .into_iter()
+        .collect();
+        assert_ne!(product.gte(0).simplify_with_intervals(&overflow), expr(1));
+        let zero = [
+            (sym("s"), DimInterval::new(0, 0)),
+            (sym("t"), DimInterval::new(0, i64::MAX)),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(product.simplify_with_intervals(&zero), expr(0));
+    }
+
+    #[test]
     fn test_add_num_does_not_fold_into_nested_num() {
         // Regression: adding an integer to `(a*b) + rest` must not fold the
         // integer into the `a` of the multiplication. `(11*16) + 15` is 191,

--- a/src/shape/tracker.rs
+++ b/src/shape/tracker.rs
@@ -282,6 +282,12 @@ impl ShapeTracker {
     /// Stride expressions are nondecreasing in z, so each axis peaks at
     /// `dim - 1`.
     pub fn physical_span(&self) -> Expression {
+        if self.is_contiguous() {
+            // The row-major offset sum telescopes to product(dims) - 1.
+            // Keep the product form so consumers can prove equal buffer sizes
+            // without saturating distributivity over dynamic expressions.
+            return self.n_elements();
+        }
         self.dims
             .into_iter()
             .zip(&self.strides)
@@ -547,6 +553,10 @@ mod tests {
         assert!(tracker.is_contiguous());
         let span = tracker.physical_span();
         let n_elem = tracker.n_elements();
+        assert_eq!(
+            span, n_elem,
+            "contiguous spans must retain the product form"
+        );
         // A contiguous view addresses exactly n_elements offsets. Evaluate at a
         // few concrete sizes: span and n_elements must agree (regression for the
         // Add fold bug that over-counted the constant as 533 instead of 383).
@@ -559,6 +569,20 @@ mod tests {
             );
             assert_eq!(span.exec(&map), Some(384 * s));
         }
+        let empty = [(sym("s"), 0)].into_iter().collect();
+        assert_eq!(span.exec(&empty), Some(1));
+    }
+
+    #[test]
+    fn physical_span_preserves_strided_and_offset_views() {
+        let mut tracker = ShapeTracker::new([expr(3), expr(4)]);
+        tracker.strides[0] = expr('z') * 16;
+        assert!(!tracker.is_contiguous());
+        assert_eq!(tracker.physical_span().to_usize(), Some(36));
+        tracker.strides[1] = expr('z') + 5;
+        assert_eq!(tracker.physical_span().to_usize(), Some(41));
+        tracker.permute(&[1, 0]);
+        assert_eq!(tracker.physical_span().to_usize(), Some(41));
     }
 
     #[test]


### PR DESCRIPTION
Make CUDA profiling and replay representative for arbitrary tensor graphs: explicit input schemas, shared immutable inputs, aliased-state snapshots/restoration, exact dynamic dimensions, and bucket-aware scoring. The server uses five buckets and one case per bucket. Family coverage and refinement retain backend choices in egglog, including precision-aware dense fusion and cuBLASLt algorithm alternatives.

Add bounded storage views and shared pointwise read boundaries so one residual-normalization kernel can return both the residual and normalized values. A bias variant preserves the FP32 bias-add boundary before BF16/F16 rounding and retains independently tuned products. Rewrites match generic shapes/dtypes/strides, with temporary subsumption of redundant input rounding. Runtime handling preserves bounds, owner lifetimes, external outputs, recurrent state and changed input bindings.

Validation includes native BF16/F16 rounding and bias comparisons, exceptional low-precision encodings, dynamic C1–64 view/readback tests, and the existing consumed-buffer, arena, bucket and state-replay regressions. Release Clippy and formatting pass. The final serving witness passes 132 answer checks and all 14 complete 1024/1024 cohorts. Earlier cuBLASLt/scatter tests and scatter memcheck/racecheck remain recorded in the branch.

The fusion is an explicitly selected equivalent witness, not a search-discovered winner. It preserves every matrix-product configuration in all five buckets and removes 36–162 cast/pointwise/norm materializations. The largest pooled serving change is about 3% at C32; other small changes are not established wins. Normalization tuning and token/routing trajectories can change. The 20%-lower-TPOT goal remains unmet at all seven concurrencies. Fresh C1/C16/C64 Nsight captures and rejected variants are retained.

[Current graph, comparison and validation](https://github.com/luminal-ai/luminal-inference-server/blob/codex/calibrated-five-bucket-search/harness/reports/20260913-residual-norm/README.md).

Keep Core #523, CUDA #14 and server #9 open and unmerged.
