### PR TITLE
Generalize automatic loop rolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,6 @@ off by default; set to `1` to enable unless noted.
 |---|---|
 | `LUMINAL_SEARCH_SEED` | Overrides the search RNG seed in the examples (integer). |
 | `SEARCH_MEMORY_MIB` | Overrides the search intermediate-memory cap in examples that support it (integer MiB). |
-| `LUMINAL_MAX_ROLL_BODY` | Caps the largest HLIR window probed by the loop-rolling prepass (default 8192 nodes). |
 | `LUMINAL_COMPUTE_MAJOR` | Overrides the detected CUDA compute capability major version. |
 | `LUMINAL_CUBLASLT_AUTOTUNE` | Enables cuBLASLt algorithm autotuning at prepare time. |
 | `FLASHINFER_CUDA_ARCH` / `LUMINAL_FLASHINFER_DIR` / `LUMINAL_FLASHINFER_DECODE_GRAPH_CAPACITY` | FlashInfer JIT: target arch, cache/library directory, and decode graph capacity override. |

--- a/crates/luminal_cuda_lite/src/kernel/quant_f8.rs
+++ b/crates/luminal_cuda_lite/src/kernel/quant_f8.rs
@@ -59,7 +59,13 @@ impl EgglogOp for KernelQuantF8 {
                 (
                     (= ?xf (Op (Cast ?xf_size (F32)) (ICons ?x (INil))))
                     (= (Bf16) (dtype ?x))
-                    (= ?recip (Op (Recip ?r_shape ?r_in_strides ?r_out_strides)
+                    ; This kernel reads scale[0], so the scale must be a
+                    ; scalar broadcast across the complete 2-D activation.
+                    ; Per-row/per-group scales have nonzero logical strides
+                    ; and must remain on their exact elementwise path.
+                    (= ?recip (Op (Recip ?r_shape
+                        (ECons (MNum 0) (ECons (MNum 0) (ENil)))
+                        ?r_out_strides)
                         (ICons ?scale (INil))))
                     (= ?mul (Op (Mul ?m_shape ?xf_strides ?recip_strides ?m_out_strides)
                         (ICons ?xf (ICons ?recip (INil)))))

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -40,7 +40,10 @@ use std::{
     fmt::Debug,
     fs::File,
     marker::PhantomData,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
     time::Duration,
 };
 use tracing::{Level, span, trace};
@@ -79,6 +82,12 @@ fn materialized_bucket_evictions(
     }
     evictions
 }
+
+/// Process-wide execution identities keep static HostOp caches isolated even
+/// when compiler search moves between freshly constructed runtime instances.
+/// Host-side planners can still share immutable preparation within one
+/// execution without carrying dynamic metadata across executions.
+static NEXT_EXECUTION_ID: AtomicU64 = AtomicU64::new(1);
 
 fn search_candidate_node_limit(baseline_nodes: usize) -> usize {
     baseline_nodes.saturating_add(MIN_SEARCH_CANDIDATE_NODE_ALLOWANCE)
@@ -477,10 +486,6 @@ pub struct CudaRuntimeImpl<O> {
     profile_start_event: CudaEvent,
     profile_end_event: CudaEvent,
     last_profile_device_duration: Option<Duration>,
-    /// Monotonic identifier passed to every HostOp in one `execute` call.
-    /// Host-side planners use it to share immutable per-tick preparation
-    /// without carrying dynamic metadata across executions.
-    next_execution_id: u64,
     max_intermediate_memory_bytes: Option<usize>,
     max_kernel_source_bytes: Option<usize>,
     /// Cheap pre-codegen limit derived from the first viable candidate in the
@@ -2124,6 +2129,19 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
             buf_dtype,
             Some(DType::U8),
             "get_u8: buffer dtype is {buf_dtype:?}, expected U8"
+        );
+        self.get_output_data(id)
+    }
+
+    /// Read the raw IEEE E4M3 byte encodings of an FP8 output.
+    pub fn get_f8e4m3_bytes(&self, id: impl ToId) -> Vec<u8> {
+        let id = id.to_id();
+        let data_id = self.resolve_data_node(id);
+        let buf_dtype = self.active().buffer_specs.get(&data_id).map(|s| s.dtype);
+        assert_eq!(
+            buf_dtype,
+            Some(DType::F8E4M3),
+            "get_f8e4m3_bytes: buffer dtype is {buf_dtype:?}, expected F8E4M3"
         );
         self.get_output_data(id)
     }
@@ -5119,7 +5137,6 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
             profile_start_event,
             profile_end_event,
             last_profile_device_duration: None,
-            next_execution_id: 0,
             max_intermediate_memory_bytes: None,
             max_kernel_source_bytes: Some(DEFAULT_MAX_KERNEL_SOURCE_BYTES),
             search_candidate_node_limit: None,
@@ -5175,8 +5192,7 @@ impl<O: IntoEgglogOp> Runtime for CudaRuntimeImpl<O> {
 
     #[tracing::instrument(skip_all)]
     fn execute(&mut self, dyn_map: &DynMap) -> Self::ExecReturn {
-        let execution_id = self.next_execution_id;
-        self.next_execution_id = self.next_execution_id.wrapping_add(1);
+        let execution_id = NEXT_EXECUTION_ID.fetch_add(1, Ordering::Relaxed);
         // `PROFILE_EXEC` measures only these coarse runtime phases. The older
         // `PROFILE_RECAPTURE` additionally instruments every CUDA-graph
         // materialization subphase and is intentionally more perturbative.

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -128,9 +128,12 @@ impl<O: IntoEgglogOp> CudaRuntimeImpl<O> {
                 metric,
                 diagnostics::append_filter_display(display, Some(&resource_display)),
             ),
-            Err(_) => {
+            Err(payload) => {
                 self.cancel_search_profile();
-                Outcome::Invalid("candidate profiling panicked".to_string())
+                Outcome::Invalid(format!(
+                    "candidate profiling panicked: {}",
+                    luminal::mask_events::panic_payload(payload.as_ref())
+                ))
             }
         }
     }

--- a/crates/luminal_cuda_lite/src/tests/dtype_contract.rs
+++ b/crates/luminal_cuda_lite/src/tests/dtype_contract.rs
@@ -47,6 +47,42 @@ fn egraph_has_enode(cx: &Graph, label: &str, child_label: Option<&str>) -> bool 
 }
 
 #[test]
+fn f32_to_f8e4m3_cast_rounds_nonrepresentable_values() {
+    let Some(stream) = get_cuda_stream() else {
+        return;
+    };
+    if !crate::tests::utilities::gpu_supports_dtype(DType::F8E4M3) {
+        return;
+    }
+
+    // These values are deliberately between E4M3 grid points. Tests that use
+    // only exactly representable inputs cannot detect a broken conversion or
+    // rounding path.
+    let input = vec![
+        -46.447_056_f32,
+        21.247_044_f32,
+        -169.976_06_f32,
+        -0.55_f32,
+        0.3_f32,
+        447.0_f32,
+    ];
+    let expected = vec![0xe4, 0x5b, 0xf3, 0xb1, 0x2a, 0x7e];
+
+    let mut cx = Graph::default();
+    let x = cx.tensor(input.len());
+    let out = x.cast(DType::F8E4M3).output();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+
+    let mut rt = CudaRuntime::initialize(stream);
+    rt.set_data(x, input.clone());
+    rt = cx.search(rt, CompileOptions::default().search_graph_limit(5));
+    rt.set_data(x, input);
+    rt.execute(&cx.dyn_map);
+
+    assert_eq!(rt.get_f8e4m3_bytes(out.id), expected);
+}
+
+#[test]
 fn test_bf16_constant_folds_into_kernel_constant() {
     // `bf16_tensor * 2.5` — the frontend emits `constant(2.5).cast(Bf16)`,
     // and the fold rule must offer a Bf16 KernelConstant in the Cast's

--- a/crates/luminal_cuda_lite/src/tests/op_functional_tests.rs
+++ b/crates/luminal_cuda_lite/src/tests/op_functional_tests.rs
@@ -9,6 +9,184 @@ use luminal::egglog_utils::{
 
 use crate::runtime::CudaRuntime;
 
+#[test]
+fn rolled_varying_inputs_and_iteration_outputs_match_cpu() {
+    const WIDTH: usize = 32;
+    const TRIPS: usize = 4;
+    let Some(stream) = get_cuda_stream() else {
+        return;
+    };
+
+    let mut cx = Graph::default();
+    let input = cx.named_tensor("input", WIDTH);
+    let left_weights: Vec<_> = (0..TRIPS)
+        .map(|i| cx.named_tensor(format!("left.{i}"), WIDTH))
+        .collect();
+    let right_weights: Vec<_> = (0..TRIPS)
+        .map(|i| cx.named_tensor(format!("right.{i}"), WIDTH))
+        .collect();
+    let mut state = input;
+    let mut side_outputs = Vec::new();
+    for i in 0..TRIPS {
+        let left = (state * left_weights[i]).sin();
+        let right = (state * right_weights[i]).exp2();
+        side_outputs.push(left.output());
+        side_outputs.push(right.output());
+        state = left + right;
+    }
+    let output = state.output();
+
+    let input_data: Vec<f32> = (0..WIDTH).map(|i| (i as f32 - 11.0) / 32.0).collect();
+    let left_data: Vec<Vec<f32>> = (0..TRIPS)
+        .map(|trip| {
+            (0..WIDTH)
+                .map(|i| 0.2 + trip as f32 * 0.07 + i as f32 * 0.001)
+                .collect()
+        })
+        .collect();
+    let right_data: Vec<Vec<f32>> = (0..TRIPS)
+        .map(|trip| {
+            (0..WIDTH)
+                .map(|i| -0.1 + trip as f32 * 0.03 - i as f32 * 0.0005)
+                .collect()
+        })
+        .collect();
+    let mut expected_state = input_data.clone();
+    let mut expected_sides = Vec::new();
+    for trip in 0..TRIPS {
+        let left = expected_state
+            .iter()
+            .zip(&left_data[trip])
+            .map(|(state, weight)| (state * weight).sin())
+            .collect::<Vec<_>>();
+        let right = expected_state
+            .iter()
+            .zip(&right_data[trip])
+            .map(|(state, weight)| (state * weight).exp2())
+            .collect::<Vec<_>>();
+        expected_sides.push(left.clone());
+        expected_sides.push(right.clone());
+        expected_state = left.iter().zip(&right).map(|(a, b)| a + b).collect();
+    }
+
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    assert!(
+        cx.graph
+            .node_weights()
+            .any(|op| op.as_any().is::<luminal::hlir::LoopStart>()),
+        "test graph did not exercise loop rolling"
+    );
+    let mut rt = CudaRuntime::initialize(stream);
+    rt.set_data(input, input_data);
+    for (tensor, data) in left_weights.iter().zip(left_data) {
+        rt.set_data(*tensor, data);
+    }
+    for (tensor, data) in right_weights.iter().zip(right_data) {
+        rt.set_data(*tensor, data);
+    }
+    rt = cx.search(rt, CompileOptions::default().search_graph_limit(1));
+    rt.execute(&cx.dyn_map);
+
+    assert_close(&rt.get_f32(output.id), &expected_state, 1e-5, 1e-5);
+    for (output, expected) in side_outputs.iter().zip(&expected_sides) {
+        assert_close(&rt.get_f32(output.id), expected, 1e-5, 1e-5);
+    }
+}
+
+#[test]
+fn rolled_varying_scatter_state_and_iteration_outputs_match_cpu() {
+    const WIDTH: usize = 8;
+    const CACHE_LEN: usize = 16;
+    const TRIPS: usize = 4;
+    let Some(stream) = get_cuda_stream() else {
+        return;
+    };
+
+    let mut cx = Graph::default();
+    let input = cx.named_tensor("input", WIDTH);
+    let indexes = cx
+        .named_tensor("indexes", WIDTH)
+        .as_dtype(DType::Int)
+        .persist();
+    let weights: Vec<_> = (0..TRIPS)
+        .map(|i| cx.named_tensor(format!("weight.{i}"), WIDTH))
+        .collect();
+    let caches: Vec<_> = (0..TRIPS)
+        .map(|i| cx.named_tensor(format!("cache.{i}"), CACHE_LEN).persist())
+        .collect();
+
+    let mut state = input;
+    let mut cache_outputs = Vec::new();
+    for i in 0..TRIPS {
+        let update = (state * weights[i]).sin();
+        let cache_out = update.scatter(indexes, caches[i]);
+        state = cache_out.gather(indexes) + weights[i];
+        cache_outputs.push(cache_out.output());
+    }
+    let output = state.output();
+
+    let input_data: Vec<f32> = (0..WIDTH).map(|i| (i as f32 - 3.0) / 8.0).collect();
+    let index_data = vec![13i32, 2, 15, 0, 9, 5, 7, 11];
+    let weight_data: Vec<Vec<f32>> = (0..TRIPS)
+        .map(|trip| {
+            (0..WIDTH)
+                .map(|i| 0.25 + trip as f32 * 0.08 + i as f32 * 0.01)
+                .collect()
+        })
+        .collect();
+    let cache_data: Vec<Vec<f32>> = (0..TRIPS)
+        .map(|trip| {
+            (0..CACHE_LEN)
+                .map(|i| -100.0 - trip as f32 * 20.0 - i as f32)
+                .collect()
+        })
+        .collect();
+
+    let mut expected_state = input_data.clone();
+    let mut expected_caches = Vec::new();
+    for trip in 0..TRIPS {
+        let update: Vec<f32> = expected_state
+            .iter()
+            .zip(&weight_data[trip])
+            .map(|(state, weight)| (state * weight).sin())
+            .collect();
+        let mut expected_cache = cache_data[trip].clone();
+        for (&index, &value) in index_data.iter().zip(&update) {
+            expected_cache[index as usize] = value;
+        }
+        expected_state = update
+            .iter()
+            .zip(&weight_data[trip])
+            .map(|(value, weight)| value + weight)
+            .collect();
+        expected_caches.push(expected_cache);
+    }
+
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    assert!(
+        cx.graph
+            .node_weights()
+            .any(|op| op.as_any().is::<luminal::hlir::LoopStart>()),
+        "test graph did not exercise loop rolling"
+    );
+    let mut rt = CudaRuntime::initialize(stream);
+    rt.set_data(input, input_data);
+    rt.set_data(indexes, index_data);
+    for (tensor, data) in weights.iter().zip(weight_data) {
+        rt.set_data(*tensor, data);
+    }
+    for (tensor, data) in caches.iter().zip(cache_data) {
+        rt.set_data(*tensor, data);
+    }
+    rt = cx.search(rt, CompileOptions::default().search_graph_limit(1));
+    rt.execute(&cx.dyn_map);
+
+    assert_close(&rt.get_f32(output.id), &expected_state, 1e-5, 1e-5);
+    for (output, expected) in cache_outputs.iter().zip(&expected_caches) {
+        assert_close(&rt.get_f32(output.id), expected, 1e-5, 1e-5);
+    }
+}
+
 #[allow(unused_imports)]
 use super::utilities::{
     ForcedExtractionConfig, GENOME_FUZZ_COUNT, TOLERANCE_SAFETY_FACTOR, assert_close,

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -52,6 +52,13 @@ const EGGLOG_RULESETS: &[&str] = &[
     "kernel_fuse_late_pre_sink_attention_request",
     "kernel_fuse_late_pre_sink_attention_past",
     "kernel_fuse_late_pre_sink_attention_finish",
+    "kernel_fuse_late_sink_attention_qk",
+    "kernel_fuse_late_sink_attention_softmax_select",
+    "kernel_fuse_late_sink_attention_softmax_max",
+    "kernel_fuse_late_sink_attention_softmax_numerator",
+    "kernel_fuse_late_sink_attention_softmax_denominator",
+    "kernel_fuse_late_sink_attention_contexts",
+    "kernel_fuse_late_sink_attention_island",
     "kernel_fuse_late_pre_flashinfer",
     "kernel_fuse_late",
     // Expensive one-shot rules that consume facts produced by the earlier
@@ -274,6 +281,14 @@ impl OpTextParts {
                 .collect(),
         }
     }
+
+    /// Add backend-wide egglog declarations to these precomputed fragments.
+    /// Keeping this on the owned, Send + Sync text bundle lets bucket builds
+    /// share all op-derived setup without sharing the non-Send op trait objects.
+    pub fn with_extra_egglog(mut self, extra_egglog: impl Into<String>) -> Self {
+        self.extra_egglog = extra_egglog.into();
+        self
+    }
 }
 
 fn full_egglog_with(program: &str, parts: &OpTextParts) -> String {
@@ -325,10 +340,11 @@ fn egglog_final_phases(use_interval_analysis: bool) -> Vec<EgglogSchedulePhase> 
         // once here (dtype facts present, raw HLIR rows not yet deleted by
         // the cleanup phases) instead of inside the saturating main cycles
         // avoids re-evaluating tens-of-seconds joins on every iteration.
-        // `seq` so each ruleset's join runs exactly once: producer stages
-        // first, then the consumer rules.
+        // Keep the large structural stages separate so progress and rule-plan
+        // cost stay observable on model-sized graphs. Each ruleset still runs
+        // exactly once in dependency order.
         EgglogSchedulePhase {
-            name: "fuse late".to_string(),
+            name: "fuse late producers".to_string(),
             // The second `kernel_fuse_late` run consumes relation facts the
             // first run produced (e.g. rope_rotated); semi-naive evaluation
             // makes it a cheap delta join.
@@ -341,7 +357,40 @@ fn egglog_final_phases(use_interval_analysis: bool) -> Vec<EgglogSchedulePhase> 
                 kernel_fuse_late_pre_sink_attention_base
                 kernel_fuse_late_pre_sink_attention_request
                 kernel_fuse_late_pre_sink_attention_past
-                kernel_fuse_late_pre_sink_attention_finish
+                kernel_fuse_late_pre_sink_attention_finish)"
+                .to_string(),
+        },
+        EgglogSchedulePhase {
+            name: "sink attention qk".to_string(),
+            schedule: "kernel_fuse_late_sink_attention_qk".to_string(),
+        },
+        EgglogSchedulePhase {
+            name: "sink attention select".to_string(),
+            schedule: "kernel_fuse_late_sink_attention_softmax_select".to_string(),
+        },
+        EgglogSchedulePhase {
+            name: "sink attention max".to_string(),
+            schedule: "kernel_fuse_late_sink_attention_softmax_max".to_string(),
+        },
+        EgglogSchedulePhase {
+            name: "sink attention numerator".to_string(),
+            schedule: "kernel_fuse_late_sink_attention_softmax_numerator".to_string(),
+        },
+        EgglogSchedulePhase {
+            name: "sink attention denominator".to_string(),
+            schedule: "kernel_fuse_late_sink_attention_softmax_denominator".to_string(),
+        },
+        EgglogSchedulePhase {
+            name: "sink attention contexts".to_string(),
+            schedule: "kernel_fuse_late_sink_attention_contexts".to_string(),
+        },
+        EgglogSchedulePhase {
+            name: "sink attention island".to_string(),
+            schedule: "kernel_fuse_late_sink_attention_island".to_string(),
+        },
+        EgglogSchedulePhase {
+            name: "fuse late backends".to_string(),
+            schedule: "(seq
                 kernel_fuse_late_pre_flashinfer
                 kernel_fuse_late
                 kernel_fuse_late
@@ -1330,6 +1379,19 @@ pub fn run_egglog_with_report_parts(
     )
 }
 
+/// Run egglog from precomputed op text with the same interval-analysis and
+/// logging controls used by Runtime compilation. This is the parallel-safe
+/// bucket-build entry point: all arguments are immutable Send + Sync data.
+pub fn run_egglog_with_report_parts_interval_analysis_and_log(
+    program: &str,
+    root: &str,
+    op_parts: &OpTextParts,
+    use_interval_analysis: bool,
+    log: bool,
+) -> Result<(SerializedEGraph, EgglogRunReport), egglog::Error> {
+    run_egglog_with_report_parts_impl(program, root, op_parts, use_interval_analysis, log)
+}
+
 fn run_egglog_with_report_parts_impl(
     program: &str,
     root: &str,
@@ -1917,7 +1979,7 @@ struct DenseNode {
 #[derive(Clone, Debug)]
 pub struct IndexedChoiceSet {
     choices: Vec<DenseIndex>,
-    hash: u64,
+    pub(crate) hash: u64,
 }
 
 struct IndexedEClass<'a> {
@@ -2235,6 +2297,138 @@ impl<'a> LlirExtractor<'a> {
     pub fn random_indexed_choice(&self, rng: &mut (impl Rng + ?Sized)) -> IndexedChoiceSet {
         let choices = random_initial_choice(self.egraph, rng);
         self.index_choice_set(&choices)
+    }
+
+    /// Deterministic first extraction seed using the smallest acyclic
+    /// derivation tree in the e-graph. Fused backend alternatives naturally
+    /// win because they replace multi-op reference expansions with one node;
+    /// no model- or operator-name preference is involved.
+    pub fn minimum_cost_indexed_choice(&mut self) -> IndexedChoiceSet {
+        #[derive(Clone, Copy)]
+        struct SeedNode {
+            class: DenseIndex,
+            slot: DenseIndex,
+            remaining_children: usize,
+            cost: u64,
+        }
+
+        let mut nodes = Vec::<SeedNode>::new();
+        let mut parents = vec![Vec::<usize>::new(); self.indexed_classes.len()];
+        for class in 0..self.indexed_classes.len() {
+            let class_index = DenseIndex::try_from(class).expect("too many e-classes to index");
+            let class_info = &self.indexed_classes[class];
+            let slots: Vec<DenseIndex> = if class_info.searchable {
+                let marker_free: Vec<DenseIndex> = class_info
+                    .nodes
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, node)| !enode_is_loop_input_marker(self.egraph, node))
+                    .map(|(slot, _)| DenseIndex::try_from(slot).unwrap())
+                    .collect();
+                let consistent: Vec<DenseIndex> = if class_info.label == "OpKind" {
+                    class_info
+                        .nodes
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, node)| opkind_metadata_consistent(self.egraph, node))
+                        .map(|(slot, _)| DenseIndex::try_from(slot).unwrap())
+                        .collect()
+                } else {
+                    vec![]
+                };
+                let synthesized: Vec<DenseIndex> = class_info
+                    .nodes
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, node)| node.as_ref().starts_with("synth_"))
+                    .map(|(slot, _)| DenseIndex::try_from(slot).unwrap())
+                    .collect();
+                let restrict_markers = |pool: Vec<DenseIndex>| {
+                    let filtered: Vec<DenseIndex> = pool
+                        .iter()
+                        .copied()
+                        .filter(|slot| marker_free.contains(slot))
+                        .collect();
+                    if filtered.is_empty() { pool } else { filtered }
+                };
+                if !consistent.is_empty() {
+                    restrict_markers(consistent)
+                } else if !synthesized.is_empty() {
+                    restrict_markers(synthesized)
+                } else if !marker_free.is_empty() {
+                    marker_free
+                } else {
+                    (0..class_info.nodes.len())
+                        .map(|slot| DenseIndex::try_from(slot).unwrap())
+                        .collect()
+                }
+            } else {
+                vec![0]
+            };
+
+            for slot in slots {
+                let node_id = &class_info.nodes[slot as usize];
+                let children = &self.egraph.enodes[node_id].1;
+                let node_index = nodes.len();
+                nodes.push(SeedNode {
+                    class: class_index,
+                    slot,
+                    remaining_children: children.len(),
+                    cost: 1,
+                });
+                for child in children {
+                    parents[self.class_to_index[child] as usize].push(node_index);
+                }
+            }
+        }
+
+        let mut ready = std::collections::BinaryHeap::new();
+        for (node_index, node) in nodes.iter().enumerate() {
+            if node.remaining_children == 0 {
+                ready.push(std::cmp::Reverse((
+                    node.cost, node.class, node.slot, node_index,
+                )));
+            }
+        }
+        let mut class_cost = vec![None::<u64>; self.indexed_classes.len()];
+        let mut selected = vec![NO_DENSE_INDEX; self.indexed_classes.len()];
+        while let Some(std::cmp::Reverse((cost, class, slot, _node_index))) = ready.pop() {
+            if class_cost[class as usize].is_some() {
+                continue;
+            }
+            class_cost[class as usize] = Some(cost);
+            selected[class as usize] = slot;
+            for &parent_index in &parents[class as usize] {
+                let parent = &mut nodes[parent_index];
+                parent.remaining_children -= 1;
+                parent.cost = parent.cost.saturating_add(cost);
+                if parent.remaining_children == 0 {
+                    ready.push(std::cmp::Reverse((
+                        parent.cost,
+                        parent.class,
+                        parent.slot,
+                        parent_index,
+                    )));
+                }
+            }
+        }
+
+        let mut hash = 0u64;
+        for (class, choice) in selected.iter_mut().enumerate() {
+            if !self.indexed_classes[class].searchable {
+                *choice = NO_DENSE_INDEX;
+                continue;
+            }
+            if *choice == NO_DENSE_INDEX {
+                *choice = self.mutation_pool(class as DenseIndex)[0];
+            }
+            let class_info = &self.indexed_classes[class];
+            hash ^= hash_choice_entry(class_info.id, &class_info.nodes[*choice as usize]);
+        }
+        IndexedChoiceSet {
+            choices: selected,
+            hash,
+        }
     }
 
     pub fn random_indexed_generation(

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,5 +1,6 @@
 use crate::egglog_utils::{
-    hlir_to_egglog, log_channel_enabled, run_egglog_with_late_passes_interval_analysis_and_log,
+    OpTextParts, hlir_to_egglog, log_channel_enabled,
+    run_egglog_with_report_parts_interval_analysis_and_log,
 };
 pub use crate::search::unroll::{collapse_loops_to_first_iter, unroll_loops_in_llir};
 use crate::search::{BucketSearchSpace, SearchSpace, bucket_index_combinations};
@@ -12,6 +13,7 @@ use crate::{hlir::CustomOpKind, op::*, prelude::*};
 use colored::Colorize;
 use itertools::Itertools;
 use petgraph::{Direction, stable_graph::StableGraph, visit::EdgeRef};
+use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::{
     fmt::Debug,
@@ -46,6 +48,13 @@ struct RollingRun {
     occurrences: Vec<RollingOccurrence>,
     starts: Vec<usize>,
     window: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RollingSeedRun {
+    start: usize,
+    window: usize,
+    repetitions: usize,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -434,15 +443,15 @@ impl Graph {
         // their own. Termination: every roll strictly deletes duplicate
         // body nodes, and marker ops are unique so they never form new
         // repeats.
-        let mut rolled = 0usize;
+        let mut rolled = 0;
         while self.auto_roll_loops_prepass_with_log(log) > 0 {
             rolled += 1;
         }
         if rolled == 0 {
             println!(
-                "   {:>6}  no loop regions found (max body={})",
+                "   {:>6}  no repeated loop regions found (nodes={})",
                 "Rolled".cyan().bold(),
-                before / 2,
+                before,
             );
         }
         if log {
@@ -994,19 +1003,17 @@ impl Graph {
     }
 
     fn auto_roll_loops_prepass_with_log(&mut self, log: bool) -> usize {
-        let max_region_size = self.graph.node_count() / 2;
-        if max_region_size < 1 {
+        if self.graph.node_count() < 2 {
             return 0;
         }
         if log {
             println!(
-                "   {:>6}  scanning {} HLIR nodes for loop regions (max body={})",
+                "   {:>6}  indexing {} HLIR nodes for repeated loop regions",
                 "Rolled".cyan().bold(),
                 self.graph.node_count(),
-                max_region_size,
             );
         }
-        let report = self.best_rolling_candidate(max_region_size);
+        let report = self.best_rolling_candidate();
         let Some(candidate) = report.candidate else {
             if log {
                 self.print_rolling_search_diagnostics(&report.diagnostics);
@@ -1155,7 +1162,7 @@ impl Graph {
             || self.try_get_op::<LoopOutputSelect>(n).is_some()
     }
 
-    fn best_rolling_candidate(&self, max_region_size: usize) -> RollingSearchReport {
+    fn best_rolling_candidate(&self) -> RollingSearchReport {
         // The signature memo is keyed by NodeIndex; clear it so entries from a
         // prior (now-mutated) graph state can't leak into this read-only search.
         clear_rolling_sig_cache();
@@ -1202,163 +1209,148 @@ impl Graph {
         };
         let topo_index: FxHashMap<NodeIndex, usize> =
             topo.iter().enumerate().map(|(i, &n)| (n, i)).collect();
-        // Cap the largest probed window. A useful rolling candidate is one
-        // repeating unit — a transformer layer (≈3.4k HLIR nodes for a gpt-oss
-        // MoE layer; ≈6.7k for a 2-minibatch dual-branch layer). With two
-        // structurally-similar branches (default + minibatch prefill share
-        // weights) the cheap rolling hash matches MANY large windows spanning
-        // both branches; each triggers an O(window) `canonicalize_occurrence`
-        // that ultimately fails the signature check. Probing windows all the way
-        // to `topo.len()/2` made those dead-end canonicalizes dominate (still
-        // minutes even after the externals-scan fix below). Capping the window
-        // comfortably above one layer skips them without changing the selected
-        // candidate (the per-layer roll has the best savings = window·(reps−1)
-        // and lives at a small window). A real body larger than the cap just
-        // isn't rolled (correctness preserved). Tunable via LUMINAL_MAX_ROLL_BODY.
-        let roll_body_cap = std::env::var("LUMINAL_MAX_ROLL_BODY")
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok())
-            .filter(|&v| v >= 1)
-            .unwrap_or(8192);
-        let max_window = max_region_size.min(topo.len() / 2).min(roll_body_cap);
-        let probe_windows = rolling_probe_window_sizes(max_window);
         let node_hashes: Vec<u64> = topo
             .iter()
             .map(|&node| cheap_rolling_node_hash(&self.graph, node, &self.custom_ops))
             .collect();
         let rolling_hash = RollingHash64::new(&node_hashes);
+        let seed_runs = rolling_seed_runs(&node_hashes, &rolling_hash);
+        if crate::egglog_utils::log_channel_enabled(false, "ROLLING_LOG") {
+            println!(
+                "   {:>6}  repeat index produced {} candidate runs",
+                "Rolled".yellow().bold(),
+                seed_runs.len()
+            );
+        }
         let mut diagnostics = RollingSearchDiagnostics::default();
         let mut best_overall: Option<RollingCandidate> = None;
         let mut discovered_runs: Vec<RollingRun> = Vec::new();
 
-        // Search all window sizes down to 1, using cheap rolling hashes only as a
-        // gate for expensive canonicalization. Candidate selection remains purely
-        // based on valid HLIR-op reduction.
-        for window in probe_windows {
-            let mut start = 0usize;
-            while start + window * 2 <= topo.len() {
-                diagnostics.windows_probed += 1;
-                let first_hash = rolling_hash.window_hash(start, window);
-                let second_hash = rolling_hash.window_hash(start + window, window);
-                if first_hash != second_hash {
-                    start += 1;
-                    continue;
-                }
-                diagnostics.adjacent_hash_matches += 1;
+        // The suffix/LCP index yields only distances that are proven to begin
+        // with two adjacent, fingerprint-identical bodies. Full canonicalization
+        // below remains the authority for graph topology and carried state.
+        for seed in seed_runs {
+            let raw_savings = seed.window * (seed.repetitions - 1);
+            if best_overall.as_ref().is_some_and(|best| {
+                let best_net = rolling_net_savings(best);
+                best_net >= 0 && raw_savings <= best_net as usize
+            }) {
+                break;
+            }
+            let start = seed.start;
+            let window = seed.window;
+            diagnostics.windows_probed += 1;
+            diagnostics.adjacent_hash_matches += 1;
 
-                let mut occs = vec![];
-                let mut starts = vec![];
-                let first_nodes = topo[start..start + window].to_vec();
-                let Some((sig, first_boundary, first_outputs)) = canonicalize_occurrence(
+            let mut occs = vec![];
+            let mut starts = vec![];
+            let first_nodes = topo[start..start + window].to_vec();
+            let Some((sig, first_boundary, first_outputs)) = canonicalize_occurrence(
+                &self.graph,
+                &first_nodes,
+                &uses,
+                &topo_index,
+                &self.custom_ops,
+            ) else {
+                continue;
+            };
+            starts.push(start);
+            occs.push(RollingOccurrence {
+                nodes: first_nodes,
+                boundary_inputs: first_boundary,
+                output_nodes: first_outputs,
+            });
+
+            let first_hash = rolling_hash.window_hash(start, window);
+            let mut pos = start + window;
+            while pos + window <= topo.len() {
+                if rolling_hash.window_hash(pos, window) != first_hash {
+                    break;
+                }
+                let nodes = topo[pos..pos + window].to_vec();
+                let Some((next_sig, boundary_inputs, output_nodes)) = canonicalize_occurrence(
                     &self.graph,
-                    &first_nodes,
+                    &nodes,
                     &uses,
                     &topo_index,
                     &self.custom_ops,
                 ) else {
-                    start += 1;
-                    continue;
+                    break;
                 };
-                starts.push(start);
+                if next_sig != sig {
+                    break;
+                }
+                starts.push(pos);
                 occs.push(RollingOccurrence {
-                    nodes: first_nodes,
-                    boundary_inputs: first_boundary,
-                    output_nodes: first_outputs,
+                    nodes,
+                    boundary_inputs,
+                    output_nodes,
                 });
+                pos += window;
+            }
+            if occs.len() < 2 {
+                continue;
+            }
+            diagnostics.repeated_signature_runs += 1;
+            discovered_runs.push(RollingRun {
+                occurrences: occs.clone(),
+                starts: starts.clone(),
+                window,
+            });
+            let stride = starts
+                .windows(2)
+                .next()
+                .map(|w| w[1].saturating_sub(w[0]))
+                .unwrap_or(0);
+            let summary = format!(
+                "body={} trips={} stride={} boundary_inputs={} state_params={} starts={:?}",
+                window,
+                occs.len(),
+                stride,
+                occs[0].boundary_inputs.len(),
+                collect_state_params(&occs, &uses, &self.graph).len(),
+                starts.iter().copied().take(4).collect::<Vec<_>>()
+            );
+            if occs.len() >= 20 && diagnostics.top_runs.len() < 16 {
+                diagnostics.top_runs.push(summary);
+            }
 
-                let mut pos = start + window;
-                while pos + window <= topo.len() {
-                    if rolling_hash.window_hash(pos, window) != first_hash {
-                        break;
-                    }
-                    let nodes = topo[pos..pos + window].to_vec();
-                    let Some((next_sig, boundary_inputs, output_nodes)) = canonicalize_occurrence(
-                        &self.graph,
-                        &nodes,
-                        &uses,
-                        &topo_index,
-                        &self.custom_ops,
-                    ) else {
-                        break;
-                    };
-                    if next_sig != sig {
-                        break;
-                    }
-                    starts.push(pos);
-                    occs.push(RollingOccurrence {
-                        nodes,
-                        boundary_inputs,
-                        output_nodes,
-                    });
-                    pos += window;
-                }
-                if occs.len() < 2 {
-                    start += 1;
-                    continue;
-                }
-                diagnostics.repeated_signature_runs += 1;
-                discovered_runs.push(RollingRun {
-                    occurrences: occs.clone(),
-                    starts: starts.clone(),
+            let state_params = collect_state_params(&occs, &uses, &self.graph);
+            if state_params.is_empty()
+                || !candidate_is_rollable(&occs, &state_params)
+                || !scope_uniform(&occs)
+            {
+                let rejected = RollingRejectedCandidate {
                     window,
-                });
-                let stride = starts
-                    .windows(2)
-                    .next()
-                    .map(|w| w[1].saturating_sub(w[0]))
-                    .unwrap_or(0);
-                let summary = format!(
-                    "body={} trips={} stride={} boundary_inputs={} state_params={} starts={:?}",
-                    window,
-                    occs.len(),
-                    stride,
-                    occs[0].boundary_inputs.len(),
-                    collect_state_params(&occs, &uses, &self.graph).len(),
-                    starts.iter().copied().take(4).collect::<Vec<_>>()
-                );
-                if occs.len() >= 20 && diagnostics.top_runs.len() < 16 {
-                    diagnostics.top_runs.push(summary);
-                }
-
-                let state_params = collect_state_params(&occs, &uses, &self.graph);
-                if state_params.is_empty()
-                    || !candidate_is_rollable(&occs, &state_params)
-                    || !scope_uniform(&occs)
-                {
-                    let rejected = RollingRejectedCandidate {
-                        window,
-                        repetitions: occs.len(),
-                        boundary_inputs: occs[0].boundary_inputs.len(),
-                        state_params: state_params.len(),
-                        savings: window * (occs.len() - 1),
-                    };
-                    diagnostics.rejected_zero_state_params += 1;
-                    let replace = diagnostics.best_rejected.as_ref().is_none_or(|best| {
-                        (rejected.savings, rejected.repetitions, rejected.window)
-                            > (best.savings, best.repetitions, best.window)
-                    });
-                    if replace {
-                        diagnostics.best_rejected = Some(rejected);
-                    }
-                    start = pos.saturating_sub(window).max(start + 1);
-                    continue;
-                }
-
-                let savings = window * (occs.len() - 1);
-                let _ = sig;
-                let candidate = RollingCandidate {
-                    occurrences: occs,
-                    state_param_indices: state_params,
-                    savings,
+                    repetitions: occs.len(),
+                    boundary_inputs: occs[0].boundary_inputs.len(),
+                    state_params: state_params.len(),
+                    savings: window * (occs.len() - 1),
                 };
-                let replace = best_overall.as_ref().is_none_or(|b| {
-                    (rolling_net_savings(&candidate), candidate.occurrences.len())
-                        > (rolling_net_savings(b), b.occurrences.len())
+                diagnostics.rejected_zero_state_params += 1;
+                let replace = diagnostics.best_rejected.as_ref().is_none_or(|best| {
+                    (rejected.savings, rejected.repetitions, rejected.window)
+                        > (best.savings, best.repetitions, best.window)
                 });
                 if replace {
-                    best_overall = Some(candidate);
+                    diagnostics.best_rejected = Some(rejected);
                 }
-                start = pos.saturating_sub(window).max(start + 1);
+                continue;
+            }
+
+            let savings = window * (occs.len() - 1);
+            let _ = sig;
+            let candidate = RollingCandidate {
+                occurrences: occs,
+                state_param_indices: state_params,
+                savings,
+            };
+            let replace = best_overall.as_ref().is_none_or(|b| {
+                (rolling_net_savings(&candidate), candidate.occurrences.len())
+                    > (rolling_net_savings(b), b.occurrences.len())
+            });
+            if replace {
+                best_overall = Some(candidate);
             }
         }
         if crate::egglog_utils::log_channel_enabled(false, "ROLLING_LOG")
@@ -1598,32 +1590,48 @@ impl Graph {
         let dim_buckets = options.dim_buckets.clone();
         let late_pass_dyn_map = self.late_pass_dyn_map(&dim_buckets);
         let late_passes = Rt::late_egglog_passes(&ops, &options, &late_pass_dyn_map);
-        let extra_egglog = Rt::extra_egglog();
+        let op_parts = OpTextParts::new_with_late_passes(&ops, Rt::CLEANUP_HLIR, &late_passes)
+            .with_extra_egglog(Rt::extra_egglog());
 
         let (program, root) = hlir_to_egglog(self);
-        let buckets = bucket_index_combinations(&dim_buckets)
+        // Build contextual programs before entering Rayon: this only borrows
+        // Graph, whose custom-op trait objects need not be Send or Sync. The
+        // expensive parse/saturate work below then shares immutable strings
+        // and precomputed op text across independent bucket jobs.
+        let bucket_programs = bucket_index_combinations(&dim_buckets)
             .into_iter()
             .map(|bucket_indices| {
                 let intervals = self.bucket_intervals(&dim_buckets, &bucket_indices);
                 let (contextual_program, use_interval_analysis) =
                     self.egglog_program_with_interval_facts(&program, &intervals);
-                let egraph = run_egglog_with_late_passes_interval_analysis_and_log(
-                    &contextual_program,
-                    &root,
-                    &ops,
-                    Rt::CLEANUP_HLIR,
-                    &late_passes,
-                    &extra_egglog,
-                    use_interval_analysis,
-                    options.egglog_log_enabled(),
-                )
-                .unwrap();
-                BucketSearchSpace {
-                    egraph,
+                (
                     bucket_indices,
                     intervals,
-                }
+                    contextual_program,
+                    use_interval_analysis,
+                )
             })
+            .collect_vec();
+        let egglog_log = options.egglog_log_enabled();
+        let buckets = bucket_programs
+            .into_par_iter()
+            .map(
+                |(bucket_indices, intervals, contextual_program, use_interval_analysis)| {
+                    let (egraph, _) = run_egglog_with_report_parts_interval_analysis_and_log(
+                        &contextual_program,
+                        &root,
+                        &op_parts,
+                        use_interval_analysis,
+                        egglog_log,
+                    )
+                    .unwrap();
+                    BucketSearchSpace {
+                        egraph,
+                        bucket_indices,
+                        intervals,
+                    }
+                },
+            )
             .collect();
         let custom_ops = self.custom_ops.iter().map(|op| op.to_llir_op()).collect();
         self.search_space = Some(SearchSpace {
@@ -1944,11 +1952,194 @@ fn rolling_op_signature_uncached(
     format!("{:?}", graph[node])
 }
 
-fn rolling_probe_window_sizes(max_window: usize) -> Vec<usize> {
-    if max_window == 0 {
+/// Discover tandem repetitions from the token sequence without guessing a
+/// maximum body size. Suffixes are joined from longest common prefix to
+/// shortest; when two components meet, neighboring source positions provide
+/// graph-derived candidate periods. At most two seeds are emitted per moved
+/// suffix before maximal equal-body runs are deduplicated.
+fn rolling_seed_runs(tokens: &[u64], rolling_hash: &RollingHash64) -> Vec<RollingSeedRun> {
+    if tokens.len() < 2 {
         return vec![];
     }
-    (1..=max_window).rev().collect()
+
+    let suffixes = suffix_array(tokens);
+    let lcp = suffix_lcp(tokens, &suffixes);
+    let mut edges: Vec<(usize, usize, usize)> = lcp
+        .into_iter()
+        .enumerate()
+        .filter_map(|(i, common)| (common > 0).then_some((common, suffixes[i], suffixes[i + 1])))
+        .collect();
+    edges.sort_unstable_by_key(|edge| std::cmp::Reverse(edge.0));
+
+    let mut parent: Vec<usize> = (0..tokens.len()).collect();
+    let mut positions: Vec<Option<std::collections::BTreeSet<usize>>> = (0..tokens.len())
+        .map(|position| Some(std::iter::once(position).collect()))
+        .collect();
+    let mut raw_seeds = Vec::with_capacity(tokens.len());
+
+    for (common, left, right) in edges {
+        let mut left_root = disjoint_set_root(&mut parent, left);
+        let mut right_root = disjoint_set_root(&mut parent, right);
+        if left_root == right_root {
+            continue;
+        }
+        if positions[left_root].as_ref().unwrap().len()
+            < positions[right_root].as_ref().unwrap().len()
+        {
+            std::mem::swap(&mut left_root, &mut right_root);
+        }
+
+        let smaller = positions[right_root].take().unwrap();
+        let larger = positions[left_root].as_mut().unwrap();
+        for position in smaller.iter().copied() {
+            let before = larger.range(..position).next_back().copied();
+            let after = larger
+                .range((
+                    std::ops::Bound::Excluded(position),
+                    std::ops::Bound::Unbounded,
+                ))
+                .next()
+                .copied();
+            for neighbor in before.into_iter().chain(after) {
+                let start = position.min(neighbor);
+                let window = position.abs_diff(neighbor);
+                if window <= common && start + window * 2 <= tokens.len() {
+                    raw_seeds.push((start, window));
+                }
+            }
+        }
+        larger.extend(smaller);
+        parent[right_root] = left_root;
+    }
+
+    let mut seen = FxHashSet::default();
+    let mut runs = Vec::new();
+    for (mut start, window) in raw_seeds {
+        let body_hash = rolling_hash.window_hash(start, window);
+        while start >= window && rolling_hash.window_hash(start - window, window) == body_hash {
+            start -= window;
+        }
+        if !seen.insert((start, window)) {
+            continue;
+        }
+        let mut repetitions = 1;
+        while start + (repetitions + 1) * window <= tokens.len()
+            && rolling_hash.window_hash(start + repetitions * window, window) == body_hash
+        {
+            repetitions += 1;
+        }
+        if repetitions >= 2 {
+            runs.push(RollingSeedRun {
+                start,
+                window,
+                repetitions,
+            });
+        }
+    }
+    runs.sort_unstable_by_key(|run| {
+        std::cmp::Reverse((
+            run.window * (run.repetitions - 1),
+            run.repetitions,
+            run.window,
+            std::cmp::Reverse(run.start),
+        ))
+    });
+    runs
+}
+
+fn disjoint_set_root(parent: &mut [usize], mut node: usize) -> usize {
+    let mut root = node;
+    while parent[root] != root {
+        root = parent[root];
+    }
+    while parent[node] != node {
+        let next = parent[node];
+        parent[node] = root;
+        node = next;
+    }
+    root
+}
+
+fn suffix_array(tokens: &[u64]) -> Vec<usize> {
+    let mut suffixes: Vec<usize> = (0..tokens.len()).collect();
+    let mut sorted_tokens = tokens.to_vec();
+    sorted_tokens.sort_unstable();
+    sorted_tokens.dedup();
+    let mut rank: Vec<usize> = tokens
+        .iter()
+        .map(|token| sorted_tokens.binary_search(token).unwrap())
+        .collect();
+    let mut next_rank = vec![0; tokens.len()];
+    let mut width = 1usize;
+    while width < tokens.len() {
+        suffixes.sort_unstable_by_key(|&start| {
+            (
+                rank[start] + 1,
+                if start + width < tokens.len() {
+                    rank[start + width] + 1
+                } else {
+                    0
+                },
+            )
+        });
+        next_rank[suffixes[0]] = 0;
+        for pair in suffixes.windows(2) {
+            let previous = pair[0];
+            let current = pair[1];
+            let previous_key = (
+                rank[previous] + 1,
+                if previous + width < tokens.len() {
+                    rank[previous + width] + 1
+                } else {
+                    0
+                },
+            );
+            let current_key = (
+                rank[current] + 1,
+                if current + width < tokens.len() {
+                    rank[current + width] + 1
+                } else {
+                    0
+                },
+            );
+            next_rank[current] = next_rank[previous] + usize::from(current_key != previous_key);
+        }
+        std::mem::swap(&mut rank, &mut next_rank);
+        if rank[*suffixes.last().unwrap()] + 1 == tokens.len() {
+            break;
+        }
+        width = width.saturating_mul(2);
+    }
+    suffixes
+}
+
+fn suffix_lcp(tokens: &[u64], suffixes: &[usize]) -> Vec<usize> {
+    if suffixes.len() < 2 {
+        return vec![];
+    }
+    let mut inverse = vec![0; suffixes.len()];
+    for (rank, &start) in suffixes.iter().enumerate() {
+        inverse[start] = rank;
+    }
+    let mut lcp = vec![0; suffixes.len() - 1];
+    let mut common = 0usize;
+    for start in 0..tokens.len() {
+        let rank = inverse[start];
+        if rank + 1 == suffixes.len() {
+            common = 0;
+            continue;
+        }
+        let next = suffixes[rank + 1];
+        while start + common < tokens.len()
+            && next + common < tokens.len()
+            && tokens[start + common] == tokens[next + common]
+        {
+            common += 1;
+        }
+        lcp[rank] = common;
+        common = common.saturating_sub(1);
+    }
+    lcp
 }
 
 fn canonicalize_occurrence(
@@ -2278,6 +2469,61 @@ mod tests {
     use crate::egglog_utils::hash_egglog_normalized;
     use crate::hlir::{Input, LoopEnd, LoopInput, LoopStart, Output, ReferenceOp, Sin};
     use crate::search::unroll::materialize_unrolled_llir;
+
+    #[test]
+    fn rolling_seed_runs_discovers_large_non_power_of_two_period() {
+        const BODY: usize = 2817;
+        const TRIPS: usize = 13;
+        let tokens: Vec<u64> = (0..TRIPS)
+            .flat_map(|_| (0..BODY).map(|token| token as u64))
+            .collect();
+        let hash = RollingHash64::new(&tokens);
+        let runs = rolling_seed_runs(&tokens, &hash);
+
+        assert!(
+            runs.iter()
+                .any(|run| { run.start == 0 && run.window == BODY && run.repetitions == TRIPS }),
+            "expected the data-derived index to find the 2817-node period"
+        );
+    }
+
+    #[test]
+    fn rolling_seed_runs_discovers_nested_periods() {
+        const INNER: usize = 524;
+        const INNER_TRIPS: usize = 3;
+        const OUTER_TRIPS: usize = 13;
+        let inner: Vec<u64> = (0..INNER).map(|token| token as u64).collect();
+        let mut outer = Vec::new();
+        for _ in 0..INNER_TRIPS {
+            outer.extend(inner.iter().copied());
+        }
+        outer.push(u64::MAX);
+        let tokens: Vec<u64> = (0..OUTER_TRIPS)
+            .flat_map(|_| outer.iter().copied())
+            .collect();
+        let hash = RollingHash64::new(&tokens);
+        let runs = rolling_seed_runs(&tokens, &hash);
+
+        assert!(
+            runs.iter().any(|run| {
+                run.start == 0 && run.window == outer.len() && run.repetitions == OUTER_TRIPS
+            }),
+            "expected the outer periodic block"
+        );
+        assert!(
+            runs.iter().any(|run| {
+                run.start == 0 && run.window == INNER && run.repetitions == INNER_TRIPS
+            }),
+            "expected the repeated inner body"
+        );
+    }
+
+    #[test]
+    fn rolling_seed_runs_rejects_aperiodic_sequence() {
+        let tokens: Vec<u64> = (0..4096).map(|token| token as u64).collect();
+        let hash = RollingHash64::new(&tokens);
+        assert!(rolling_seed_runs(&tokens, &hash).is_empty());
+    }
 
     // A rolling candidate is only collapsible if every non-state boundary input
     // is fed from OUTSIDE the candidate's occurrences. A non-state input produced

--- a/src/hlir.rs
+++ b/src/hlir.rs
@@ -697,11 +697,12 @@ impl EgglogOp for LoopInput {
     }
 
     fn rewrites(&self) -> Vec<Rule> {
-        // Declare the `identical_inputs` relation and the three-way unification
-        // chain between `LoopInput`, `LoopInputStatic`, and an inlined source.
-        // Running alongside fusion rules (e.g. GLUMoE) so that fusion patterns
-        // that expect raw op kinds at boundary positions can match via the
-        // unioned eclass.
+        // Prove invariant input streams only for lists attached to LoopInput.
+        // A global IList proof makes the e-graph recursively inspect every
+        // argument list in the model, even though only loop-boundary lists can
+        // become LoopInputStatic.  Scoping the relation from LoopInput roots
+        // keeps the same equivalences available to fusion rules without making
+        // saturation scale with all unrelated IR lists.
         vec![
             // Loop rolling stamps the concrete stream dtype into the marker;
             // the field is the same type contract consumed by rewrites and
@@ -709,29 +710,45 @@ impl EgglogOp for LoopInput {
             dtype_from_kind_field(&self.sort(), "dtype"),
             Rule::raw(
                 r#"
-            (relation identical_inputs (IList))
+            (relation loop_input_list (IList))
+            (relation identical_loop_inputs (IList))
 
-            ; All four rules live in the `expr` ruleset, which the schedule
+            ; All rules live in the `expr` ruleset, which the schedule
             ; saturates each iteration. Default-ruleset scheduling only runs
             ; each rule once per outer step, which is not enough to propagate
-            ; `identical_inputs` through an N-element IList.
+            ; the proof through an N-element IList.
+
+            ; Seed the proof only from lists that are actual LoopInput operands.
+            (rule ((= ?e (Op (LoopInput ?id ?stream ?dt) ?l)))
+                  ((loop_input_list ?l))
+                  :ruleset expr
+                  :name "loop input list seed")
+
+            ; Mark only tails reachable from a LoopInput list.
+            (rule ((loop_input_list ?l)
+                   (= ?l (ICons ?x ?tail)))
+                  ((loop_input_list ?tail))
+                  :ruleset expr
+                  :name "loop input list tail")
 
             ; Base: single-element list is trivially identical.
-            (rule ((= ?l (ICons ?x (INil))))
-                  ((identical_inputs ?l))
+            (rule ((loop_input_list ?l)
+                   (= ?l (ICons ?x (INil))))
+                  ((identical_loop_inputs ?l))
                   :ruleset expr
-                  :name "identical_inputs base")
+                  :name "identical loop inputs base")
 
             ; Inductive: head equals next-head, and the tail starting at next-head is identical.
-            (rule ((= ?l (ICons ?x (ICons ?x ?tail)))
-                   (identical_inputs (ICons ?x ?tail)))
-                  ((identical_inputs ?l))
+            (rule ((loop_input_list ?l)
+                   (= ?l (ICons ?x (ICons ?x ?tail)))
+                   (identical_loop_inputs (ICons ?x ?tail)))
+                  ((identical_loop_inputs ?l))
                   :ruleset expr
-                  :name "identical_inputs ind")
+                  :name "identical loop inputs ind")
 
             ; LoopInput with an identical IList is equivalent to LoopInputStatic over a single copy.
             (rule ((= ?e (Op (LoopInput ?id ?stream ?dt) (ICons ?x ?cont)))
-                   (identical_inputs (ICons ?x ?cont)))
+                   (identical_loop_inputs (ICons ?x ?cont)))
                   ((let ?static (Op (LoopInputStatic ?id ?stream ?dt) (ICons ?x (INil))))
                    (union ?e ?static))
                   :ruleset expr
@@ -802,7 +819,7 @@ impl ReferenceOp for LoopInput {
 
 /// Iteration-independent boundary input: the same value flows into every
 /// iteration of a loop. Structurally a `LoopInput` whose per-iteration
-/// sources have all been proven equal (via the `identical_inputs` egglog
+/// sources have all been proven equal (via the `identical_loop_inputs` egglog
 /// relation) collapses into `LoopInputStatic` with a single-element IList,
 /// and that in turn collapses via a further rewrite into just its inner
 /// value — so egglog search can explore any of the three representations.

--- a/src/search/genetic.rs
+++ b/src/search/genetic.rs
@@ -132,6 +132,7 @@ pub struct GeneticSearch<'a, M> {
     generation_found_new_best: bool,
     slower_since_faster: usize,
     slower_line_visible: bool,
+    tried_minimum_cost_seed: bool,
 }
 
 impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
@@ -197,6 +198,7 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
             generation_found_new_best: false,
             slower_since_faster: 0,
             slower_line_visible: false,
+            tried_minimum_cost_seed: false,
         }
     }
 
@@ -235,14 +237,24 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
             match self.phase {
                 Phase::Done => return None,
                 Phase::Initial => {
-                    let mut generation =
-                        self.extractor
-                            .random_indexed_generation(1, &mut self.prev_selected, rng);
-                    let Some(genome) = generation.pop() else {
-                        panic_initial_filter_limit(
-                            self.filter_fails,
-                            self.last_filter_rejection.as_deref(),
+                    let genome = if !self.tried_minimum_cost_seed {
+                        self.tried_minimum_cost_seed = true;
+                        let genome = self.extractor.minimum_cost_indexed_choice();
+                        self.prev_selected.insert(genome.hash);
+                        genome
+                    } else {
+                        let mut generation = self.extractor.random_indexed_generation(
+                            1,
+                            &mut self.prev_selected,
+                            rng,
                         );
+                        let Some(genome) = generation.pop() else {
+                            panic_initial_filter_limit(
+                                self.filter_fails,
+                                self.last_filter_rejection.as_deref(),
+                            );
+                        };
+                        genome
                     };
                     match self.extract(&genome) {
                         Ok(Some((_, llir))) => return Some(self.hand_out(genome, llir, None)),
@@ -422,7 +434,15 @@ impl<'a, M: PartialOrd + Clone + Debug> GeneticSearch<'a, M> {
                 return;
             }
             Outcome::Measured(..) => self.n_timed_out += 1,
-            Outcome::Invalid(_) => self.n_invalid_profile += 1,
+            Outcome::Invalid(reason) => {
+                self.n_invalid_profile += 1;
+                if self.search_log && self.n_invalid_profile <= 5 {
+                    eprintln!(
+                        "   Search  initial-genome execution invalid #{}: {reason}",
+                        self.n_invalid_profile
+                    );
+                }
+            }
         }
         self.invalid_attempts += 1;
         if self.invalid_attempts > MAX_INVALID_INITIAL_ATTEMPTS {


### PR DESCRIPTION
## Summary

- discover repeated graph regions without model-specific body-size limits using suffix-array/LCP candidates
- roll nested and disjoint regions to a fixpoint while preserving typed varying inputs and loop state
- make extraction deterministic and scope loop-input invariants correctly across e-graph saturation

## Tests

- cargo fmt --all -- --check
- cargo test --lib (194 passed)