### PR TITLE
egglog fork onto d61ba050 + egglog-experimental back-off scheduler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,18 @@ generational-box = "0.5.6"
 serde_json = "1.0.140"
 # The luminal-ai fork carries the atomic add_subsumed write the substitution
 # walk needs (proposed upstream alongside egglog-experimental #60), on branch
-# `luminal/subsumed-c2c0f151`. Bumping egglog = rebasing that branch, new rev.
+# `luminal/subsumed-d61ba050` (upstream d61ba050 + the 58-line patch).
+# Bumping egglog = rebasing that branch, new rev, and re-pointing the
+# [patch] section below.
 # Core is the ONLY crate that names egglog; every other crate uses
 # `luminal::prelude::{egglog, egglog_ast, egraph_serialize}`.
-egglog = { git = "https://github.com/luminal-ai/egglog", rev = "1bb30831e11121bd639caf93d84465d8d110e3f7" }
-egglog-ast = { git = "https://github.com/luminal-ai/egglog", rev = "1bb30831e11121bd639caf93d84465d8d110e3f7" }
+egglog = { git = "https://github.com/luminal-ai/egglog", rev = "64a4ee1444322de3084b1e31f8250720b5d36d81" }
+egglog-ast = { git = "https://github.com/luminal-ai/egglog", rev = "64a4ee1444322de3084b1e31f8250720b5d36d81" }
+# egglog-experimental supplies the back-off scheduler (`let-scheduler`,
+# `run-with`) as user-defined commands; it pins upstream egglog at d61ba050,
+# which the [patch] section below redirects onto the same fork rev so the
+# workspace holds ONE egglog.
+egglog-experimental = { git = "https://github.com/egraphs-good/egglog-experimental", rev = "55240709e9cd287b4aad9c04090efdb361c896e8", default-features = false }
 # egglog-reports: crate absorbed upstream; RunReport types re-export via egglog (pin bump 2026-08-11)
 egraph-serialize = { version = "0.3.0", default-features = false, features = ["graphviz", "serde"]}
 tracing = "0.1.43"
@@ -111,3 +118,10 @@ exclude = ["crates/luminal_bench"]
 # debug-assertions stay ON everywhere (this changes opt-level only).
 [profile.dev.package."*"]
 opt-level = 3
+
+# egglog-experimental depends on upstream egglog by URL; route those three
+# crates onto the fork rev above so there is exactly one egglog in the graph.
+[patch."https://github.com/egraphs-good/egglog.git"]
+egglog = { git = "https://github.com/luminal-ai/egglog", rev = "64a4ee1444322de3084b1e31f8250720b5d36d81" }
+egglog-ast = { git = "https://github.com/luminal-ai/egglog", rev = "64a4ee1444322de3084b1e31f8250720b5d36d81" }
+egglog-reports = { git = "https://github.com/luminal-ai/egglog", rev = "64a4ee1444322de3084b1e31f8250720b5d36d81" }

--- a/src/egglog_snippet.rs
+++ b/src/egglog_snippet.rs
@@ -134,6 +134,23 @@ pub fn new_egraph() -> egglog::EGraph {
         },
         None,
     );
+    // egglog-experimental's scheduling: `run-schedule` becomes the extended
+    // form (a superset of the core grammar, same RunSchedule output) and
+    // `let-scheduler` binds a named scheduler, e.g.
+    // `(let-scheduler bo (back-off :match-limit 1000 :ban-length 5))`, used
+    // as `(run-with bo <ruleset>)` inside a schedule.
+    egraph
+        .add_command(
+            "run-schedule".into(),
+            std::sync::Arc::new(egglog_experimental::RunExtendedSchedule),
+        )
+        .expect("run-schedule command registers");
+    egraph
+        .add_command(
+            "let-scheduler".into(),
+            std::sync::Arc::new(egglog_experimental::LetSchedulerCommand),
+        )
+        .expect("let-scheduler command registers");
     egraph
 }
 

--- a/src/subst_primitive.rs
+++ b/src/subst_primitive.rs
@@ -1,5 +1,7 @@
 //! VENDORED from egglog-experimental PR #60 (branch `unstable-subst`,
-//! head eaf27ca, author oflatt) — verbatim below this header. Vendored
+//! head eaf27ca, author oflatt) — verbatim below this header except for
+//! one rename tracking upstream egglog d61ba050: `Read::enodes_for_eclass`
+//! became `Read::constructor_enodes_for_eclass`. Vendored
 //! rather than depended-on while the PR is unmerged (ruling: take
 //! exactly the audited contract; drop this file for the upstream crate
 //! once it merges). Registered by `new_egraph()` in egglog_snippet.rs.
@@ -239,7 +241,7 @@ impl Walk<'_> {
             let mut nodes = Vec::new();
             for index in candidates {
                 let mut rows = Vec::new();
-                state.enodes_for_eclass(&self.ctors[index].name, value, |enode| {
+                state.constructor_enodes_for_eclass(&self.ctors[index].name, value, |enode| {
                     rows.push((enode.children.to_vec(), enode.subsumed));
                 })?;
                 nodes.extend(rows.into_iter().map(|(children, subsumed)| ENode {
@@ -399,7 +401,7 @@ impl Walk<'_> {
             // skipped, and which children are still imageless.
             for ctor in &self.ctors {
                 let mut rows = Vec::new();
-                let _ = state.enodes_for_eclass(&ctor.name, *eclass, |enode| {
+                let _ = state.constructor_enodes_for_eclass(&ctor.name, *eclass, |enode| {
                     rows.push((enode.children.to_vec(), enode.subsumed));
                 });
                 for (children, subsumed) in rows {


### PR DESCRIPTION
## What
- Fork branch `luminal/subsumed-d61ba050` (luminal-ai/egglog@64a4ee14) = upstream egglog d61ba050 (2026-09-03, PR #1005 scheduler context) + the unchanged 58-line `add_subsumed` patch, rebased from 1bb30831 (c2c0f151). Upstream still lacks `add_subsumed`, so the fork stays.
- `egglog-experimental` @55240709 (2026-09-03) added with `default-features = false`; its upstream egglog pin is redirected onto the fork rev via `[patch."https://github.com/egraphs-good/egglog.git"]` for egglog / egglog-ast / egglog-reports, so `cargo tree` shows exactly one egglog.
- `new_egraph` registers egglog-experimental's `run-schedule` (extended grammar, superset of core, still emits `CommandOutput::RunSchedule`) and `let-scheduler`, so `(let-scheduler bo (back-off :match-limit N :ban-length M))` + `(run-with bo <ruleset>)` are available to schedules.
- Vendored `subst_primitive.rs`: one rename tracking upstream, `enodes_for_eclass` -> `constructor_enodes_for_eclass` (noted in the header).

## Checks
- `cargo check --workspace --tests` clean; `cargo fmt --check` clean; `cargo clippy -p luminal --lib` 20 warnings (baseline 21).
- `cargo test -p luminal --lib snapshot` (1) and `subst` (10) pass; `test_runtime --test cublaslt_marker` 4/4; `cublaslt_election election_row_gemma3` pass.
- Saturation fixpoint fingerprints (sorted table sizes) identical to trunk on gemma3-4B dims: 8 layers dad7cafa148473c9 (130,940 rows), 16 layers 8f8db5a23436f5ca (231,868 rows); wall 4.0 s / 9.4 s vs 3.8-4.1 / 9.2-9.3 s on trunk.

Full workspace gate running detached; not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)