### PR TITLE
Pre-saturate shape/dtype/rank propagation in its own ruleset (2.5x faster saturation)

### DIFF
--- a/crates/luminal_cuda_lite/src/bindings.rs
+++ b/crates/luminal_cuda_lite/src/bindings.rs
@@ -22,7 +22,7 @@ impl CudaBindings {
     /// The schedule tail this runtime appends to every assembled
     /// program. Identical to the reference schedule today; CUDA-native
     /// rulesets (cuBLASLt matching) will extend it here.
-    pub const SCHEDULE: &'static str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run cleanup)) (saturate (run fixpoint-invariants)))\n\n";
+    pub const SCHEDULE: &'static str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run cleanup)) (saturate (run fixpoint-invariants)))\n\n";
 }
 
 impl RuntimeBindingsGenerator for CudaBindings {

--- a/crates/luminal_reference/src/bindings.rs
+++ b/crates/luminal_reference/src/bindings.rs
@@ -21,7 +21,7 @@ pub struct ReferenceBindings;
 impl ReferenceBindings {
     /// The standard schedule tail shared by every assembled reference
     /// program.
-    pub const SCHEDULE: &'static str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run cleanup)) (saturate (run fixpoint-invariants)))\n\n";
+    pub const SCHEDULE: &'static str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run cleanup)) (saturate (run fixpoint-invariants)))\n\n";
 }
 
 impl RuntimeBindingsGenerator for ReferenceBindings {

--- a/src/egglog_core/egglog_preamble.egg
+++ b/src/egglog_core/egglog_preamble.egg
@@ -891,6 +891,16 @@
 ; Propagate thing-of functions from Literals
 
 ; Propagate rank-of
+; Propagation ruleset: the shape-of / dtype-of / rank-of analyses (this
+; rule, the input-literal rule below, and every op's shape.egg and
+; dtype.egg). These are pure derived-attribute rules that never mint
+; terms. They run to saturation BEFORE the main loop and again alongside
+; the default ruleset inside it, so a schedule that runs (run) must also
+; run (run prop); rules whose actions are only such sets belong here (a
+; test in egglog_snippet.rs pins both directions). Pre-saturating them
+; cut saturation wall time 2.5x at gemma3 depth: the tables stop churning,
+; so the wide match rules that read them are re-evaluated far less often.
+(ruleset prop)
 (rule
   (
     (= ?shape (ShapeLit ?expr_list))
@@ -899,6 +909,7 @@
   (
     (set (rank-of ?shape) ?rank)
   )
+  :ruleset prop
 )
 
 ; Propagate dtype-of , shape-of
@@ -910,6 +921,7 @@
     (set (dtype-of ?logical_tensor) ?dtype)
     (set (shape-of ?logical_tensor) ?shape)
   )
+  :ruleset prop
 )
 
 ; Eager bits-of entries: top-level SETS, not rules — fixture lets evaluate
@@ -3823,7 +3835,7 @@
 ; reason). The walk copies the reachable region under σ — every
 ; spelling at once, simultaneous by construction — from a :naive rule
 ; in the subst-walk ruleset. The schedule runs that ruleset as an
-; OUTER STRATUM ((saturate (saturate (run)) (run subst-walk))): the
+; OUTER STRATUM ((saturate (saturate (run) (run prop)) (run subst-walk))): the
 ; ring saturates between walk generations, so re-walks happen per
 ; GENERATION, not per round. Both halves are load-bearing: per-round
 ; re-walks cost 2-9x on model-scale searches, and per-generation
@@ -4530,7 +4542,7 @@
 ; every invariant lives in egglog; nothing is checked in the extractor).
 ;
 ; This ruleset runs to saturation ONLY AFTER the main run has saturated:
-;   (run-schedule (saturate (run)) ... (saturate (run fixpoint-invariants)))
+;   (run-schedule (saturate (run prop)) (saturate (run) (run prop)) ... (saturate (run fixpoint-invariants)))
 ; That ordering is what makes its optimistic rules LEGAL. The main
 ; stratum is the prover; by its fixpoint every provable equality has
 ; landed and every bound is final. Rules here may therefore do what

--- a/src/egglog_core/test_scripts/assoc_fence_example.egg
+++ b/src/egglog_core/test_scripts/assoc_fence_example.egg
@@ -49,7 +49,7 @@
 (let uncertifiable_inner (IntAdd maybe_empty_dim (IntLit -3)))
 (let blocked_regroup (IntAdd uncertifiable_inner (IntLit 5)))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (saturate (run fixpoint-invariants)))
 
 ; POSITIVE: the certified inner (5 + v0) regroups — both association
 ; orders land in one class...

--- a/src/egglog_core/test_scripts/bool_bridge_example.egg
+++ b/src/egglog_core/test_scripts/bool_bridge_example.egg
@@ -28,7 +28,7 @@
     (IntCastFromBool (BoolLessThanInt (IntLit 0) position))
     (IntCastFromBool (BoolLessThanInt position (IntLit 3)))))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 ; Decided comparisons ARE their literals — at the BOOL level first, and
 ; through the cast's literal mapping at the ring level.

--- a/src/egglog_core/test_scripts/boundary_aliased_views.egg
+++ b/src/egglog_core/test_scripts/boundary_aliased_views.egg
@@ -95,7 +95,7 @@
       (BufferTensorCons row1_output_buffer_tensor
         (BufferTensorNil)))))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 ; Each view is passed through without changing its boundary object.
 (check (= row0_input_buffer_tensor row0_output_buffer_tensor))

--- a/src/egglog_core/test_scripts/boundary_aliased_views_in_place.egg
+++ b/src/egglog_core/test_scripts/boundary_aliased_views_in_place.egg
@@ -86,7 +86,7 @@
       (BufferTensorCons row1_output_buffer_tensor
         (BufferTensorNil)))))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 ; The inputs alias each other, and the output writes into that same storage.
 (check (= (buffer-id-of row0_input_buffer_tensor)

--- a/src/egglog_core/test_scripts/boundary_donated_input.egg
+++ b/src/egglog_core/test_scripts/boundary_donated_input.egg
@@ -42,7 +42,7 @@
 (let output
   (BufferOutputLit (BufferTensorCons y_output_buffer_tensor (BufferTensorNil))))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 ; The sqrt implementation derives (the plan behavior under test — the free
 ; insertion and its ordering — lives in the golden, not the e-graph).

--- a/src/egglog_core/test_scripts/boundary_gather.egg
+++ b/src/egglog_core/test_scripts/boundary_gather.egg
@@ -53,7 +53,7 @@
     (BufferTensorCons lookup_output_buffer_tensor
       (BufferTensorNil))))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 ; Iota authoring contract: every constructed iota demands its expression's
 ; bounds — an absent entry fails the check loudly at the fixpoint.

--- a/src/egglog_core/test_scripts/boundary_iota.egg
+++ b/src/egglog_core/test_scripts/boundary_iota.egg
@@ -38,7 +38,7 @@
     (BufferTensorCons iota_output_buffer_tensor
       (BufferTensorNil))))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 ; Iota authoring contract: every constructed iota demands its expression's
 ; bounds — an absent entry fails the check loudly at the fixpoint.

--- a/src/egglog_core/test_scripts/boundary_pass_through.egg
+++ b/src/egglog_core/test_scripts/boundary_pass_through.egg
@@ -34,7 +34,7 @@
     (BufferTensorCons x_output_buffer_tensor
       (BufferTensorNil))))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 ; The output is exactly the input buffer tensor.
 (check (= x_input_buffer_tensor x_output_buffer_tensor))

--- a/src/egglog_core/test_scripts/boundary_scalar.egg
+++ b/src/egglog_core/test_scripts/boundary_scalar.egg
@@ -40,7 +40,7 @@
 (let output
   (BufferOutputLit (BufferTensorCons total_output_buffer_tensor (BufferTensorNil))))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 ; The scalar source is implementable...
 (check

--- a/src/egglog_core/test_scripts/boundary_scatter.egg
+++ b/src/egglog_core/test_scripts/boundary_scatter.egg
@@ -59,7 +59,7 @@
 (let output
   (BufferOutputLit (BufferTensorCons updated_output_buffer_tensor (BufferTensorNil))))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 ; Iota authoring contract: every constructed iota demands its expression's
 ; bounds — an absent entry fails the check loudly at the fixpoint.

--- a/src/egglog_core/test_scripts/boundary_war_hazard.egg
+++ b/src/egglog_core/test_scripts/boundary_war_hazard.egg
@@ -39,4 +39,4 @@
       (BufferTensorCons z_output_buffer_tensor
         (BufferTensorNil)))))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))

--- a/src/egglog_core/test_scripts/bounds_lattice_example.egg
+++ b/src/egglog_core/test_scripts/bounds_lattice_example.egg
@@ -45,7 +45,7 @@
     (IntLit 64)) (IntLit 64)) (IntLit 64)) (IntLit 64)) (IntLit 64)) (IntLit 64))
     (IntLit 64)) (IntLit 64)) (IntLit 64)))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (saturate (run fixpoint-invariants)))
 
 ; Literals are exact.
 (check (= (lower-bound-of (IntLit 64)) (bigint 64)))

--- a/src/egglog_core/test_scripts/dist_bridge_example.egg
+++ b/src/egglog_core/test_scripts/dist_bridge_example.egg
@@ -49,7 +49,7 @@
 ; must stay out of the transient window.
 (let zero_summand_seed (IntMul (IntAdd coord_inner (IntLit 0)) (IntLit 32)))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (saturate (run fixpoint-invariants)))
 
 ; The concrete bridge holds...
 (check (= concrete_factored concrete_expanded))

--- a/src/egglog_core/test_scripts/division_semantics_example.egg
+++ b/src/egglog_core/test_scripts/division_semantics_example.egg
@@ -49,7 +49,7 @@
 ; the fail-closed partiality gate: NOTHING may derive for this one
 (let quotient_maybe_zero (IntTruncDiv bounded_dividend maybe_zero_divisor))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (saturate (run fixpoint-invariants)))
 
 ; --- truncation is TOWARD ZERO, all quadrants (fail-pins guard the
 ; floor drift on the negative-dividend case) ---

--- a/src/egglog_core/test_scripts/dynamic_dim_example.egg
+++ b/src/egglog_core/test_scripts/dynamic_dim_example.egg
@@ -166,7 +166,7 @@
 ; each as a root (root-only substitution mints no per-subterm rows).
 (int-subst-demand seq_len row0_map)
 (int-subst-demand gap_probe_offset gap_transpose_map)
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 ; The right-major fold over [4, seq_len] produces SYMBOLIC strides
 ; [seq_len, 1]...
@@ -187,7 +187,7 @@
 ; it here and re-saturate.
 (int-subst-demand storage_offset row0_map)
 (int-subst-demand storage_offset transpose_map)
-(run-schedule (saturate (saturate (run)) (run subst-walk)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)))
 (check
   (= storage_layout
      (ElementOffsetExpressionLayoutLit storage_offset storage_shape (bits-of storage_dtype))))

--- a/src/egglog_core/test_scripts/elementwise_parity_example.egg
+++ b/src/egglog_core/test_scripts/elementwise_parity_example.egg
@@ -23,7 +23,7 @@
 (let less_logical (LogicalLessThan x_logical y_logical))
 (let half_logical (LogicalCast x_logical (F16)))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (saturate (run fixpoint-invariants)))
 
 ; --- the unary four: dtype and shape propagate; the functional match is
 ; pinned in full for Exp2 (the other three are byte-identical clones) ---

--- a/src/egglog_core/test_scripts/exact_division_example.egg
+++ b/src/egglog_core/test_scripts/exact_division_example.egg
@@ -70,7 +70,7 @@
 (let sum_trunc (IntTruncDiv sum_of_multiples (IntLit 64)))
 (let sum_ceil (IntCeilDiv sum_of_multiples (IntLit 64)))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (saturate (run fixpoint-invariants)))
 
 ; --- the tiling round trip: quotient recovers the tile index, the
 ; remainder is the zero function and is eliminated as a summand ---

--- a/src/egglog_core/test_scripts/gather_example.egg
+++ b/src/egglog_core/test_scripts/gather_example.egg
@@ -63,7 +63,7 @@
       table_shape)
     transpose_shape))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (saturate (run fixpoint-invariants)))
 
 ; Iota authoring contract: every constructed iota demands its expression's
 ; bounds — an absent entry fails the check loudly at the fixpoint.

--- a/src/egglog_core/test_scripts/gather_pending_union_example.egg
+++ b/src/egglog_core/test_scripts/gather_pending_union_example.egg
@@ -30,7 +30,7 @@
     (LogicalTensorCons ids_a
       (LogicalTensorCons iota_b (LogicalTensorNil)))))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (saturate (run fixpoint-invariants)))
 
 ; Iota authoring contract: every constructed iota demands its expression's
 ; bounds — an absent entry fails the check loudly at the fixpoint.

--- a/src/egglog_core/test_scripts/iota_example.egg
+++ b/src/egglog_core/test_scripts/iota_example.egg
@@ -27,7 +27,7 @@
 (let folded_iota (LogicalIota (IntAdd (IntLit 2) (IntLit 3)) scalar_shape))
 (let literal_iota (LogicalIota (IntLit 5) scalar_shape))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (saturate (run fixpoint-invariants)))
 
 ; Iota authoring contract: every constructed iota demands its expression's
 ; bounds — an absent entry fails the check loudly at the fixpoint.

--- a/src/egglog_core/test_scripts/min_max_example.egg
+++ b/src/egglog_core/test_scripts/min_max_example.egg
@@ -56,7 +56,7 @@
   (IndexMapLit (IntExprCons tile_coordinate (IntExprNil)) minmax_source_shape))
 (int-subst-demand coordinate_minimum identity_rank1_map)
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (saturate (run fixpoint-invariants)))
 
 ; --- folds ---
 (check (= fold_min_mixed (IntLit -3)))

--- a/src/egglog_core/test_scripts/nonzero_certificate_example.egg
+++ b/src/egglog_core/test_scripts/nonzero_certificate_example.egg
@@ -112,7 +112,7 @@
 ; SOURCE SEAM rows for list-authored strided layouts (affine migration)
 (strided-lists stall_layout stall_shape (IntExprCons (IntLit 12) (IntExprCons (IntLit 4) (IntExprNil))) (IntExprCons maybe_empty_dim (IntExprCons (IntLit 1) (IntExprNil))) (bits-of (F32)))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (saturate (run fixpoint-invariants)))
 
 ; --- the value route ---
 (check (provably-cannot-union-with-zero positive_literal))

--- a/src/egglog_core/test_scripts/reduction_shape.egg
+++ b/src/egglog_core/test_scripts/reduction_shape.egg
@@ -36,7 +36,7 @@
 (let sum_axis1 (LogicalReduceSum x_logical 1))
 (let max_axis2 (LogicalReduceMax x_logical 2))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 (check (= (expr-list-remove-axis-from-end
             (IntExprCons (IntLit 30)

--- a/src/egglog_core/test_scripts/scalar_example.egg
+++ b/src/egglog_core/test_scripts/scalar_example.egg
@@ -31,7 +31,7 @@
 ; --- scalar elementwise: rank-0 Add of the constant with the total ---
 (let shifted_total_logical (LogicalAdd total_logical bias_constant))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (saturate (run fixpoint-invariants)))
 
 ; --- the constant: rank 0, F32, congruence-deduped ---
 (check (= (shape-of bias_constant) scalar_shape))

--- a/src/egglog_core/test_scripts/scatter_example.egg
+++ b/src/egglog_core/test_scripts/scatter_example.egg
@@ -37,7 +37,7 @@
 
 (let updated_logical (LogicalScatter cache_logical coordinate_list new_row_logical))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (saturate (run fixpoint-invariants)))
 
 ; Iota authoring contract: every constructed iota demands its expression's
 ; bounds — an absent entry fails the check loudly at the fixpoint.

--- a/src/egglog_core/test_scripts/subst_aliased_min.egg
+++ b/src/egglog_core/test_scripts/subst_aliased_min.egg
@@ -18,7 +18,7 @@
 (int-subst-demand probe_off probe_row0_map)
 (int-subst-demand probe_off probe_row1_map)
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (saturate (run fixpoint-invariants)))
 
 ; expected images: row0 -> probe_v (0*3 + v folds), row1 -> 3 + v
 (check (= (int-subst-of probe_off probe_row0_map) probe_v))

--- a/src/egglog_core/test_scripts/subst_example.egg
+++ b/src/egglog_core/test_scripts/subst_example.egg
@@ -191,7 +191,7 @@
   (IntCastFromBool (BoolLessThanInt (CoordVar p9_source_shape 0) (IntLit 2))))
 (int-subst-demand p9_parent p9_map)
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (saturate (run fixpoint-invariants)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; P1: swap lands both variables at once: 3*v0 + v1.

--- a/src/egglog_core/test_scripts/subst_range_guard_example.egg
+++ b/src/egglog_core/test_scripts/subst_range_guard_example.egg
@@ -27,7 +27,7 @@
 (let oor_map (IndexMapLit (IntExprCons (IntAdd c0 (IntLit 1)) (IntExprNil)) d_shape))
 (let oor_view (LogicalIndexMapApply d oor_map d_shape))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 ; (1) The in-range composition completed: the parent bit-offset expression
 ; has an image under rev_map, and the composed layout tensor was minted.

--- a/src/egglog_core/test_scripts/tiled_view_example.egg
+++ b/src/egglog_core/test_scripts/tiled_view_example.egg
@@ -85,7 +85,7 @@
   (IndexMapLit (IntExprCons standalone_inner_coordinate (IntExprNil)) identity_rank1_source_shape))
 (int-subst-demand direct_quotient identity_rank1_map)
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 ; --- TILING: the composed layout is linear in the tile coordinates and
 ; discovery classifies it completely ---

--- a/src/egglog_core/test_scripts/transformer.egg
+++ b/src/egglog_core/test_scripts/transformer.egg
@@ -551,7 +551,7 @@
               (BufferTensorNil))))))))
 
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Shape checks.

--- a/src/egglog_snippet.rs
+++ b/src/egglog_snippet.rs
@@ -218,4 +218,47 @@ mod tests {
             .parse_and_run_program(None, &assembled_program_for(&[]))
             .expect("assembled program loads");
     }
+
+    /// The `prop` ruleset holds exactly the shape-of / dtype-of / rank-of
+    /// propagation rules: every default-ruleset rule does something else,
+    /// and every `prop` rule does nothing else. The schedule runs `prop`
+    /// to saturation before the main loop and alongside `(run)` inside
+    /// it, so a propagation rule left in the default ruleset would lose
+    /// the pre-pass and a minting rule tagged `prop` would run in it.
+    #[test]
+    fn prop_ruleset_is_exactly_the_propagation_rules() {
+        use egglog::ast::{Command, GenericAction};
+        const PROP: [&str; 3] = ["shape-of", "dtype-of", "rank-of"];
+        let only_propagation = |rule: &egglog::ast::Rule| {
+            !rule.head.0.is_empty()
+                && rule.head.0.iter().all(|action| match action {
+                    GenericAction::Set(_, head, _, _) => PROP.contains(&head.as_str()),
+                    _ => false,
+                })
+        };
+        let commands = new_egraph()
+            .parse_program(None, &assembled_program_for(&[]))
+            .expect("assembled program parses");
+        let mut prop_rules = 0;
+        for command in &commands {
+            let Command::Rule { rule } = command else {
+                continue;
+            };
+            match rule.ruleset.as_str() {
+                "prop" => {
+                    prop_rules += 1;
+                    assert!(
+                        only_propagation(rule),
+                        "prop rule does more than propagate: {rule}"
+                    );
+                }
+                "" => assert!(
+                    !only_propagation(rule),
+                    "propagation rule missing `:ruleset prop`: {rule}"
+                ),
+                _ => {}
+            }
+        }
+        assert!(prop_rules > 0, "no prop rules found");
+    }
 }

--- a/src/extraction.rs
+++ b/src/extraction.rs
@@ -4604,7 +4604,7 @@ mod chain_stride_tests {
 (let v (LogicalIndexMapApply plog (IndexMapLit (IntExprCons (CoordVar osh 2) (IntExprCons (CoordVar osh 0) (IntExprNil))) psh) osh))
 (let dsh (ShapeLit (IntExprCons (IntLit 1) (IntExprCons (IntLit 2) (IntExprNil)))))
 (let d (RightMajorContiguousElementLayoutLit dsh (bits-of (F32))))
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 "#;
         let full = format!("{}\n\n{body}", luminal_reference::assembled_program());
         let mut egraph = luminal::egglog_snippet::new_egraph();

--- a/src/logical_op/add/dtype.egg
+++ b/src/logical_op/add/dtype.egg
@@ -9,4 +9,5 @@
     (set (dtype-of ?out_logical_tensor) ?in1_dtype) ; DUPLICATIVE This is to trigger no merge runtime errors
     (set (dtype-of ?out_logical_tensor) ?in2_dtype) ; DUPLICATIVE This is to trigger no merge runtime errors
   )
+  :ruleset prop
 )

--- a/src/logical_op/add/shape.egg
+++ b/src/logical_op/add/shape.egg
@@ -15,4 +15,5 @@
   (
     (set (shape-of ?out_logical) ?shape)
   )
+  :ruleset prop
 )

--- a/src/logical_op/cast/dtype.egg
+++ b/src/logical_op/cast/dtype.egg
@@ -6,4 +6,5 @@
   (
     (set (dtype-of ?out_logical_tensor) ?target_dtype)
   )
+  :ruleset prop
 )

--- a/src/logical_op/cast/shape.egg
+++ b/src/logical_op/cast/shape.egg
@@ -8,4 +8,5 @@
   (
     (set (shape-of ?out_logical) ?shape)
   )
+  :ruleset prop
 )

--- a/src/logical_op/constant/dtype.egg
+++ b/src/logical_op/constant/dtype.egg
@@ -7,4 +7,5 @@
   (
     (set (dtype-of ?out_logical_tensor) (F32))
   )
+  :ruleset prop
 )

--- a/src/logical_op/constant/shape.egg
+++ b/src/logical_op/constant/shape.egg
@@ -6,4 +6,5 @@
   (
     (set (shape-of ?out_logical) (ShapeLit (IntExprNil)))
   )
+  :ruleset prop
 )

--- a/src/logical_op/div/dtype.egg
+++ b/src/logical_op/div/dtype.egg
@@ -9,4 +9,5 @@
     (set (dtype-of ?out_logical_tensor) ?in1_dtype) ; DUPLICATIVE This is to trigger no merge runtime errors
     (set (dtype-of ?out_logical_tensor) ?in2_dtype) ; DUPLICATIVE This is to trigger no merge runtime errors
   )
+  :ruleset prop
 )

--- a/src/logical_op/div/shape.egg
+++ b/src/logical_op/div/shape.egg
@@ -8,4 +8,5 @@
   (
     (set (shape-of ?out_logical) ?shape)
   )
+  :ruleset prop
 )

--- a/src/logical_op/exp/dtype.egg
+++ b/src/logical_op/exp/dtype.egg
@@ -7,4 +7,5 @@
   (
     (set (dtype-of ?out_logical_tensor) ?dtype)
   )
+  :ruleset prop
 )

--- a/src/logical_op/exp/shape.egg
+++ b/src/logical_op/exp/shape.egg
@@ -7,4 +7,5 @@
   (
     (set (shape-of ?out_logical) ?shape)
   )
+  :ruleset prop
 )

--- a/src/logical_op/exp2/dtype.egg
+++ b/src/logical_op/exp2/dtype.egg
@@ -7,4 +7,5 @@
   (
     (set (dtype-of ?out_logical_tensor) ?dtype)
   )
+  :ruleset prop
 )

--- a/src/logical_op/exp2/shape.egg
+++ b/src/logical_op/exp2/shape.egg
@@ -7,4 +7,5 @@
   (
     (set (shape-of ?out_logical) ?shape)
   )
+  :ruleset prop
 )

--- a/src/logical_op/gather/dtype.egg
+++ b/src/logical_op/gather/dtype.egg
@@ -7,4 +7,5 @@
   (
     (set (dtype-of ?out_logical_tensor) ?data_dtype)
   )
+  :ruleset prop
 )

--- a/src/logical_op/gather/shape.egg
+++ b/src/logical_op/gather/shape.egg
@@ -7,4 +7,5 @@
   (
     (set (shape-of ?out_logical) ?common_shape)
   )
+  :ruleset prop
 )

--- a/src/logical_op/index_map_apply/dtype.egg
+++ b/src/logical_op/index_map_apply/dtype.egg
@@ -7,4 +7,5 @@
   (
     (set (dtype-of ?out_logical_tensor) ?dtype)
   )
+  :ruleset prop
 )

--- a/src/logical_op/index_map_apply/shape.egg
+++ b/src/logical_op/index_map_apply/shape.egg
@@ -6,4 +6,5 @@
   (
     (set (shape-of ?out_logical) ?shape)
   )
+  :ruleset prop
 )

--- a/src/logical_op/iota/dtype.egg
+++ b/src/logical_op/iota/dtype.egg
@@ -7,4 +7,5 @@
   (
     (set (dtype-of ?out_logical_tensor) (Int))
   )
+  :ruleset prop
 )

--- a/src/logical_op/iota/shape.egg
+++ b/src/logical_op/iota/shape.egg
@@ -6,4 +6,5 @@
   (
     (set (shape-of ?out_logical) ?shape)
   )
+  :ruleset prop
 )

--- a/src/logical_op/less_than/dtype.egg
+++ b/src/logical_op/less_than/dtype.egg
@@ -8,4 +8,5 @@
   (
     (set (dtype-of ?out_logical_tensor) (Bool))
   )
+  :ruleset prop
 )

--- a/src/logical_op/less_than/shape.egg
+++ b/src/logical_op/less_than/shape.egg
@@ -8,4 +8,5 @@
   (
     (set (shape-of ?out_logical) ?shape)
   )
+  :ruleset prop
 )

--- a/src/logical_op/log2/dtype.egg
+++ b/src/logical_op/log2/dtype.egg
@@ -7,4 +7,5 @@
   (
     (set (dtype-of ?out_logical_tensor) ?dtype)
   )
+  :ruleset prop
 )

--- a/src/logical_op/log2/shape.egg
+++ b/src/logical_op/log2/shape.egg
@@ -7,4 +7,5 @@
   (
     (set (shape-of ?out_logical) ?shape)
   )
+  :ruleset prop
 )

--- a/src/logical_op/modulo/dtype.egg
+++ b/src/logical_op/modulo/dtype.egg
@@ -9,4 +9,5 @@
     (set (dtype-of ?out_logical_tensor) ?in1_dtype) ; DUPLICATIVE This is to trigger no merge runtime errors
     (set (dtype-of ?out_logical_tensor) ?in2_dtype) ; DUPLICATIVE This is to trigger no merge runtime errors
   )
+  :ruleset prop
 )

--- a/src/logical_op/modulo/shape.egg
+++ b/src/logical_op/modulo/shape.egg
@@ -8,4 +8,5 @@
   (
     (set (shape-of ?out_logical) ?shape)
   )
+  :ruleset prop
 )

--- a/src/logical_op/mul/dtype.egg
+++ b/src/logical_op/mul/dtype.egg
@@ -9,4 +9,5 @@
     (set (dtype-of ?out_logical_tensor) ?in1_dtype) ; DUPLICATIVE This is to trigger no merge runtime errors
     (set (dtype-of ?out_logical_tensor) ?in2_dtype) ; DUPLICATIVE This is to trigger no merge runtime errors
   )
+  :ruleset prop
 )

--- a/src/logical_op/mul/shape.egg
+++ b/src/logical_op/mul/shape.egg
@@ -8,4 +8,5 @@
   (
     (set (shape-of ?out_logical) ?shape)
   )
+  :ruleset prop
 )

--- a/src/logical_op/recip/dtype.egg
+++ b/src/logical_op/recip/dtype.egg
@@ -7,4 +7,5 @@
   (
     (set (dtype-of ?out_logical_tensor) ?dtype)
   )
+  :ruleset prop
 )

--- a/src/logical_op/recip/shape.egg
+++ b/src/logical_op/recip/shape.egg
@@ -7,4 +7,5 @@
   (
     (set (shape-of ?out_logical) ?shape)
   )
+  :ruleset prop
 )

--- a/src/logical_op/reduce_max/dtype.egg
+++ b/src/logical_op/reduce_max/dtype.egg
@@ -7,4 +7,5 @@
   (
     (set (dtype-of ?out_logical_tensor) ?in_dtype)
   )
+  :ruleset prop
 )

--- a/src/logical_op/reduce_max/shape.egg
+++ b/src/logical_op/reduce_max/shape.egg
@@ -8,4 +8,5 @@
   (
     (set (shape-of ?out_logical) (ShapeLit ?out_dims))
   )
+  :ruleset prop
 )

--- a/src/logical_op/reduce_sum/dtype.egg
+++ b/src/logical_op/reduce_sum/dtype.egg
@@ -7,4 +7,5 @@
   (
     (set (dtype-of ?out_logical_tensor) ?in_dtype)
   )
+  :ruleset prop
 )

--- a/src/logical_op/reduce_sum/shape.egg
+++ b/src/logical_op/reduce_sum/shape.egg
@@ -8,4 +8,5 @@
   (
     (set (shape-of ?out_logical) (ShapeLit ?out_dims))
   )
+  :ruleset prop
 )

--- a/src/logical_op/scatter/dtype.egg
+++ b/src/logical_op/scatter/dtype.egg
@@ -14,4 +14,5 @@
     (set (dtype-of ?out_logical_tensor) ?init_dtype)
     (set (dtype-of ?out_logical_tensor) ?src_dtype)
   )
+  :ruleset prop
 )

--- a/src/logical_op/scatter/shape.egg
+++ b/src/logical_op/scatter/shape.egg
@@ -9,4 +9,5 @@
   (
     (set (shape-of ?out_logical) ?init_shape)
   )
+  :ruleset prop
 )

--- a/src/logical_op/sin/dtype.egg
+++ b/src/logical_op/sin/dtype.egg
@@ -7,4 +7,5 @@
   (
     (set (dtype-of ?out_logical_tensor) ?dtype)
   )
+  :ruleset prop
 )

--- a/src/logical_op/sin/shape.egg
+++ b/src/logical_op/sin/shape.egg
@@ -7,4 +7,5 @@
   (
     (set (shape-of ?out_logical) ?shape)
   )
+  :ruleset prop
 )

--- a/src/logical_op/sqrt/dtype.egg
+++ b/src/logical_op/sqrt/dtype.egg
@@ -7,4 +7,5 @@
   (
     (set (dtype-of ?out_logical_tensor) ?dtype)
   )
+  :ruleset prop
 )

--- a/src/logical_op/sqrt/shape.egg
+++ b/src/logical_op/sqrt/shape.egg
@@ -7,4 +7,5 @@
   (
     (set (shape-of ?out_logical) ?shape)
   )
+  :ruleset prop
 )

--- a/src/logical_op/trunc_div/dtype.egg
+++ b/src/logical_op/trunc_div/dtype.egg
@@ -9,4 +9,5 @@
     (set (dtype-of ?out_logical_tensor) ?in1_dtype) ; DUPLICATIVE This is to trigger no merge runtime errors
     (set (dtype-of ?out_logical_tensor) ?in2_dtype) ; DUPLICATIVE This is to trigger no merge runtime errors
   )
+  :ruleset prop
 )

--- a/src/logical_op/trunc_div/shape.egg
+++ b/src/logical_op/trunc_div/shape.egg
@@ -8,4 +8,5 @@
   (
     (set (shape-of ?out_logical) ?shape)
   )
+  :ruleset prop
 )

--- a/src/logical_op/trunc_rem/dtype.egg
+++ b/src/logical_op/trunc_rem/dtype.egg
@@ -9,4 +9,5 @@
     (set (dtype-of ?out_logical_tensor) ?in1_dtype) ; DUPLICATIVE This is to trigger no merge runtime errors
     (set (dtype-of ?out_logical_tensor) ?in2_dtype) ; DUPLICATIVE This is to trigger no merge runtime errors
   )
+  :ruleset prop
 )

--- a/src/logical_op/trunc_rem/shape.egg
+++ b/src/logical_op/trunc_rem/shape.egg
@@ -8,4 +8,5 @@
   (
     (set (shape-of ?out_logical) ?shape)
   )
+  :ruleset prop
 )

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1286,7 +1286,7 @@ mod harness_tests {
     (LogicalTensorCons row_iota (LogicalTensorCons col_iota (LogicalTensorNil)))))
 (let data_layout (RightMajorContiguousElementLayoutLit data_shape (bits-of (F32))))
 (let data_layout_tensor (LayoutTensorLit data_logical data_layout))
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 "#;
         let full = format!("{}\n\n{}", luminal_reference::assembled_program(), body);
         luminal::egglog_snippet::new_egraph()
@@ -1396,7 +1396,7 @@ mod harness_tests {
   (LogicalScatter cache
     (LogicalTensorCons position (LogicalTensorCons column (LogicalTensorNil)))
     src))
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (saturate (run fixpoint-invariants)))
 "#;
         let program = format!(
             "{preamble}
@@ -1552,7 +1552,7 @@ mod harness_tests {
 (set (buffer-freed-by out_buffer) (CallerFrees))
 (let output
   (BufferOutputLit (BufferTensorCons (BufferTensorLit out_lt out_buffer) (BufferTensorNil))))
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 "#;
         let program = format!("{preamble}\n\n{script}");
         let mut egraph = luminal::egglog_snippet::new_egraph();
@@ -1578,7 +1578,7 @@ mod harness_tests {
 (let mystery_var (IntVar "mystery_var"))
 (let unsafe_shape (ShapeLit (IntExprCons (IntLit 4) (IntExprNil))))
 (let unbounded_iota (LogicalIota mystery_var unsafe_shape))
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (saturate (run fixpoint-invariants)))
 (check (= ?demanded_lower (lower-bound-of mystery_var)))
 (check (= ?demanded_upper (upper-bound-of mystery_var)))
 "#;
@@ -2076,7 +2076,7 @@ mod intcoordvar_probe {
   (IndexMapLit (IntExprCons (CoordVar out_shape 0) (IntExprNil)) vec_shape) out_shape))
 (let v_layout (RightMajorContiguousElementLayoutLit vec_shape (bits-of (F32))))
 (let v_lt (LayoutTensorLit v_in v_layout))
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 "#,
         );
         let mut egraph = crate::egglog_snippet::new_egraph();
@@ -2599,7 +2599,7 @@ mod stage4b_probes {
 (let plt (LayoutTensorLit plog p))
 (let osh (ShapeLit (IntExprCons (IntLit 5) (IntExprCons (IntLit 4) (IntExprNil)))))
 (let v (LogicalIndexMapApply plog (IndexMapLit (IntExprCons (CoordVar osh 1) (IntExprCons (CoordVar osh 0) (IntExprNil))) psh) osh))
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 "#;
         let full = format!("{}\n\n{body}", luminal_reference::assembled_program());
         let err = luminal::egglog_snippet::new_egraph()
@@ -2691,7 +2691,7 @@ mod subst_guard_study {
 (let sg_map (IndexMapLit (IntExprCons sg_entry (IntExprNil)) sg_src))\n\
 (let sg_coord (CoordVar sg_src 0))\n\
 (int-subst-demand sg_coord sg_map)\n\
-(run-schedule (saturate (saturate (run)) (run subst-walk)))\n";
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)))\n";
         let sg4_common = "\
 (let s4n (IntVar \"s4n\"))\n\
 (set (lower-bound-of s4n) (bigint 1))\n\
@@ -2701,7 +2701,7 @@ mod subst_guard_study {
 (let s4_map (IndexMapLit (IntExprCons s4_entry (IntExprNil)) s4_src))\n\
 (let s4_coord (CoordVar s4_src 0))\n\
 (int-subst-demand s4_coord s4_map)\n\
-(run-schedule (saturate (saturate (run)) (run subst-walk)))\n";
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)))\n";
         vec![
             (
                 "sg1_admits",
@@ -2710,7 +2710,7 @@ mod subst_guard_study {
             (
                 "sg1_tighten",
                 format!(
-                    "{sg1_common}(set (upper-bound-of sgn) (bigint 1))\n(run-schedule (saturate (saturate (run)) (run subst-walk)))\n"
+                    "{sg1_common}(set (upper-bound-of sgn) (bigint 1))\n(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)))\n"
                 ),
             ),
             (
@@ -2723,7 +2723,7 @@ mod subst_guard_study {
 (let s2_map (IndexMapLit (IntExprCons s2_entry (IntExprNil)) s2_src))\n\
 (let s2_coord (CoordVar s2_src 0))\n\
 (int-subst-demand s2_coord s2_map)\n\
-(run-schedule (saturate (saturate (run)) (run subst-walk)))\n\
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)))\n\
 (check (= (int-subst-of s2_coord s2_map) s2_entry))\n"
                     .to_string(),
             ),
@@ -2739,7 +2739,7 @@ mod subst_guard_study {
 (let s3_map (IndexMapLit (IntExprCons s3_entry (IntExprNil)) s3_src))\n\
 (let s3_coord (CoordVar s3_src 0))\n\
 (int-subst-demand s3_coord s3_map)\n\
-(run-schedule (saturate (saturate (run)) (run subst-walk)))\n\
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)))\n\
 (check (= (int-subst-of s3_coord s3_map) s3_entry))\n"
                     .to_string(),
             ),
@@ -2753,7 +2753,7 @@ mod subst_guard_study {
             (
                 "sg4_tighten",
                 format!(
-                    "{s4}(set (upper-bound-of s4n) (bigint 1))\n(run-schedule (saturate (saturate (run)) (run subst-walk)))\n",
+                    "{s4}(set (upper-bound-of s4n) (bigint 1))\n(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)))\n",
                     s4 = sg4_common
                 ),
             ),
@@ -3093,8 +3093,8 @@ mod ring_ignition_battery {
         map
     }
 
-    const RING_ONLY: &str = "(run 1)";
-    const RING_AND_SUBST: &str = "(run 1) (run subst-walk 1)";
+    const RING_ONLY: &str = "(run 1) (run prop 1)";
+    const RING_AND_SUBST: &str = "(run 1) (run prop 1) (run subst-walk 1)";
 
     /// Hard per-round wall-clock bail: a healthy round on this suite is
     /// milliseconds; one slow round means the ring is burning.

--- a/tests/test_runtime/fixtures/basic_program.egg
+++ b/tests/test_runtime/fixtures/basic_program.egg
@@ -159,7 +159,7 @@
 ; SOURCE SEAM rows for list-authored strided layouts (affine migration)
 (strided-lists x_input_layout x_shape (IntExprCons (IntLit 4) (IntExprCons (IntLit 2) (IntExprNil))) x_input_strides (bits-of x_dtype))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 ; The transpose substitution swaps both variables SIMULTANEOUSLY:
 ; x offset v1*8 + v0*2 over x's coords becomes 8*z_v0 + 2*z_v1 over z's

--- a/tests/test_runtime/fixtures/boundary_alias_safe_add.egg
+++ b/tests/test_runtime/fixtures/boundary_alias_safe_add.egg
@@ -37,7 +37,7 @@
     (BufferTensorCons z_output_buffer_tensor
       (BufferTensorNil))))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 ; In-place accumulation is represented by storage identity across the boundary.
 (check (= (buffer-id-of x_input_buffer_tensor)

--- a/tests/test_runtime/fixtures/boundary_in_place_mutation.egg
+++ b/tests/test_runtime/fixtures/boundary_in_place_mutation.egg
@@ -37,7 +37,7 @@
     (BufferTensorCons y_output_buffer_tensor
       (BufferTensorNil))))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 ; In-place mutation is represented by storage identity across the boundary.
 (check (= (buffer-id-of x_input_buffer_tensor)

--- a/tests/test_runtime/fixtures/boundary_scatter.egg
+++ b/tests/test_runtime/fixtures/boundary_scatter.egg
@@ -70,7 +70,7 @@
 (let output
   (BufferOutputLit (BufferTensorCons updated_output_buffer_tensor (BufferTensorNil))))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 ; Iota authoring contract: every constructed iota demands its expression's
 ; bounds — an absent entry fails the check loudly at the fixpoint.

--- a/tests/test_runtime/fixtures/boundary_view_feeds_compute.egg
+++ b/tests/test_runtime/fixtures/boundary_view_feeds_compute.egg
@@ -58,7 +58,7 @@
 (let output
   (BufferOutputLit (BufferTensorCons y_output_buffer_tensor (BufferTensorNil))))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 ; The composed view layout — the parent's fold-derived bit offset pushed
 ; through the transpose map — lands in the hand-written left-major class.

--- a/tests/test_runtime/fixtures/boundary_write_into_viewed_buffer.egg
+++ b/tests/test_runtime/fixtures/boundary_write_into_viewed_buffer.egg
@@ -77,7 +77,7 @@
       (BufferTensorCons r_output_buffer_tensor
         (BufferTensorNil)))))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 
 ; The composed row-0 layout is DISCOVERED contiguous (zero entry annihilates,
 ; strides fold, contiguity classified)...

--- a/tests/test_runtime/fixtures/elementwise_parity_example.egg
+++ b/tests/test_runtime/fixtures/elementwise_parity_example.egg
@@ -34,7 +34,7 @@
 (let less_logical (LogicalLessThan x_logical y_logical))
 (let half_logical (LogicalCast x_logical (F16)))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (saturate (run fixpoint-invariants)))
 
 ; --- the unary four: dtype and shape propagate; the functional match is
 ; pinned in full for Exp2 (the other three are byte-identical clones) ---

--- a/tests/test_runtime/fixtures/scatter_example.egg
+++ b/tests/test_runtime/fixtures/scatter_example.egg
@@ -48,7 +48,7 @@
 
 (let updated_logical (LogicalScatter cache_logical coordinate_list new_row_logical))
 
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (saturate (run fixpoint-invariants)))
 
 ; Iota authoring contract: every constructed iota demands its expression's
 ; bounds — an absent entry fails the check loudly at the fixpoint.

--- a/tests/test_runtime/src/bindings.rs
+++ b/tests/test_runtime/src/bindings.rs
@@ -29,7 +29,7 @@ pub struct TestRuntimeBindings;
 impl TestRuntimeBindings {
     /// The standard schedule tail shared by every assembled program on
     /// this runtime.
-    pub const SCHEDULE: &'static str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run cleanup)) (saturate (run fixpoint-invariants)))\n\n";
+    pub const SCHEDULE: &'static str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run cleanup)) (saturate (run fixpoint-invariants)))\n\n";
 }
 
 impl RuntimeBindingsGenerator for TestRuntimeBindings {

--- a/tests/test_runtime/tests/cublaslt_marker_adversarial.rs
+++ b/tests/test_runtime/tests/cublaslt_marker_adversarial.rs
@@ -12,7 +12,7 @@ use luminal::dtype::DType;
 use luminal::layout_ir::ExtractedNode;
 use test_runtime::cublaslt_marker::CublasLt;
 
-const SCHEDULE: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
+const SCHEDULE: &str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
 
 const PIN: &[&str] = &[
     "LayoutTensorOpCublasLtAccumulateBias",

--- a/tests/test_runtime/tests/cublaslt_marker_hypothesis.rs
+++ b/tests/test_runtime/tests/cublaslt_marker_hypothesis.rs
@@ -9,7 +9,7 @@
 //!     "Panic: Illegal merge attempted for function cu-trans-a-of"
 //! With descriptor TERMS the same programs are legal multiplicity.
 
-const SCHEDULE: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
+const SCHEDULE: &str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
 
 const PIN: &[&str] = &[
     "LayoutTensorOpCublasLtAccumulateBias",

--- a/tests/test_runtime/tests/cublaslt_marker_round2_attack.rs
+++ b/tests/test_runtime/tests/cublaslt_marker_round2_attack.rs
@@ -37,7 +37,7 @@ type GraphBuilder = Box<dyn Fn(&mut Graph)>;
 type FormProgram = (&'static str, CublasLtForm, GraphBuilder);
 type EpilogueProgram = (&'static str, CublasLtForm, CuEpilogue, GraphBuilder);
 
-const SCHEDULE: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
+const SCHEDULE: &str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
 
 const PIN: &[&str] = &[
     "LayoutTensorOpCublasLtAccumulateBias",

--- a/tests/test_runtime/tests/cublaslt_marker_round3_attack.rs
+++ b/tests/test_runtime/tests/cublaslt_marker_round3_attack.rs
@@ -35,7 +35,7 @@ use luminal::layout_ir::ExtractedNode;
 use luminal::prelude::egraph_serialize::{ClassId, EGraph, Node, NodeId};
 use test_runtime::cublaslt_marker::{CuDim, CuEpilogue, CublasLt, LtMatmulSpec};
 
-const SCHEDULE: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
+const SCHEDULE: &str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
 
 const PIN: &[&str] = &[
     "LayoutTensorOpCublasLtAccumulateBias",

--- a/tests/test_runtime/tests/cublaslt_marker_round4.rs
+++ b/tests/test_runtime/tests/cublaslt_marker_round4.rs
@@ -11,7 +11,7 @@ use test_runtime::cublaslt_marker::{CuDim, CuEpilogue, CublasLt, CublasLtDps, Cu
 type GraphBuilder = Box<dyn Fn(&mut Graph)>;
 type FormProgram = (&'static str, CublasLtForm, GraphBuilder);
 
-const SCHEDULE: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
+const SCHEDULE: &str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
 
 const PIN: &[&str] = &[
     "LayoutTensorOpCublasLtAccumulateBias",

--- a/tests/test_runtime/tests/double_transpose_probe.rs
+++ b/tests/test_runtime/tests/double_transpose_probe.rs
@@ -17,7 +17,7 @@
 //! that anchor: if the collapse rule is ever weakened or dropped, the
 //! transpose-sandwich rewrite mints views-of-views without bound and
 //! saturation never closes (see tests/r11_collapse_revert_probe.rs).
-const SCHEDULE: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
+const SCHEDULE: &str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
 
 #[test]
 fn double_transpose_rejoins_via_the_collapse_rule() {

--- a/tests/test_runtime/tests/gap_probe.rs
+++ b/tests/test_runtime/tests/gap_probe.rs
@@ -13,7 +13,7 @@
 //! (:3865, :3882 and the native chain-walk seed :4076, :4090), so a pitched
 //! operand's broadcast has NO composed layout, and the layout-native arms
 //! have nothing to read. That is why one map-spelling B arm survives.
-const SCHEDULE: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
+const SCHEDULE: &str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
 
 #[test]
 fn raw_strided_never_climbs_to_bit_offset() {

--- a/tests/test_runtime/tests/r10_debug.rs
+++ b/tests/test_runtime/tests/r10_debug.rs
@@ -401,7 +401,7 @@ fn r10_debug_p1() {
     // replicate p1's seeded fixture and print the matched op enodes
     let fx_text = {
         // Fx::default() equivalent: hand 2D A[m,k],B[k,n] matmul x[2,4] w[4,3]
-        let sched = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
+        let sched = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
         let base = format!(
             r#"(let a_shape (ShapeLit (IntExprCons (IntLit 2) (IntExprCons (IntLit 4) (IntExprNil)))))
 (let b_shape (ShapeLit (IntExprCons (IntLit 4) (IntExprCons (IntLit 3) (IntExprNil)))))
@@ -468,7 +468,7 @@ fn r10_debug_p1() {
 
 #[test]
 fn r10_debug_rc3() {
-    let sched = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
+    let sched = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
     let fx = format!(
         r#"(let a_shape (ShapeLit (IntExprCons (IntLit 2) (IntExprCons (IntLit 4) (IntExprNil)))))
 (let b_shape (ShapeLit (IntExprCons (IntLit 4) (IntExprCons (IntLit 3) (IntExprNil)))))

--- a/tests/test_runtime/tests/r7_e2_probe.rs
+++ b/tests/test_runtime/tests/r7_e2_probe.rs
@@ -89,7 +89,7 @@ fn e2_composition_canonicalization_probe() {
 (let x_buffer_tensor (BufferTensorLit x_lt x_buffer_id))
 (let out_buffer_tensor (BufferTensorLit probe_lt out_buffer_id))
 (let output (BufferOutputLit (BufferTensorCons out_buffer_tensor (BufferTensorNil))))
-(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
+(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))
 "#;
     let s = test_runtime::serialize_fixture(fx);
     let const_classes: std::collections::BTreeSet<_> = s

--- a/tests/test_runtime/tests/r7_probes.rs
+++ b/tests/test_runtime/tests/r7_probes.rs
@@ -1,7 +1,7 @@
 //! E3 pins: what the injectivity premise and the nonnegativity bound each
 //! refuse (the revert-probe anchors for the deleted certificate relation).
 
-const SCHEDULE: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
+const SCHEDULE: &str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
 
 fn skeleton(x_layout_lines: &str) -> String {
     format!(

--- a/tests/test_runtime/tests/r8_form_hypothesis.rs
+++ b/tests/test_runtime/tests/r8_form_hypothesis.rs
@@ -17,7 +17,7 @@ use luminal::dtype::DType;
 use luminal::graph::Graph;
 use luminal::prelude::egraph_serialize::{ClassId, EGraph};
 
-const SCHEDULE: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
+const SCHEDULE: &str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
 
 fn class_has(s: &EGraph, class: &ClassId, op: &str) -> bool {
     s.nodes.values().any(|n| &n.eclass == class && n.op == op)

--- a/tests/test_runtime/tests/r8d_chain_probe.rs
+++ b/tests/test_runtime/tests/r8d_chain_probe.rs
@@ -23,7 +23,7 @@ use luminal::layout_ir::{ExtractionSite, SerializedIndex};
 use luminal::prelude::egraph_serialize::{ClassId, EGraph};
 use test_runtime::cublaslt_marker::{CublasLtForm, parse_spec};
 
-const SCHEDULE: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
+const SCHEDULE: &str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
 
 /// Two matmuls sharing ONE square weight `b` [3,3]:
 ///   out1 = x[2,3] @ b        (A[m,k],B[k,n] spelling, map (c0 c1))

--- a/tests/test_runtime/tests/r9_pitched_operand_probe.rs
+++ b/tests/test_runtime/tests/r9_pitched_operand_probe.rs
@@ -32,7 +32,7 @@ use luminal::layout_ir::ExtractedNode;
 use luminal::prelude::egraph_serialize::EGraph;
 use test_runtime::cublaslt_marker::CublasLt;
 
-const SCHEDULE: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
+const SCHEDULE: &str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
 
 /// x[2,3] @ w[3,4], where w is a column-slice VIEW of a [3,8] parent.
 /// `certificate` supplies the creator's injectivity assertion (or not).

--- a/tests/test_runtime/tests/sep_probe.rs
+++ b/tests/test_runtime/tests/sep_probe.rs
@@ -19,7 +19,7 @@
 
 use luminal::prelude::egraph_serialize::{ClassId, EGraph};
 
-const SCHEDULE: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
+const SCHEDULE: &str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
 
 fn fixture() -> String {
     format!(

--- a/tests/test_runtime/tests/slice_inj_inheritance_probe.rs
+++ b/tests/test_runtime/tests/slice_inj_inheritance_probe.rs
@@ -36,7 +36,7 @@
 
 use luminal::prelude::egraph_serialize::{ClassId, EGraph};
 
-const SCHEDULE: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
+const SCHEDULE: &str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
 
 /// THE CANDIDATE RULE (probe-local; rank-2 axis-aligned arm). Derived,
 /// never asserted: every premise is structural or an anchored membership

--- a/tests/test_runtime/tests/strided_lists_authoring_probe.rs
+++ b/tests/test_runtime/tests/strided_lists_authoring_probe.rs
@@ -12,7 +12,7 @@
 //! If YES: the creator-pitched population is unblocked by a fixture/creator
 //! convention change (no preamble edit); only genuinely list-less layouts
 //! (chain-walk-composed views used as parents) need the chain-walk seed fix.
-const SCHEDULE: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
+const SCHEDULE: &str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
 
 #[test]
 fn strided_lists_authored_pitch_climbs_the_ladder() {

--- a/tests/test_runtime/tests/view_arity_lock.rs
+++ b/tests/test_runtime/tests/view_arity_lock.rs
@@ -20,8 +20,8 @@
 
 use luminal::layout_ir::OpMatcher;
 
-const FULL: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
-const NO_INVARIANTS: &str = "(run-schedule (saturate (saturate (run)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata))";
+const FULL: &str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata) (saturate (run fixpoint-invariants)))";
+const NO_INVARIANTS: &str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) (run materializing-copy-mint) (run layout-tensor-op-metadata))";
 
 /// This runtime's vocabulary WITHOUT the cuBLASLt marker estate — the
 /// tripwire's behaviour must not depend on any backend's rules.


### PR DESCRIPTION
## What
Experiment A made permanent. The 44 rules whose only actions set `shape-of`, `dtype-of` or `rank-of` (every op's `shape.egg` and `dtype.egg`, plus the preamble's rank-of and input-literal rules) carry `:ruleset prop`; `(ruleset prop)` is declared in the preamble. Every schedule in the tree (2 bindings constants, test_support, extraction, 33 core test scripts, test_runtime bindings/tests/fixtures — 74 sites) becomes

```
(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)) ...)
```

Rule bodies are untouched: 44 tag lines, one declaration, schedule strings, one test.

Interleaving `(run) (run prop)` inside the inner loop was chosen over `unstable-combined-ruleset`: measured identical speed (2.36 vs 2.37 s at 8 layers, 12.5 vs 12.3 s at 34), no dependence on an unstable egglog feature, and no need to retag the other 373 default rules.

## Measured (gemma3-4B dims, Mac, tree decomposition off)
| layers | trunk | this branch |
|---|---|---|
| 8 | 3.80 s | 2.40 s |
| 16 | 9.15 s | 4.55 s |
| 34 | 31.0 s | 12.5 s |

cuBLASLt canonical-chain trio at 34 layers: 17.5 s -> 1.7 s. The `prop` pre-pass costs 10-42 ms.

## Fixpoint
All constructor/e-node tables have identical row counts at every depth. Five analysis relations (`axis-free`, `axis-free-demand`, `int-subst-closed`, `int-subst-closed-demand`, `provably-exact-division-expression`) gain the same 22 rows at 8/16/34 layers — closure and certificate facts about `(IntLit 1)` and extent-1 axes that the old order never demanded. The order-dependence itself is filed as LUM-818 (https://linear.app/luminalai/issue/LUM-818); this PR does not introduce it, it exposes it. Class counts were not compared.

## Checks
`cargo check --workspace --tests`, `cargo fmt --check`, `cargo clippy -p luminal --lib` (20 warnings, baseline 21); `cargo test -p luminal --lib` 257 passed (includes the new `prop_ruleset_is_exactly_the_propagation_rules`); `test_runtime --test cublaslt_marker` 4/4; `cublaslt_election election_row_gemma3`; `luminal_reference --lib` 44/44. Full workspace gate running detached; `model_example_boundary` is known-failing on trunk (nine example files vs eight expected) and unrelated.

Not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)