### PR TITLE
Add graph-only CUDA Lite execution with dynamic shapes and shared bucket arena

### DIFF
--- a/crates/luminal_cuda_lite/README.md
+++ b/crates/luminal_cuda_lite/README.md
@@ -1,0 +1,77 @@
+# CUDA Lite execution
+
+CUDA Lite has one execution path: a CUDA graph launch. Serving, candidate warmup,
+and profiling use `CudaDevice::execute`. Graph compilation and instantiation are
+outside timed trials. An execution stages inputs, launches the graph, waits for
+completion, and returns owned host output bytes.
+
+## Compilation and memory
+
+Egglog selects all operations. Bucket searches extract from range-seeded e-graphs,
+so implementation guards must hold throughout the interval. Representative
+shapes are used for timing, without freezing the installed plan's geometry.
+
+The storage planner evaluates conservative interval capacities for each buffer.
+It respects the bufferizer's allocation/free events and data/anti-dependencies.
+Each bucket has fixed offsets into one runtime-owned device arena containing:
+
+- The dynamic-dimension parameter block.
+- Temporary buffers, with reuse after their last access.
+- Private device copies of boundary inputs and escaping outputs.
+- Shared HostOp scratch, sized to the largest host operation's requirement.
+
+The arena allocation is the **maximum** requirement across installed buckets.
+Pinned host staging is shared across buckets too. Execution is serialized on one
+nonblocking stream; buckets cannot run concurrently against these shared ranges.
+Returned output data owns its host memory and survives later launches.
+
+Installing a new plan set synchronizes and destroys old executables before any
+allocation can move. Search releases candidate graphs, staging, and arena memory
+between candidates, while retaining the CUDA context and compiled module cache.
+
+## Dynamic updates
+
+| Change | Work before graph launch |
+| --- | --- |
+| Input contents | Fill the existing pinned staging ranges. |
+| Dimension used only inside kernels | Write the parameter block; no graph node updates. |
+| Copy length | Patch dependent copy nodes; disable zero-length copies. |
+| Explicit kernel launch geometry | Patch dependent kernel nodes. |
+| HostOp capture dimensions | Reuse a cached capture, or prepare and capture that HostOp. |
+| Compatible child graph topology | Update the existing executable's child node. |
+| Incompatible child graph topology | Rebind a cached parent executable, or instantiate a new one. |
+| Bucket switch | Select that bucket's graph using the same arena and staging allocations. |
+
+Dimension-to-node dependencies are built once. Host captures and parent topology
+variants have bounded caches (eight each). Parents retain the preparations
+referenced by their source and executable nodes, even after capture-cache
+eviction. A failed partial update invalidates
+the affected compiled plan before another launch can use it.
+
+## Operation interfaces
+
+`KernelOp::codegen` returns CUDA source plus symbolic launch metadata. The kernel
+ABI is input pointers, output pointer, then `const long long* params`. Dimension
+identifiers returned by `symbolic::variable` are defined as entries in `params`.
+Default launches cover the bucket capacity and kernels guard against the live
+extent. `KernelSource::launch` can instead specify symbolic grid, block, and
+shared-memory geometry through `KernelLaunch`.
+
+`HostOp::prepare` resolves host descriptors and algorithms outside capture.
+`PreparedHostOp::record` submits GPU work during capture; its Rust body is not
+called on replay. The executor treats the resulting child graph as opaque.
+`workspace_bytes` reserves device scratch in the shared arena. `capture_dims`
+may narrow invalidation to the dimensions that affect captured work; its default
+conservatively depends on all dimensions.
+
+cuBLASLt uses this interface for all DPS forms. Geometry changes rebuild its
+public library descriptors and capture a new child graph. The executor never
+inspects or edits cuBLASLt's private kernel arguments.
+
+During bucket profiling, dynamic payloads supplied at another size are truncated
+or zero-extended to the representative size for timing. Serving requires exact
+live payload sizes. Profiling includes staging and readback, matching serving.
+
+`CudaRuntime::graph_stats` exposes counters and arena/staging footprint for
+checking reuse. GPU regressions live in `tests/dynamic_graphs.rs` and
+`tests/execution_traits.rs`.

--- a/crates/luminal_cuda_lite/README.md
+++ b/crates/luminal_cuda_lite/README.md
@@ -13,13 +13,28 @@ shapes are used for timing, without freezing the installed plan's geometry.
 
 The storage planner evaluates conservative interval capacities for each buffer.
 It respects the bufferizer's allocation/free events and data/anti-dependencies.
-Each bucket has fixed offsets into one runtime-owned device arena containing:
+One schedule places input uploads immediately before their first device use,
+then bufferized operations and output readbacks at their output boundaries.
+Graph construction consumes this schedule directly.
 
-- The dynamic-dimension parameter block.
-- Temporary buffers, with reuse after their last access.
-- Private device copies of boundary inputs and escaping outputs.
-- Shared HostOp scratch, sized to the largest host operation's requirement.
+One interval allocator packs every physical resource:
 
+- The dynamic-dimension parameter block remains live throughout execution.
+- Interior tensors follow their bufferizer alloc/free markers.
+- Donated device copies end at their explicit free; other boundary copies end
+  at their final device use, including any required readback.
+- Escaping device outputs start at their allocation and end after their final
+  use/readback. Returned host bytes keep the caller's output alive separately.
+- Each HostOp's scratch is live only during that operation's child graph, and
+  can reuse storage occupied by tensors or other HostOps at different times.
+
+Pinned staging uses the same allocator with byte alignment. All input payloads
+remain live from host preparation through their upload; each output remains live
+from readback through host result collection. Completed uploads can therefore
+provide space for outputs, while late inputs remain protected. Multiple output
+slots sharing a buffer at one boundary share a single readback and staging range.
+
+Each bucket keeps its capacity-sized offsets fixed as live dimensions change.
 The arena allocation is the **maximum** requirement across installed buckets.
 Pinned host staging is shared across buckets too. Execution is serialized on one
 nonblocking stream; buckets cannot run concurrently against these shared ranges.
@@ -60,7 +75,9 @@ shared-memory geometry through `KernelLaunch`.
 `HostOp::prepare` resolves host descriptors and algorithms outside capture.
 `PreparedHostOp::record` submits GPU work during capture; its Rust body is not
 called on replay. The executor treats the resulting child graph as opaque.
-`workspace_bytes` reserves device scratch in the shared arena. `capture_dims`
+`workspace_bytes` reserves operation-local device scratch in the shared arena;
+preparation must not access scratch contents or preserve them beyond that
+operation's captured work. `capture_dims`
 may narrow invalidation to the dimensions that affect captured work; its default
 conservatively depends on all dimensions.
 

--- a/crates/luminal_cuda_lite/src/arena.rs
+++ b/crates/luminal_cuda_lite/src/arena.rs
@@ -1,68 +1,10 @@
-//! THE ARENA: one runtime-owned slab of device bytes, and the
-//! DEVICE-FREE pass that decides who lives where in it.
-//!
-//! # Why this module exists (#422, superseding #401)
-//!
-//! CL-2's executor materialized EVERY plan buffer up front — one
-//! `alloc_zeros` per `BufferId`, all of them live for the whole call.
-//! That is the sum of every buffer the plan ever names, whether or not
-//! two of them are ever live at the same instant. The bufferizer
-//! already computes the lifetimes (`BufferAlloc` brings storage into
-//! existence, `BufferFree` ends it, and the containment certificate
-//! guarantees every toucher sits between the two); nothing consumed
-//! them. This pass does.
-//!
-//! Austin's division of labour (2026-09-03): "first produce the
-//! bufferizer, this will do the allocations / frees. Then a separate
-//! thing will map those allocation / frees to slices on memory in the
-//! arena allocator." This IS the separate thing. It reads a bufferized
-//! plan and answers two questions:
-//!
-//!  1. **In what order should the runtime issue the plan's nodes?**
-//!     Any topological order is legal (the plan supplies dependency
-//!     structure only — see the BufferCopy contract); the order chosen
-//!     here is LIVENESS-AWARE, because the order is what sets the
-//!     high-water mark.
-//!  2. **Which slab range backs each buffer, over that order?** A
-//!     first-fit free-list walk of the alloc/free events.
-//!
-//! # The three ownership rows (`Owner` × `FreedBy`), and why only one is in the slab
-//!
-//! | row | `Owner` | `FreedBy` | alloc? | free? | arena treatment |
-//! |---|---|---|---|---|---|
-//! | BOUNDARY | `Caller` | `Caller` | no | no | `standalone` |
-//! | DONATED | `Caller` | `Program` | no | yes | `donated` |
-//! | ESCAPING | `System` | `Caller` | yes | no | `standalone` |
-//! | INTERIOR | `System` | `Program` | yes | yes | **slab member** |
-//!
-//! This pass recycles only the INTERIOR row. storage::plan subsequently places
-//! the other rows in disjoint regions of the same runtime allocation.
-//! Their device storage holds private copies of host-owned boundary values.
-//!
-//! Only the INTERIOR row has BOTH ends of a lifetime inside the
-//! program, which is exactly the precondition for handing its bytes to
-//! a later buffer. An ESCAPING buffer's bytes are the caller's from
-//! return on — recycling them would hand the caller a range the next
-//! call overwrites. A DONATED buffer's storage came from the caller;
-//! the program's free RELEASES it, it does not license the arena to
-//! re-let it. BOUNDARY storage is never the program's at all.
-//!
-//! # Sizing
-//!
-//! `bytes_of` is the caller's, so tests can plan with mock sizes and
-//! the executor can pass the one real rule (`literal_span_elements() *
-//! dtype_bytes(dtype)` — see `crate::device`). Symbolic extents are the
-//! caller's responsibility: storage::plan evaluates conservative interval
-//! capacities for symbolic buffers.
-//!
-//! # What is NOT here
-//!
-//! No device types, no cudarc: this file compiles and its tests run on
-//! a laptop. Search-time slab policy (sizing the slab across the
-//! candidate plans a search evaluates) is Phase 4's; this pass sizes
-//! ONE installed plan.
+//! Physical storage planning for graph execution. One schedule places uploads,
+//! bufferized nodes, and readbacks; one interval allocator packs device tensors,
+//! operation scratch, parameters, and pinned staging. Logical ownership remains
+//! in the bufferized plan: the arena holds private device copies, and returned
+//! outputs own their host bytes.
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Result, anyhow, bail, ensure};
 use luminal::bufferize::{Buffer, BufferId, BufferIrGraph, BufferNode, Owner, PlanLayout};
 use luminal::layout_ir::FreedBy;
 use luminal::prelude::{FxHashMap, NodeIndex, petgraph};
@@ -112,7 +54,7 @@ fn align_up(bytes: usize) -> usize {
 /// One buffer's home in the slab. `bytes` is the buffer's TRUE size
 /// (what a memcpy of it moves); the range RESERVED is `align_up(bytes)`,
 /// which is what disjointness is checked over.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ArenaSlice {
     pub offset: usize,
     pub bytes: usize,
@@ -122,44 +64,42 @@ impl ArenaSlice {
     /// The reserved (aligned) extent — `bytes` rounded up to
     /// [`ARENA_ALIGN`].
     pub fn reserved(&self) -> usize {
-        align_up(self.bytes)
+        align_up(self.bytes.max(1))
     }
 }
 
-/// The answer: an issue order, a slab size, and who sits where.
-#[derive(Debug, Clone, Default)]
-pub struct ArenaPlan {
-    /// The order the runtime issues plan nodes in — a topological order
-    /// of the dag (Data and Anti edges alike), chosen for a small
-    /// high-water mark. Every node of the dag appears exactly once.
-    pub order: Vec<NodeIndex>,
-    /// The high-water mark: how many bytes the slab must hold for this
-    /// plan under this order.
-    pub slab_bytes: usize,
-    /// The FRAGMENTATION-FREE lower bound: the largest total of
-    /// simultaneously-live reservations over the same order. A perfect
-    /// allocator would need exactly this; `slab_bytes - peak_live_bytes`
-    /// is what first-fit's holes cost. Diagnostic only — nothing binds
-    /// to it.
-    pub peak_live_bytes: usize,
-    /// Slab members (the INTERIOR row) and their ranges.
-    pub slices: FxHashMap<BufferId, ArenaSlice>,
-    /// Buffers that live OUTSIDE the slab in their own allocations: the
-    /// BOUNDARY row (inputs and caller-bound outputs) and the ESCAPING
-    /// row (minted storage handed to the caller).
-    pub standalone: Vec<BufferId>,
-    /// The DONATED row: caller storage the program frees. Its bytes are
-    /// the caller's staged storage; it gets no slab range, and its free
-    /// releases rather than recycles.
-    pub donated: Vec<BufferId>,
+/// The exact schedule consumed by graph construction. Transfers of multiple
+/// output views sharing a buffer are grouped within each output boundary.
+#[derive(Debug, Clone)]
+pub enum ArenaStep {
+    Upload {
+        buffer: BufferId,
+        staging: ArenaSlice,
+    },
+    Node(NodeIndex),
+    Download {
+        buffer: BufferId,
+        node: NodeIndex,
+        slots: Vec<usize>,
+        staging: ArenaSlice,
+    },
 }
 
-/// Which of the four rows a buffer is in, as the arena treats it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Row {
-    Slab,
-    Standalone,
-    Donated,
+#[derive(Debug, Clone, Default)]
+pub struct ArenaPlan {
+    /// A topological order respecting data and anti-dependencies, with late
+    /// allocations and eager frees. `steps` expands this order with transfers.
+    pub order: Vec<NodeIndex>,
+    pub steps: Vec<ArenaStep>,
+    pub slab_bytes: usize,
+    /// Peak simultaneous reservations, including parameters and scratch.
+    pub peak_live_bytes: usize,
+    pub slices: FxHashMap<BufferId, ArenaSlice>,
+    /// Scratch is live only during its owning operation's child graph.
+    pub workspaces: FxHashMap<NodeIndex, ArenaSlice>,
+    pub parameters: ArenaSlice,
+    pub staging_parameters: ArenaSlice,
+    pub staging_bytes: usize,
 }
 
 /// Node kinds, for the order policy.
@@ -399,164 +339,301 @@ impl FreeList {
     }
 }
 
-/// Plan the arena for one bufferized plan.
-///
-/// `bytes_of` sizes a buffer (the executor passes the span-of-layout
-/// rule; tests pass whatever they like). It is called for SLAB MEMBERS
-/// only — standalone and donated buffers are the executor's to size, in
-/// its own allocation phase, exactly as before.
+/// Half-open lifetime in the execution schedule. Requests alive at the same
+/// step must be disjoint, including a copy's source and destination.
+#[derive(Debug, Clone, Copy)]
+struct Lifetime {
+    start: usize,
+    end: usize,
+    bytes: usize,
+}
+
+/// The same allocator serves device memory and pinned host memory. Only their
+/// alignment and lifetimes differ. Returned slices follow request order.
+fn pack(lifetimes: &[Lifetime], alignment: usize) -> Result<(Vec<ArenaSlice>, usize, usize)> {
+    let mut events = Vec::with_capacity(lifetimes.len() * 2);
+    for (id, life) in lifetimes.iter().enumerate() {
+        ensure!(life.start < life.end, "empty physical lifetime");
+        events.push((life.start, true, id));
+        events.push((life.end, false, id));
+    }
+    events.sort_unstable(); // releases before allocations at the same boundary
+    let mut slices = vec![ArenaSlice::default(); lifetimes.len()];
+    let mut free_list = FreeList::default();
+    let mut live = BTreeMap::<usize, usize>::new();
+    let mut live_bytes = 0usize;
+    let mut peak = 0;
+    for (_, alloc, id) in events {
+        let bytes = lifetimes[id].bytes;
+        let need = bytes
+            .max(1)
+            .checked_add(alignment - 1)
+            .map(|v| v / alignment * alignment)
+            .ok_or_else(|| anyhow!("arena alignment overflow"))?;
+        if alloc {
+            let offset = free_list.alloc(need)?;
+            ensure!(
+                live.range(..=offset)
+                    .next_back()
+                    .is_none_or(|(&p, &n)| p + n <= offset),
+                "arena overlaps a live predecessor"
+            );
+            ensure!(
+                live.range(offset..)
+                    .next()
+                    .is_none_or(|(&p, _)| offset + need <= p),
+                "arena overlaps a live successor"
+            );
+            live.insert(offset, need);
+            live_bytes = live_bytes
+                .checked_add(need)
+                .ok_or_else(|| anyhow!("live size overflow"))?;
+            peak = peak.max(live_bytes);
+            slices[id] = ArenaSlice { offset, bytes };
+        } else {
+            let offset = slices[id].offset;
+            ensure!(
+                live.remove(&offset) == Some(need),
+                "release of non-live range"
+            );
+            live_bytes -= need;
+            free_list.free(offset, need);
+        }
+    }
+    Ok((slices, free_list.top, peak))
+}
+
+/// Plan private device copies of a bufferized program. Unlike logical caller
+/// storage, these ranges only need to survive through their GPU uses/readbacks.
+/// The CUDA adapter also supplies parameter and per-operation scratch sizes.
 pub fn plan_arena<L: PlanLayout>(
     plan: &BufferIrGraph<L>,
     bytes_of: impl Fn(&Buffer<L>) -> Result<usize>,
 ) -> Result<ArenaPlan> {
-    plan_arena_over(plan, bytes_of, issue_order(plan)?)
+    plan_arena_over(plan, bytes_of, |_| Ok(0), 0, issue_order(plan)?)
 }
 
-/// [`plan_arena`] over a CALLER-SUPPLIED issue order — the seam the
-/// order-policy comparison test uses to price one order against
-/// another. The order must be a topological order of `plan.dag`
-/// covering every node; nothing here re-checks that.
-pub(crate) fn plan_arena_over<L: PlanLayout>(
+pub(crate) fn plan_with_workspace<L: PlanLayout>(
     plan: &BufferIrGraph<L>,
     bytes_of: impl Fn(&Buffer<L>) -> Result<usize>,
+    scratch_of: impl Fn(NodeIndex) -> Result<usize>,
+    parameter_bytes: usize,
+) -> Result<ArenaPlan> {
+    plan_arena_over(
+        plan,
+        bytes_of,
+        scratch_of,
+        parameter_bytes,
+        issue_order(plan)?,
+    )
+}
+
+fn plan_arena_over<L: PlanLayout>(
+    plan: &BufferIrGraph<L>,
+    bytes_of: impl Fn(&Buffer<L>) -> Result<usize>,
+    scratch_of: impl Fn(NodeIndex) -> Result<usize>,
+    parameter_bytes: usize,
     order: Vec<NodeIndex>,
 ) -> Result<ArenaPlan> {
-    // ---- classification: the ownership rows -------------------------
-    //
-    // A slab member needs BOTH ends of its lifetime in the program. The
-    // rows say which buffers those are; the dag says whether the nodes
-    // that mark the ends are actually there. A plan built by hand (or
-    // an older plan loaded from disk) may carry an INTERIOR buffer with
-    // no alloc/free pair — bufferize's `optimize` always mints them,
-    // but nothing here re-derives them. Such a buffer is DEMOTED to
-    // standalone: it gets its own allocation for the whole call, which
-    // is precisely CL-2's pre-arena behaviour, and the plan still runs.
-    let mut alloc_node: FxHashMap<BufferId, NodeIndex> = FxHashMap::default();
-    let mut free_node: FxHashMap<BufferId, NodeIndex> = FxHashMap::default();
-    for index in plan.dag.node_indices() {
-        if let Some(buffer) = allocated(&plan.dag[index])
-            && alloc_node.insert(buffer.clone(), index).is_some()
-        {
-            bail!(
-                "arena: buffer {buffer:?} is allocated twice — one \
-                     BufferAlloc per buffer is the plan's invariant, and a \
-                     second one would re-let a live range"
+    let mut allocs = FxHashMap::default();
+    let mut frees = FxHashMap::default();
+    for &node in &order {
+        if let Some(id) = allocated(&plan.dag[node]) {
+            ensure!(
+                allocs.insert(id.clone(), node).is_none(),
+                "buffer {id:?} allocated twice"
+            );
+            ensure!(
+                plan.buffers[id].owner == Owner::System,
+                "caller buffer {id:?} has an alloc"
             );
         }
-        if let Some(buffer) = freed(&plan.dag[index])
-            && free_node.insert(buffer.clone(), index).is_some()
-        {
-            bail!(
-                "arena: buffer {buffer:?} is freed twice — one BufferFree \
-                     per buffer is the plan's invariant, and a second one \
-                     would hand a live range to the next allocation"
+        if let Some(id) = freed(&plan.dag[node]) {
+            ensure!(
+                frees.insert(id.clone(), node).is_none(),
+                "buffer {id:?} freed twice"
+            );
+            ensure!(
+                plan.buffers[id].freed_by == FreedBy::Program,
+                "caller-freed buffer {id:?} has a free"
             );
         }
     }
-
-    let mut rows: Vec<(BufferId, Row)> = Vec::with_capacity(plan.buffers.len());
-    for (id, buffer) in &plan.buffers {
-        let row = match (buffer.owner, buffer.freed_by) {
-            // INTERIOR — the only recyclable row, and only with both
-            // lifetime ends present in the dag.
-            (Owner::System, FreedBy::Program)
-                if alloc_node.contains_key(id) && free_node.contains_key(id) =>
-            {
-                Row::Slab
-            }
-            (Owner::System, FreedBy::Program) => Row::Standalone,
-            // DONATED — caller storage the program frees.
-            (Owner::Caller, FreedBy::Program) => Row::Donated,
-            // BOUNDARY and ESCAPING — the caller's bytes after the call.
-            (_, FreedBy::Caller) => Row::Standalone,
+    // Hand-built plans without alloc/free markers keep their existing implicit
+    // bindings. Explicit markers are authoritative and checked for containment.
+    let mut live: std::collections::HashSet<_> = plan
+        .buffers
+        .keys()
+        .filter(|id| !allocs.contains_key(*id))
+        .cloned()
+        .collect();
+    let mut uploaded = std::collections::HashSet::new();
+    let mut steps = vec![];
+    for &node in &order {
+        let op = &plan.dag[node];
+        if let Some(id) = allocated(op) {
+            ensure!(live.insert(id.clone()), "alloc of live buffer {id:?}");
+        }
+        let mut touched: Vec<&BufferId> = match op {
+            BufferNode::Compute { reads, writes, .. } => reads.iter().chain(writes).collect(),
+            BufferNode::BufferCopy { src, dst } => vec![src, dst],
+            BufferNode::BufferOutput { slots } => slots.iter().map(|s| &s.buffer).collect(),
+            BufferNode::BufferInput { .. } => vec![],
         };
-        rows.push((id.clone(), row));
+        // Preserve operand order, deduplicating tied operands/results.
+        let mut seen = std::collections::HashSet::new();
+        touched.retain(|id| seen.insert((*id).clone()));
+        for id in touched {
+            ensure!(
+                live.contains(id),
+                "node {node:?} touches non-live buffer {id:?}"
+            );
+            if plan.buffers[id].lit.is_some() && uploaded.insert(id.clone()) {
+                steps.push(ArenaStep::Upload {
+                    buffer: id.clone(),
+                    staging: ArenaSlice::default(),
+                });
+            }
+        }
+        steps.push(ArenaStep::Node(node));
+        if let BufferNode::BufferOutput { slots } = op {
+            let mut groups: Vec<(BufferId, Vec<usize>)> = vec![];
+            for (i, slot) in slots.iter().enumerate() {
+                ensure!(
+                    plan.buffers[&slot.buffer].freed_by == FreedBy::Caller,
+                    "output slot {} has NON-ESCAPING buffer",
+                    slot.index
+                );
+                if let Some((_, indices)) = groups.iter_mut().find(|(id, _)| id == &slot.buffer) {
+                    indices.push(i);
+                } else {
+                    groups.push((slot.buffer.clone(), vec![i]));
+                }
+            }
+            for (buffer, slots) in groups {
+                steps.push(ArenaStep::Download {
+                    buffer,
+                    node,
+                    slots,
+                    staging: ArenaSlice::default(),
+                });
+            }
+        }
+        if let Some(id) = freed(op) {
+            ensure!(live.remove(id), "free of non-live buffer {id:?}");
+        }
     }
-    // `plan.buffers` is a hash map; sort so the reported vectors read
-    // the same on every run (the slab LAYOUT is already deterministic —
-    // it follows `order`, not this iteration).
-    rows.sort_by_key(|(id, _)| format!("{id:?}"));
 
-    let mut arena = ArenaPlan {
-        order,
-        ..Default::default()
+    let mut intervals = vec![];
+    let mut buffers = FxHashMap::<BufferId, usize>::default();
+    let mut workspaces = FxHashMap::default();
+    let parameter = (parameter_bytes > 0).then(|| {
+        intervals.push(Lifetime {
+            start: 0,
+            end: steps.len().max(1),
+            bytes: parameter_bytes,
+        });
+        0
+    });
+    let mut touch = |id: &BufferId, at: usize, intervals: &mut Vec<Lifetime>| -> Result<()> {
+        if let Some(&i) = buffers.get(id) {
+            intervals[i].end = at + 1;
+        } else {
+            buffers.insert(id.clone(), intervals.len());
+            intervals.push(Lifetime {
+                start: at,
+                end: at + 1,
+                bytes: bytes_of(&plan.buffers[id])?,
+            });
+        }
+        Ok(())
     };
-    let mut sizes: FxHashMap<BufferId, usize> = FxHashMap::default();
-    for (id, row) in &rows {
-        match row {
-            Row::Slab => {
-                let buffer = &plan.buffers[id];
-                sizes.insert(id.clone(), bytes_of(buffer)?);
+    for (at, step) in steps.iter().enumerate() {
+        match step {
+            ArenaStep::Upload { buffer, .. } | ArenaStep::Download { buffer, .. } => {
+                touch(buffer, at, &mut intervals)?
             }
-            Row::Standalone => arena.standalone.push(id.clone()),
-            Row::Donated => arena.donated.push(id.clone()),
+            ArenaStep::Node(node) => {
+                match &plan.dag[*node] {
+                    BufferNode::Compute { reads, writes, .. } => {
+                        for id in reads.iter().chain(writes) {
+                            touch(id, at, &mut intervals)?;
+                        }
+                    }
+                    BufferNode::BufferCopy { src, dst } => {
+                        touch(src, at, &mut intervals)?;
+                        touch(dst, at, &mut intervals)?;
+                    }
+                    _ => {}
+                }
+                let scratch = scratch_of(*node)?;
+                if scratch > 0 {
+                    workspaces.insert(*node, intervals.len());
+                    intervals.push(Lifetime {
+                        start: at,
+                        end: at + 1,
+                        bytes: scratch,
+                    });
+                }
+            }
         }
     }
+    let (slices, slab_bytes, peak_live_bytes) = pack(&intervals, ARENA_ALIGN)?;
+    let parameters = parameter.map(|i| slices[i]).unwrap_or_default();
+    let buffers: FxHashMap<_, _> = buffers.into_iter().map(|(id, i)| (id, slices[i])).collect();
+    let workspaces = workspaces
+        .into_iter()
+        .map(|(node, i)| (node, slices[i]))
+        .collect();
 
-    // ---- the walk: first-fit over the issue order -------------------
-    let mut free_list = FreeList::default();
-    // CONTRACT-1, LIVE-RANGE FORM. The whole-plan disjointness assert
-    // the executor used to run at bind time is vacuous under a slab
-    // (every range is a sub-range of one allocation) — and it was never
-    // the right question anyway: what folded-view reads and WAR
-    // ordering need is that two SIMULTANEOUSLY BOUND BufferIds do not
-    // share a byte. That is a property of THIS walk, so it is checked
-    // here, once per allocation, against the live set's neighbours (a
-    // sorted disjoint set stays disjoint iff each insertion clears its
-    // two neighbours). The executor keeps `binding_check::assert_disjoint`
-    // for the allocations it makes itself.
-    let mut live: BTreeMap<usize, (usize, BufferId)> = BTreeMap::new();
-    let mut live_bytes = 0usize;
-    for &index in &arena.order {
-        if let Some(buffer) = allocated(&plan.dag[index]) {
-            let Some(&bytes) = sizes.get(buffer) else {
-                continue; // not a slab member (demoted, escaping, …)
-            };
-            let need = bytes
-                .max(1)
-                .checked_add(ARENA_ALIGN - 1)
-                .map(|n| n / ARENA_ALIGN * ARENA_ALIGN)
-                .ok_or_else(|| anyhow!("arena alignment overflow"))?;
-            let offset = free_list.alloc(need)?;
-            if let Some((&prev, (prev_len, prev_id))) = live.range(..offset).next_back()
-                && prev + prev_len > offset
-            {
-                bail!(
-                    "CONTRACT-1 violation (arena): {prev_id:?} holds \
-                         [{prev}, {}) and {buffer:?} was given [{offset}, {}) \
-                         — simultaneously bound BufferIds must be disjoint",
-                    prev + prev_len,
-                    offset + need
-                );
+    // All host inputs are populated before launch and must survive until their
+    // upload; each output survives from readback through host result collection.
+    // A separate time 0 represents the parameter upload preceding `steps`.
+    let mut staging = vec![];
+    let staging_parameter = parameter.map(|_| {
+        staging.push(Lifetime {
+            start: 0,
+            end: 1,
+            bytes: parameter_bytes,
+        });
+        0
+    });
+    let mut transfers = vec![];
+    for (at, step) in steps.iter().enumerate() {
+        let (buffer, start, end) = match step {
+            ArenaStep::Upload { buffer, .. } => (buffer, 0, at + 2),
+            ArenaStep::Download { buffer, .. } => (buffer, at + 1, steps.len() + 2),
+            ArenaStep::Node(_) => continue,
+        };
+        transfers.push((at, staging.len()));
+        staging.push(Lifetime {
+            start,
+            end,
+            bytes: buffers[buffer].bytes,
+        });
+    }
+    let (staging_slices, staging_bytes, _) = pack(&staging, 1)?;
+    for (at, i) in transfers {
+        match &mut steps[at] {
+            ArenaStep::Upload { staging, .. } | ArenaStep::Download { staging, .. } => {
+                *staging = staging_slices[i]
             }
-            if let Some((&next, (_, next_id))) = live.range(offset..).next()
-                && offset + need > next
-            {
-                bail!(
-                    "CONTRACT-1 violation (arena): {buffer:?} was given \
-                         [{offset}, {}) and {next_id:?} holds [{next}, …) — \
-                         simultaneously bound BufferIds must be disjoint",
-                    offset + need
-                );
-            }
-            live.insert(offset, (need, buffer.clone()));
-            live_bytes += need;
-            arena.peak_live_bytes = arena.peak_live_bytes.max(live_bytes);
-            arena
-                .slices
-                .insert(buffer.clone(), ArenaSlice { offset, bytes });
-        }
-        if let Some(buffer) = freed(&plan.dag[index])
-            && let Some(slice) = arena.slices.get(buffer)
-        {
-            let need = align_up(slice.bytes.max(1));
-            live.remove(&slice.offset);
-            live_bytes -= need;
-            free_list.free(slice.offset, need);
+            ArenaStep::Node(_) => unreachable!(),
         }
     }
-    arena.slab_bytes = free_list.top;
-    Ok(arena)
+    Ok(ArenaPlan {
+        order,
+        steps,
+        slab_bytes,
+        peak_live_bytes,
+        slices: buffers,
+        workspaces,
+        parameters,
+        staging_parameters: staging_parameter
+            .map(|i| staging_slices[i])
+            .unwrap_or_default(),
+        staging_bytes,
+    })
 }
 
 #[cfg(test)]
@@ -660,12 +737,16 @@ mod tests {
         let by_index = plan_arena_over(
             &plan,
             unit_bytes,
+            |_| Ok(0),
+            0,
             plan.dag.node_indices().collect::<Vec<_>>(),
         )
         .expect("node-index order plans");
         let raw = plan_arena_over(
             &plan,
             unit_bytes,
+            |_| Ok(0),
+            0,
             petgraph::algo::toposort(&plan.dag, None).expect("acyclic"),
         )
         .expect("raw toposort plans");
@@ -678,17 +759,16 @@ mod tests {
             arena.slab_bytes <= by_index.slab_bytes,
             "the liveness-aware order is never worse than emission order"
         );
-        assert_eq!(
-            raw.slab_bytes, sum,
-            "a raw toposort really does pay the sum"
+        assert!(
+            raw.slab_bytes > arena.slab_bytes,
+            "hoisted allocations cost more"
         );
     }
 
-    /// t2 — ESCAPING (`Owner::System` + `FreedBy::Caller`): minted
-    /// storage the caller receives. It has an alloc and NO free, so its
-    /// bytes must outlive the call: outside the slab.
+    /// Escaping storage keeps its logical ownership, while its private device
+    /// copy participates in physical packing through the output readback.
     #[test]
-    fn escaping_minted_storage_stays_out_of_the_slab() {
+    fn escaping_minted_storage_is_packed_without_a_logical_free() {
         let mut g = TestGraph::new();
         let x = g.input("x", "B", Access::ReadWrite, "rm");
         let p = g.op(
@@ -717,23 +797,16 @@ mod tests {
             .map(|(id, _)| id.clone())
             .unwrap_or_else(|| panic!("no escaping buffer:\n{}", plan.summary()));
         let arena = plan_arena(&plan, unit_bytes).expect("arena plans");
-        assert!(
-            !arena.slices.contains_key(&escaping),
-            "escaping storage must not be a slab member:\n{}",
-            plan.summary()
-        );
-        assert!(
-            arena.standalone.contains(&escaping),
-            "escaping storage is standalone:\n{}",
-            plan.summary()
-        );
+        assert!(arena.slices.contains_key(&escaping));
+        assert!(plan.dag.node_weights().all(|n| freed(n) != Some(&escaping)));
+        assert!(arena.steps.iter().any(|step| matches!(step,
+            ArenaStep::Download { buffer, .. } if buffer == &escaping)));
     }
 
-    /// t3 — DONATED (`Owner::Caller` + `FreedBy::Program`): the caller's
-    /// bytes, released by the program. No slab range; the free lands
-    /// after every toucher.
+    /// Donation's explicit free remains authoritative, and the private copy
+    /// receives an ordinary arena range.
     #[test]
-    fn donated_caller_storage_gets_no_slab_range_and_frees_last() {
+    fn donated_device_copy_is_packed_and_frees_after_all_uses() {
         let mut g = TestGraph::new();
         let x = g.input_binding(
             "x",
@@ -760,16 +833,7 @@ mod tests {
             .map(|(id, _)| id.clone())
             .unwrap_or_else(|| panic!("no donated buffer:\n{}", plan.summary()));
         let arena = plan_arena(&plan, unit_bytes).expect("arena plans");
-        assert!(
-            arena.donated.contains(&donated),
-            "donated storage is its own row:\n{}",
-            plan.summary()
-        );
-        assert!(
-            !arena.slices.contains_key(&donated),
-            "donated storage gets no slab range:\n{}",
-            plan.summary()
-        );
+        assert!(arena.slices.contains_key(&donated));
         let at = positions(&arena);
         let free = plan
             .dag
@@ -793,45 +857,43 @@ mod tests {
     fn a_recycled_range_is_only_re_let_after_its_occupant_is_finished() {
         let plan = chain(5);
         let arena = plan_arena(&plan, unit_bytes).expect("arena plans");
-        let at = positions(&arena);
         let mut sharing = 0usize;
-        let members: Vec<(&BufferId, &ArenaSlice)> = arena.slices.iter().collect();
-        for (a, sa) in &members {
-            for (b, sb) in &members {
-                if a == b || sa.offset != sb.offset {
+        let lifetime = |id: &BufferId| {
+            let uses: Vec<_> = arena
+                .steps
+                .iter()
+                .enumerate()
+                .filter_map(|(i, step)| {
+                    let touches = match step {
+                        ArenaStep::Upload { buffer, .. } | ArenaStep::Download { buffer, .. } => {
+                            buffer == id
+                        }
+                        ArenaStep::Node(node) => match &plan.dag[*node] {
+                            BufferNode::Compute { reads, writes, .. } => {
+                                reads.contains(id) || writes.contains(id)
+                            }
+                            BufferNode::BufferCopy { src, dst } => src == id || dst == id,
+                            _ => false,
+                        },
+                    };
+                    touches.then_some(i)
+                })
+                .collect();
+            (*uses.first().unwrap(), *uses.last().unwrap())
+        };
+        let members: Vec<_> = arena.slices.iter().collect();
+        for (i, (a, sa)) in members.iter().enumerate() {
+            for (b, sb) in &members[i + 1..] {
+                if sa.offset >= sb.offset + sb.reserved() || sb.offset >= sa.offset + sa.reserved()
+                {
                     continue;
                 }
-                // Same range, two buffers: order them by their allocs.
-                let alloc_a = plan
-                    .dag
-                    .node_indices()
-                    .find(|&i| allocated(&plan.dag[i]) == Some(a))
-                    .expect("slab member has an alloc");
-                let alloc_b = plan
-                    .dag
-                    .node_indices()
-                    .find(|&i| allocated(&plan.dag[i]) == Some(b))
-                    .expect("slab member has an alloc");
-                if at[&alloc_a] > at[&alloc_b] {
-                    continue; // handled from the other side
-                }
                 sharing += 1;
-                let last_old = touchers(&plan, a)
-                    .into_iter()
-                    .map(|n| at[&n])
-                    .max()
-                    .expect("an occupant is touched");
-                let first_new = touchers(&plan, b)
-                    .into_iter()
-                    .map(|n| at[&n])
-                    .min()
-                    .expect("an occupant is touched");
+                let (start_a, end_a) = lifetime(a);
+                let (start_b, end_b) = lifetime(b);
                 assert!(
-                    last_old < first_new,
-                    "range {} was re-let to {b:?} at position {first_new} while \
-                     {a:?} was still touching it at {last_old}:\n{}",
-                    sa.offset,
-                    plan.summary()
+                    end_a < start_b || end_b < start_a,
+                    "overlapping ranges have intersecting lifetimes: {a:?}, {b:?}"
                 );
             }
         }
@@ -869,5 +931,134 @@ mod tests {
             );
         }
         println!("{} anti edges honoured", anti);
+    }
+    #[test]
+    fn interval_packing_checks_all_live_ranges_with_fixed_seed() {
+        // Vary sizes, lifetimes, and alignment independently of bufferization.
+        let mut seed = 42u64;
+        let mut next = || {
+            seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+            seed as usize
+        };
+        for alignment in [1, ARENA_ALIGN] {
+            for _ in 0..30 {
+                let lives: Vec<_> = (0..80)
+                    .map(|_| {
+                        let start = next() % 40;
+                        Lifetime {
+                            start,
+                            end: start + 1 + next() % 15,
+                            bytes: next() % 2049,
+                        }
+                    })
+                    .collect();
+                let (slices, total, peak) = pack(&lives, alignment).unwrap();
+                let reservation = |bytes: usize| bytes.max(1).div_ceil(alignment) * alignment;
+                let expected_peak = (0..55)
+                    .map(|t| {
+                        lives
+                            .iter()
+                            .filter(|l| l.start <= t && t < l.end)
+                            .map(|l| reservation(l.bytes))
+                            .sum::<usize>()
+                    })
+                    .max()
+                    .unwrap();
+                assert_eq!(peak, expected_peak);
+                assert!(total >= peak);
+                for (i, a) in lives.iter().enumerate() {
+                    let sa = slices[i];
+                    assert_eq!(sa.offset % alignment, 0);
+                    assert!(sa.offset + reservation(sa.bytes) <= total);
+                    for (j, b) in lives.iter().enumerate().skip(i + 1) {
+                        if a.start < b.end && b.start < a.end {
+                            let sb = slices[j];
+                            assert!(
+                                sa.offset + reservation(sa.bytes) <= sb.offset
+                                    || sb.offset + reservation(sb.bytes) <= sa.offset
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn scratch_reuses_tensor_storage_and_staging_reuses_uploaded_inputs() {
+        let plan = chain(6);
+        let nodes: Vec<_> = plan
+            .dag
+            .node_indices()
+            .filter(|&n| {
+                matches!(&plan.dag[n],
+            BufferNode::Compute { op, .. } if !matches!(op.label(), "BufferAlloc" | "BufferFree"))
+            })
+            .collect();
+        let BufferNode::Compute { writes, .. } = &plan.dag[nodes[0]] else {
+            unreachable!()
+        };
+        let large = &writes[0];
+        let bytes = |b: &Buffer<MockLayout>| Ok(if &b.id == large { 8 * RESERVED } else { UNIT });
+        let baseline = plan_with_workspace(&plan, bytes, |_| Ok(0), 8).unwrap();
+        let host = *nodes.last().unwrap();
+        let arena = plan_with_workspace(
+            &plan,
+            bytes,
+            |n| Ok(if n == host { 4 * RESERVED } else { 0 }),
+            8,
+        )
+        .unwrap();
+        let scratch = arena.workspaces[&host];
+        let early = arena.slices[large];
+        assert!(
+            scratch.offset < early.offset + early.reserved()
+                && early.offset < scratch.offset + scratch.reserved(),
+            "scratch must reuse the dead large tensor's range"
+        );
+        assert_eq!(
+            arena.slab_bytes, baseline.slab_bytes,
+            "scratch fits inside the existing high-water mark"
+        );
+        let staging_sum: usize = arena
+            .steps
+            .iter()
+            .map(|s| match s {
+                ArenaStep::Upload { staging, .. } | ArenaStep::Download { staging, .. } => {
+                    staging.bytes
+                }
+                _ => 0,
+            })
+            .sum();
+        assert!(
+            arena.staging_bytes < staging_sum + 8,
+            "staging must reuse completed uploads"
+        );
+    }
+
+    #[test]
+    fn packing_rejects_overflow_and_invalid_lifetimes() {
+        assert!(
+            pack(
+                &[Lifetime {
+                    start: 0,
+                    end: 1,
+                    bytes: usize::MAX
+                }],
+                ARENA_ALIGN
+            )
+            .is_err()
+        );
+        assert!(
+            pack(
+                &[Lifetime {
+                    start: 2,
+                    end: 2,
+                    bytes: 1
+                }],
+                1
+            )
+            .is_err()
+        );
     }
 }

--- a/crates/luminal_cuda_lite/src/arena.rs
+++ b/crates/luminal_cuda_lite/src/arena.rs
@@ -35,6 +35,10 @@
 //! | ESCAPING | `System` | `Caller` | yes | no | `standalone` |
 //! | INTERIOR | `System` | `Program` | yes | yes | **slab member** |
 //!
+//! This pass recycles only the INTERIOR row. storage::plan subsequently places
+//! the other rows in disjoint regions of the same runtime allocation.
+//! Their device storage holds private copies of host-owned boundary values.
+//!
 //! Only the INTERIOR row has BOTH ends of a lifetime inside the
 //! program, which is exactly the precondition for handing its bytes to
 //! a later buffer. An ESCAPING buffer's bytes are the caller's from
@@ -48,8 +52,8 @@
 //! `bytes_of` is the caller's, so tests can plan with mock sizes and
 //! the executor can pass the one real rule (`literal_span_elements() *
 //! dtype_bytes(dtype)` — see `crate::device`). Symbolic extents are the
-//! caller's error to raise. Buckets are always concrete (D7), so the
-//! slab is always a number.
+//! caller's responsibility: storage::plan evaluates conservative interval
+//! capacities for symbolic buffers.
 //!
 //! # What is NOT here
 //!
@@ -333,7 +337,7 @@ struct FreeList {
 }
 
 impl FreeList {
-    fn alloc(&mut self, need: usize) -> usize {
+    fn alloc(&mut self, need: usize) -> Result<usize> {
         // FIRST fit, in offset order — MEASURED against the obvious
         // alternative and kept. First fit leaves about a fifth of the
         // slab in holes on the two-layer mini-llama block (596480 B
@@ -351,7 +355,7 @@ impl FreeList {
             if len > need {
                 self.holes.insert(offset + need, len - need);
             }
-            return offset;
+            return Ok(offset);
         }
         // No hole fits. If the LAST hole runs right up to the top, grow
         // through it instead of stranding it (coalescing with the
@@ -360,12 +364,17 @@ impl FreeList {
             && offset + len == self.top
         {
             self.holes.remove(&offset);
-            self.top = offset + need;
-            return offset;
+            self.top = offset
+                .checked_add(need)
+                .ok_or_else(|| anyhow!("arena size overflow"))?;
+            return Ok(offset);
         }
         let offset = self.top;
-        self.top += need;
-        offset
+        self.top = self
+            .top
+            .checked_add(need)
+            .ok_or_else(|| anyhow!("arena size overflow"))?;
+        Ok(offset)
     }
 
     fn free(&mut self, offset: usize, len: usize) {
@@ -503,8 +512,12 @@ pub(crate) fn plan_arena_over<L: PlanLayout>(
             let Some(&bytes) = sizes.get(buffer) else {
                 continue; // not a slab member (demoted, escaping, …)
             };
-            let need = align_up(bytes.max(1));
-            let offset = free_list.alloc(need);
+            let need = bytes
+                .max(1)
+                .checked_add(ARENA_ALIGN - 1)
+                .map(|n| n / ARENA_ALIGN * ARENA_ALIGN)
+                .ok_or_else(|| anyhow!("arena alignment overflow"))?;
+            let offset = free_list.alloc(need)?;
             if let Some((&prev, (prev_len, prev_id))) = live.range(..offset).next_back()
                 && prev + prev_len > offset
             {

--- a/crates/luminal_cuda_lite/src/cuda_graph.rs
+++ b/crates/luminal_cuda_lite/src/cuda_graph.rs
@@ -256,19 +256,14 @@ pub(crate) enum CopyKind {
 
 /// A bucket's view into the runtime's shared pinned staging allocation.
 /// The runtime serializes launches and completes readback before reusing it.
-#[derive(Clone, Copy)]
-pub(crate) struct StagingRange {
-    pub offset: usize,
-    pub len: usize,
-}
-impl StagingRange {
-    pub fn ptr(self, staging: &Pinned) -> u64 {
+impl crate::arena::ArenaSlice {
+    pub(crate) fn ptr(self, staging: &Pinned) -> u64 {
         staging.ptr() as u64 + self.offset as u64
     }
-    pub fn bytes(self, staging: &Pinned) -> &[u8] {
-        &staging.bytes()[self.offset..self.offset + self.len]
+    pub(crate) fn bytes(self, staging: &Pinned) -> &[u8] {
+        &staging.bytes()[self.offset..self.offset + self.bytes]
     }
-    pub fn bytes_mut(self, staging: &mut Pinned) -> &mut [u8] {
-        &mut staging.bytes_mut()[self.offset..self.offset + self.len]
+    pub(crate) fn bytes_mut(self, staging: &mut Pinned) -> &mut [u8] {
+        &mut staging.bytes_mut()[self.offset..self.offset + self.bytes]
     }
 }

--- a/crates/luminal_cuda_lite/src/cuda_graph.rs
+++ b/crates/luminal_cuda_lite/src/cuda_graph.rs
@@ -1,0 +1,274 @@
+//! CUDA graph ownership and updates. All graph work is serialized on one stream.
+use crate::host::{CaptureCtx, PreparedHostOp};
+use anyhow::{Context, Result, ensure};
+use cudarc::driver::{CudaContext, CudaStream, sys as cu};
+use std::{ptr, sync::Arc};
+
+pub(crate) type Node = cu::CUgraphNode;
+pub(crate) struct Graph {
+    pub raw: cu::CUgraph,
+    ctx: Arc<CudaContext>,
+}
+pub(crate) struct Executable {
+    raw: cu::CUgraphExec,
+    ctx: Arc<CudaContext>,
+}
+impl Graph {
+    pub fn new(ctx: &Arc<CudaContext>) -> Result<Self> {
+        ctx.bind_to_thread()?;
+        let mut raw = ptr::null_mut();
+        unsafe {
+            cu::cuGraphCreate(&mut raw, 0).result()?;
+        }
+        Ok(Self {
+            raw,
+            ctx: ctx.clone(),
+        })
+    }
+    pub fn capture(stream: &Arc<CudaStream>, prepared: &dyn PreparedHostOp) -> Result<Self> {
+        stream.context().bind_to_thread()?;
+        unsafe {
+            cu::cuStreamBeginCapture_v2(
+                stream.cu_stream(),
+                cu::CUstreamCaptureMode::CU_STREAM_CAPTURE_MODE_THREAD_LOCAL,
+            )
+            .result()?;
+        }
+        // End capture even on an error or unwind, so subsequent candidates can use the stream.
+        struct Capture<'a>(&'a Arc<CudaStream>, bool);
+        impl Drop for Capture<'_> {
+            fn drop(&mut self) {
+                if self.1 {
+                    unsafe {
+                        let mut graph = ptr::null_mut();
+                        let _ = cu::cuStreamEndCapture(self.0.cu_stream(), &mut graph);
+                        if !graph.is_null() {
+                            let _ = cu::cuGraphDestroy(graph);
+                        }
+                    }
+                }
+            }
+        }
+        let mut capture = Capture(stream, true);
+        let recorded = unsafe { prepared.record(&CaptureCtx { stream }) };
+        let mut raw = ptr::null_mut();
+        let ended = unsafe { cu::cuStreamEndCapture(stream.cu_stream(), &mut raw).result() };
+        capture.1 = false;
+        let graph = Self {
+            raw,
+            ctx: stream.context().clone(),
+        };
+        recorded.context("host op record")?;
+        ended.context("end host op capture")?;
+        ensure!(!raw.is_null(), "capture produced no graph");
+        Ok(graph)
+    }
+    pub fn instantiate(&self) -> Result<Executable> {
+        let mut raw = ptr::null_mut();
+        unsafe {
+            cu::cuGraphInstantiateWithFlags(&mut raw, self.raw, 0).result()?;
+        }
+        Ok(Executable {
+            raw,
+            ctx: self.ctx.clone(),
+        })
+    }
+    pub fn copy(&self, deps: &[Node], params: &cu::CUDA_MEMCPY3D) -> Result<Node> {
+        let mut node = ptr::null_mut();
+        unsafe {
+            cu::cuGraphAddMemcpyNode(
+                &mut node,
+                self.raw,
+                deps.as_ptr(),
+                deps.len(),
+                params,
+                self.ctx.cu_ctx(),
+            )
+            .result()?;
+        }
+        Ok(node)
+    }
+    pub fn kernel(&self, deps: &[Node], params: &cu::CUDA_KERNEL_NODE_PARAMS) -> Result<Node> {
+        let mut node = ptr::null_mut();
+        unsafe {
+            cu::cuGraphAddKernelNode_v2(&mut node, self.raw, deps.as_ptr(), deps.len(), params)
+                .result()?;
+        }
+        Ok(node)
+    }
+    pub fn child(&self, deps: &[Node], child: &Graph) -> Result<Node> {
+        let mut node = ptr::null_mut();
+        unsafe {
+            cu::cuGraphAddChildGraphNode(&mut node, self.raw, deps.as_ptr(), deps.len(), child.raw)
+                .result()?;
+        }
+        Ok(node)
+    }
+}
+impl Executable {
+    pub fn launch(&self, stream: &Arc<CudaStream>) -> Result<()> {
+        self.ctx.bind_to_thread()?;
+        unsafe {
+            cu::cuGraphLaunch(self.raw, stream.cu_stream()).result()?;
+        }
+        Ok(())
+    }
+    pub fn copy(&self, node: Node, params: &cu::CUDA_MEMCPY3D) -> Result<()> {
+        unsafe {
+            cu::cuGraphExecMemcpyNodeSetParams(self.raw, node, params, self.ctx.cu_ctx())
+                .result()?;
+        }
+        Ok(())
+    }
+    pub fn child(&self, node: Node, child: &Graph) -> Result<()> {
+        unsafe {
+            cu::cuGraphExecChildGraphNodeSetParams(self.raw, node, child.raw).result()?;
+        }
+        Ok(())
+    }
+    pub fn kernel(&self, node: Node, params: &cu::CUDA_KERNEL_NODE_PARAMS) -> Result<()> {
+        unsafe {
+            cu::cuGraphExecKernelNodeSetParams_v2(self.raw, node, params).result()?;
+        }
+        Ok(())
+    }
+    pub fn enable(&self, node: Node, enabled: bool) -> Result<()> {
+        unsafe {
+            cu::cuGraphNodeSetEnabled(self.raw, node, u32::from(enabled)).result()?;
+        }
+        Ok(())
+    }
+}
+impl Drop for Graph {
+    fn drop(&mut self) {
+        let _ = self.ctx.bind_to_thread();
+        if !self.raw.is_null() {
+            unsafe {
+                let _ = cu::cuGraphDestroy(self.raw);
+            }
+        }
+    }
+}
+impl Drop for Executable {
+    fn drop(&mut self) {
+        let _ = self.ctx.bind_to_thread();
+        unsafe {
+            let _ = cu::cuGraphExecDestroy(self.raw);
+        }
+    }
+}
+
+/// Stable, pinned staging memory. Only touched by the CPU between synchronized launches.
+pub(crate) struct Pinned {
+    ptr: *mut u8,
+    len: usize,
+    ctx: Arc<CudaContext>,
+}
+impl Pinned {
+    pub fn new(ctx: &Arc<CudaContext>, len: usize) -> Result<Self> {
+        ctx.bind_to_thread()?;
+        let mut ptr = ptr::null_mut();
+        unsafe {
+            cu::cuMemHostAlloc(&mut ptr, len.max(1), 0).result()?;
+            std::ptr::write_bytes(ptr.cast::<u8>(), 0, len.max(1));
+        }
+        Ok(Self {
+            ptr: ptr.cast(),
+            len,
+            ctx: ctx.clone(),
+        })
+    }
+    pub fn ptr(&self) -> *mut std::ffi::c_void {
+        self.ptr.cast()
+    }
+    pub fn bytes(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+    }
+    pub fn bytes_mut(&mut self) -> &mut [u8] {
+        unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
+    }
+}
+impl Drop for Pinned {
+    fn drop(&mut self) {
+        let _ = self.ctx.bind_to_thread();
+        unsafe {
+            let _ = cu::cuMemFreeHost(self.ptr.cast());
+        }
+    }
+}
+
+pub(crate) fn copy_params(src: u64, dst: u64, bytes: usize, kind: CopyKind) -> cu::CUDA_MEMCPY3D {
+    let mut p = cu::CUDA_MEMCPY3D {
+        srcXInBytes: 0,
+        srcY: 0,
+        srcZ: 0,
+        srcLOD: 0,
+        srcMemoryType: cu::CUmemorytype::CU_MEMORYTYPE_DEVICE,
+        srcHost: ptr::null(),
+        srcDevice: 0,
+        srcArray: ptr::null_mut(),
+        reserved0: ptr::null_mut(),
+        srcPitch: 0,
+        srcHeight: 0,
+        dstXInBytes: 0,
+        dstY: 0,
+        dstZ: 0,
+        dstLOD: 0,
+        dstMemoryType: cu::CUmemorytype::CU_MEMORYTYPE_DEVICE,
+        dstHost: ptr::null_mut(),
+        dstDevice: 0,
+        dstArray: ptr::null_mut(),
+        reserved1: ptr::null_mut(),
+        dstPitch: 0,
+        dstHeight: 0,
+        WidthInBytes: 0,
+        Height: 1,
+        Depth: 1,
+    };
+    p.srcMemoryType = cu::CUmemorytype::CU_MEMORYTYPE_DEVICE;
+    p.dstMemoryType = cu::CUmemorytype::CU_MEMORYTYPE_DEVICE;
+    p.srcDevice = src;
+    p.dstDevice = dst;
+    p.WidthInBytes = bytes.max(1);
+    p.Height = 1;
+    p.Depth = 1;
+    match kind {
+        CopyKind::HtoD => {
+            p.srcMemoryType = cu::CUmemorytype::CU_MEMORYTYPE_HOST;
+            p.srcHost = src as *const _;
+            p.srcDevice = 0;
+        }
+        CopyKind::DtoH => {
+            p.dstMemoryType = cu::CUmemorytype::CU_MEMORYTYPE_HOST;
+            p.dstHost = dst as *mut _;
+            p.dstDevice = 0;
+        }
+        CopyKind::DtoD => {}
+    }
+    p
+}
+#[derive(Clone, Copy)]
+pub(crate) enum CopyKind {
+    HtoD,
+    DtoH,
+    DtoD,
+}
+
+/// A bucket's view into the runtime's shared pinned staging allocation.
+/// The runtime serializes launches and completes readback before reusing it.
+#[derive(Clone, Copy)]
+pub(crate) struct StagingRange {
+    pub offset: usize,
+    pub len: usize,
+}
+impl StagingRange {
+    pub fn ptr(self, staging: &Pinned) -> u64 {
+        staging.ptr() as u64 + self.offset as u64
+    }
+    pub fn bytes(self, staging: &Pinned) -> &[u8] {
+        &staging.bytes()[self.offset..self.offset + self.len]
+    }
+    pub fn bytes_mut(self, staging: &mut Pinned) -> &mut [u8] {
+        &mut staging.bytes_mut()[self.offset..self.offset + self.len]
+    }
+}

--- a/crates/luminal_cuda_lite/src/device.rs
+++ b/crates/luminal_cuda_lite/src/device.rs
@@ -1,574 +1,1015 @@
-//! CL-2: the device executor — the reference runtime's four execution
-//! phases reimplemented over cudarc, consuming the identical
-//! `BufferIrGraph`.
-//!
-//! PHASE 3 OF THE #420/#422 REJOIN (2026-09-03) rebuilt two things
-//! here:
-//!
-//! * THE DEVICE IS PERSISTENT. [`CudaDevice`] holds the context, the
-//!   one stream, the NVRTC module cache, and the arena slab, and the
-//!   runtime owns it across calls. Before, every `execute` built a
-//!   fresh context and a fresh kernel cache and recompiled every
-//!   kernel.
-//! * MEMORY COMES FROM AN ARENA. Phase 1 used to `alloc_zeros` one
-//!   slice per plan buffer, all live for the whole call — the sum of
-//!   every buffer the plan names. Now [`crate::arena`] reads the
-//!   plan's own `BufferAlloc`/`BufferFree` lifetimes, picks an issue
-//!   order that keeps few buffers live at once, and assigns each
-//!   INTERIOR buffer a range of ONE runtime-owned slab, sized to the
-//!   high-water mark and grown (never shrunk) across calls. Boundary,
-//!   escaping and donated storage keep their own allocations — see the
-//!   ownership-row table on [`crate::arena`].
-//!
-//! The phases themselves are unchanged in kind. Phase 1 materializes
-//! the standalone rows and stages inputs (loud on missing
-//! geometry/dtype, exactly like the reference). Phase 2 is the arena's
-//! issue order — a topological order over Data AND Anti edges, so WAR
-//! ordering is enforced by construction, chosen for a small high-water
-//! mark. Phase 3 dispatches: `BufferAlloc` binds its buffer to its slab
-//! range, `BufferFree` drops the binding, D2D for copies,
-//! NVRTC-compiled launches for compute (the destination is the range
-//! the planner assigned — no longer a fresh zeroed slice; every CL
-//! kernel writes every element it owns, see the KERNEL INVARIANT note
-//! below). Phase 4 copies each output SLOT's backing buffer back to a
-//! host `HostBuffer`, keyed by slot index and paired with the slot's
-//! [`OutputBinding`] — the escape-and-disclose contract (ruling
-//! 2026-08-27): the caller gets the backing bytes (possibly
-//! parent-sized, for an escaped view election) plus the layout to
-//! interpret them under.
-//!
-//! # THE KERNEL INVARIANT (why an unzeroed destination is safe)
-//!
-//! A recycled slab range arrives holding the previous occupant's
-//! bytes. That is sound iff no kernel READS its destination before
-//! writing it, and every kernel writes every element it owns. Audited
-//! 2026-09-03, one family at a time:
-//!
-//! * ELEMENTWISE (`kernels::binary`/`unary` and every op that lowers
-//!   through them), CAST, CONSTANT, IOTA, GATHER,
-//!   INDEXMAPAPPLYMATERIALIZE, COPY: one thread per destination
-//!   element, `out[i] = <expr>` over `n = numel(dest_dims)`. The
-//!   destination is never an operand of the launch (the executor
-//!   passes `reads[..reads.len()-writes.len()]`, dropping the DPS dest
-//!   operand), so it cannot even be read.
-//! * REDUCE: `out[i] = acc` over `n = outer*inner` — the whole
-//!   destination, `acc` seeded from `init` and folded over the input.
-//! * SCATTER: TWO launches. The first is `out[i] = init[...]` over the
-//!   FULL destination numel (`init_dims != dest_dims` is a bail), so
-//!   the destination is completely written before the second launch
-//!   scatters into it. Same stream, so the phases are ordered.
-//! * CUBLASLT D: `beta = 0` on the non-fold forms, which is the BLAS
-//!   skip — C (aliased to D) is not read, D is fully written. The
-//!   C-fold forms read their C operand at `beta = 1`; C is a DEFINED
-//!   resident — a distinct buffer, or D's own range when the bufferizer
-//!   seeded D onto C's ReadWrite caller buffer through the May permit —
-//!   never an undefined recycled range.
-//!
-//! So no memset is emitted anywhere. The one standing assumption is
-//! that a destination's `numel(dest_dims)` covers its buffer's SPAN:
-//! true for every codegen'd kernel because the elected destination
-//! layout must be right-major contiguous (the egglog write-capability
-//! guard, 2026-09-01) and for cuBLASLt because `bind_destination`
-//! refuses anything but the two dense orders. A future non-dense
-//! destination would leave the span's tail holding the previous
-//! occupant's bytes, and would need the memset this note says we do
-//! not do.
-
-use crate::arena::{ArenaPlan, buffer_bytes, plan_arena};
-use crate::host_buffer::HostBuffer;
-use anyhow::{Context, Result, anyhow, bail};
-use cudarc::driver::{
-    CudaContext, CudaFunction, CudaModule, CudaSlice, CudaStream, DevicePtr, LaunchConfig,
-    PushKernelArg, result as cu,
+//! Persistent graph-only executor. Buckets overlay one arena, and all GPU work
+//! (including staging/readback) is submitted by the same graph launch path.
+use crate::{
+    cuda_graph::{CopyKind, Executable, Graph, Node, Pinned, StagingRange, copy_params},
+    host::{DeviceRange, HostOpContext, PreparedHostOp},
+    host_buffer::HostBuffer,
+    kernels::{CodegenCtx, KernelLaunch},
+    layouts::CudaPlan,
+    storage::{self, StoragePlan},
+    symbolic::{self, Bounds, Expr},
 };
-use cudarc::nvrtc::compile_ptx;
-use luminal::bufferize::{BufferId, BufferIrGraph, BufferNode, EdgeKind, OutputBinding};
-use luminal::dtype::PlanDtype;
-use luminal::prelude::FxHashMap;
-use std::collections::HashMap;
-use std::sync::Arc;
+use anyhow::{Context, Result, anyhow, bail, ensure};
+use cudarc::{
+    driver::{CudaContext, CudaSlice, CudaStream, DevicePtr, result, sys as cu},
+    nvrtc::compile_ptx,
+};
+use luminal::{
+    bufferize::{BufferId, BufferNode, OutputBinding, SlotDescriptor},
+    layouts::DecodedLayout,
+    prelude::{FxHashMap, NodeIndex},
+    shape::{DynMap, Symbol},
+};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
+    ffi::CString,
+    rc::Rc,
+    sync::Arc,
+};
 
-use crate::host::{DeviceRange as Bound, HostOpContext};
-use crate::kernels::CodegenCtx;
-use crate::{as_host_op, as_kernel_op};
+type Outputs = FxHashMap<usize, (HostBuffer, OutputBinding<DecodedLayout>)>;
+const HOST_VARIANTS: usize = 8;
 
-/// STAGING AND READBACK are memcpys now (ruling D4, 2026-09-03): a
-/// [`HostBuffer`] IS bytes plus a dtype tag, which is exactly what an
-/// H2D/D2H copy wants. The eleven-variant match these two used to be
-/// went with `TypedBuffer` to the reference runtime, where kernels
-/// really do need typed Rust slices.
-fn typed_to_bytes(data: &HostBuffer) -> &[u8] {
-    &data.bytes
+/// Cumulative counters for inspecting replay, dynamic updates, and arena reuse.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GraphStats {
+    pub launches: u64,
+    pub instantiations: u64,
+    pub graph_cache_hits: u64,
+    pub host_captures: u64,
+    pub host_cache_hits: u64,
+    pub node_updates: u64,
+    pub kernel_compilations: u64,
+    pub arena_generation: u64,
+    pub arena_base: u64,
+    pub arena_bytes: usize,
+    pub staging_bytes: usize,
 }
-
-/// D2H: the device's bytes under the plan's dtype. Boolean readback
-/// still passes the VALIDATED door — a device that wrote a byte other
-/// than 0x00/0x01 into a Bool8 buffer has broken the two-legal-codes
-/// contract, and this is where that becomes visible.
-fn bytes_to_typed(bytes: &[u8], dtype: PlanDtype) -> Result<HostBuffer> {
-    match dtype {
-        PlanDtype::Bool | PlanDtype::Bool8 => HostBuffer::bool8(bytes.to_vec()),
-        other => HostBuffer::new(other, bytes.to_vec()),
-    }
-}
-
-struct KernelCache {
+struct Module {
+    raw: cu::CUmodule,
+    func: cu::CUfunction,
     ctx: Arc<CudaContext>,
-    modules: HashMap<u64, (Arc<CudaModule>, CudaFunction)>,
 }
-
-impl KernelCache {
-    fn function(&mut self, source: &str) -> Result<CudaFunction> {
-        use std::hash::{Hash, Hasher};
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        source.hash(&mut hasher);
-        let key = hasher.finish();
-        if let Some((_, func)) = self.modules.get(&key) {
-            return Ok(func.clone());
+impl Drop for Module {
+    fn drop(&mut self) {
+        let _ = self.ctx.bind_to_thread();
+        unsafe {
+            let _ = result::module::unload(self.raw);
         }
-        let ptx =
-            compile_ptx(source).map_err(|e| anyhow!("NVRTC failed: {e:?}\nsource:\n{source}"))?;
-        let module = self.ctx.load_module(ptx).context("module load")?;
-        let func = module.load_function("k").context("entry `k` missing")?;
-        self.modules.insert(key, (module, func.clone()));
-        Ok(func)
     }
 }
-
-/// THE PERSISTENT DEVICE: everything an execution needs that should
-/// outlive one call — the context, the one stream every kernel and
-/// copy is issued on, the compiled-module cache, and the arena slab.
-/// The runtime owns exactly one of these and hands it to
-/// [`execute_plan`] by `&mut`.
-///
-/// The slab is GROW-ONLY and never parked (#401 as amended by #422):
-/// one runtime-owned allocation, resized upward when an installed plan
-/// needs more than it holds. SERVING never releases it between
-/// [`CudaRuntime::execute`](crate::CudaRuntime::execute) calls; the
-/// SEARCH is the one exception — it releases the slab after every
-/// profiled candidate through [`Self::release_slab`] (#422's search-time
-/// policy), and the next [`execute_plan`] re-allocates through
-/// `ensure_slab`. Nothing has to be invalidated on a grow — CL captures
-/// no CUDA graphs and holds no device pointers across calls.
-pub struct CudaDevice {
-    #[allow(dead_code)]
-    ctx: Arc<CudaContext>,
-    stream: Arc<CudaStream>,
-    cache: KernelCache,
-    slab: Option<CudaSlice<u8>>,
+struct Installed {
+    plan: CudaPlan,
+    storage: StoragePlan,
+    bounds: Bounds,
+    compiled: Option<CompiledPlan>,
 }
-
+pub struct CudaDevice {
+    // Executables/resources must die before their arena or modules.
+    installed: Vec<Installed>,
+    staging: Option<Pinned>,
+    slab: Option<CudaSlice<u8>>,
+    cache: HashMap<String, Module>,
+    stream: Arc<CudaStream>,
+    ctx: Arc<CudaContext>,
+    stats: GraphStats,
+}
 impl CudaDevice {
-    /// Bind device `ordinal` and take its default stream.
     pub fn new(ordinal: usize) -> Result<Self> {
-        let ctx = CudaContext::new(ordinal).with_context(|| format!("no CUDA device {ordinal}"))?;
-        let stream = ctx.default_stream();
-        Ok(CudaDevice {
-            cache: KernelCache {
-                ctx: ctx.clone(),
-                modules: HashMap::new(),
-            },
-            ctx,
-            stream,
+        let ctx = CudaContext::new(ordinal)?;
+        let stream = ctx.new_stream()?;
+        Ok(Self {
+            installed: vec![],
+            staging: None,
             slab: None,
+            cache: HashMap::new(),
+            stream,
+            ctx,
+            stats: GraphStats::default(),
         })
     }
-
-    /// Grow the slab to at least `bytes`. The old slab is released
-    /// BEFORE the new one is taken, so a grow never needs both at once.
-    fn ensure_slab(&mut self, bytes: usize) -> Result<()> {
-        if bytes == 0 || self.slab.as_ref().map(|slab| slab.len()).unwrap_or(0) >= bytes {
-            return Ok(());
+    pub fn stats(&self) -> GraphStats {
+        self.stats
+    }
+    pub fn slab_bytes(&self) -> usize {
+        self.stats.arena_bytes
+    }
+    /// Validate all capacities first, then reserve their maximum once. Replacing
+    /// the plan set invalidates every executable before any pointer can change.
+    pub fn install(&mut self, plans: Vec<(CudaPlan, Bounds)>) -> Result<()> {
+        let installed = plans
+            .into_iter()
+            .map(|(plan, bounds)| {
+                let storage = storage::plan(&plan, &bounds)?;
+                Ok(Installed {
+                    plan,
+                    storage,
+                    bounds,
+                    compiled: None,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let bytes = installed
+            .iter()
+            .map(|p| p.storage.arena.slab_bytes)
+            .max()
+            .unwrap_or(1);
+        self.stream.synchronize()?;
+        self.installed.clear();
+        let staging_bytes = installed
+            .iter()
+            .map(|p| p.storage.staging_bytes)
+            .max()
+            .unwrap_or(1);
+        if self
+            .staging
+            .as_ref()
+            .is_none_or(|p| p.bytes().len() < staging_bytes)
+        {
+            self.staging = None;
+            self.staging = Some(Pinned::new(&self.ctx, staging_bytes)?);
         }
-        self.slab = None;
-        self.slab = Some(
-            self.stream
+        self.stats.staging_bytes = self.staging.as_ref().unwrap().bytes().len();
+        if self.slab_bytes() < bytes {
+            self.slab = None;
+            self.stats.arena_bytes = 0;
+            self.stats.arena_base = 0;
+            let slab = self
+                .stream
                 .alloc_zeros::<u8>(bytes)
-                .with_context(|| format!("arena slab alloc, {bytes} bytes"))?,
-        );
+                .context("shared CUDA arena")?;
+            self.stats.arena_base = slab.device_ptr(&self.stream).0;
+            self.stats.arena_bytes = bytes;
+            self.stats.arena_generation += 1;
+            self.slab = Some(slab);
+        }
+        self.installed = installed;
         Ok(())
     }
-
-    /// The slab's current size in bytes (0 before the first plan needs
-    /// one) — the runtime's resident device footprint.
-    pub fn slab_bytes(&self) -> usize {
-        self.slab.as_ref().map(|slab| slab.len()).unwrap_or(0)
+    pub fn is_installed(&self) -> bool {
+        !self.installed.is_empty()
     }
-
-    /// RELEASE THE SLAB — the SEARCH-TIME hygiene (#422 policy, Phase
-    /// 4, reversing #401's retention for this one caller):
-    /// [`crate::search`] calls this after every profiled candidate, so a
-    /// candidate whose arena high-water mark is outsized cannot hold
-    /// that memory for the rest of the search and starve its successors.
-    /// The next [`execute_plan`] re-allocates through `ensure_slab`.
-    ///
-    /// SERVING NEVER CALLS IT. `CudaRuntime::execute` keeps the slab
-    /// exactly as Phase 3 landed it: one grow-only allocation for the
-    /// runtime's life, which is the point of the persistent device.
-    /// Nothing else is released here — the context, the stream and the
-    /// NVRTC module cache all survive, which is what keeps kernel
-    /// compilation a once-per-source cost across a whole search.
+    /// Search candidates release both graphs and arena, retaining compiled code.
     pub fn release_slab(&mut self) {
+        // Every public launch is synchronous, including error paths.
+        let _ = self.stream.synchronize();
+        self.installed.clear();
         self.slab = None;
+        self.staging = None;
+        self.stats.staging_bytes = 0;
+        self.stats.arena_bytes = 0;
+        self.stats.arena_base = 0;
+    }
+    pub fn execute(
+        &mut self,
+        bucket: usize,
+        staged: &FxHashMap<i64, &HostBuffer>,
+        dims: &DynMap,
+    ) -> Result<Outputs> {
+        self.ctx.bind_to_thread()?;
+        let installed = self
+            .installed
+            .get_mut(bucket)
+            .ok_or_else(|| anyhow!("CUDA bucket {bucket} is not installed"))?;
+        for (dim, (lo, hi)) in &installed.bounds {
+            let value = dims
+                .get(dim)
+                .ok_or_else(|| anyhow!("dimension `{dim}` is unset"))?;
+            ensure!(
+                value >= lo && value <= hi,
+                "dimension `{dim}`={value} is outside [{lo}, {hi}]"
+            );
+        }
+        if installed.compiled.is_none() {
+            installed.compiled = Some(CompiledPlan::compile(
+                &installed.plan,
+                &installed.storage,
+                &installed.bounds,
+                dims,
+                self.stats.arena_base,
+                &self.ctx,
+                &self.stream,
+                self.staging.as_ref().unwrap(),
+                &mut self.cache,
+                &mut self.stats,
+            )?);
+        }
+        // Move the executable out while updating it. An error or unwind drops
+        // any partially patched state before a later invocation can reuse it.
+        let mut compiled = installed.compiled.take().unwrap();
+        compiled.update(
+            &installed.plan,
+            &installed.storage,
+            dims,
+            self.stats.arena_base,
+            &self.stream,
+            &mut self.stats,
+        )?;
+        let result = compiled.launch(
+            staged,
+            dims,
+            self.staging.as_mut().unwrap(),
+            &self.stream,
+            &mut self.stats,
+        );
+        installed.compiled = Some(compiled);
+        result
+    }
+}
+impl Drop for CudaDevice {
+    fn drop(&mut self) {
+        let _ = self.stream.synchronize();
     }
 }
 
-fn bound_of(bindings: &FxHashMap<BufferId, Bound>, id: &BufferId, who: &str) -> Result<Bound> {
-    bindings.get(id).copied().ok_or_else(|| {
-        anyhow!(
-            "{who}: buffer {id:?} has no live binding — it was never allocated, \
-             or its BufferFree already ran"
-        )
-    })
-}
-
-/// Execute a bufferized plan on `device`. Returns, per output slot
-/// index, a host copy of the slot's BACKING buffer plus its
-/// [`OutputBinding`] (the elected layout) — the escape-and-disclose
-/// fetch, universal over dense and view elections.
-///
-/// `staged` is a map of BORROWED payloads by BufferLit id (Phase 4). It
-/// used to hold the payloads themselves, which was fine while the only
-/// caller was the serving ladder — the runtime already owns them. The
-/// search now stages too, and it stages the CALLER's map, which for a
-/// full-size model is gigabytes of weights: a map of references costs
-/// one pointer per input and no copy at all.
+/// Standalone static-plan convenience. Serving and profiling install once and
+/// call CudaDevice::execute repeatedly to retain the executable.
 pub fn execute_plan(
     device: &mut CudaDevice,
-    plan: &BufferIrGraph<luminal::layouts::DecodedLayout>,
+    plan: &CudaPlan,
     staged: &FxHashMap<i64, &HostBuffer>,
-) -> Result<FxHashMap<usize, (HostBuffer, OutputBinding<luminal::layouts::DecodedLayout>)>> {
-    // ESCAPE GUARD (ruling 2026-08-27): an output slot's backing storage
-    // must SURVIVE the call — FreedBy::Caller, whatever the owner.
-    // FreedBy::Program backing an output hands the caller bytes the
-    // program destroys: minted non-escaping storage (Owner::System) and
-    // DONATED boundary storage (Owner::Caller — validate()'s donated arm
-    // forbids exactly this plan shape) alike. The pre-lowering
-    // certificate enforces this for planner-built plans; hand-built /
-    // externally loaded plans never met it — re-check here, loudly,
-    // before any bytes move.
-    for node in plan.dag.node_weights() {
-        if let BufferNode::BufferOutput { slots } = node {
-            for slot in slots {
-                let buffer = plan
-                    .buffers
-                    .get(&slot.buffer)
-                    .ok_or_else(|| anyhow!("output slot {} names unknown buffer", slot.index))?;
-                if buffer.freed_by != luminal::layout_ir::FreedBy::Caller {
-                    bail!(
-                        "output slot {} is backed by NON-ESCAPING buffer {} \
-                         (FreedBy::Program, {:?}-owned) — escaped output storage \
-                         must be FreedBy::Caller; refusing to hand the caller bytes \
-                         the program destroys",
-                        slot.index,
-                        buffer.label,
-                        buffer.owner,
-                    );
-                }
-            }
-        }
-    }
-
-    // Phase 2, hoisted: the arena decides the issue order AND the slab
-    // layout in one device-free pass (Anti edges ride it, so WAR
-    // ordering is enforced by construction). Everything below walks
-    // `arena.order`.
-    let arena = plan_arena(plan, buffer_bytes).context("arena planning")?;
-    debug_assert!(
-        plan.dag
-            .edge_weights()
-            .all(|e| matches!(e.kind, EdgeKind::Data | EdgeKind::Anti))
-    );
-    device.ensure_slab(arena.slab_bytes)?;
-    let stream = device.stream.clone();
-    let slab_base = match &device.slab {
-        Some(slab) => {
-            let (base, _record) = slab.device_ptr(&stream);
-            base
-        }
-        None => 0,
-    };
-
-    // Phase 1: materialize the buffers that do NOT come from the slab —
-    // the BOUNDARY and ESCAPING rows (their bytes are the caller's after
-    // the call) and the DONATED row (the caller's bytes, which in CL
-    // means the staged payload's device copy). Slab members stay unbound
-    // until their `BufferAlloc` is issued.
-    let mut owned: FxHashMap<BufferId, CudaSlice<u8>> = FxHashMap::default();
-    let mut bindings: FxHashMap<BufferId, Bound> = FxHashMap::default();
-    let mut geometry: FxHashMap<BufferId, PlanDtype> = FxHashMap::default();
-    for (id, buffer) in &plan.buffers {
-        let dtype = buffer.layout.dtype.ok_or_else(|| {
-            anyhow!(
-                "buffer {:?} (backing {}) carries no dtype fact",
-                buffer.label,
-                buffer.backs
-            )
-        })?;
-        geometry.insert(id.clone(), dtype);
-    }
-    for id in arena.standalone.iter().chain(arena.donated.iter()) {
-        let buffer = &plan.buffers[id];
-        let bytes = buffer_bytes(buffer)?;
-        let mut slice = stream
-            .alloc_zeros::<u8>(bytes.max(1))
-            .with_context(|| format!("device alloc {} bytes for {:?}", bytes, buffer.label))?;
-        if let Some(lit) = buffer.lit
-            && let Some(data) = staged.get(&lit)
-        {
-            let host = typed_to_bytes(data);
-            if host.len() != bytes {
-                bail!(
-                    "staged buffer {lit} is {} bytes, plan expects {bytes} for {:?}",
-                    host.len(),
-                    buffer.label
-                );
-            }
-            stream.memcpy_htod(host, &mut slice).context("H2D")?;
-        }
-        let ptr = {
-            let (ptr, _record) = slice.device_ptr(&stream);
-            ptr
-        };
-        bindings.insert(id.clone(), Bound { ptr, bytes });
-        owned.insert(id.clone(), slice);
-    }
-
-    // CONTRACT-1 (bind-time), NARROWED. Distinct BufferIds must be
-    // backed by disjoint device ranges — folded-view reads and WAR
-    // ordering are both keyed on BufferId identity. This assert covers
-    // the allocations the EXECUTOR makes (the standalone and donated
-    // rows), which is the surface it was written for: "when raw caller
-    // pointers arrive at this binding surface". It can no longer be a
-    // whole-plan check, because slab members are sub-ranges of ONE
-    // allocation by design — for them the question is whether two
-    // SIMULTANEOUSLY LIVE ranges overlap, which is decidable at
-    // planning time and is checked there (see the CONTRACT-1 live-range
-    // note in `crate::arena`).
-    {
-        let bound: Vec<crate::binding_check::BoundRange> = owned
-            .iter()
-            .map(|(id, slice)| crate::binding_check::BoundRange {
-                buffer: format!("{id:?}"),
-                base: bindings[id].ptr,
-                bytes: slice.len() as u64,
-            })
-            .collect();
-        crate::binding_check::assert_disjoint(&bound).context("CONTRACT-1 bind-time check")?;
-    }
-
-    if std::env::var_os("LUMINAL_CL_ARENA").is_some() {
-        arena_report(plan, &arena, device.slab_bytes());
-    }
-
-    // Phase 3: dispatch, in the arena's issue order.
-    for node in arena.order.iter().copied() {
-        match &plan.dag[node] {
-            BufferNode::BufferInput { .. } | BufferNode::BufferOutput { .. } => {}
-            BufferNode::BufferCopy { src, dst } => {
-                // THE BUFFERCOPY CONTRACT, executor side (Austin, ruled
-                // 2026-08-31 — see `bufferize::BufferNode::BufferCopy`):
-                //
-                // * The node carries ONLY {src, dst}.
-                // * Semantics: a DUMB EXACT-SIZE WHOLE-BUFFER copy — one
-                //   `memcpy_dtod` of the whole slice, no layout awareness,
-                //   no element walk. "If a runtime chooses to do resource
-                //   reuse and do unequal sized buffer that is an entirely
-                //   runtime owned choice"; CL sizes both ends from the same
-                //   span-of-layout rule and makes no such choice, so
-                //   unequal lengths are a bug HERE and bail loudly (this is
-                //   the executor's own discipline over bufferizer-authored
-                //   nodes, NOT a type fence re-checking an e-graph premise).
-                // * ORDERING IS THIS RUNTIME'S OBLIGATION. The plan supplied
-                //   dependency structure only (data + WAR anti-edges); we
-                //   discharge it by issuing in the arena's topological order
-                //   onto ONE stream, which serializes the copy against every
-                //   op that depends on it and every prior reader of `dst`. A
-                //   multi-stream executor would owe events/barriers here.
-                // * The three causes (conflict repair, boundary placement,
-                //   lifetime repair) are the bufferizer's business; all
-                //   three execute identically.
-                let from = bound_of(&bindings, src, "copy src")?;
-                let to = bound_of(&bindings, dst, "copy dst")?;
-                if from.bytes != to.bytes {
-                    bail!("copy length mismatch: {} -> {} bytes", from.bytes, to.bytes);
-                }
-                unsafe { cu::memcpy_dtod_async(to.ptr, from.ptr, from.bytes, stream.cu_stream()) }
-                    .context("D2D copy")?;
-            }
-            BufferNode::Compute {
-                op,
-                reads,
-                writes,
-                operand_info,
-                result_info,
-                ..
-            } => {
-                let label = op.label();
-                // THE ARENA'S TWO EVENTS. An alloc binds its buffer to
-                // the range the planner assigned it (nothing is zeroed —
-                // see the KERNEL INVARIANT note at the top of this
-                // module); a free drops the binding, and the range is
-                // already back on the planner's free list, waiting for
-                // the next alloc that fits. A buffer the planner did not
-                // put in the slab (standalone, donated, or an interior
-                // buffer demoted for want of a lifetime pair) is bound
-                // from Phase 1 and its alloc is a no-op.
-                if label == "BufferAlloc" {
-                    if let Some(buffer) = writes.first()
-                        && let Some(slice) = arena.slices.get(buffer)
-                    {
-                        bindings.insert(
-                            buffer.clone(),
-                            Bound {
-                                ptr: slab_base + slice.offset as u64,
-                                bytes: slice.bytes,
-                            },
-                        );
-                    }
-                    continue;
-                }
-                if label == "BufferFree" {
-                    if let Some(buffer) = reads.first() {
-                        bindings.remove(buffer);
-                    }
-                    continue;
-                }
-                if writes.len() != 1 {
-                    bail!(
-                        "{label}: CL handles single-destination ops, got {}",
-                        writes.len()
-                    );
-                }
-                let dest = bound_of(&bindings, &writes[0], label)?;
-                let input_count = reads.len().saturating_sub(writes.len());
-                let inputs: Vec<Bound> = reads[..input_count]
-                    .iter()
-                    .map(|id| bound_of(&bindings, id, label))
-                    .collect::<Result<_>>()?;
-
-                // Phase 3: codegen geometry comes from the node's OWN slot
-                // descriptors, never the shared buffer table — the buffer
-                // table sizes ALLOCATIONS and nothing else. A compute node
-                // arriving without its descriptors is malformed: bail
-                // loudly (mirror of the None-dims bail).
-                if operand_info.len() != reads.len() || result_info.len() != writes.len() {
-                    bail!(
-                        "{label}: compute node lacks slot descriptors \
-                         (operand_info {}/{}, result_info {}/{})",
-                        operand_info.len(),
-                        reads.len(),
-                        result_info.len(),
-                        writes.len()
-                    );
-                }
-                if let Some(host) = as_host_op(op.as_ref()) {
-                    let ctx = HostOpContext {
-                        stream: &stream,
-                        inputs: &inputs,
-                        dest,
-                        operand_info,
-                        result_info,
-                    };
-                    // SAFETY: the plan's arena bindings are live through the
-                    // stream synchronization below; bufferization enforces the
-                    // op's alias and memory-effect contract.
-                    unsafe { host.execute(&ctx) }
-                        .with_context(|| format!("host execution for {label}"))?;
-                    continue;
-                }
-                let Some(kernel) = as_kernel_op(op.as_ref()) else {
-                    bail!("no CUDA execution interface for {label}");
-                };
-                let ctxinfo = CodegenCtx::from_descriptors(label, operand_info, result_info)?;
-                let launches = kernel
-                    .codegen(&ctxinfo)
-                    .with_context(|| format!("codegen for {label}"))?;
-
-                // Kernel inputs are the non-destination operands; the
-                // destination is the buffer the planner assigned, in
-                // place. Launches in one sequence share the stream, so
-                // phase ordering (e.g. scatter's init-copy then writes)
-                // is free.
-                let input_ptrs: Vec<u64> = inputs.iter().map(|b| b.ptr).collect();
-                let dest_ptr = dest.ptr;
-                for generated in &launches {
-                    let func = device.cache.function(&generated.source)?;
-                    let n = generated.n as u64;
-                    let cfg = LaunchConfig {
-                        grid_dim: ((generated.n as u32).max(1).div_ceil(256), 1, 1),
-                        block_dim: (256, 1, 1),
-                        shared_mem_bytes: 0,
-                    };
-                    let mut builder = stream.launch_builder(&func);
-                    for ptr in &input_ptrs {
-                        builder.arg(ptr);
-                    }
-                    builder.arg(&dest_ptr);
-                    builder.arg(&n);
-                    unsafe { builder.launch(cfg) }.with_context(|| format!("launch {label}"))?;
-                }
-            }
-        }
-    }
-    stream.synchronize().context("stream sync")?;
-
-    // Phase 4: D2H each output SLOT's backing buffer — the escaped
-    // buffer for a view election, the boundary buffer for a dense one —
-    // keyed by slot index and paired with the binding's layout. (The
-    // declared-but-unused Boundary buffer of an escaped slot never
-    // reaches this plan: buffer DCE dropped it, so Phase 1 never
-    // allocated it; and no free node exists for an escaping buffer, so
-    // every output slot is still bound here.)
-    let mut outputs = FxHashMap::default();
-    for node in plan.dag.node_weights() {
-        if let BufferNode::BufferOutput { slots } = node {
-            for slot in slots {
-                let bound = bound_of(&bindings, &slot.buffer, "output slot")?;
-                let mut host = vec![0u8; bound.bytes];
-                unsafe { cu::memcpy_dtoh_async(&mut host, bound.ptr, stream.cu_stream()) }
-                    .context("D2H")?;
-                let dtype = geometry[&slot.buffer];
-                outputs.insert(slot.index, (bytes_to_typed(&host, dtype)?, slot.clone()));
-            }
-        }
-    }
-    Ok(outputs)
+) -> Result<Outputs> {
+    device.install(vec![(plan.clone(), Bounds::new())])?;
+    device.execute(0, staged, &DynMap::default())
 }
 
-/// The arena's cost, on demand (`LUMINAL_CL_ARENA=1`): the high-water
-/// mark this plan needs against the sum CL-2 used to pay — one
-/// allocation per plan buffer, all live for the whole call.
-fn arena_report(
-    plan: &BufferIrGraph<luminal::layouts::DecodedLayout>,
-    arena: &ArenaPlan,
-    slab_now: usize,
-) {
-    let sum_all: usize = plan
-        .buffers
-        .values()
-        .filter_map(|b| buffer_bytes(b).ok())
-        .sum();
-    let slab_sum: usize = arena.slices.values().map(|s| s.bytes).sum();
-    let standalone: usize = arena
-        .standalone
+struct HostVariant {
+    key: Vec<(Symbol, usize)>,
+    graph: Graph,
+    _prepared: Box<dyn PreparedHostOp>,
+}
+struct HostNode {
+    source: NodeIndex,
+    dims: Vec<Symbol>,
+    all_dims: bool,
+    variants: VecDeque<Rc<HostVariant>>,
+    resource_slot: usize,
+}
+enum Action {
+    Copy {
+        src: u64,
+        dst: u64,
+        kind: CopyKind,
+        size: Expr,
+        other_size: Option<Expr>,
+        bytes: usize,
+    },
+    Kernel {
+        func: cu::CUfunction,
+        args: Vec<u64>,
+        geometry: Option<KernelLaunch>,
+        launch: Launch,
+    },
+    Host(HostNode),
+}
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct Launch {
+    grid: [u32; 3],
+    block: [u32; 3],
+    shared: u32,
+}
+impl Launch {
+    fn eval(spec: &KernelLaunch, dims: &DynMap) -> Result<Self> {
+        let grid = spec
+            .grid
+            .iter()
+            .map(|e| Ok(u32::try_from(e.eval(dims)?)?))
+            .collect::<Result<Vec<_>>>()?;
+        let block = spec
+            .block
+            .iter()
+            .map(|e| Ok(u32::try_from(e.eval(dims)?)?))
+            .collect::<Result<Vec<_>>>()?;
+        ensure!(block.iter().all(|v| *v > 0), "zero kernel block extent");
+        Ok(Self {
+            grid: grid.try_into().unwrap(),
+            block: block.try_into().unwrap(),
+            shared: u32::try_from(spec.shared_bytes.eval(dims)?)?,
+        })
+    }
+    fn enabled(self) -> bool {
+        self.grid.iter().all(|v| *v != 0)
+    }
+    fn params(
+        self,
+        func: cu::CUfunction,
+        pointers: &mut [*mut std::ffi::c_void],
+    ) -> cu::CUDA_KERNEL_NODE_PARAMS {
+        let mut p: cu::CUDA_KERNEL_NODE_PARAMS = unsafe { std::mem::zeroed() };
+        p.func = func;
+        p.gridDimX = self.grid[0].max(1);
+        p.gridDimY = self.grid[1].max(1);
+        p.gridDimZ = self.grid[2].max(1);
+        p.blockDimX = self.block[0];
+        p.blockDimY = self.block[1];
+        p.blockDimZ = self.block[2];
+        p.sharedMemBytes = self.shared;
+        p.kernelParams = pointers.as_mut_ptr();
+        p
+    }
+}
+struct CachedGraph {
+    executable: Executable,
+    graph: Graph,
+    nodes: Vec<Node>,
+    // Original source nodes and updated executable nodes can refer to different
+    // captures. Keep both sets alive, including while this parent is cached.
+    source_resources: Vec<Rc<HostVariant>>,
+    live_resources: Vec<Rc<HostVariant>>,
+}
+struct Input {
+    lit: i64,
+    pinned: StagingRange,
+    size: Expr,
+    dtype: luminal::dtype::PlanDtype,
+}
+struct Output {
+    slot: OutputBinding<DecodedLayout>,
+    resolved: OutputBinding<DecodedLayout>,
+    pinned: StagingRange,
+    size: Expr,
+    bytes: usize,
+    dtype: luminal::dtype::PlanDtype,
+}
+struct CompiledPlan {
+    // Declared first so graph handles are destroyed before captured resources.
+    executable: Option<Executable>,
+    graph: Option<Graph>,
+    nodes: Vec<Node>,
+    cached: VecDeque<CachedGraph>,
+    source_resources: Vec<Rc<HostVariant>>,
+    live_resources: Vec<Rc<HostVariant>>,
+    actions: Vec<Action>,
+    inputs: Vec<Input>,
+    outputs: Vec<Output>,
+    params: StagingRange,
+    schema: Vec<Symbol>,
+    deps: BTreeMap<Symbol, Vec<usize>>,
+    all_dim_hosts: Vec<usize>,
+    last_dims: DynMap,
+}
+fn size(layout: &DecodedLayout) -> Result<Expr> {
+    Ok(symbolic::span(layout)?
+        * Expr::from(crate::host_buffer::dtype_bytes(
+            layout.dtype.ok_or_else(|| anyhow!("missing dtype"))?,
+        )?))
+}
+fn range(
+    plan: &CudaPlan,
+    storage: &StoragePlan,
+    id: &BufferId,
+    base: u64,
+    dims: &DynMap,
+) -> Result<DeviceRange> {
+    let slice = storage
+        .arena
+        .slices
+        .get(id)
+        .ok_or_else(|| anyhow!("unbound buffer {id:?}"))?;
+    let bytes = symbolic::bytes(&plan.buffers[id].layout, dims)?;
+    ensure!(bytes <= slice.bytes, "buffer exceeded its bucket capacity");
+    Ok(DeviceRange {
+        ptr: base + slice.offset as u64,
+        bytes,
+    })
+}
+fn resolve_slots(
+    slots: &[SlotDescriptor<DecodedLayout>],
+    dims: &DynMap,
+) -> Result<Vec<SlotDescriptor<DecodedLayout>>> {
+    slots
         .iter()
-        .chain(arena.donated.iter())
-        .filter_map(|id| plan.buffers.get(id))
-        .filter_map(|b| buffer_bytes(b).ok())
-        .sum();
-    eprintln!(
-        "[cl-arena] slab high-water {} B (peak live {} B, resident {} B) for {} \
-         interior buffers summing {} B; standalone+donated {} B over {} buffers; \
-         whole-plan sum (the CL-2 cost) {} B; total now {} B",
-        arena.slab_bytes,
-        arena.peak_live_bytes,
-        slab_now,
-        arena.slices.len(),
-        slab_sum,
-        standalone,
-        arena.standalone.len() + arena.donated.len(),
-        sum_all,
-        arena.slab_bytes + standalone,
-    );
+        .map(|s| {
+            let mut s = s.clone();
+            s.layout = symbolic::resolve_layout(&s.layout, dims)?;
+            Ok(s)
+        })
+        .collect()
+}
+impl HostNode {
+    fn select(
+        &mut self,
+        plan: &CudaPlan,
+        storage: &StoragePlan,
+        dims: &DynMap,
+        base: u64,
+        stream: &Arc<CudaStream>,
+        stats: &mut GraphStats,
+    ) -> Result<()> {
+        let key = if self.all_dims {
+            let mut values: Vec<_> = dims.iter().map(|(s, v)| (*s, *v)).collect();
+            values.sort_unstable();
+            values
+        } else {
+            self.dims
+                .iter()
+                .map(|s| {
+                    dims.get(s)
+                        .copied()
+                        .map(|v| (*s, v))
+                        .ok_or_else(|| anyhow!("missing host dimension {s}"))
+                })
+                .collect::<Result<Vec<_>>>()?
+        };
+        if self.variants.front().is_some_and(|v| v.key == key) {
+            return Ok(());
+        }
+        if let Some(i) = self.variants.iter().position(|v| v.key == key) {
+            let variant = self.variants.remove(i).unwrap();
+            self.variants.push_front(variant);
+            stats.host_cache_hits += 1;
+            return Ok(());
+        }
+        let BufferNode::Compute {
+            op,
+            reads,
+            writes,
+            operand_info,
+            result_info,
+            ..
+        } = &plan.dag[self.source]
+        else {
+            unreachable!()
+        };
+        let host = crate::as_host_op(op.as_ref()).unwrap();
+        let inputs = reads[..reads.len() - writes.len()]
+            .iter()
+            .map(|id| range(plan, storage, id, base, dims))
+            .collect::<Result<Vec<_>>>()?;
+        let ctx = HostOpContext {
+            stream,
+            inputs: &inputs,
+            dest: range(plan, storage, &writes[0], base, dims)?,
+            workspace: DeviceRange {
+                ptr: base + storage.workspace.offset as u64,
+                bytes: storage.workspace.bytes,
+            },
+            dims,
+            operand_info: &resolve_slots(operand_info, dims)?,
+            result_info: &resolve_slots(result_info, dims)?,
+        };
+        let prepared =
+            unsafe { host.prepare(&ctx) }.with_context(|| format!("prepare {}", op.label()))?;
+        let graph = Graph::capture(stream, prepared.as_ref())
+            .with_context(|| format!("capture {}", op.label()))?;
+        stats.host_captures += 1;
+        self.variants.push_front(Rc::new(HostVariant {
+            key,
+            graph,
+            _prepared: prepared,
+        }));
+        // Eviction happens after the old executable has been updated/replaced.
+        Ok(())
+    }
+}
+impl CompiledPlan {
+    #[allow(clippy::too_many_arguments)]
+    fn compile(
+        plan: &CudaPlan,
+        storage: &StoragePlan,
+        bounds: &Bounds,
+        dims: &DynMap,
+        base: u64,
+        ctx: &Arc<CudaContext>,
+        stream: &Arc<CudaStream>,
+        staging: &Pinned,
+        cache: &mut HashMap<String, Module>,
+        stats: &mut GraphStats,
+    ) -> Result<Self> {
+        let schema: Vec<_> = bounds.keys().copied().collect();
+        let mut cursor = 0usize;
+        let mut reserve = |len: usize| -> Result<StagingRange> {
+            let range = StagingRange {
+                offset: cursor,
+                len: len.max(1),
+            };
+            cursor = cursor
+                .checked_add(range.len)
+                .ok_or_else(|| anyhow!("staging offset overflow"))?;
+            ensure!(cursor <= staging.bytes().len(), "staging capacity exceeded");
+            Ok(range)
+        };
+        let params = reserve((schema.len() * 8).max(8))?;
+        let mut out = Self {
+            executable: None,
+            graph: None,
+            nodes: vec![],
+            cached: VecDeque::new(),
+            source_resources: vec![],
+            live_resources: vec![],
+            actions: vec![],
+            inputs: vec![],
+            outputs: vec![],
+            params,
+            schema,
+            deps: BTreeMap::new(),
+            all_dim_hosts: vec![],
+            last_dims: dims.clone(),
+        };
+        out.actions.push(Action::Copy {
+            src: out.params.ptr(staging),
+            dst: base,
+            kind: CopyKind::HtoD,
+            size: Expr::from(out.params.len),
+            other_size: None,
+            bytes: out.params.len,
+        });
+        let mut ids: Vec<_> = plan.buffers.keys().collect();
+        ids.sort_by_key(|id| format!("{id:?}"));
+        for id in ids {
+            let buffer = &plan.buffers[id];
+            if let Some(lit) = buffer.lit {
+                let pinned = reserve(storage.arena.slices[id].bytes)?;
+                let size = size(&buffer.layout)?;
+                out.actions.push(Action::Copy {
+                    src: pinned.ptr(staging),
+                    dst: range(plan, storage, id, base, dims)?.ptr,
+                    kind: CopyKind::HtoD,
+                    bytes: size.eval(dims)?,
+                    size: size.clone(),
+                    other_size: None,
+                });
+                out.inputs.push(Input {
+                    lit,
+                    pinned,
+                    size,
+                    dtype: buffer.layout.dtype.unwrap(),
+                });
+            }
+        }
+        let mut live: std::collections::HashSet<_> = storage
+            .arena
+            .standalone
+            .iter()
+            .chain(&storage.arena.donated)
+            .cloned()
+            .collect();
+        for node in &storage.arena.order {
+            match &plan.dag[*node] {
+                BufferNode::Compute {
+                    op,
+                    reads,
+                    writes,
+                    operand_info,
+                    result_info,
+                    ..
+                } => {
+                    let label = op.label();
+                    if label == "BufferAlloc" {
+                        live.extend(writes.iter().cloned());
+                        continue;
+                    }
+                    if label == "BufferFree" {
+                        for id in reads {
+                            live.remove(id);
+                        }
+                        continue;
+                    }
+                    ensure!(
+                        writes.len() == 1,
+                        "{label}: CUDA requires a single destination"
+                    );
+                    ensure!(
+                        operand_info.len() == reads.len() && result_info.len() == writes.len(),
+                        "{label}: missing slot descriptors"
+                    );
+                    for id in reads.iter().chain(writes) {
+                        ensure!(
+                            live.contains(id),
+                            "{label}: buffer {id:?} has no live binding"
+                        );
+                    }
+                    if let Some(host) = crate::as_host_op(op.as_ref()) {
+                        let dependencies = host.capture_dims();
+                        let mut host = HostNode {
+                            source: *node,
+                            all_dims: dependencies.is_none(),
+                            dims: dependencies.unwrap_or_default(),
+                            variants: VecDeque::new(),
+                            resource_slot: out.live_resources.len(),
+                        };
+                        host.select(plan, storage, dims, base, stream, stats)?;
+                        out.live_resources
+                            .push(host.variants.front().unwrap().clone());
+                        out.actions.push(Action::Host(host));
+                    } else if let Some(kernel) = crate::as_kernel_op(op.as_ref()) {
+                        let codegen =
+                            CodegenCtx::from_descriptors(label, operand_info, result_info)?;
+                        let mut args = reads[..reads.len() - writes.len()]
+                            .iter()
+                            .map(|id| range(plan, storage, id, base, dims).map(|r| r.ptr))
+                            .collect::<Result<Vec<_>>>()?;
+                        args.push(range(plan, storage, &writes[0], base, dims)?.ptr);
+                        args.push(base);
+                        for generated in kernel.codegen(&codegen)? {
+                            let mut source = symbolic::CUDA_HELPERS.to_owned();
+                            for (i, s) in out.schema.iter().enumerate() {
+                                source.push_str(&format!(
+                                    "#define {} params[{i}]\n",
+                                    symbolic::variable(&s.to_string())
+                                ));
+                            }
+                            source.push_str(&generated.source);
+                            let func = if let Some(module) = cache.get(&source) {
+                                module.func
+                            } else {
+                                let ptx = compile_ptx(&source)
+                                    .map_err(|e| anyhow!("NVRTC {label}: {e:?}\n{source}"))?;
+                                let image = CString::new(ptx.to_src())?;
+                                let raw =
+                                    unsafe { result::module::load_data(image.as_ptr().cast()) }?;
+                                let mut module = Module {
+                                    raw,
+                                    func: std::ptr::null_mut(),
+                                    ctx: ctx.clone(),
+                                };
+                                module.func = unsafe {
+                                    result::module::get_function(raw, CString::new("k")?)
+                                }?;
+                                let func = module.func;
+                                cache.insert(source, module);
+                                stats.kernel_compilations += 1;
+                                func
+                            };
+                            let grid =
+                                u32::try_from(generated.n.capacity(bounds)?.max(1).div_ceil(256))?;
+                            ensure!(
+                                grid <= i32::MAX as u32,
+                                "kernel capacity exceeds CUDA grid limit"
+                            );
+                            let launch = if let Some(spec) = &generated.launch {
+                                for expr in spec.expressions() {
+                                    expr.capacity(bounds)?;
+                                }
+                                let shared = spec.shared_bytes.capacity(bounds)?;
+                                if shared > 48 * 1024 {
+                                    unsafe {
+                                        result::function::set_function_attribute(func,cu::CUfunction_attribute::CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,i32::try_from(shared)?)
+                                    }?;
+                                }
+                                Launch::eval(spec, dims)?
+                            } else {
+                                Launch {
+                                    grid: [grid, 1, 1],
+                                    block: [256, 1, 1],
+                                    shared: 0,
+                                }
+                            };
+                            out.actions.push(Action::Kernel {
+                                func,
+                                args: args.clone(),
+                                geometry: generated.launch,
+                                launch,
+                            });
+                        }
+                    } else {
+                        bail!("no CUDA execution interface for {label}");
+                    }
+                }
+                BufferNode::BufferCopy { src, dst } => {
+                    ensure!(
+                        live.contains(src) && live.contains(dst),
+                        "copy touches a dead buffer"
+                    );
+                    let from = range(plan, storage, src, base, dims)?;
+                    let to = range(plan, storage, dst, base, dims)?;
+                    ensure!(from.bytes == to.bytes, "copy length mismatch");
+                    out.actions.push(Action::Copy {
+                        src: from.ptr,
+                        dst: to.ptr,
+                        kind: CopyKind::DtoD,
+                        size: size(&plan.buffers[src].layout)?,
+                        other_size: Some(size(&plan.buffers[dst].layout)?),
+                        bytes: from.bytes,
+                    });
+                }
+                _ => {}
+            }
+        }
+        for node in plan.dag.node_weights() {
+            if let BufferNode::BufferOutput { slots } = node {
+                for slot in slots {
+                    ensure!(live.contains(&slot.buffer), "output has no live binding");
+                    let buffer = &plan.buffers[&slot.buffer];
+                    let range = range(plan, storage, &slot.buffer, base, dims)?;
+                    let pinned = reserve(storage.arena.slices[&slot.buffer].bytes)?;
+                    let size = size(&buffer.layout)?;
+                    out.actions.push(Action::Copy {
+                        src: range.ptr,
+                        dst: pinned.ptr(staging),
+                        kind: CopyKind::DtoH,
+                        size: size.clone(),
+                        other_size: None,
+                        bytes: range.bytes,
+                    });
+                    let mut resolved = slot.clone();
+                    resolved.layout = symbolic::resolve_layout(&slot.layout, dims)?;
+                    out.outputs.push(Output {
+                        slot: slot.clone(),
+                        resolved,
+                        pinned,
+                        size,
+                        bytes: range.bytes,
+                        dtype: buffer.layout.dtype.unwrap(),
+                    });
+                }
+            }
+        }
+        for (i, action) in out.actions.iter().enumerate() {
+            let mut vars = BTreeSet::new();
+            match action {
+                Action::Copy {
+                    size, other_size, ..
+                } => {
+                    symbolic::vars(&size.0, &mut vars);
+                    if let Some(s) = other_size {
+                        symbolic::vars(&s.0, &mut vars);
+                    }
+                }
+                Action::Host(h) => {
+                    if h.all_dims {
+                        out.all_dim_hosts.push(i);
+                    } else {
+                        vars.extend(h.dims.iter().copied());
+                    }
+                }
+                Action::Kernel {
+                    geometry: Some(spec),
+                    ..
+                } => {
+                    for e in spec.expressions() {
+                        symbolic::vars(&e.0, &mut vars);
+                    }
+                }
+                Action::Kernel { .. } => {}
+            }
+            for s in vars {
+                out.deps.entry(s).or_default().push(i);
+            }
+        }
+        out.rebuild(ctx, stats)?;
+        Ok(out)
+    }
+    fn rebuild(&mut self, ctx: &Arc<CudaContext>, stats: &mut GraphStats) -> Result<()> {
+        let old = self.executable.take().map(|executable| CachedGraph {
+            executable,
+            graph: self.graph.take().unwrap(),
+            nodes: std::mem::take(&mut self.nodes),
+            source_resources: std::mem::take(&mut self.source_resources),
+            live_resources: std::mem::take(&mut self.live_resources),
+        });
+        let mut selected = None;
+        for _ in 0..self.cached.len() {
+            let mut cached = self.cached.pop_front().unwrap();
+            if self.rebind(&mut cached).is_ok() {
+                selected = Some(cached);
+                break;
+            }
+            self.cached.push_back(cached);
+        }
+        if let Some(old) = old {
+            self.cached.push_front(old);
+        }
+        self.cached.truncate(HOST_VARIANTS - 1);
+        if let Some(cached) = selected {
+            self.executable = Some(cached.executable);
+            self.graph = Some(cached.graph);
+            self.nodes = cached.nodes;
+            self.source_resources = cached.source_resources;
+            self.live_resources = cached.live_resources;
+            stats.graph_cache_hits += 1;
+            return Ok(());
+        }
+        let graph = Graph::new(ctx)?;
+        let mut nodes = vec![];
+        for action in &self.actions {
+            let deps = nodes.last().copied().into_iter().collect::<Vec<_>>();
+            nodes.push(match action {
+                Action::Copy {
+                    src,
+                    dst,
+                    kind,
+                    bytes,
+                    ..
+                } => graph.copy(&deps, &copy_params(*src, *dst, *bytes, *kind))?,
+                Action::Host(h) => graph.child(&deps, &h.variants.front().unwrap().graph)?,
+                Action::Kernel {
+                    func, args, launch, ..
+                } => {
+                    let mut args = args.clone();
+                    let mut pointers: Vec<_> =
+                        args.iter_mut().map(|p| (p as *mut u64).cast()).collect();
+                    graph.kernel(&deps, &launch.params(*func, &mut pointers))?
+                }
+            });
+        }
+        let executable = graph.instantiate()?;
+        for (i, action) in self.actions.iter().enumerate() {
+            if matches!(action, Action::Copy { bytes: 0, .. })
+                || matches!(action,Action::Kernel{launch,..} if !launch.enabled())
+            {
+                executable.enable(nodes[i], false)?;
+            }
+        }
+        self.live_resources = self
+            .actions
+            .iter()
+            .filter_map(|action| match action {
+                Action::Host(h) => Some(h.variants.front().unwrap().clone()),
+                _ => None,
+            })
+            .collect();
+        self.source_resources = self.live_resources.clone();
+        self.executable = Some(executable);
+        self.graph = Some(graph);
+        self.nodes = nodes;
+        stats.instantiations += 1;
+        Ok(())
+    }
+    fn rebind(&self, cached: &mut CachedGraph) -> Result<()> {
+        ensure!(
+            cached.nodes.len() == self.actions.len(),
+            "cached graph topology mismatch"
+        );
+        for (action, &node) in self.actions.iter().zip(&cached.nodes) {
+            match action {
+                Action::Host(h) => {
+                    let capture = h.variants.front().unwrap();
+                    cached.executable.child(node, &capture.graph)?;
+                    cached.live_resources[h.resource_slot] = capture.clone();
+                }
+                Action::Copy {
+                    src,
+                    dst,
+                    kind,
+                    bytes,
+                    ..
+                } => {
+                    if *bytes != 0 {
+                        cached
+                            .executable
+                            .copy(node, &copy_params(*src, *dst, *bytes, *kind))?;
+                    }
+                    cached.executable.enable(node, *bytes != 0)?;
+                }
+                Action::Kernel {
+                    func, args, launch, ..
+                } => {
+                    let mut args = args.clone();
+                    let mut pointers: Vec<_> =
+                        args.iter_mut().map(|p| (p as *mut u64).cast()).collect();
+                    cached
+                        .executable
+                        .kernel(node, &launch.params(*func, &mut pointers))?;
+                    cached.executable.enable(node, launch.enabled())?;
+                }
+            }
+        }
+        Ok(())
+    }
+    fn update(
+        &mut self,
+        plan: &CudaPlan,
+        storage: &StoragePlan,
+        dims: &DynMap,
+        base: u64,
+        stream: &Arc<CudaStream>,
+        stats: &mut GraphStats,
+    ) -> Result<()> {
+        if self.last_dims == *dims {
+            return Ok(());
+        }
+        let mut affected: BTreeSet<_> = self.all_dim_hosts.iter().copied().collect();
+        for (s, nodes) in &self.deps {
+            if self.last_dims.get(s) != dims.get(s) {
+                affected.extend(nodes.iter().copied());
+            }
+        }
+        let mut rebuild = false;
+        for &i in &affected {
+            match &mut self.actions[i] {
+                Action::Copy {
+                    src,
+                    dst,
+                    kind,
+                    size,
+                    other_size,
+                    bytes,
+                } => {
+                    let next = size.eval(dims)?;
+                    if let Some(other) = other_size {
+                        ensure!(next == other.eval(dims)?, "dynamic copy length mismatch");
+                    }
+                    if *bytes != next {
+                        let exec = self.executable.as_ref().unwrap();
+                        if next != 0 {
+                            exec.copy(self.nodes[i], &copy_params(*src, *dst, next, *kind))?;
+                        }
+                        exec.enable(self.nodes[i], next != 0)?;
+                        *bytes = next;
+                        stats.node_updates += 1;
+                    }
+                }
+                Action::Host(host) => {
+                    host.select(plan, storage, dims, base, stream, stats)?;
+                    if self
+                        .executable
+                        .as_ref()
+                        .unwrap()
+                        .child(self.nodes[i], &host.variants.front().unwrap().graph)
+                        .is_err()
+                    {
+                        rebuild = true;
+                    } else {
+                        self.live_resources[host.resource_slot] =
+                            host.variants.front().unwrap().clone();
+                    }
+                    stats.node_updates += 1;
+                }
+                Action::Kernel {
+                    func,
+                    args,
+                    geometry: Some(spec),
+                    launch,
+                } => {
+                    let next = Launch::eval(spec, dims)?;
+                    if *launch != next {
+                        let mut args = args.clone();
+                        let mut pointers: Vec<_> =
+                            args.iter_mut().map(|p| (p as *mut u64).cast()).collect();
+                        let exec = self.executable.as_ref().unwrap();
+                        exec.kernel(self.nodes[i], &next.params(*func, &mut pointers))?;
+                        exec.enable(self.nodes[i], next.enabled())?;
+                        *launch = next;
+                        stats.node_updates += 1;
+                    }
+                }
+                Action::Kernel { .. } => {}
+            }
+        }
+        if rebuild {
+            self.rebuild(stream.context(), stats)?;
+        }
+        for &i in &affected {
+            if let Action::Host(host) = &mut self.actions[i] {
+                host.variants.truncate(HOST_VARIANTS);
+            }
+        }
+        for out in &mut self.outputs {
+            out.bytes = out.size.eval(dims)?;
+            out.resolved.layout = symbolic::resolve_layout(&out.slot.layout, dims)?;
+        }
+        self.last_dims = dims.clone();
+        Ok(())
+    }
+    fn launch(
+        &mut self,
+        staged: &FxHashMap<i64, &HostBuffer>,
+        dims: &DynMap,
+        staging: &mut Pinned,
+        stream: &Arc<CudaStream>,
+        stats: &mut GraphStats,
+    ) -> Result<Outputs> {
+        for (i, s) in self.schema.iter().enumerate() {
+            self.params.bytes_mut(staging)[i * 8..i * 8 + 8]
+                .copy_from_slice(&i64::try_from(dims[s])?.to_ne_bytes());
+        }
+        for input in &mut self.inputs {
+            let bytes = input.size.eval(dims)?;
+            if let Some(data) = staged.get(&input.lit) {
+                ensure!(
+                    data.bytes.len() == bytes,
+                    "staged buffer {} is {} bytes, plan expects {bytes}",
+                    input.lit,
+                    data.bytes.len()
+                );
+                ensure!(
+                    data.dtype == input.dtype,
+                    "staged buffer {} dtype mismatch",
+                    input.lit
+                );
+                input.pinned.bytes_mut(staging)[..bytes].copy_from_slice(&data.bytes);
+            } else {
+                input.pinned.bytes_mut(staging)[..bytes].fill(0);
+            }
+        }
+        let launched = self.executable.as_ref().unwrap().launch(stream);
+        // Synchronize even on launch failure before staging/resources can be reused.
+        let completed = stream.synchronize();
+        launched?;
+        completed?;
+        stats.launches += 1;
+        let mut outputs = FxHashMap::default();
+        for output in &self.outputs {
+            let bytes = output.pinned.bytes(staging)[..output.bytes].to_vec();
+            let host = match output.dtype {
+                luminal::dtype::PlanDtype::Bool | luminal::dtype::PlanDtype::Bool8 => {
+                    HostBuffer::bool8(bytes)?
+                }
+                dtype => HostBuffer::new(dtype, bytes)?,
+            };
+            outputs.insert(output.slot.index, (host, output.resolved.clone()));
+        }
+        Ok(outputs)
+    }
 }

--- a/crates/luminal_cuda_lite/src/device.rs
+++ b/crates/luminal_cuda_lite/src/device.rs
@@ -1,12 +1,13 @@
 //! Persistent graph-only executor. Buckets overlay one arena, and all GPU work
 //! (including staging/readback) is submitted by the same graph launch path.
 use crate::{
-    cuda_graph::{CopyKind, Executable, Graph, Node, Pinned, StagingRange, copy_params},
+    arena::{ArenaPlan, ArenaSlice, ArenaStep},
+    cuda_graph::{CopyKind, Executable, Graph, Node, Pinned, copy_params},
     host::{DeviceRange, HostOpContext, PreparedHostOp},
     host_buffer::HostBuffer,
     kernels::{CodegenCtx, KernelLaunch},
     layouts::CudaPlan,
-    storage::{self, StoragePlan},
+    storage,
     symbolic::{self, Bounds, Expr},
 };
 use anyhow::{Context, Result, anyhow, bail, ensure};
@@ -60,7 +61,7 @@ impl Drop for Module {
 }
 struct Installed {
     plan: CudaPlan,
-    storage: StoragePlan,
+    storage: ArenaPlan,
     bounds: Bounds,
     compiled: Option<CompiledPlan>,
 }
@@ -111,7 +112,7 @@ impl CudaDevice {
             .collect::<Result<Vec<_>>>()?;
         let bytes = installed
             .iter()
-            .map(|p| p.storage.arena.slab_bytes)
+            .map(|p| p.storage.slab_bytes)
             .max()
             .unwrap_or(1);
         self.stream.synchronize()?;
@@ -319,14 +320,14 @@ struct CachedGraph {
 }
 struct Input {
     lit: i64,
-    pinned: StagingRange,
+    pinned: ArenaSlice,
     size: Expr,
     dtype: luminal::dtype::PlanDtype,
 }
 struct Output {
     slot: OutputBinding<DecodedLayout>,
     resolved: OutputBinding<DecodedLayout>,
-    pinned: StagingRange,
+    pinned: ArenaSlice,
     size: Expr,
     bytes: usize,
     dtype: luminal::dtype::PlanDtype,
@@ -342,7 +343,7 @@ struct CompiledPlan {
     actions: Vec<Action>,
     inputs: Vec<Input>,
     outputs: Vec<Output>,
-    params: StagingRange,
+    params: ArenaSlice,
     schema: Vec<Symbol>,
     deps: BTreeMap<Symbol, Vec<usize>>,
     all_dim_hosts: Vec<usize>,
@@ -356,13 +357,12 @@ fn size(layout: &DecodedLayout) -> Result<Expr> {
 }
 fn range(
     plan: &CudaPlan,
-    storage: &StoragePlan,
+    storage: &ArenaPlan,
     id: &BufferId,
     base: u64,
     dims: &DynMap,
 ) -> Result<DeviceRange> {
     let slice = storage
-        .arena
         .slices
         .get(id)
         .ok_or_else(|| anyhow!("unbound buffer {id:?}"))?;
@@ -390,7 +390,7 @@ impl HostNode {
     fn select(
         &mut self,
         plan: &CudaPlan,
-        storage: &StoragePlan,
+        storage: &ArenaPlan,
         dims: &DynMap,
         base: u64,
         stream: &Arc<CudaStream>,
@@ -436,13 +436,18 @@ impl HostNode {
             .iter()
             .map(|id| range(plan, storage, id, base, dims))
             .collect::<Result<Vec<_>>>()?;
+        let workspace = storage
+            .workspaces
+            .get(&self.source)
+            .copied()
+            .unwrap_or_default();
         let ctx = HostOpContext {
             stream,
             inputs: &inputs,
             dest: range(plan, storage, &writes[0], base, dims)?,
             workspace: DeviceRange {
-                ptr: base + storage.workspace.offset as u64,
-                bytes: storage.workspace.bytes,
+                ptr: base + workspace.offset as u64,
+                bytes: workspace.bytes,
             },
             dims,
             operand_info: &resolve_slots(operand_info, dims)?,
@@ -466,7 +471,7 @@ impl CompiledPlan {
     #[allow(clippy::too_many_arguments)]
     fn compile(
         plan: &CudaPlan,
-        storage: &StoragePlan,
+        storage: &ArenaPlan,
         bounds: &Bounds,
         dims: &DynMap,
         base: u64,
@@ -477,19 +482,11 @@ impl CompiledPlan {
         stats: &mut GraphStats,
     ) -> Result<Self> {
         let schema: Vec<_> = bounds.keys().copied().collect();
-        let mut cursor = 0usize;
-        let mut reserve = |len: usize| -> Result<StagingRange> {
-            let range = StagingRange {
-                offset: cursor,
-                len: len.max(1),
-            };
-            cursor = cursor
-                .checked_add(range.len)
-                .ok_or_else(|| anyhow!("staging offset overflow"))?;
-            ensure!(cursor <= staging.bytes().len(), "staging capacity exceeded");
-            Ok(range)
-        };
-        let params = reserve((schema.len() * 8).max(8))?;
+        ensure!(
+            storage.staging_bytes <= staging.bytes().len(),
+            "staging capacity exceeded"
+        );
+        let params = storage.staging_parameters;
         let mut out = Self {
             executable: None,
             graph: None,
@@ -508,191 +505,46 @@ impl CompiledPlan {
         };
         out.actions.push(Action::Copy {
             src: out.params.ptr(staging),
-            dst: base,
+            dst: base + storage.parameters.offset as u64,
             kind: CopyKind::HtoD,
-            size: Expr::from(out.params.len),
+            size: Expr::from(out.params.bytes),
             other_size: None,
-            bytes: out.params.len,
+            bytes: out.params.bytes,
         });
-        let mut ids: Vec<_> = plan.buffers.keys().collect();
-        ids.sort_by_key(|id| format!("{id:?}"));
-        for id in ids {
-            let buffer = &plan.buffers[id];
-            if let Some(lit) = buffer.lit {
-                let pinned = reserve(storage.arena.slices[id].bytes)?;
-                let size = size(&buffer.layout)?;
-                out.actions.push(Action::Copy {
-                    src: pinned.ptr(staging),
-                    dst: range(plan, storage, id, base, dims)?.ptr,
-                    kind: CopyKind::HtoD,
-                    bytes: size.eval(dims)?,
-                    size: size.clone(),
-                    other_size: None,
-                });
-                out.inputs.push(Input {
-                    lit,
-                    pinned,
-                    size,
-                    dtype: buffer.layout.dtype.unwrap(),
-                });
-            }
-        }
-        let mut live: std::collections::HashSet<_> = storage
-            .arena
-            .standalone
-            .iter()
-            .chain(&storage.arena.donated)
-            .cloned()
-            .collect();
-        for node in &storage.arena.order {
-            match &plan.dag[*node] {
-                BufferNode::Compute {
-                    op,
-                    reads,
-                    writes,
-                    operand_info,
-                    result_info,
-                    ..
+        for step in &storage.steps {
+            match step {
+                ArenaStep::Upload {
+                    buffer: id,
+                    staging: pinned,
                 } => {
-                    let label = op.label();
-                    if label == "BufferAlloc" {
-                        live.extend(writes.iter().cloned());
-                        continue;
-                    }
-                    if label == "BufferFree" {
-                        for id in reads {
-                            live.remove(id);
-                        }
-                        continue;
-                    }
-                    ensure!(
-                        writes.len() == 1,
-                        "{label}: CUDA requires a single destination"
-                    );
-                    ensure!(
-                        operand_info.len() == reads.len() && result_info.len() == writes.len(),
-                        "{label}: missing slot descriptors"
-                    );
-                    for id in reads.iter().chain(writes) {
-                        ensure!(
-                            live.contains(id),
-                            "{label}: buffer {id:?} has no live binding"
-                        );
-                    }
-                    if let Some(host) = crate::as_host_op(op.as_ref()) {
-                        let dependencies = host.capture_dims();
-                        let mut host = HostNode {
-                            source: *node,
-                            all_dims: dependencies.is_none(),
-                            dims: dependencies.unwrap_or_default(),
-                            variants: VecDeque::new(),
-                            resource_slot: out.live_resources.len(),
-                        };
-                        host.select(plan, storage, dims, base, stream, stats)?;
-                        out.live_resources
-                            .push(host.variants.front().unwrap().clone());
-                        out.actions.push(Action::Host(host));
-                    } else if let Some(kernel) = crate::as_kernel_op(op.as_ref()) {
-                        let codegen =
-                            CodegenCtx::from_descriptors(label, operand_info, result_info)?;
-                        let mut args = reads[..reads.len() - writes.len()]
-                            .iter()
-                            .map(|id| range(plan, storage, id, base, dims).map(|r| r.ptr))
-                            .collect::<Result<Vec<_>>>()?;
-                        args.push(range(plan, storage, &writes[0], base, dims)?.ptr);
-                        args.push(base);
-                        for generated in kernel.codegen(&codegen)? {
-                            let mut source = symbolic::CUDA_HELPERS.to_owned();
-                            for (i, s) in out.schema.iter().enumerate() {
-                                source.push_str(&format!(
-                                    "#define {} params[{i}]\n",
-                                    symbolic::variable(&s.to_string())
-                                ));
-                            }
-                            source.push_str(&generated.source);
-                            let func = if let Some(module) = cache.get(&source) {
-                                module.func
-                            } else {
-                                let ptx = compile_ptx(&source)
-                                    .map_err(|e| anyhow!("NVRTC {label}: {e:?}\n{source}"))?;
-                                let image = CString::new(ptx.to_src())?;
-                                let raw =
-                                    unsafe { result::module::load_data(image.as_ptr().cast()) }?;
-                                let mut module = Module {
-                                    raw,
-                                    func: std::ptr::null_mut(),
-                                    ctx: ctx.clone(),
-                                };
-                                module.func = unsafe {
-                                    result::module::get_function(raw, CString::new("k")?)
-                                }?;
-                                let func = module.func;
-                                cache.insert(source, module);
-                                stats.kernel_compilations += 1;
-                                func
-                            };
-                            let grid =
-                                u32::try_from(generated.n.capacity(bounds)?.max(1).div_ceil(256))?;
-                            ensure!(
-                                grid <= i32::MAX as u32,
-                                "kernel capacity exceeds CUDA grid limit"
-                            );
-                            let launch = if let Some(spec) = &generated.launch {
-                                for expr in spec.expressions() {
-                                    expr.capacity(bounds)?;
-                                }
-                                let shared = spec.shared_bytes.capacity(bounds)?;
-                                if shared > 48 * 1024 {
-                                    unsafe {
-                                        result::function::set_function_attribute(func,cu::CUfunction_attribute::CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,i32::try_from(shared)?)
-                                    }?;
-                                }
-                                Launch::eval(spec, dims)?
-                            } else {
-                                Launch {
-                                    grid: [grid, 1, 1],
-                                    block: [256, 1, 1],
-                                    shared: 0,
-                                }
-                            };
-                            out.actions.push(Action::Kernel {
-                                func,
-                                args: args.clone(),
-                                geometry: generated.launch,
-                                launch,
-                            });
-                        }
-                    } else {
-                        bail!("no CUDA execution interface for {label}");
-                    }
-                }
-                BufferNode::BufferCopy { src, dst } => {
-                    ensure!(
-                        live.contains(src) && live.contains(dst),
-                        "copy touches a dead buffer"
-                    );
-                    let from = range(plan, storage, src, base, dims)?;
-                    let to = range(plan, storage, dst, base, dims)?;
-                    ensure!(from.bytes == to.bytes, "copy length mismatch");
+                    let buffer = &plan.buffers[id];
+                    let size = size(&buffer.layout)?;
                     out.actions.push(Action::Copy {
-                        src: from.ptr,
-                        dst: to.ptr,
-                        kind: CopyKind::DtoD,
-                        size: size(&plan.buffers[src].layout)?,
-                        other_size: Some(size(&plan.buffers[dst].layout)?),
-                        bytes: from.bytes,
+                        src: pinned.ptr(staging),
+                        dst: range(plan, storage, id, base, dims)?.ptr,
+                        kind: CopyKind::HtoD,
+                        bytes: size.eval(dims)?,
+                        size: size.clone(),
+                        other_size: None,
+                    });
+                    out.inputs.push(Input {
+                        lit: buffer.lit.unwrap(),
+                        pinned: *pinned,
+                        size,
+                        dtype: buffer.layout.dtype.unwrap(),
                     });
                 }
-                _ => {}
-            }
-        }
-        for node in plan.dag.node_weights() {
-            if let BufferNode::BufferOutput { slots } = node {
-                for slot in slots {
-                    ensure!(live.contains(&slot.buffer), "output has no live binding");
-                    let buffer = &plan.buffers[&slot.buffer];
-                    let range = range(plan, storage, &slot.buffer, base, dims)?;
-                    let pinned = reserve(storage.arena.slices[&slot.buffer].bytes)?;
+                ArenaStep::Download {
+                    buffer: id,
+                    node,
+                    slots: indices,
+                    staging: pinned,
+                } => {
+                    let BufferNode::BufferOutput { slots } = &plan.dag[*node] else {
+                        unreachable!()
+                    };
+                    let buffer = &plan.buffers[id];
+                    let range = range(plan, storage, id, base, dims)?;
                     let size = size(&buffer.layout)?;
                     out.actions.push(Action::Copy {
                         src: range.ptr,
@@ -702,17 +554,145 @@ impl CompiledPlan {
                         other_size: None,
                         bytes: range.bytes,
                     });
-                    let mut resolved = slot.clone();
-                    resolved.layout = symbolic::resolve_layout(&slot.layout, dims)?;
-                    out.outputs.push(Output {
-                        slot: slot.clone(),
-                        resolved,
-                        pinned,
-                        size,
-                        bytes: range.bytes,
-                        dtype: buffer.layout.dtype.unwrap(),
-                    });
+                    for &i in indices {
+                        let slot = &slots[i];
+                        let mut resolved = slot.clone();
+                        resolved.layout = symbolic::resolve_layout(&slot.layout, dims)?;
+                        out.outputs.push(Output {
+                            slot: slot.clone(),
+                            resolved,
+                            pinned: *pinned,
+                            size: size.clone(),
+                            bytes: range.bytes,
+                            dtype: buffer.layout.dtype.unwrap(),
+                        });
+                    }
                 }
+                ArenaStep::Node(node) => match &plan.dag[*node] {
+                    BufferNode::Compute {
+                        op,
+                        reads,
+                        writes,
+                        operand_info,
+                        result_info,
+                        ..
+                    } => {
+                        let label = op.label();
+                        if matches!(label, "BufferAlloc" | "BufferFree") {
+                            continue;
+                        }
+                        ensure!(
+                            writes.len() == 1,
+                            "{label}: CUDA requires a single destination"
+                        );
+                        ensure!(
+                            operand_info.len() == reads.len() && result_info.len() == writes.len(),
+                            "{label}: missing slot descriptors"
+                        );
+                        if let Some(host) = crate::as_host_op(op.as_ref()) {
+                            let dependencies = host.capture_dims();
+                            let mut host = HostNode {
+                                source: *node,
+                                all_dims: dependencies.is_none(),
+                                dims: dependencies.unwrap_or_default(),
+                                variants: VecDeque::new(),
+                                resource_slot: out.live_resources.len(),
+                            };
+                            host.select(plan, storage, dims, base, stream, stats)?;
+                            out.live_resources
+                                .push(host.variants.front().unwrap().clone());
+                            out.actions.push(Action::Host(host));
+                        } else if let Some(kernel) = crate::as_kernel_op(op.as_ref()) {
+                            let codegen =
+                                CodegenCtx::from_descriptors(label, operand_info, result_info)?;
+                            let mut args = reads[..reads.len() - writes.len()]
+                                .iter()
+                                .map(|id| range(plan, storage, id, base, dims).map(|r| r.ptr))
+                                .collect::<Result<Vec<_>>>()?;
+                            args.push(range(plan, storage, &writes[0], base, dims)?.ptr);
+                            args.push(base + storage.parameters.offset as u64);
+                            for generated in kernel.codegen(&codegen)? {
+                                let mut source = symbolic::CUDA_HELPERS.to_owned();
+                                for (i, s) in out.schema.iter().enumerate() {
+                                    source.push_str(&format!(
+                                        "#define {} params[{i}]\n",
+                                        symbolic::variable(&s.to_string())
+                                    ));
+                                }
+                                source.push_str(&generated.source);
+                                let func = if let Some(module) = cache.get(&source) {
+                                    module.func
+                                } else {
+                                    let ptx = compile_ptx(&source)
+                                        .map_err(|e| anyhow!("NVRTC {label}: {e:?}\n{source}"))?;
+                                    let image = CString::new(ptx.to_src())?;
+                                    let raw = unsafe {
+                                        result::module::load_data(image.as_ptr().cast())
+                                    }?;
+                                    let mut module = Module {
+                                        raw,
+                                        func: std::ptr::null_mut(),
+                                        ctx: ctx.clone(),
+                                    };
+                                    module.func = unsafe {
+                                        result::module::get_function(raw, CString::new("k")?)
+                                    }?;
+                                    let func = module.func;
+                                    cache.insert(source, module);
+                                    stats.kernel_compilations += 1;
+                                    func
+                                };
+                                let grid = u32::try_from(
+                                    generated.n.capacity(bounds)?.max(1).div_ceil(256),
+                                )?;
+                                ensure!(
+                                    grid <= i32::MAX as u32,
+                                    "kernel capacity exceeds CUDA grid limit"
+                                );
+                                let launch = if let Some(spec) = &generated.launch {
+                                    for expr in spec.expressions() {
+                                        expr.capacity(bounds)?;
+                                    }
+                                    let shared = spec.shared_bytes.capacity(bounds)?;
+                                    if shared > 48 * 1024 {
+                                        unsafe {
+                                            result::function::set_function_attribute(func,cu::CUfunction_attribute::CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,i32::try_from(shared)?)
+                                        }?;
+                                    }
+                                    Launch::eval(spec, dims)?
+                                } else {
+                                    Launch {
+                                        grid: [grid, 1, 1],
+                                        block: [256, 1, 1],
+                                        shared: 0,
+                                    }
+                                };
+                                out.actions.push(Action::Kernel {
+                                    func,
+                                    args: args.clone(),
+                                    geometry: generated.launch,
+                                    launch,
+                                });
+                            }
+                        } else {
+                            bail!("no CUDA execution interface for {label}");
+                        }
+                    }
+                    BufferNode::BufferCopy { src, dst } => {
+                        let from = range(plan, storage, src, base, dims)?;
+                        let to = range(plan, storage, dst, base, dims)?;
+                        ensure!(from.bytes == to.bytes, "copy length mismatch");
+                        out.actions.push(Action::Copy {
+                            src: from.ptr,
+                            dst: to.ptr,
+                            kind: CopyKind::DtoD,
+                            size: size(&plan.buffers[src].layout)?,
+                            other_size: Some(size(&plan.buffers[dst].layout)?),
+                            bytes: from.bytes,
+                        });
+                    }
+                    _ => {}
+                },
             }
         }
         for (i, action) in out.actions.iter().enumerate() {
@@ -870,7 +850,7 @@ impl CompiledPlan {
     fn update(
         &mut self,
         plan: &CudaPlan,
-        storage: &StoragePlan,
+        storage: &ArenaPlan,
         dims: &DynMap,
         base: u64,
         stream: &Arc<CudaStream>,

--- a/crates/luminal_cuda_lite/src/finalists.rs
+++ b/crates/luminal_cuda_lite/src/finalists.rs
@@ -52,7 +52,7 @@
 
 use anyhow::Result;
 
-use crate::arena::{ArenaPlan, buffer_bytes, plan_arena};
+use crate::arena::ArenaPlan;
 use crate::extractor::{self, Genome};
 use crate::layouts::CudaPlan;
 use luminal::prelude::egraph_serialize;
@@ -74,10 +74,12 @@ pub struct PendingFinalist {
     /// The arena plan for `plan` — the issue order and the slab layout.
     /// `slab_bytes` is what the aggregate device-budget check reads.
     pub arena: ArenaPlan,
+    pub shapes: crate::symbolic::ShapeEnv,
 }
 
 /// The ranked finalists of one bucket, materialized lazily.
 pub struct Finalists<'a> {
+    shapes: crate::symbolic::ShapeEnv,
     /// How this bucket names itself in a failure message (`"bucket 0
     /// (a in [2, 4])"`, or `"the search"` when unbucketed).
     label: String,
@@ -135,6 +137,7 @@ impl<'a> Finalists<'a> {
         winner_plan: Option<CudaPlan>,
     ) -> Self {
         Self {
+            shapes: Default::default(),
             label: label.into(),
             egraph,
             session: None,
@@ -148,6 +151,11 @@ impl<'a> Finalists<'a> {
             last_rejection: None,
             layout_cache: luminal::layouts::LayoutDecodeCache::new(),
         }
+    }
+
+    pub fn with_shapes(mut self, shapes: crate::symbolic::ShapeEnv) -> Self {
+        self.shapes = shapes;
+        self
     }
 
     /// This bucket's label, as failure messages spell it.
@@ -216,8 +224,11 @@ impl<'a> Finalists<'a> {
                 self.build_plan(genome)?
             }
         };
-        let arena = plan_arena(&plan, buffer_bytes).map_err(|err| format!("arena: {err:#}"))?;
+        let arena = crate::storage::plan(&plan, &self.shapes.bounds)
+            .map_err(|err| format!("arena: {err:#}"))?
+            .arena;
         Ok(PendingFinalist {
+            shapes: self.shapes.clone(),
             rank,
             metric,
             genome: genome.clone(),

--- a/crates/luminal_cuda_lite/src/finalists.rs
+++ b/crates/luminal_cuda_lite/src/finalists.rs
@@ -225,8 +225,7 @@ impl<'a> Finalists<'a> {
             }
         };
         let arena = crate::storage::plan(&plan, &self.shapes.bounds)
-            .map_err(|err| format!("arena: {err:#}"))?
-            .arena;
+            .map_err(|err| format!("arena: {err:#}"))?;
         Ok(PendingFinalist {
             shapes: self.shapes.clone(),
             rank,

--- a/crates/luminal_cuda_lite/src/host.rs
+++ b/crates/luminal_cuda_lite/src/host.rs
@@ -35,14 +35,17 @@ pub trait PreparedHostOp {
     /// Record GPU work into the active capture. Preparation must already have
     /// loaded modules and resolved host-side descriptors/algorithms.
     /// # Safety
-    /// Bound device ranges must remain live until the last graph replay finishes.
+    /// Bound allocations and addresses must remain valid until the last graph
+    /// replay finishes. Their contents are only live during this operation:
+    /// other graph nodes may use the same ranges at different times.
     unsafe fn record(&self, capture: &CaptureCtx<'_>) -> anyhow::Result<()>;
 }
 
 pub trait HostOp: BufferTensorIrOp {
-    /// Scratch reserved in the runtime's shared arena. A host op must not retain
-    /// invocation state in scratch across graph launches or bucket switches.
-    /// All device scratch must come from this reservation.
+    /// Scratch reserved in the runtime's shared arena, exclusively for this
+    /// operation's captured GPU work. Its contents must not be read or written
+    /// during preparation or retained after that work completes. Other nodes
+    /// and buckets may reuse the same bytes. All device scratch comes from here.
     fn workspace_bytes(&self, _bounds: &crate::symbolic::Bounds) -> anyhow::Result<usize> {
         Ok(0)
     }

--- a/crates/luminal_cuda_lite/src/host.rs
+++ b/crates/luminal_cuda_lite/src/host.rs
@@ -1,37 +1,63 @@
-//! Opaque host-launched operations, such as cuBLASLt library calls.
-
+//! Opaque library operations compiled into captured CUDA child graphs.
 use luminal::buffer_tensor_ir::BufferTensorIrOp;
 
-/// A device buffer or arena subrange bound by the executor.
-/// Raw pointers allow simultaneously live ranges within one arena allocation.
-/// Calls use the executor's single stream, which orders access to those ranges.
 #[derive(Debug, Clone, Copy)]
 pub struct DeviceRange {
     pub ptr: u64,
     pub bytes: usize,
 }
 
-/// Bindings and layout descriptors for a single-destination host operation.
 #[cfg(feature = "device")]
 pub struct HostOpContext<'a> {
     pub stream: &'a std::sync::Arc<cudarc::driver::CudaStream>,
-    /// Read operands, excluding the destination appended by DPS lowering.
     pub inputs: &'a [DeviceRange],
     pub dest: DeviceRange,
-    /// Plan-order descriptors, including the appended destination operand.
+    pub workspace: DeviceRange,
+    pub dims: &'a luminal::shape::DynMap,
     pub operand_info: &'a [luminal::bufferize::SlotDescriptor<luminal::layouts::DecodedLayout>],
     pub result_info: &'a [luminal::bufferize::SlotDescriptor<luminal::layouts::DecodedLayout>],
 }
 
-/// An operation that launches work from the host on the executor's CUDA stream.
-/// The trait remains available in device-free builds for operation selection.
-pub trait HostOp: BufferTensorIrOp {
-    /// Execute using the bufferizer's bindings and declared memory effects.
-    ///
+/// Created only inside an active graph capture. Recording never executes model work.
+#[cfg(feature = "device")]
+pub struct CaptureCtx<'a> {
+    pub(crate) stream: &'a std::sync::Arc<cudarc::driver::CudaStream>,
+}
+#[cfg(feature = "device")]
+impl CaptureCtx<'_> {
+    pub fn stream(&self) -> &std::sync::Arc<cudarc::driver::CudaStream> {
+        self.stream
+    }
+}
+
+#[cfg(feature = "device")]
+pub trait PreparedHostOp {
+    /// Record GPU work into the active capture. Preparation must already have
+    /// loaded modules and resolved host-side descriptors/algorithms.
     /// # Safety
-    /// The device ranges must be live on `ctx.stream`'s device, large enough
-    /// for their descriptors, and aliased only as permitted by the op's
-    /// bufferization contract. They must remain live until the work completes.
+    /// Bound device ranges must remain live until the last graph replay finishes.
+    unsafe fn record(&self, capture: &CaptureCtx<'_>) -> anyhow::Result<()>;
+}
+
+pub trait HostOp: BufferTensorIrOp {
+    /// Scratch reserved in the runtime's shared arena. A host op must not retain
+    /// invocation state in scratch across graph launches or bucket switches.
+    /// All device scratch must come from this reservation.
+    fn workspace_bytes(&self, _bounds: &crate::symbolic::Bounds) -> anyhow::Result<usize> {
+        Ok(0)
+    }
+
+    /// Dimensions affecting captured library work. None conservatively means
+    /// all dimensions; Some(empty) describes a shape-independent capture.
+    /// Include every dimension affecting descriptors, pointers, or recorded work.
+    fn capture_dims(&self) -> Option<Vec<luminal::shape::Symbol>> {
+        None
+    }
+
+    /// Prepare a capture-compatible library call without executing it.
+    /// # Safety
+    /// ctx's ranges must be valid, sized for their descriptors, and obey this
+    /// operation's alias contract. Returned state may retain their addresses.
     #[cfg(feature = "device")]
-    unsafe fn execute(&self, ctx: &HostOpContext<'_>) -> anyhow::Result<()>;
+    unsafe fn prepare(&self, ctx: &HostOpContext<'_>) -> anyhow::Result<Box<dyn PreparedHostOp>>;
 }

--- a/crates/luminal_cuda_lite/src/kernels.rs
+++ b/crates/luminal_cuda_lite/src/kernels.rs
@@ -3,6 +3,7 @@
 //! Each operation implements `KernelOp` and produces CUDA source
 //! with fixed dimensions. Generation needs no GPU; `device` compiles and runs it.
 
+use crate::symbolic::Expr;
 use anyhow::{Result, bail};
 use luminal::buffer_tensor_ir::BufferTensorIrOp;
 use luminal::bufferize::SlotDescriptor;
@@ -21,9 +22,9 @@ use luminal::layouts::{
 /// layouts, and all reads use [`layout_read_index`].
 #[derive(Debug)]
 pub struct CodegenCtx {
-    pub operand_dims: Vec<Vec<usize>>,
+    pub operand_dims: Vec<Vec<Expr>>,
     pub operand_dtypes: Vec<PlanDtype>,
-    pub dest_dims: Vec<Vec<usize>>,
+    pub dest_dims: Vec<Vec<Expr>>,
     pub dest_dtypes: Vec<PlanDtype>,
     /// Read layouts in the same order as `operand_dims`.
     /// View layouts include the full mapping to the underlying buffer.
@@ -32,23 +33,21 @@ pub struct CodegenCtx {
 
 impl CodegenCtx {
     /// Read shapes and data types from the node's slot layouts.
-    /// Return an error for symbolic dimensions or missing data types.
+    /// Preserve symbolic dimensions; refuse missing data types.
     pub fn from_descriptors(
         label: &str,
         operand_info: &[SlotDescriptor<DecodedLayout>],
         result_info: &[SlotDescriptor<DecodedLayout>],
     ) -> Result<Self> {
-        let dims_of = |slot: &SlotDescriptor<DecodedLayout>, role: &str| -> Result<Vec<usize>> {
-            slot.layout.literal_extents().ok_or_else(|| {
-                anyhow::anyhow!("{label} {role} has symbolic layout extents (no numeric codegen)")
-            })
+        let dims_of = |slot: &SlotDescriptor<DecodedLayout>, _role: &str| -> Result<Vec<Expr>> {
+            Ok(slot.layout.shape().0.iter().cloned().map(Expr).collect())
         };
         let dtype_of = |slot: &SlotDescriptor<DecodedLayout>, role: &str| -> Result<PlanDtype> {
             slot.layout
                 .dtype
                 .ok_or_else(|| anyhow::anyhow!("{label} {role} carries no dtype fact"))
         };
-        let dest_dims: Vec<Vec<usize>> = result_info
+        let dest_dims: Vec<Vec<Expr>> = result_info
             .iter()
             .map(|s| dims_of(s, "dest"))
             .collect::<Result<_>>()?;
@@ -223,7 +222,7 @@ fn read_affine(layout: &DecodedLayout, dims: &[usize]) -> Option<Affine> {
     }
     // Contiguous layouts provide strides directly.
     if layout.has::<RM>() {
-        Affine::from_strides(&strides_of(dims))
+        Affine::from_strides(&literal_strides(dims))
     } else if layout.has::<LM>() {
         let mut strides = vec![1usize; rank];
         for axis in 1..rank {
@@ -246,7 +245,7 @@ fn read_affine(layout: &DecodedLayout, dims: &[usize]) -> Option<Affine> {
 
 /// Convert a layout integer expression to C using `long long`.
 /// Coordinates use `{prefix}{axis}`, numbered from the first dimension.
-/// Return an error for symbolic variables or invalid coordinate axes.
+/// Lower runtime variables; refuse invalid coordinate axes.
 fn lower_layout_term(
     expr: &luminal::layouts::IntExprTerm,
     rank: usize,
@@ -255,8 +254,8 @@ fn lower_layout_term(
     use luminal::layouts::IntExprTerm as T;
     let rec = |e: &T| lower_layout_term(e, rank, prefix);
     Ok(match expr {
-        T::Lit(v) => format!("{v}LL"),
-        T::Var(name) => bail!("layout read: symbolic dim `{name}` has no numeric codegen"),
+        T::Lit(v) => crate::symbolic::integer_literal(*v),
+        T::Var(name) => crate::symbolic::variable(name),
         T::Coord { axis_from_end } => {
             let axis = usize::try_from(*axis_from_end)
                 .ok()
@@ -272,11 +271,7 @@ fn lower_layout_term(
         T::Mul(a, b) => format!("({} * {})", rec(a)?, rec(b)?),
         T::TruncDiv(a, b) => format!("({} / {})", rec(a)?, rec(b)?),
         T::TruncRem(a, b) => format!("({} % {})", rec(a)?, rec(b)?),
-        T::CeilDiv(a, b) => {
-            // CeilDiv is unsupported until its behavior for negative operands is defined.
-            let (_, _) = (rec(a)?, rec(b)?);
-            bail!("layout read: IntCeilDiv lowering not implemented (fail-closed)")
-        }
+        T::CeilDiv(a, b) => format!("luminal_ceil_div({}, {})", rec(a)?, rec(b)?),
         T::Min(a, b) => {
             let (a, b) = (rec(a)?, rec(b)?);
             format!("(({a}) < ({b}) ? ({a}) : ({b}))")
@@ -319,20 +314,30 @@ impl<'a> Coords<'a> {
 pub fn layout_read_index(
     operand: &str,
     layout: &DecodedLayout,
-    slot_dims: &[usize],
+    slot_dims: &[Expr],
     coords: Coords<'_>,
 ) -> Result<(String, String)> {
+    if matches!(coords, Coords::FlatIndex { .. })
+        && layout.has::<RM>()
+        && layout.shape().0 == slot_dims.iter().map(|e| e.0.clone()).collect::<Vec<_>>()
+    {
+        return Ok((String::new(), "i".into()));
+    }
     // If the offset equals the row-major index used to compute these
     // coordinates, replace it with `i`.
     if let Coords::FlatIndex { .. } = coords
-        && let Some(affine) = read_affine(layout, slot_dims)
+        && let Some(literals) = slot_dims
+            .iter()
+            .map(Expr::literal)
+            .collect::<Option<Vec<_>>>()
+        && let Some(affine) = read_affine(layout, &literals)
     {
-        let strides = strides_of(slot_dims);
+        let strides = literal_strides(&literals);
         let is_flat_index = affine.constant == 0
             && (0..slot_dims.len()).all(|axis| {
                 // A size-one axis always has coordinate zero, so its coefficient
                 // can be ignored.
-                slot_dims[axis] == 1 || i64::try_from(strides[axis]) == Ok(affine.coeffs[axis])
+                literals[axis] == 1 || i64::try_from(strides[axis]) == Ok(affine.coeffs[axis])
             });
         if is_flat_index {
             return Ok((String::new(), "i".to_string()));
@@ -342,14 +347,7 @@ pub fn layout_read_index(
     let rank = slot_dims.len();
     let idx = format!("{operand}_idx");
     let check_domain = |shape: &luminal::layouts::ShapeTerm| -> Result<()> {
-        let extents: Option<Vec<usize>> = shape
-            .0
-            .iter()
-            .map(|e| e.eval_literal().and_then(|v| usize::try_from(v).ok()))
-            .collect();
-        let Some(extents) = extents else {
-            bail!("operand {operand}: layout has symbolic extents (no numeric codegen)");
-        };
+        let extents: Vec<Expr> = shape.0.iter().cloned().map(Expr).collect();
         if extents != slot_dims {
             bail!(
                 "operand {operand}: layout domain {extents:?} differs from the slot's \
@@ -367,21 +365,21 @@ pub fn layout_read_index(
             "0LL".to_string()
         } else {
             (0..rank)
-                .map(|axis| format!("{in_prefix}{axis} * {}LL", strides[axis]))
+                .map(|axis| format!("{in_prefix}{axis} * {}", strides[axis]))
                 .collect::<Vec<_>>()
                 .join(" + ")
         }
     } else if let Some(lm) = layout.first::<LM>() {
         check_domain(&lm.shape)?;
-        let mut strides = vec![1usize; rank];
+        let mut strides = vec![Expr::from(1usize); rank];
         for axis in 1..rank {
-            strides[axis] = strides[axis - 1] * slot_dims[axis - 1];
+            strides[axis] = strides[axis - 1].clone() * slot_dims[axis - 1].clone();
         }
         if rank == 0 {
             "0LL".to_string()
         } else {
             (0..rank)
-                .map(|axis| format!("{in_prefix}{axis} * {}LL", strides[axis]))
+                .map(|axis| format!("{in_prefix}{axis} * {}", strides[axis]))
                 .collect::<Vec<_>>()
                 .join(" + ")
         }
@@ -408,7 +406,7 @@ pub fn layout_read_index(
         // ensure the offset is divisible by the element width.
         let bits_var = format!("{operand}_bits");
         let code = format!(
-            "    long long {bits_var} = {bits};\n    long long {idx} = {bits_var} / {width}LL;\n"
+            "    long long {bits_var} = {bits};\n    long long {idx} = {bits_var} / {width};\n"
         );
         return Ok((code, idx));
     } else {
@@ -422,16 +420,56 @@ pub fn layout_read_index(
 }
 
 /// CUDA source for one launch of kernel `k`, with `n` threads.
-/// Arguments are the operation's inputs, followed by `out` and `n`.
+/// ABI: input pointers, output pointer, then `const long long* params`.
+/// The runtime defines each dimension's identifier (`symbolic::variable`) as
+/// params[index]. Default launches cover the bucket capacity; the kernel must
+/// guard threads against its live `n`. Custom geometry can depend on dimensions.
 #[derive(Debug)]
 pub struct KernelSource {
     pub source: String,
-    pub n: usize,
+    pub n: Expr,
+    pub launch: Option<KernelLaunch>,
 }
 
 impl KernelSource {
-    pub(crate) fn plain(source: String, n: usize) -> Self {
-        Self { source, n }
+    pub fn plain(source: String, n: Expr) -> Self {
+        Self {
+            source,
+            n,
+            launch: None,
+        }
+    }
+}
+
+/// Optional live launch geometry. Only nodes depending on changed dimensions
+/// are patched. Zero grids disable a node; block extents must stay positive.
+#[derive(Debug, Clone)]
+pub struct KernelLaunch {
+    pub grid: [Expr; 3],
+    pub block: [Expr; 3],
+    pub shared_bytes: Expr,
+}
+impl KernelLaunch {
+    pub fn linear(n: Expr, block: usize) -> Self {
+        Self {
+            grid: [
+                Expr(luminal::layouts::IntExprTerm::CeilDiv(
+                    Box::new(n.0),
+                    Box::new(Expr::from(block).0),
+                )),
+                1usize.into(),
+                1usize.into(),
+            ],
+            block: [block.into(), 1usize.into(), 1usize.into()],
+            shared_bytes: 0usize.into(),
+        }
+    }
+    #[cfg(feature = "device")]
+    pub(crate) fn expressions(&self) -> impl Iterator<Item = &Expr> {
+        self.grid
+            .iter()
+            .chain(&self.block)
+            .chain(std::iter::once(&self.shared_bytes))
     }
 }
 
@@ -471,7 +509,7 @@ pub(crate) fn cuda_f64_literal(v: f64) -> String {
     format!("{v:e}")
 }
 
-pub(crate) fn numel(dims: &[usize]) -> usize {
+pub(crate) fn numel(dims: &[Expr]) -> Expr {
     dims.iter().product()
 }
 
@@ -546,7 +584,8 @@ fn elementwise(
     if chains.is_empty() {
         // All reads use `i`, so no coordinate calculations are needed.
         let source = format!(
-            r#"extern "C" __global__ void k({sig}, {to}* out, unsigned long long n) {{
+            r#"extern "C" __global__ void k({sig}, {to}* out, const long long* params) {{
+    const unsigned long long n = {n};
     unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
     if (i < n) out[i] = {rendered};
 }}"#
@@ -555,7 +594,8 @@ fn elementwise(
     }
     let prelude = coord_prelude(out_dims);
     let source = format!(
-        r#"extern "C" __global__ void k({sig}, {to}* out, unsigned long long n) {{
+        r#"extern "C" __global__ void k({sig}, {to}* out, const long long* params) {{
+    const unsigned long long n = {n};
     unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= n) return;
 {prelude}{chains}    out[i] = {rendered};
@@ -579,11 +619,11 @@ pub(crate) fn reduce(
         bail!("reduce axis {axis_from_end} out of rank {}", in_dims.len());
     }
     let axis = in_dims.len() - 1 - axis_from_end;
-    let extent = in_dims[axis];
+    let extent = in_dims[axis].clone();
     // Count the input elements before and after the reduced axis.
-    let inner: usize = in_dims[axis + 1..].iter().product();
-    let outer: usize = in_dims[..axis].iter().product();
-    let n = outer * inner;
+    let inner: Expr = in_dims[axis + 1..].iter().product();
+    let outer: Expr = in_dims[..axis].iter().product();
+    let n = outer * inner.clone();
     // Input coordinates combine the output position with the reduction
     // loop index. Use `Coords::Bound`: the input offset cannot simplify
     // to `i`, which indexes the smaller output shape.
@@ -593,14 +633,14 @@ pub(crate) fn reduce(
     let mut coords = String::from("    unsigned long long rem = inner;\n");
     for ax in ((axis + 1)..in_dims.len()).rev() {
         coords.push_str(&format!(
-            "    long long c{ax} = (long long)(rem % {d}ULL); rem /= {d}ULL;\n",
+            "    long long c{ax} = (long long)(rem % {d}); rem /= {d};\n",
             d = in_dims[ax]
         ));
     }
     coords.push_str("    rem = outer;\n");
     for ax in (0..axis).rev() {
         coords.push_str(&format!(
-            "    long long c{ax} = (long long)(rem % {d}ULL); rem /= {d}ULL;\n",
+            "    long long c{ax} = (long long)(rem % {d}); rem /= {d};\n",
             d = in_dims[ax]
         ));
     }
@@ -608,13 +648,14 @@ pub(crate) fn reduce(
     // Indent the generated index code inside the loop.
     let chain = chain.replace("    ", "        ");
     let source = format!(
-        r#"extern "C" __global__ void k(const {ta}* a, {to}* out, unsigned long long n) {{
+        r#"extern "C" __global__ void k(const {ta}* a, {to}* out, const long long* params) {{
+    const unsigned long long n = {n};
     unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= n) return;
-    unsigned long long outer = i / {inner}ULL;
-    unsigned long long inner = i % {inner}ULL;
+    unsigned long long outer = i / {inner};
+    unsigned long long inner = i % {inner};
 {coords}    {ta} acc = {init};
-    for (unsigned long long r = 0; r < {extent}ULL; ++r) {{
+    for (unsigned long long r = 0; r < {extent}; ++r) {{
         long long c{axis} = (long long)r;
 {chain}        {ta} v = a[{idx}];
         acc = {fold};
@@ -636,7 +677,8 @@ pub(crate) fn lower_expr(expr: &IotaExpr, rank: usize) -> Result<String> {
 pub(crate) fn lower_expr_pref(expr: &IotaExpr, rank: usize, prefix: &str) -> Result<String> {
     let rec = |e: &IotaExpr| lower_expr_pref(e, rank, prefix);
     Ok(match expr {
-        IotaExpr::Lit(v) => format!("{v}LL"),
+        IotaExpr::Lit(v) => crate::symbolic::integer_literal(*v),
+        IotaExpr::Var(name) => crate::symbolic::variable(name),
         IotaExpr::Coord(axis_from_end) => {
             if *axis_from_end >= rank {
                 bail!("coordinate axis {axis_from_end} out of rank {rank}");
@@ -651,6 +693,7 @@ pub(crate) fn lower_expr_pref(expr: &IotaExpr, rank: usize, prefix: &str) -> Res
         IotaExpr::TruncRem(a, b) => {
             format!("({} % {})", rec(a)?, rec(b)?)
         }
+        IotaExpr::CeilDiv(a, b) => format!("luminal_ceil_div({}, {})", rec(a)?, rec(b)?),
         IotaExpr::Min(a, b) => {
             let (a, b) = (rec(a)?, rec(b)?);
             format!("(({a}) < ({b}) ? ({a}) : ({b}))")
@@ -666,11 +709,11 @@ pub(crate) fn lower_expr_pref(expr: &IotaExpr, rank: usize, prefix: &str) -> Res
 }
 
 /// Generate row-major coordinates `c0..c{rank-1}` from flat index `i`.
-pub(crate) fn coord_prelude(dims: &[usize]) -> String {
+pub(crate) fn coord_prelude(dims: &[Expr]) -> String {
     let mut out = String::from("    unsigned long long rem = i;\n");
     for axis in (0..dims.len()).rev() {
         out.push_str(&format!(
-            "    long long c{axis} = (long long)(rem % {}ULL); rem /= {}ULL;\n",
+            "    long long c{axis} = (long long)(rem % {}); rem /= {};\n",
             dims[axis], dims[axis]
         ));
     }
@@ -678,10 +721,18 @@ pub(crate) fn coord_prelude(dims: &[usize]) -> String {
 }
 
 /// Return row-major strides for `dims`.
-pub(crate) fn strides_of(dims: &[usize]) -> Vec<usize> {
+fn literal_strides(dims: &[usize]) -> Vec<usize> {
     let mut strides = vec![1usize; dims.len()];
     for k in (0..dims.len().saturating_sub(1)).rev() {
         strides[k] = strides[k + 1] * dims[k + 1];
+    }
+    strides
+}
+
+pub(crate) fn strides_of(dims: &[Expr]) -> Vec<Expr> {
+    let mut strides = vec![Expr::from(1usize); dims.len()];
+    for k in (0..dims.len().saturating_sub(1)).rev() {
+        strides[k] = strides[k + 1].clone() * dims[k + 1].clone();
     }
     strides
 }

--- a/crates/luminal_cuda_lite/src/lib.rs
+++ b/crates/luminal_cuda_lite/src/lib.rs
@@ -48,16 +48,17 @@
 //!   the arena slab the runtime will hold. Unconstrained (the default)
 //!   the walk installs the search's own winner and costs nothing.
 //!
-//! Out-of-place by design: kernels read operand buffers and write a
-//! destination that shares no byte with any simultaneously bound buffer
-//! — the same alias-safety PROPERTY as the reference executor, by a
-//! different mechanism. Since Phase 3 (#420/#422 rejoin) the destination
-//! is a recycled slab range assigned by [`arena`] (its CONTRACT-1
-//! live-range check; [`binding_check`] covers the standalone rows), NOT
-//! a fresh zeroed slice: nothing is zeroed, so every kernel must write
-//! every element it owns and never read its destination — the KERNEL
-//! INVARIANT recorded at the top of `device.rs`. `ties` and `Anti` edges
-//! are honored in the toposort order but no in-place claim is made.
+//! Execution always launches CUDA graphs. Owned kernels and copies are parent
+//! graph nodes; HostOps prepare library calls and capture opaque child graphs.
+//! Dynamic dimensions live in an arena-resident parameter block. Buckets overlay
+//! one capacity-sized arena, including boundary device copies and host-op scratch.
+//! Input staging and output readback are graph nodes backed by one shared pinned
+//! host allocation. Returned outputs own their host bytes.
+//!
+//! Bufferization supplies alias/lifetime contracts and dependency edges. The
+//! arena preserves them in a serial issue order; generated kernels must fully
+//! initialize their destinations, since temporary ranges are reused without
+//! clearing. cuBLASLt's accumulate forms follow their declared alias contracts.
 
 pub mod arena;
 pub mod binding_check;
@@ -66,6 +67,8 @@ pub mod bindings;
 /// calls it with its own matcher list and it names no runtime type.
 /// Kept under this crate's old module name so call sites read the same.
 pub use luminal::extraction as extractor;
+#[cfg(feature = "device")]
+mod cuda_graph;
 /// FINALISTS (Phase 5 of the #420/#422 rejoin): a bucket's ranked
 /// genomes, re-materialized one at a time under a hard filter.
 pub mod finalists;
@@ -81,6 +84,8 @@ pub mod op;
 pub mod ops;
 pub mod runtime;
 pub mod search;
+mod storage;
+pub mod symbolic;
 
 #[cfg(feature = "device")]
 pub mod device;

--- a/crates/luminal_cuda_lite/src/ops/constant/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/constant/mod.rs
@@ -96,7 +96,8 @@ impl KernelOp for ConstantDps {
         let n = numel(&ctx.dest_dims[0]);
         let value = cuda_f64_literal(self.value);
         let source = format!(
-            r#"extern "C" __global__ void k({to}* out, unsigned long long n) {{
+            r#"extern "C" __global__ void k({to}* out, const long long* params) {{
+    const unsigned long long n = {n};
     unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
     if (i < n) out[i] = ({to}){value};
 }}"#
@@ -151,7 +152,7 @@ mod tests {
         CodegenCtx {
             operand_dims: vec![],
             operand_dtypes: vec![],
-            dest_dims: vec![vec![4]],
+            dest_dims: vec![vec![4usize.into()]],
             dest_dtypes: vec![PlanDtype::F32],
             operand_layouts: vec![],
         }
@@ -246,7 +247,8 @@ mod tests {
     fn constant_kernel_text_is_otherwise_unchanged() {
         assert_eq!(
             source_for(3.0),
-            r#"extern "C" __global__ void k(float* out, unsigned long long n) {
+            r#"extern "C" __global__ void k(float* out, const long long* params) {
+    const unsigned long long n = 4LL;
     unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
     if (i < n) out[i] = (float)3e0;
 }"#

--- a/crates/luminal_cuda_lite/src/ops/cublaslt/device_call.rs
+++ b/crates/luminal_cuda_lite/src/ops/cublaslt/device_call.rs
@@ -1,35 +1,9 @@
-//! The device half of the cuBLASLt host call: cudarc **result layer**
-//! dispatch of a resolved [`LtCall`].
-//!
-//! LAYER CHOICE (Train 3, documented decision): cudarc's SAFE layer
-//! (`cudarc::cublaslt::safe`) routes ONE `c_layout` handle into both
-//! the C and D descriptor arguments and hands `cublasLtMatmul` the same
-//! pointer for C and D unconditionally — it cannot express contract 3
-//! (a VALID standalone Cdesc with C=D aliasing under our control), a
-//! separate ldc/ldd, or an explicit POINTER_MODE attribute. The RESULT
-//! layer (`cudarc::cublaslt::result`) exposes exactly the descriptor
-//! calls we need (`create_matrix_layout`, `create_matmul_desc`,
-//! `set_matmul_desc_attribute`, `get_matmul_algo_heuristic`, `matmul`)
-//! with error-code handling, so nothing is taken from raw `sys` except
-//! enum values and the one GetAttribute the TF32 detector reads back.
-//!
-//! Contracts implemented here (see `exec.rs` module doc for the list):
-//! POINTER_MODE_HOST set explicitly with compile-time literal scalars
-//! (alpha = 1.0f const; beta in {0.0f, 1.0f} structural); strict
-//! CUBLAS_COMPUTE_32F with a startup detector at handle creation; a
-//! valid Cdesc on every call; workspace OWNED explicitly (allocated by
-//! us ONCE per CUDA context and reused by every dispatch — see
-//! [`workspace_slab`] — sized into the heuristic preference; no silent
-//! fallback: zero heuristic results is a loud bail); stream-ordered on
-//! the CALLER's stream (the same stream the surrounding NVRTC kernels
-//! run on).
-
+//! Prepared cuBLASLt calls recorded into opaque CUDA child graphs.
+use crate::host::{CaptureCtx, PreparedHostOp};
 use anyhow::{Context, Result, anyhow};
 use cudarc::cublaslt::result as lt;
 use cudarc::cublaslt::sys;
-use cudarc::driver::{CudaSlice, CudaStream, DevicePtr};
-use std::collections::HashMap;
-use std::collections::hash_map::Entry;
+use cudarc::driver::{CudaStream, DevicePtr};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use super::exec::{CSource, LtCall, LtDesc, LtOrder};
@@ -124,47 +98,6 @@ pub fn assert_compute_strictness() -> Result<()> {
     handle().map(|_| ())
 }
 
-/// THE cuBLASLt WORKSPACE SLAB: [`WORKSPACE_BYTES`] allocated ONCE per
-/// CUDA context and held for the life of the process, reached the same
-/// way [`handle`] is (a `static OnceLock` behind a `Mutex`).
-///
-/// WHY ONCE — SEARCH-TIME ELECTION BIAS. This used to be an
-/// `alloc_zeros` on EVERY dispatch. The search calls dispatch once per
-/// candidate genome per profiling round, so a 32 MiB allocation was
-/// charged to the marker on every measurement while the decomposed
-/// route it competes against pays nothing of the kind: the op is then
-/// ranked on its allocator cost, not its matmul. That is exactly the
-/// failure main's FlashInfer host op documents — "global workspaces
-/// (`static OnceLock`) are shared across all instances ... without this,
-/// the GA never selects FlashInfer because the first-run allocation cost
-/// dwarfs the kernel time" — and main's cuBLASLt handle cache
-/// (`try_create_cublaslt`) is the same shape for the same reason.
-///
-/// WHY KEYED BY CONTEXT, NOT BY STREAM. A `CudaSlice` is memory in the
-/// context its stream belongs to, so the key has to separate contexts.
-/// Main keys its handle cache by `stream.cu_stream()`, which cannot work
-/// here: `CudaDevice::new` takes `ctx.default_stream()`, whose
-/// `cu_stream` is the NULL stream for every ordinal, so a stream key
-/// would hand a context-A allocation to a context-B dispatch. Keying on
-/// `cu_ctx` is the faithful adaptation. Within one context CL issues
-/// everything on that one NULL stream (see `device.rs`), so a shared
-/// slab cannot be touched by two overlapping matmuls.
-///
-/// The map holds each slice PERMANENTLY and a `CudaSlice` owns an
-/// `Arc<CudaStream>`, which owns its `Arc<CudaContext>` — so a live
-/// entry pins its own context and the `cu_ctx` address behind a key can
-/// never be recycled by a different context. The cost of that is 32 MiB
-/// per context, never freed; main accepts the same trade for the same
-/// reason.
-///
-/// LOCK ORDER: [`dispatch`] takes the handle mutex and then this one,
-/// and it is the only site that holds both. Nothing takes them the other
-/// way round.
-fn workspace_slab() -> &'static Mutex<HashMap<usize, CudaSlice<u8>>> {
-    static WORKSPACES: OnceLock<Mutex<HashMap<usize, CudaSlice<u8>>>> = OnceLock::new();
-    WORKSPACES.get_or_init(Default::default)
-}
-
 /// RAII matrix layout. CUBLASLT_MATRIX_LAYOUT_ORDER is ALWAYS declared
 /// explicitly and ALWAYS read off the [`LtDesc`] — never a constant
 /// here, and never the library default. The library default is COL;
@@ -234,12 +167,12 @@ pub use crate::host::DeviceRange;
 /// arena assigned it. The caller has ALREADY run
 /// `call.validate_against` — this function re-checks (defense in depth)
 /// and then never re-derives a number the `LtCall` carries.
-pub fn dispatch(
+pub fn prepare(
     call: &LtCall,
     operands: &[DeviceRange],
     dest: DeviceRange,
-    stream: &Arc<CudaStream>,
-) -> Result<()> {
+    workspace: DeviceRange,
+) -> Result<PreparedCall> {
     // BIAS/ORDER TRIPWIRE, DEFENSE IN DEPTH (ruling 2026-09-01): a
     // planned bias form arrives with a COL D — the estate's bias
     // decorators require a LeftMajor D and `exec::bind_destination`
@@ -326,26 +259,6 @@ pub fn dispatch(
     let c_layout = Layout::new(&call.c)?;
     let d_layout = Layout::new(&call.d)?;
 
-    // Workspace: OURS, explicitly, sized into the preference so the
-    // heuristic can only pick algos that fit it. Zero heuristic hits is
-    // a loud bail (the result layer maps that to NOT_SUPPORTED).
-    //
-    // Allocated ONCE per CUDA context and reused by every dispatch (see
-    // `workspace_slab`), never per call — a per-call 32 MiB alloc priced
-    // the marker out of its own search. Zeroed only at creation:
-    // cuBLASLt treats the workspace as scratch and neither reads it
-    // before writing nor requires it clean between calls.
-    let mut workspaces = workspace_slab()
-        .lock()
-        .map_err(|_| anyhow!("cuBLASLt workspace mutex poisoned"))?;
-    let workspace = match workspaces.entry(stream.context().cu_ctx() as usize) {
-        Entry::Occupied(slot) => slot.into_mut(),
-        Entry::Vacant(slot) => slot.insert(
-            stream
-                .alloc_zeros::<u8>(WORKSPACE_BYTES)
-                .context("cuBLASLt workspace alloc")?,
-        ),
-    };
     let pref =
         lt::create_matmul_pref().map_err(|e| anyhow!("cublasLtMatmulPreferenceCreate: {e:?}"))?;
     struct Pref {
@@ -359,7 +272,7 @@ pub fn dispatch(
         }
     }
     let pref = Pref { raw: pref };
-    let ws_size: usize = WORKSPACE_BYTES;
+    let ws_size = workspace.bytes;
     unsafe {
         lt::set_matmul_pref_attribute(
             pref.raw,
@@ -410,28 +323,91 @@ pub fn dispatch(
             (operands[i].ptr, &BETA_ONE)
         }
     };
-    let (w_ptr, _rw) = workspace.device_ptr(stream);
+    Ok(PreparedCall {
+        desc,
+        a_layout,
+        b_layout,
+        c_layout,
+        d_layout,
+        algo: heuristic.algo,
+        a_ptr,
+        b_ptr,
+        c_ptr,
+        d_ptr,
+        beta,
+        workspace,
+    })
+}
 
-    unsafe {
-        lt::matmul(
-            guard.raw,
-            desc.raw,
-            (&ALPHA) as *const f32 as *const _,
-            beta as *const f32 as *const _,
-            a_ptr as *const _,
-            a_layout.raw,
-            b_ptr as *const _,
-            b_layout.raw,
-            c_ptr as *const _,
-            c_layout.raw,
-            d_ptr as *mut _,
-            d_layout.raw,
-            (&heuristic.algo) as *const _,
-            w_ptr as *mut _,
-            WORKSPACE_BYTES,
-            stream.cu_stream() as *mut _,
-        )
+/// Descriptors and selected algorithm remain alive alongside their captured graph.
+pub struct PreparedCall {
+    desc: Desc,
+    a_layout: Layout,
+    b_layout: Layout,
+    c_layout: Layout,
+    d_layout: Layout,
+    algo: sys::cublasLtMatmulAlgo_t,
+    a_ptr: u64,
+    b_ptr: u64,
+    c_ptr: u64,
+    d_ptr: u64,
+    beta: &'static f32,
+    workspace: DeviceRange,
+}
+impl PreparedHostOp for PreparedCall {
+    unsafe fn record(&self, capture: &CaptureCtx<'_>) -> Result<()> {
+        let guard = handle()?
+            .lock()
+            .map_err(|_| anyhow!("cuBLASLt handle mutex poisoned"))?;
+        unsafe {
+            lt::matmul(
+                guard.raw,
+                self.desc.raw,
+                (&ALPHA) as *const f32 as *const _,
+                self.beta as *const f32 as *const _,
+                self.a_ptr as *const _,
+                self.a_layout.raw,
+                self.b_ptr as *const _,
+                self.b_layout.raw,
+                self.c_ptr as *const _,
+                self.c_layout.raw,
+                self.d_ptr as *mut _,
+                self.d_layout.raw,
+                &self.algo,
+                self.workspace.ptr as *mut _,
+                self.workspace.bytes,
+                capture.stream().cu_stream() as *mut _,
+            )
+        }
+        .map_err(|e| anyhow!("cublasLtMatmul capture failed: {e:?}"))
     }
-    .map_err(|e| anyhow!("cublasLtMatmul failed: {e:?}"))?;
+}
+
+/// Standalone contract-test convenience; execution uses a CUDA graph too.
+pub fn dispatch(
+    call: &LtCall,
+    operands: &[DeviceRange],
+    dest: DeviceRange,
+    stream: &Arc<CudaStream>,
+) -> Result<()> {
+    // A private nonblocking stream supports capture even if the caller uses the
+    // legacy default stream. Complete caller uploads before recording/launching.
+    stream.synchronize()?;
+    let capture_stream = stream.context().new_stream()?;
+    let workspace = capture_stream.alloc_zeros::<u8>(WORKSPACE_BYTES)?;
+    let ptr = workspace.device_ptr(&capture_stream).0;
+    let prepared = prepare(
+        call,
+        operands,
+        dest,
+        DeviceRange {
+            ptr,
+            bytes: WORKSPACE_BYTES,
+        },
+    )?;
+    let graph = crate::cuda_graph::Graph::capture(&capture_stream, &prepared)?;
+    let exec = graph.instantiate()?;
+    exec.launch(&capture_stream)?;
+    capture_stream.synchronize()?;
     Ok(())
 }

--- a/crates/luminal_cuda_lite/src/ops/cublaslt/exec.rs
+++ b/crates/luminal_cuda_lite/src/ops/cublaslt/exec.rs
@@ -447,6 +447,33 @@ pub fn plan_call(op: &CublasLt) -> Result<LtCall> {
     plan_call_from_spec(spec)
 }
 
+/// Bind symbolic dimensions before constructing the library descriptors.
+pub fn plan_call_at(op: &CublasLt, dims: &luminal::shape::DynMap) -> Result<LtCall> {
+    let mut bound = op.clone();
+    let spec = bound
+        .spec
+        .as_mut()
+        .ok_or_else(|| anyhow::anyhow!("cuBLASLt has no spec"))?;
+    for dim in [
+        &mut spec.m,
+        &mut spec.n,
+        &mut spec.k,
+        &mut spec.lda,
+        &mut spec.ldb,
+        &mut spec.ldc,
+        &mut spec.ldd,
+    ] {
+        if let CuDim::Symbolic(class) = dim {
+            let expr = spec
+                .dim_exprs
+                .get(class)
+                .ok_or_else(|| anyhow::anyhow!("unresolved cuBLASLt dimension {class:?}"))?;
+            *dim = CuDim::Literal(crate::symbolic::eval(expr, dims)?);
+        }
+    }
+    plan_call(&bound)
+}
+
 /// [`plan_call`] over the spec alone (test seam).
 pub fn plan_call_from_spec(spec: &LtMatmulSpec) -> Result<LtCall> {
     // NO BIAS REFUSAL HERE (ruling 2026-09-01). The unconditional

--- a/crates/luminal_cuda_lite/src/ops/cublaslt/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/cublaslt/mod.rs
@@ -207,6 +207,8 @@ impl std::fmt::Display for CuDim {
 /// The single Rust endpoint: one struct, every contract and decoration.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LtMatmulSpec {
+    /// Symbolic geometry decoded before the extraction e-graph is released.
+    pub dim_exprs: std::collections::BTreeMap<ClassId, luminal::layouts::IntExprTerm>,
     pub form: CublasLtForm,
     pub m: CuDim,
     pub n: CuDim,
@@ -753,7 +755,15 @@ pub fn parse_spec(site: &ExtractionSite<'_>, form: CublasLtForm) -> Option<LtMat
         (true, true) => CuEpilogue::ReluBias,
     };
 
+    let mut dim_exprs = std::collections::BTreeMap::new();
+    for dim in [&m, &n, &k, &lda, &ldb, &ldd] {
+        if let CuDim::Symbolic(class) = dim {
+            let expr = luminal::index_expr::parse_int_expr(site, class, 64, None)?;
+            dim_exprs.insert(class.clone(), crate::symbolic::iota_term(&expr)?);
+        }
+    }
     let spec = LtMatmulSpec {
+        dim_exprs,
         form,
         m,
         n,
@@ -896,12 +906,27 @@ impl ToDps for CublasLtDps {
 impl LayoutIrOp for CublasLtDps {}
 
 impl crate::host::HostOp for CublasLtDps {
+    fn workspace_bytes(&self, _: &crate::symbolic::Bounds) -> anyhow::Result<usize> {
+        Ok(32 * 1024 * 1024)
+    }
+    fn capture_dims(&self) -> Option<Vec<luminal::shape::Symbol>> {
+        let mut vars = std::collections::BTreeSet::new();
+        if let Some(spec) = &self.op.spec {
+            for expr in spec.dim_exprs.values() {
+                crate::symbolic::vars(expr, &mut vars);
+            }
+        }
+        Some(vars.into_iter().collect())
+    }
     #[cfg(feature = "device")]
-    unsafe fn execute(&self, ctx: &crate::host::HostOpContext<'_>) -> anyhow::Result<()> {
+    unsafe fn prepare(
+        &self,
+        ctx: &crate::host::HostOpContext<'_>,
+    ) -> anyhow::Result<Box<dyn crate::host::PreparedHostOp>> {
         use anyhow::{Context, anyhow};
 
         let label = self.label();
-        let mut call = exec::plan_call(&self.op)
+        let mut call = exec::plan_call_at(&self.op, ctx.dims)
             .with_context(|| format!("cuBLASLt call planning for {label}"))?;
         // The elected destination layout is authoritative. Reconcile it with
         // the library call frame before dispatch, including its storage order.
@@ -912,8 +937,9 @@ impl crate::host::HostOp for CublasLtDps {
             .ok_or_else(|| anyhow!("{label}: host-call node carries no result descriptor"))?;
         exec::bind_destination(&mut call, &dest_slot.layout, label)
             .with_context(|| format!("cuBLASLt destination frame binding for {label}"))?;
-        device_call::dispatch(&call, ctx.inputs, ctx.dest, ctx.stream)
-            .with_context(|| format!("cuBLASLt dispatch for {label}"))
+        device_call::prepare(&call, ctx.inputs, ctx.dest, ctx.workspace)
+            .map(|p| Box::new(p) as Box<dyn crate::host::PreparedHostOp>)
+            .with_context(|| format!("cuBLASLt preparation for {label}"))
     }
 }
 

--- a/crates/luminal_cuda_lite/src/ops/gather/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/gather/mod.rs
@@ -195,7 +195,8 @@ impl KernelOp for GatherDps {
         body.push_str(&chain);
         let read = format!("data[{idx}]");
         let source = format!(
-            r#"extern "C" __global__ void k({sig}, {to}* out, unsigned long long n) {{
+            r#"extern "C" __global__ void k({sig}, {to}* out, const long long* params) {{
+    const unsigned long long n = {n};
     unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= n) return;
 {body}    out[i] = {read};

--- a/crates/luminal_cuda_lite/src/ops/index_map_apply_materialize/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/index_map_apply_materialize/mod.rs
@@ -162,7 +162,8 @@ impl KernelOp for IndexMapApplyMaterializeDps {
         )?;
         body.push_str(&chain);
         let source = format!(
-            r#"extern "C" __global__ void k(const {t}* parent, {to}* out, unsigned long long n) {{
+            r#"extern "C" __global__ void k(const {t}* parent, {to}* out, const long long* params) {{
+    const unsigned long long n = {n};
     unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= n) return;
 {prelude}{body}    out[i] = parent[{pidx}];

--- a/crates/luminal_cuda_lite/src/ops/iota/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/iota/mod.rs
@@ -109,7 +109,8 @@ impl KernelOp for IotaDps {
         let prelude = coord_prelude(out_dims);
         let value = lower_expr(expr, out_dims.len())?;
         let source = format!(
-            r#"extern "C" __global__ void k({to}* out, unsigned long long n) {{
+            r#"extern "C" __global__ void k({to}* out, const long long* params) {{
+    const unsigned long long n = {n};
     unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= n) return;
 {prelude}    out[i] = ({to})({value});

--- a/crates/luminal_cuda_lite/src/ops/scatter/mod.rs
+++ b/crates/luminal_cuda_lite/src/ops/scatter/mod.rs
@@ -201,7 +201,8 @@ impl KernelOp for ScatterFunctionalDps {
         )?;
         let copy_src = if init_chain.is_empty() {
             format!(
-                r#"extern "C" __global__ void k({sig}, {t}* out, unsigned long long n) {{
+                r#"extern "C" __global__ void k({sig}, {t}* out, const long long* params) {{
+    const unsigned long long n = {dest_n};
     unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
     if (i < n) out[i] = init[{init_idx}];
 }}"#
@@ -209,7 +210,8 @@ impl KernelOp for ScatterFunctionalDps {
         } else {
             let prelude = coord_prelude(dest_dims);
             format!(
-                r#"extern "C" __global__ void k({sig}, {t}* out, unsigned long long n) {{
+                r#"extern "C" __global__ void k({sig}, {t}* out, const long long* params) {{
+    const unsigned long long n = {dest_n};
     unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= n) return;
 {prelude}{init_chain}    out[i] = init[{init_idx}];
@@ -264,7 +266,7 @@ impl KernelOp for ScatterFunctionalDps {
             any_chain |= !chain.is_empty();
             reads.push_str(&chain);
             reads.push_str(&format!("    coord = (long long){name}[{idx}];\n"));
-            reads.push_str(&format!("    flat += coord * {stride}LL;\n"));
+            reads.push_str(&format!("    flat += coord * {stride};\n"));
         }
         let (src_chain, src_idx) = layout_read_index(
             "src",
@@ -282,7 +284,8 @@ impl KernelOp for ScatterFunctionalDps {
         body.push_str(&src_chain);
         let src_read = format!("src[{src_idx}]");
         let scatter_src = format!(
-            r#"extern "C" __global__ void k({sig}, {t}* out, unsigned long long n) {{
+            r#"extern "C" __global__ void k({sig}, {t}* out, const long long* params) {{
+    const unsigned long long n = {src_n};
     unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= n) return;
 {body}    out[flat] = {src_read};

--- a/crates/luminal_cuda_lite/src/profile.rs
+++ b/crates/luminal_cuda_lite/src/profile.rs
@@ -1,54 +1,12 @@
-//! THE DEVICE EVALUATOR — this runtime's price for one candidate plan,
-//! measured on the GPU.
-//!
-//! PHASE 4 OF THE #420/#422 REJOIN (2026-09-03), discharging the debt
-//! `lib.rs` has carried since CL-1 ("STILL OWED: profiling ON DEVICE")
-//! and ruling 4 on #386: CL must profile on device *"just like the
-//! existing profiler actually does. we need to mirror that design"*.
-//! The template is `luminal_reference::search`'s
-//! `profile_on_reference_runtime`: stage, warm up once, time `trials`
-//! executes, take the MEAN, and stop early once the candidate has
-//! provably lost.
-//!
-//! # What is mirrored, and the two places this differs
-//!
-//! MIRRORED. One warmup execution (validity + first-touch costs), then
-//! `trials` timed executions; the metric is the MEAN over trials (ruling
-//! 2, 2026-09-02 — a mean only rises as trials accumulate, which is what
-//! makes the early stop an exact argument rather than a guess); the
-//! early stop applies [`crate::search::early_stop_exceeded`] at factor
-//! 1.0 to a LOWER BOUND on the final mean.
-//!
-//! DIFFERENCE 1 — THE DEVICE IS PERSISTENT, the runtime is not rebuilt.
-//! The reference evaluator builds a FRESH `ReferenceRuntime` per
-//! candidate because its runtime is a cheap host object. Here the
-//! equivalent would throw away the CUDA context and the NVRTC module
-//! cache between candidates and recompile every kernel, which is most of
-//! a CUDA search's wall time. So the caller's [`crate::device::CudaDevice`]
-//! is reused: compilation is paid ONCE PER DISTINCT KERNEL SOURCE across
-//! the whole search. What is NOT carried between candidates is the arena
-//! slab — see the slab note on [`profile_candidate`].
-//!
-//! DIFFERENCE 2 — THE TIMED REGION INCLUDES STAGING AND READBACK.
-//! [`crate::device::execute_plan`] is one call that allocates, H2Ds the
-//! staged inputs, launches, synchronizes and D2Hs the outputs; the
-//! reference's `execute()` runs only the kernels, because its
-//! `set_data_buffer` is a separate ladder step. Splitting CL's execute
-//! into stage-once/run-many is real surgery on the executor and is NOT
-//! done here. The consequence is stated rather than hidden: a candidate's
-//! measured mean carries a per-call H2D/D2H term that is essentially the
-//! same for every candidate (same inputs, same outputs), so the RANKING
-//! is preserved while the absolute numbers are inflated — read a CL
-//! device measurement as "the cost of one whole `execute` call", which
-//! is exactly what the serving ladder pays anyway.
-
+//! Search profiling uses the serving graph path. Preparation/instantiation is
+//! outside the timed trials; staging, graph replay, and readback are timed.
 use std::time::{Duration, Instant};
 
 use luminal::bufferize::BufferIrGraph;
 use luminal::layouts::DecodedLayout;
 use luminal::prelude::FxHashMap;
 
-use crate::device::{CudaDevice, execute_plan};
+use crate::device::CudaDevice;
 use crate::host_buffer::HostBuffer;
 use crate::search::early_stop_exceeded;
 
@@ -100,50 +58,27 @@ impl std::fmt::Display for ProfileFailure {
     }
 }
 
-/// PRICE ONE CANDIDATE ON THE DEVICE.
-///
-/// Phases, in order:
-///
-/// 1. PREPARE — one untimed `execute_plan`. This compiles every kernel
-///    the plan needs through the device's persistent module cache, grows
-///    the slab, stages the inputs and runs once, so it doubles as the
-///    validity check the reference evaluator's warmup is. A failure here
-///    is [`ProfileFailure::Prepare`].
-/// 2. TIMED RUN — `trials.max(1)` executions, each timed host-side
-///    around `execute_plan`, which synchronizes the stream before it
-///    returns. (CUDA events would measure the same interval minus the
-///    host-side launch overhead; host timers are used because the whole
-///    call — allocation, H2D, launches, D2H — is what is being priced,
-///    and the synchronize makes the host clock honest about the device
-///    work. Events are the deferred refinement, not a correction.)
-/// 3. EARLY STOP — after each trial, if even the LOWER BOUND on this
-///    candidate's final mean (sum so far divided by ALL trials) already
-///    exceeds `best_so_far`, the remaining trials cannot change the
-///    outcome and are skipped.
-///
-/// THE TIMEOUT COVERS THE TIMED RUN AND NOTHING ELSE (Austin, ambiguity
-/// 1: *"timeout should just cover run"*). The clock starts at the first
-/// timed trial — after compilation — and is read BETWEEN trials, so a
-/// budget is never charged for NVRTC work that the next candidate gets
-/// for free from the module cache, and a trial in flight is never
-/// interrupted (there is no cancel for a launched kernel; the honest
-/// thing is to finish the trial and then stop).
-///
-/// THE SLAB IS THE CALLER'S TO RELEASE. This function grows it through
-/// `execute_plan` and leaves it; `crate::search` releases it after each
-/// candidate (#422 reversing #401's search-time retention), so one
-/// outsized candidate cannot hold device memory hostage for the rest of
-/// the search. Serving never releases it.
-pub fn profile_candidate(
+/// Compile and instantiate once, warm up once, then time the same execution
+/// path used for serving: host staging, graph launch, synchronization, readback.
+/// Timeouts cover timed trials only. The caller releases candidate graphs and
+/// arena afterwards, retaining the shared context and compiled module cache.
+#[allow(clippy::too_many_arguments)]
+pub fn profile_candidate_at(
     device: &mut CudaDevice,
     plan: &BufferIrGraph<DecodedLayout>,
     staged: &FxHashMap<i64, &HostBuffer>,
     trials: usize,
     best_so_far: Option<u128>,
     candidate_timeout: Option<Duration>,
+    shapes: &crate::symbolic::ShapeEnv,
 ) -> Result<Measurement, ProfileFailure> {
     // 1. PREPARE: compile + stage + one untimed run (warmup + validity).
-    execute_plan(device, plan, staged).map_err(ProfileFailure::Prepare)?;
+    let staged =
+        prepare_candidate(device, plan, staged, shapes).map_err(ProfileFailure::Prepare)?;
+    let staged = staged.iter().map(|(k, v)| (*k, v.as_ref())).collect();
+    device
+        .execute(0, &staged, &shapes.values)
+        .map_err(ProfileFailure::Prepare)?;
 
     // 2. THE TIMED RUN. The budget's clock starts HERE.
     let total = trials.max(1);
@@ -151,7 +86,9 @@ pub fn profile_candidate(
     let mut sum = 0u128;
     for trial in 0..total {
         let start = Instant::now();
-        execute_plan(device, plan, staged).map_err(ProfileFailure::Execute)?;
+        device
+            .execute(0, &staged, &shapes.values)
+            .map_err(ProfileFailure::Execute)?;
         sum += start.elapsed().as_nanos();
         let completed = trial + 1;
         if completed == total {
@@ -185,4 +122,57 @@ pub fn profile_candidate(
         mean_nanos: sum / total as u128,
         completed_trials: total,
     })
+}
+
+/// Static-plan entry point retained for lower-level callers.
+pub fn profile_candidate(
+    device: &mut CudaDevice,
+    plan: &BufferIrGraph<DecodedLayout>,
+    staged: &FxHashMap<i64, &HostBuffer>,
+    trials: usize,
+    best: Option<u128>,
+    timeout: Option<Duration>,
+) -> Result<Measurement, ProfileFailure> {
+    profile_candidate_at(
+        device,
+        plan,
+        staged,
+        trials,
+        best,
+        timeout,
+        &Default::default(),
+    )
+}
+
+/// Search probes geometry at a bucket's representative. If supplied dynamic
+/// input data belongs to another size, preserve its prefix and zero-fill the
+/// rest for timing. Serving always requires exact payload sizes.
+pub(crate) fn prepare_candidate<'a>(
+    device: &mut CudaDevice,
+    plan: &BufferIrGraph<DecodedLayout>,
+    staged: &FxHashMap<i64, &'a HostBuffer>,
+    shapes: &crate::symbolic::ShapeEnv,
+) -> anyhow::Result<FxHashMap<i64, std::borrow::Cow<'a, HostBuffer>>> {
+    let mut owned = FxHashMap::default();
+    for buffer in plan.buffers.values() {
+        if let Some(lit) = buffer.lit
+            && let Some(data) = staged.get(&lit)
+        {
+            let mut data = std::borrow::Cow::Borrowed(*data);
+            let mut vars = std::collections::BTreeSet::new();
+            crate::symbolic::vars(&crate::symbolic::span(&buffer.layout)?.0, &mut vars);
+            if vars
+                .iter()
+                .any(|s| shapes.bounds.get(s).is_some_and(|(lo, hi)| lo != hi))
+            {
+                let bytes = crate::symbolic::bytes(&buffer.layout, &shapes.values)?;
+                if bytes != data.bytes.len() {
+                    data.to_mut().bytes.resize(bytes, 0);
+                }
+            }
+            owned.insert(lit, data);
+        }
+    }
+    device.install(vec![(plan.clone(), shapes.bounds.clone())])?;
+    Ok(owned)
 }

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -84,6 +84,7 @@ pub struct CudaRuntime {
     dim_buckets: std::collections::BTreeMap<shape::Symbol, Vec<graph::DimBucket>>,
     /// One finished plan per Cartesian bucket combination.
     bucket_plans: Vec<crate::search::BucketPlan>,
+    selected_bucket: Option<usize>,
     /// The dim values this runtime currently holds — every `[n, n]`
     /// `bind_dyn_range` pin plus whatever [`Self::set_dim`] sets. With
     /// buckets bound this is what picks the plan at execute time.
@@ -229,6 +230,17 @@ impl CudaRuntime {
         &self.allow
     }
 
+    fn invalidate_plans(&mut self) {
+        self.plan = None;
+        self.bucket_plans.clear();
+        self.selected_bucket = None;
+        self.outputs_host.clear();
+        #[cfg(feature = "device")]
+        if let Some(device) = &mut self.device {
+            device.release_slab();
+        }
+    }
+
     /// Seed interval bounds for a dynamic dimension (facts, never pins:
     /// `[n, n]` is how a caller pins).
     pub fn bind_dyn_range(
@@ -238,6 +250,16 @@ impl CudaRuntime {
         upper: u64,
     ) -> Result<()> {
         let name = var.into();
+        let (lower, upper) = self
+            .range_bound
+            .get(&name)
+            .map(|(lo, hi)| (lower.max(*lo), upper.min(*hi)))
+            .unwrap_or((lower, upper));
+        anyhow::ensure!(
+            lower <= upper,
+            "empty dimension range for `{name}`: [{lower}, {upper}]"
+        );
+        anyhow::ensure!(upper <= i64::MAX as u64, "dimension range exceeds i64");
         anyhow::ensure!(
             !self.dim_buckets.contains_key(&name),
             "dim `{name}` has buckets bound; a bucketed dim is seeded per bucket \
@@ -259,6 +281,7 @@ impl CudaRuntime {
         if lower == upper {
             self.dims.insert(name, lower as usize);
         }
+        self.invalidate_plans();
         Ok(())
     }
 
@@ -303,6 +326,7 @@ impl CudaRuntime {
             );
         }
         self.dim_buckets.insert(dim, buckets);
+        self.invalidate_plans();
         Ok(())
     }
 
@@ -317,40 +341,25 @@ impl CudaRuntime {
         &self.bucket_plans
     }
 
-    /// Pick and load the bucket plan covering the current dims.
-    ///
-    /// THE STATIC-PLAN REFUSAL (the Phase 1 limitation, stated rather
-    /// than solved): a bucket's winning plan was searched at ONE pin and
-    /// carries LITERAL spans, so it allocates and indexes for that pin
-    /// and nothing else. Executing it at another value inside the same
-    /// bucket would silently run the representative's geometry over the
-    /// caller's data, so it is refused by name. Lifting this needs
-    /// symbolic plans (spans as expressions) and the capacity contract
-    /// that goes with them.
+    /// Pick the range-valid plan covering the current dimensions.
     fn select_bucket_plan(&mut self) -> Result<()> {
-        let Some(plan) = crate::search::select_bucket(&self.bucket_plans, &self.dims) else {
-            let covered: Vec<_> = self.bucket_plans.iter().map(|p| p.ranges.clone()).collect();
-            bail!(
-                "no bucket covers dims {:?}; the searched buckets are {covered:?}",
-                self.dims
-            );
-        };
-        for (dim, representative) in &plan.representative {
-            if let Some(value) = self.dims.get(dim) {
-                anyhow::ensure!(
-                    value == representative,
-                    "bucket {:?} was searched at `{dim} = {representative}` and its plan is \
-                     STATIC at that pin (plan spans are literals), but this runtime is set \
-                     to `{dim} = {value}`. Re-search at this pin, or pick a bucket whose \
-                     representative is it. Running the representative's plan here would \
-                     silently use the wrong geometry — the open item is symbolic plans \
-                     (spans as expressions) and the capacity contract that goes with them.",
-                    plan.ranges
-                );
-            }
-        }
-        self.plan = Some(plan.plan.clone());
+        let index = self
+            .bucket_plans
+            .iter()
+            .position(|p| {
+                p.ranges
+                    .iter()
+                    .all(|(s, (lo, hi))| self.dims.get(s).is_some_and(|v| v >= lo && v <= hi))
+            })
+            .ok_or_else(|| anyhow!("no bucket covers dims {:?}", self.dims))?;
+        self.selected_bucket = Some(index);
         Ok(())
+    }
+
+    /// Cumulative graph/arena counters, available after first device use.
+    #[cfg(feature = "device")]
+    pub fn graph_stats(&self) -> Option<crate::device::GraphStats> {
+        self.device.as_ref().map(|d| d.stats())
     }
 
     /// The ops this runtime claims: the CUDA analogue of
@@ -482,6 +491,22 @@ impl CudaRuntime {
         input_data: &FxHashMap<NodeIndex, HostBuffer>,
         options: &CompileOptions,
     ) -> Result<SearchOutcome> {
+        self.invalidate_plans();
+        let mut resolved_options = options.clone();
+        resolved_options.shapes.bounds = self
+            .range_bound
+            .iter()
+            .map(|(s, (lo, hi))| Ok((*s, (usize::try_from(*lo)?, usize::try_from(*hi)?))))
+            .collect::<Result<_>>()?;
+        resolved_options.shapes.values = self.dims.clone();
+        for (s, (lo, hi)) in &resolved_options.shapes.bounds {
+            resolved_options
+                .shapes
+                .values
+                .entry(*s)
+                .or_insert(lo + (hi - lo) / 2);
+        }
+        let options = &resolved_options;
         let native = self
             .native
             .as_ref()
@@ -610,14 +635,17 @@ impl CudaRuntime {
             // installed plan fits the caller's device budget is a
             // property of what is installed, and an unbucketed install is
             // a set of one.
-            let finalists = vec![crate::finalists::Finalists::new(
-                "the search",
-                &serialized,
-                Some(allow.clone()),
-                matchers,
-                outcome.ranked.clone(),
-                Some(outcome.best_plan.clone()),
-            )];
+            let finalists = vec![
+                crate::finalists::Finalists::new(
+                    "the search",
+                    &serialized,
+                    Some(allow.clone()),
+                    matchers,
+                    outcome.ranked.clone(),
+                    Some(outcome.best_plan.clone()),
+                )
+                .with_shapes(options.shapes.clone()),
+            ];
             let (selected, rejections) =
                 crate::search::select_finalist_set(finalists, options, &mut evaluator)?;
             outcome.lattice_rejections = rejections;
@@ -628,8 +656,7 @@ impl CudaRuntime {
             (outcome, Some(finalist.plan), Vec::new())
         } else {
             // BUCKETED (D7): one search per Cartesian combination, each
-            // validated bucket-wide before its representative is
-            // searched. The caller's data is staged ONCE and every
+            // searched and validated over the complete interval. The caller's data is staged ONCE and every
             // bucket's search borrows the same map — a bucket only
             // changes the dim seeds, never the payloads.
             let assembly = crate::search::BucketAssembly {
@@ -640,7 +667,7 @@ impl CudaRuntime {
                 post_checks: &native.post_checks,
                 input_slots: &native.input_slots,
                 output_slots: &native.output_slots,
-                base_dims: &self.dims,
+                base_dims: &options.shapes.values,
                 decoders: &self.decoders,
             };
             let plans = crate::search::bucketed_search_implementations(
@@ -657,9 +684,8 @@ impl CudaRuntime {
                 .ok_or_else(|| anyhow!("bucketed search produced no plans"))?;
             (first, None, plans)
         };
-        if !searched_buckets.is_empty() {
-            self.bucket_plans = searched_buckets;
-        }
+        self.bucket_plans = searched_buckets;
+        self.selected_bucket = None;
 
         let native = self
             .native
@@ -702,9 +728,7 @@ impl CudaRuntime {
     /// Run the plan on the CUDA device. Requires the `device` feature
     /// and an available device; refuses loudly otherwise.
     pub fn execute(&mut self) -> Result<()> {
-        // With buckets bound, the plan is chosen HERE, from the current
-        // dims (see [`Self::select_bucket_plan`] for the static-plan
-        // refusal). Without them nothing changes.
+        // Select a range-valid plan using the current dimensions.
         if !self.bucket_plans.is_empty() {
             self.select_bucket_plan()?;
         }
@@ -716,28 +740,42 @@ impl CudaRuntime {
             if self.device.is_none() {
                 self.device = Some(crate::device::CudaDevice::new(0)?);
             }
-            let plan = self
-                .plan
-                .as_ref()
-                .ok_or_else(|| anyhow!("search before execute"))?;
-            // SERVING KEEPS THE SLAB (#422 policy, Phase 4): nothing
-            // here releases it — only the search does, between
-            // candidates.
-            let staged: FxHashMap<i64, &HostBuffer> =
-                self.staged.iter().map(|(lit, data)| (*lit, data)).collect();
-            let device = self
-                .device
-                .as_mut()
-                .expect("the device was just created if it was missing");
-            let outputs = crate::device::execute_plan(device, plan, &staged)?;
+            anyhow::ensure!(
+                self.plan.is_some() || !self.bucket_plans.is_empty(),
+                "search before execute"
+            );
+            let device = self.device.as_mut().unwrap();
+            if !device.is_installed() {
+                let base_bounds: crate::symbolic::Bounds = self
+                    .range_bound
+                    .iter()
+                    .map(|(s, (lo, hi))| Ok((*s, (usize::try_from(*lo)?, usize::try_from(*hi)?))))
+                    .collect::<Result<_>>()?;
+
+                let plans = if self.bucket_plans.is_empty() {
+                    vec![(self.plan.as_ref().unwrap().clone(), base_bounds)]
+                } else {
+                    self.bucket_plans
+                        .iter()
+                        .map(|p| {
+                            let mut bounds = base_bounds.clone();
+                            bounds.extend(p.ranges.iter().map(|(k, v)| (*k, *v)));
+                            (p.plan.clone(), bounds)
+                        })
+                        .collect()
+                };
+                device.install(plans)?;
+            }
+            let bucket = self.selected_bucket.unwrap_or(0);
+            let staged = self.staged.iter().map(|(lit, data)| (*lit, data)).collect();
+            let outputs = device.execute(bucket, &staged, &self.dims)?;
             self.outputs_host = outputs;
             Ok(())
         }
         #[cfg(not(feature = "device"))]
         {
             let _ = self
-                .plan
-                .as_ref()
+                .plan()
                 .ok_or_else(|| anyhow!("search before execute"))?;
             bail!(
                 "cuda-lite built without the `device` feature: plans can be \
@@ -828,6 +866,9 @@ impl CudaRuntime {
 
     /// The searched plan, for inspection and tests.
     pub fn plan(&self) -> Option<&BufferIrGraph<DecodedLayout>> {
-        self.plan.as_ref()
+        self.selected_bucket
+            .and_then(|i| self.bucket_plans.get(i))
+            .map(|p| &p.plan)
+            .or(self.plan.as_ref())
     }
 }

--- a/crates/luminal_cuda_lite/src/search.rs
+++ b/crates/luminal_cuda_lite/src/search.rs
@@ -124,6 +124,8 @@ pub struct CompileOptions {
     /// has to fit is `max` over the buckets, and no single bucket's
     /// search can see that number.
     pub device_budget_bytes: Option<usize>,
+    /// Shape environment for lower-level search callers. The runtime fills this from bindings.
+    pub shapes: crate::symbolic::ShapeEnv,
 }
 
 impl Default for CompileOptions {
@@ -139,6 +141,7 @@ impl Default for CompileOptions {
             candidate_timeout: None,
             keep_finalists: 4,
             device_budget_bytes: None,
+            shapes: Default::default(),
         }
     }
 }
@@ -551,13 +554,14 @@ pub fn search_implementations(
                                      before the loop"
                                 )
                             };
-                            let measured = crate::profile::profile_candidate(
+                            let measured = crate::profile::profile_candidate_at(
                                 device,
                                 &plan,
                                 staged,
                                 options.trials,
                                 best.as_ref().map(|incumbent| incumbent.nanos),
                                 options.candidate_timeout,
+                                &options.shapes,
                             );
                             device.release_slab();
                             match measured {
@@ -729,7 +733,7 @@ pub fn search_implementations(
 ///   already extracted, bufferized and arena-planned, and there is
 ///   nothing further a host with no GPU can check. The filter passes.
 /// * ON DEVICE (`profile_on_device` with a live evaluator): ONE warmup
-///   `execute_plan` — NVRTC compile, stage, launch, synchronize — which
+///   graph preparation and execution — compile, stage, launch, synchronize — which
 ///   is exactly the viability check the profiler's prepare phase is. The
 ///   slab is released afterwards, matching the search's own per-candidate
 ///   hygiene (#422): finalist validation must not leave an outsized
@@ -748,7 +752,12 @@ pub fn finalist_validate(
         if options.profile_on_device
             && let Evaluator::Device { device, staged } = evaluator
         {
-            let ran = crate::device::execute_plan(device, &pending.plan, staged);
+            let ran =
+                crate::profile::prepare_candidate(device, &pending.plan, staged, &pending.shapes)
+                    .and_then(|staged| {
+                        let borrowed = staged.iter().map(|(k, v)| (*k, v.as_ref())).collect();
+                        device.execute(0, &borrowed, &pending.shapes.values)
+                    });
             device.release_slab();
             ran.map_err(|err| format!("device warmup of ranked #{}: {err:#}", pending.rank))?;
         }
@@ -760,26 +769,9 @@ pub fn finalist_validate(
     Ok(())
 }
 
-/// THE SET CONSTRAINT — the aggregate half of the Phase 5 gate, and the
-/// whole reason a lattice exists on this runtime.
-///
-/// WHAT IS AGGREGATE HERE. This runtime's one resource that spans bucket
-/// plans is the ARENA SLAB: [`crate::device::CudaDevice`] keeps a single
-/// grow-only slab for its whole life and `ensure_slab` grows it to
-/// whatever the plan being executed needs, so a runtime serving several
-/// bucket plans ends up holding `max` over their `slab_bytes`. That
-/// maximum is what a device budget has to bound, and no single bucket's
-/// search can see it — which is precisely a set-level constraint.
-///
-/// WHY `max` AND NOT A SUM. The alternative reading — add each plan's
-/// standalone (boundary + escaping) allocations to the slab — was
-/// considered and rejected: those buffers are allocated inside one
-/// `execute_plan` call and dropped at its end, so they are never
-/// resident across buckets and adding them would charge a budget for
-/// memory that is never simultaneously held. The slab IS the retained
-/// footprint; everything else is per-execution.
-///
-/// `None` budget = unconstrained, which is every pre-Phase-5 caller.
+/// Bound the maximum resident arena across the installed bucket set. Each
+/// bucket includes temporaries, boundary device copies, metadata, and HostOp
+/// scratch. Their offsets overlay one allocation because launches are serial.
 fn validate_set(slab_bytes: &[usize], options: &CompileOptions) -> Result<(), String> {
     let Some(budget) = options.device_budget_bytes else {
         return Ok(());
@@ -892,9 +884,8 @@ pub struct BucketAssembly<'a> {
     pub post_checks: &'a str,
     pub input_slots: &'a [luminal::graph::InputSlot],
     pub output_slots: &'a [luminal::graph::OutputSlot],
-    /// Dim values the runtime already holds, carried into every bucket's
-    /// representative map so a plan records the full pin it was searched
-    /// at.
+    /// Values for profiling non-bucket dimensions. These never narrow the
+    /// range facts already present in binding_seeds.
     pub base_dims: &'a luminal::shape::DynMap,
     /// The runtime's `(sort, constructor)` decoders — what every
     /// bucket's saturated program is checked against by the assembly
@@ -902,21 +893,10 @@ pub struct BucketAssembly<'a> {
     pub decoders: &'a luminal::egglog_utils::eclass::ConstructorRegistry,
 }
 
-/// Range-seeded bucketed search: one Cartesian combination of
-/// `DimBucket`s per search, each combination run TWICE — a bucket-wide
-/// RANGE-seeded render whose WHOLE FIXPOINT (authoring checks included)
-/// must pass, proving the base logical program valid over the entire
-/// interval, then a representative-pinned render that is searched.
-/// [`select_bucket`] picks the covering plan at execute time.
-///
-/// THE LIMITATION, stated rather than solved (Phase 1 scope): each
-/// winning plan is STATIC at its representative — plans carry LITERAL
-/// spans, so a plan searched at `a = 3` allocates and indexes for `a =
-/// 3` and nothing else. Executing a bucket's plan at any OTHER value
-/// inside that bucket is REFUSED loudly by the runtime, naming the
-/// representative; it is never silently run. Lifting this needs symbolic
-/// plans (spans as expressions) and the capacity contract that goes with
-/// them — the open item this note points at.
+/// Search one range-seeded e-graph per Cartesian bucket combination. Both
+/// authoring checks and implementation selection use the entire interval.
+/// Representatives are used only to measure candidates; the installed plans
+/// retain symbolic geometry and are capacity-planned over their full bounds.
 pub fn bucketed_search_implementations(
     assembly: &BucketAssembly<'_>,
     dim_buckets: &BTreeMap<luminal::shape::Symbol, Vec<luminal::graph::DimBucket>>,
@@ -935,11 +915,17 @@ pub fn bucketed_search_implementations(
     let mut egraphs: Vec<egraph_serialize::EGraph> = Vec::new();
     let mut searched: Vec<SearchedBucket> = Vec::new();
     for (ranges, representative, program) in bucket_renders(assembly, dim_buckets)? {
+        let mut bucket_options = options.clone();
+        bucket_options.shapes.values = representative.clone();
+        bucket_options
+            .shapes
+            .bounds
+            .extend(ranges.iter().map(|(k, v)| (*k, *v)));
         let text = format!("{}\n\n{}", assembly.assembled_program, program.text);
         let mut egraph = luminal::egglog_snippet::new_egraph();
         egraph
             .parse_and_run_program(None, &text)
-            .map_err(|err| anyhow!("bucket {ranges:?} representative render fails: {err}"))?;
+            .map_err(|err| anyhow!("bucket {ranges:?} range render fails: {err}"))?;
         assembly.decoders.check(&egraph)?;
         let serialized = egraph
             .serialize(luminal::prelude::egglog::SerializeConfig::default())
@@ -947,7 +933,7 @@ pub fn bucketed_search_implementations(
         let outcome = search_implementations(
             &serialized,
             &program,
-            options,
+            &bucket_options,
             allow_override.clone(),
             matchers,
             // Every bucket's search prices on the SAME device: the
@@ -966,7 +952,10 @@ pub fn bucketed_search_implementations(
             .iter()
             .zip(&egraphs)
             .enumerate()
-            .map(|(index, ((ranges, _, _, outcome), egraph))| {
+            .map(|(index, ((ranges, representative, _, outcome), egraph))| {
+                let mut shapes = options.shapes.clone();
+                shapes.bounds.extend(ranges.iter().map(|(k, v)| (*k, *v)));
+                shapes.values = representative.clone();
                 crate::finalists::Finalists::new(
                     bucket_label(index, ranges),
                     egraph,
@@ -975,6 +964,7 @@ pub fn bucketed_search_implementations(
                     outcome.ranked.clone(),
                     Some(outcome.best_plan.clone()),
                 )
+                .with_shapes(shapes)
             })
             .collect();
         select_finalist_set(buckets, options, &mut evaluator)?
@@ -1004,7 +994,7 @@ pub fn bucketed_search_implementations(
 
 /// One combination after its genetic search, before the lattice has
 /// chosen which of its finalists to install: `(ranges, representative,
-/// pinned render, the search's report)`.
+/// range-valid render, the search's report)`.
 type SearchedBucket = (
     BTreeMap<luminal::shape::Symbol, (usize, usize)>,
     luminal::shape::DynMap,
@@ -1025,14 +1015,7 @@ pub(crate) fn bucket_label(
     format!("bucket {index} ({})", dims.join(", "))
 }
 
-/// One bucket combination's `(ranges, representative pins, pinned
-/// render)`, in sorted-dim Cartesian order. Each combination's
-/// BUCKET-WIDE VALIDATION render runs here, before its pinned render is
-/// handed back to be searched: the range-seeded program's whole fixpoint
-/// — authoring-contract checks included — must pass, which is what makes
-/// "the base logical program is valid over the whole bucket" a checked
-/// claim rather than an assumption. Ranges are seeded as intervals and
-/// do NOT collapse; only the representative render pins `[n, n]`.
+/// One combination's ranges, profiling dimensions, and range-valid program.
 type BucketRender = (
     BTreeMap<luminal::shape::Symbol, (usize, usize)>,
     luminal::shape::DynMap,
@@ -1096,9 +1079,6 @@ fn bucket_renders(
         // BUCKET-WIDE SOUNDNESS: the range-seeded render must run its
         // whole fixpoint over the interval.
         let mut validation_seeds: BTreeMap<luminal::shape::Symbol, (u64, u64)> = BTreeMap::new();
-        for (dim, value) in &representative {
-            validation_seeds.insert(*dim, (*value as u64, *value as u64));
-        }
         for (dim, (min, max)) in &ranges {
             validation_seeds.insert(*dim, (*min as u64, *max as u64));
         }
@@ -1108,12 +1088,9 @@ fn bucket_renders(
             .parse_and_run_program(None, &text)
             .map_err(|err| anyhow!("bucket {ranges:?} fails bucket-wide validation: {err}"))?;
 
-        // Representative render: pinned via tight bounds.
-        let mut pin_seeds: BTreeMap<luminal::shape::Symbol, (u64, u64)> = BTreeMap::new();
-        for (dim, value) in &representative {
-            pin_seeds.insert(*dim, (*value as u64, *value as u64));
-        }
-        renders.push((ranges, representative, assemble(&pin_seeds)));
+        // Extract from the range-valid fixpoint; pinning here can select an
+        // implementation whose guards do not hold at other bucket dimensions.
+        renders.push((ranges, representative, validation));
     }
     Ok(renders)
 }

--- a/crates/luminal_cuda_lite/src/storage.rs
+++ b/crates/luminal_cuda_lite/src/storage.rs
@@ -1,120 +1,362 @@
-//! Capacity layouts overlay every bucket in one device arena. Boundary buffers
-//! are private device copies: returned outputs are owned host bytes, so those
-//! ranges can also be reused by the next invocation/bucket.
+//! CUDA sizing adapter for the shared physical-lifetime planner. Finalist
+//! budgets and installed graphs use exactly the same schedule and offsets.
 use crate::{
-    arena::{ARENA_ALIGN, ArenaPlan, ArenaSlice, plan_arena},
+    arena::{ArenaPlan, plan_with_workspace},
     layouts::CudaPlan,
     symbolic::{Bounds, capacity_bytes},
 };
-use anyhow::{Result, anyhow, ensure};
+use anyhow::{Result, anyhow};
 
-#[cfg_attr(not(feature = "device"), allow(dead_code))]
-pub(crate) struct StoragePlan {
-    pub arena: ArenaPlan,
-    pub workspace: ArenaSlice,
-    pub staging_bytes: usize,
+pub(crate) fn plan(plan: &CudaPlan, bounds: &Bounds) -> Result<ArenaPlan> {
+    let parameter_bytes = bounds
+        .len()
+        .checked_mul(8)
+        .ok_or_else(|| anyhow!("parameter size overflow"))?
+        .max(8);
+    plan_with_workspace(
+        plan,
+        |buffer| capacity_bytes(&buffer.layout, bounds),
+        |node| match &plan.dag[node] {
+            luminal::bufferize::BufferNode::Compute { op, .. } => {
+                crate::as_host_op(op.as_ref()).map_or(Ok(0), |host| host.workspace_bytes(bounds))
+            }
+            _ => Ok(0),
+        },
+        parameter_bytes,
+    )
 }
-pub(crate) fn plan(plan: &CudaPlan, bounds: &Bounds) -> Result<StoragePlan> {
-    let mut arena = plan_arena(plan, |b| capacity_bytes(&b.layout, bounds))?;
-    let mut end = arena.slab_bytes;
-    let aligned = |v: usize| {
-        v.checked_add(ARENA_ALIGN - 1)
-            .map(|v| v / ARENA_ALIGN * ARENA_ALIGN)
-            .ok_or_else(|| anyhow!("arena size overflow"))
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arena::{ARENA_ALIGN, ArenaStep};
+    use luminal::{
+        buffer_tensor_ir::{BufferAlloc, BufferFree, BufferTensorIrOp, OpSlotNames},
+        bufferize::{
+            Buffer, BufferEdge, BufferId, BufferNode, EdgeKind, OutputBinding, Owner,
+            SlotDescriptor,
+        },
+        dtype::PlanDtype,
+        layout_ir::{Access, FreedBy},
+        layouts::{
+            BitWidthTerm, DecodedLayout, IntExprTerm, RightMajorContiguousElementLayout, ShapeTerm,
+        },
     };
-    // Stable order makes per-bucket pointer layouts reproducible.
-    let mut ids: Vec<_> = arena
-        .standalone
-        .iter()
-        .chain(&arena.donated)
-        .cloned()
-        .collect();
-    ids.sort_by_key(|id| format!("{id:?}"));
-    for id in ids {
-        let bytes = capacity_bytes(&plan.buffers[&id].layout, bounds)?;
-        let offset = aligned(end)?;
-        end = offset
-            .checked_add(bytes.max(1))
-            .ok_or_else(|| anyhow!("arena size overflow"))?;
-        arena.slices.insert(id, ArenaSlice { offset, bytes });
-    }
-    let mut scratch = 0;
-    for node in plan.dag.node_weights() {
-        if let luminal::bufferize::BufferNode::Compute { op, .. } = node
-            && let Some(host) = crate::as_host_op(op.as_ref())
-        {
-            scratch = scratch.max(host.workspace_bytes(bounds)?);
+
+    #[derive(Debug, Clone)]
+    struct ScratchCopy;
+    impl OpSlotNames for ScratchCopy {}
+    impl BufferTensorIrOp for ScratchCopy {
+        fn label(&self) -> &str {
+            "ScratchCopy"
         }
-        if let luminal::bufferize::BufferNode::BufferOutput { slots } = node {
-            for slot in slots {
-                let buffer = plan
-                    .buffers
-                    .get(&slot.buffer)
-                    .ok_or_else(|| anyhow!("unknown output buffer"))?;
-                ensure!(
-                    buffer.freed_by == luminal::layout_ir::FreedBy::Caller,
-                    "output slot {} has NON-ESCAPING buffer {} (FreedBy::Program)",
-                    slot.index,
-                    buffer.label
+        fn operand_reads_memory(&self, i: usize) -> bool {
+            i == 0
+        }
+        fn runtime_interface(&self) -> Option<&dyn std::any::Any> {
+            Some(crate::CudaOpInterface::host::<Self>())
+        }
+    }
+    impl crate::HostOp for ScratchCopy {
+        fn workspace_bytes(&self, bounds: &Bounds) -> Result<usize> {
+            Ok(bounds[&'n'.into()].1 * 16)
+        }
+        #[cfg(feature = "device")]
+        unsafe fn prepare(
+            &self,
+            ctx: &crate::host::HostOpContext<'_>,
+        ) -> Result<Box<dyn crate::host::PreparedHostOp>> {
+            struct Prepared {
+                src: u64,
+                dst: u64,
+                scratch: u64,
+                bytes: usize,
+            }
+            impl crate::host::PreparedHostOp for Prepared {
+                unsafe fn record(&self, capture: &crate::host::CaptureCtx<'_>) -> Result<()> {
+                    if self.bytes > 0 {
+                        unsafe {
+                            cudarc::driver::result::memcpy_dtod_async(
+                                self.scratch,
+                                self.src,
+                                self.bytes,
+                                capture.stream().cu_stream(),
+                            )?;
+                            cudarc::driver::result::memcpy_dtod_async(
+                                self.dst,
+                                self.scratch,
+                                self.bytes,
+                                capture.stream().cu_stream(),
+                            )?;
+                        }
+                    }
+                    Ok(())
+                }
+            }
+            Ok(Box::new(Prepared {
+                src: ctx.inputs[0].ptr,
+                dst: ctx.dest.ptr,
+                scratch: ctx.workspace.ptr,
+                bytes: ctx.dest.bytes,
+            }))
+        }
+    }
+
+    /// Two independent results with an early output boundary, a donated input,
+    /// a late input, and a HostOp whose scratch can overwrite the early result.
+    fn copy_plan() -> (CudaPlan, Vec<BufferId>) {
+        let mut plan = CudaPlan {
+            dag: Default::default(),
+            buffers: Default::default(),
+            value_buffer: Default::default(),
+            outputs: vec![],
+        };
+        let mut ids = vec![];
+        for (i, (name, owned, donated, wide)) in [
+            ("a", false, true, true),
+            ("early", true, false, true),
+            ("b", false, false, false),
+            ("temp", true, true, false),
+            ("out", true, false, false),
+            ("c", false, false, true),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let id = if owned {
+                BufferId::Allocated(i as u32)
+            } else {
+                BufferId::Boundary(name.into())
+            };
+            let layout = DecodedLayout::of(
+                RightMajorContiguousElementLayout {
+                    shape: ShapeTerm(vec![IntExprTerm::Mul(
+                        Box::new(IntExprTerm::Var("n".into())),
+                        Box::new(IntExprTerm::Lit(if wide { 4 } else { 1 })),
+                    )]),
+                    width: BitWidthTerm(32),
+                },
+                Some(PlanDtype::F32),
+            );
+            plan.buffers.insert(
+                id.clone(),
+                Buffer {
+                    id: id.clone(),
+                    access: Access::ReadWrite,
+                    freed_by: if donated {
+                        FreedBy::Program
+                    } else {
+                        FreedBy::Caller
+                    },
+                    owner: if owned { Owner::System } else { Owner::Caller },
+                    label: name.into(),
+                    lit: (!owned).then_some(i as i64),
+                    backs: name.into(),
+                    layout,
+                },
+            );
+            ids.push(id);
+        }
+        let desc = |i: usize| SlotDescriptor {
+            value: plan.buffers[&ids[i]].backs.clone(),
+            buffer: ids[i].clone(),
+            layout: plan.buffers[&ids[i]].layout.clone(),
+        };
+        let compute = |op: Box<dyn BufferTensorIrOp>, reads: Vec<usize>, writes: Vec<usize>| {
+            BufferNode::Compute {
+                op,
+                operand_info: reads.iter().map(|&i| desc(i)).collect(),
+                result_info: writes.iter().map(|&i| desc(i)).collect(),
+                reads: reads.into_iter().map(|i| ids[i].clone()).collect(),
+                writes: writes.into_iter().map(|i| ids[i].clone()).collect(),
+                ties: vec![],
+            }
+        };
+        let output = |slots: &[(usize, usize)]| BufferNode::BufferOutput {
+            slots: slots
+                .iter()
+                .map(|&(index, i)| OutputBinding {
+                    index,
+                    value: plan.buffers[&ids[i]].backs.clone(),
+                    buffer: ids[i].clone(),
+                    layout: plan.buffers[&ids[i]].layout.clone(),
+                })
+                .collect(),
+        };
+        let nodes = vec![
+            compute(Box::new(BufferAlloc), vec![], vec![1]),
+            BufferNode::BufferCopy {
+                src: ids[0].clone(),
+                dst: ids[1].clone(),
+            },
+            compute(Box::new(BufferFree), vec![0], vec![]),
+            output(&[(0, 1), (1, 1)]),
+            compute(Box::new(BufferAlloc), vec![], vec![3]),
+            BufferNode::BufferCopy {
+                src: ids[2].clone(),
+                dst: ids[3].clone(),
+            },
+            compute(Box::new(BufferAlloc), vec![], vec![4]),
+            compute(Box::new(ScratchCopy), vec![3, 4], vec![4]),
+            compute(Box::new(BufferFree), vec![3], vec![]),
+            output(&[(2, 4)]),
+            output(&[(3, 5)]),
+        ];
+        let mut previous = None;
+        for node in nodes {
+            let free =
+                matches!(&node, BufferNode::Compute { op, .. } if op.label() == "BufferFree");
+            let output = matches!(&node, BufferNode::BufferOutput { .. });
+            let at = plan.dag.add_node(node);
+            if let Some(prev) = previous {
+                plan.dag.add_edge(
+                    prev,
+                    at,
+                    BufferEdge {
+                        buffer: ids[0].clone(),
+                        port: "order".into(),
+                        kind: EdgeKind::Anti,
+                    },
                 );
             }
-        }
-    }
-    let workspace = ArenaSlice {
-        offset: aligned(end)?,
-        bytes: scratch,
-    };
-    arena.slab_bytes = workspace
-        .offset
-        .checked_add(scratch)
-        .ok_or_else(|| anyhow!("arena workspace overflow"))?
-        .max(1);
-    let prefix = aligned(
-        bounds
-            .len()
-            .checked_mul(8)
-            .ok_or_else(|| anyhow!("parameter size overflow"))?
-            .max(8),
-    )?;
-    for slice in arena.slices.values_mut() {
-        slice.offset = slice
-            .offset
-            .checked_add(prefix)
-            .ok_or_else(|| anyhow!("arena offset overflow"))?;
-    }
-    let workspace = ArenaSlice {
-        offset: workspace
-            .offset
-            .checked_add(prefix)
-            .ok_or_else(|| anyhow!("arena offset overflow"))?,
-        bytes: workspace.bytes,
-    };
-    arena.slab_bytes = arena
-        .slab_bytes
-        .checked_add(prefix)
-        .ok_or_else(|| anyhow!("arena size overflow"))?;
-    let mut staging_bytes = (bounds.len() * 8).max(8);
-    let mut reserve = |bytes: usize| -> Result<()> {
-        staging_bytes = staging_bytes
-            .checked_add(bytes.max(1))
-            .ok_or_else(|| anyhow!("staging size overflow"))?;
-        Ok(())
-    };
-    for (id, buffer) in &plan.buffers {
-        if buffer.lit.is_some() {
-            reserve(arena.slices[id].bytes)?;
-        }
-    }
-    for node in plan.dag.node_weights() {
-        if let luminal::bufferize::BufferNode::BufferOutput { slots } = node {
-            for slot in slots {
-                reserve(arena.slices[&slot.buffer].bytes)?;
+            if !free {
+                previous = Some(at);
+            }
+            if output {
+                plan.outputs.push(at);
             }
         }
+        (plan, ids)
     }
-    Ok(StoragePlan {
-        arena,
-        workspace,
-        staging_bytes,
-    })
+    fn bounds(hi: usize) -> Bounds {
+        [('n'.into(), (0, hi))].into_iter().collect()
+    }
+
+    #[test]
+    fn all_storage_classes_share_physical_ranges_and_transfer_lifetimes() {
+        let (graph, ids) = copy_plan();
+        let p = plan(&graph, &bounds(128)).unwrap();
+        let overlaps = |a: crate::arena::ArenaSlice, b: crate::arena::ArenaSlice| {
+            a.offset < b.offset + b.reserved() && b.offset < a.offset + a.reserved()
+        };
+        let scratch = *p.workspaces.values().next().unwrap();
+        assert!(
+            overlaps(scratch, p.slices[&ids[0]]) || overlaps(scratch, p.slices[&ids[1]]),
+            "scratch recycles donation/early output"
+        );
+        assert!(
+            overlaps(p.slices[&ids[0]], p.slices[&ids[5]])
+                || overlaps(p.slices[&ids[1]], p.slices[&ids[5]]),
+            "late input reuses an earlier device copy"
+        );
+        assert!(!overlaps(scratch, p.slices[&ids[3]]));
+        assert!(!overlaps(scratch, p.slices[&ids[4]]));
+        let uploads: Vec<_> = p
+            .steps
+            .iter()
+            .enumerate()
+            .filter_map(|(t, s)| match s {
+                ArenaStep::Upload { buffer, staging } => Some((t, buffer, staging)),
+                _ => None,
+            })
+            .collect();
+        let downloads: Vec<_> = p
+            .steps
+            .iter()
+            .enumerate()
+            .filter_map(|(t, s)| match s {
+                ArenaStep::Download {
+                    buffer,
+                    slots,
+                    staging,
+                    ..
+                } => Some((t, buffer, slots, staging)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            downloads.len(),
+            3,
+            "two aliased output slots use one transfer"
+        );
+        assert_eq!(downloads[0].2.len(), 2);
+        assert!(
+            downloads[0].0 < uploads.last().unwrap().0,
+            "early readback precedes late upload"
+        );
+        // Host inputs are all populated before launch: early downloads must
+        // not overwrite an input which has yet to be uploaded.
+        for (dt, _, _, dst) in &downloads {
+            for (ut, _, src) in &uploads {
+                if ut >= dt {
+                    assert!(
+                        dst.offset + dst.bytes <= src.offset
+                            || src.offset + src.bytes <= dst.offset
+                    );
+                }
+            }
+        }
+        let naive: usize = p.slices.values().map(|s| s.reserved()).sum::<usize>()
+            + scratch.reserved()
+            + ARENA_ALIGN;
+        assert!(
+            p.slab_bytes * 2 < naive,
+            "physical packing should more than halve this fixture: {} vs {naive}",
+            p.slab_bytes
+        );
+        assert_eq!(p.peak_live_bytes, p.slab_bytes);
+    }
+
+    #[cfg(feature = "device")]
+    #[test]
+    fn replay_preserves_early_outputs_and_late_inputs_across_shapes_and_buckets() {
+        use crate::{device::CudaDevice, host_buffer::HostBuffer};
+        use luminal::prelude::FxHashMap;
+        let (graph, _) = copy_plan();
+        let capacities = [32, 128];
+        let expected_bytes = capacities
+            .iter()
+            .map(|&hi| plan(&graph, &bounds(hi)).unwrap().slab_bytes)
+            .max()
+            .unwrap();
+        let mut device = CudaDevice::new(0).unwrap();
+        device
+            .install(
+                capacities
+                    .iter()
+                    .map(|&hi| (graph.clone(), bounds(hi)))
+                    .collect(),
+            )
+            .unwrap();
+        let mut retained = None;
+        for (bucket, n) in [(0, 7), (1, 128), (0, 0), (1, 13), (0, 32), (0, 7)] {
+            let a: Vec<_> = (0..n * 4).map(|i| i as f32 + 1.).collect();
+            let b: Vec<_> = (0..n).map(|i| i as f32 - 1000.).collect();
+            let c = vec![99f32; n * 4];
+            let data: FxHashMap<i64, HostBuffer> = [
+                (0, a.clone().into()),
+                (2, b.clone().into()),
+                (5, c.clone().into()),
+            ]
+            .into_iter()
+            .collect();
+            let staged = data.iter().map(|(&k, v)| (k, v)).collect();
+            let outputs = device
+                .execute(bucket, &staged, &[('n'.into(), n)].into_iter().collect())
+                .unwrap();
+            assert_eq!(outputs[&0].0.as_f32().unwrap(), a);
+            assert_eq!(outputs[&1].0.as_f32().unwrap(), a);
+            assert_eq!(outputs[&2].0.as_f32().unwrap(), b);
+            assert_eq!(outputs[&3].0.as_f32().unwrap(), c);
+            if retained.is_none() {
+                retained = Some(outputs);
+            }
+            assert_eq!(device.stats().arena_bytes, expected_bytes);
+            assert_eq!(device.stats().arena_generation, 1);
+        }
+        assert_eq!(
+            retained.unwrap()[&0].0.as_f32().unwrap(),
+            (1..=28).map(|i| i as f32).collect::<Vec<_>>()
+        );
+    }
 }

--- a/crates/luminal_cuda_lite/src/storage.rs
+++ b/crates/luminal_cuda_lite/src/storage.rs
@@ -1,0 +1,120 @@
+//! Capacity layouts overlay every bucket in one device arena. Boundary buffers
+//! are private device copies: returned outputs are owned host bytes, so those
+//! ranges can also be reused by the next invocation/bucket.
+use crate::{
+    arena::{ARENA_ALIGN, ArenaPlan, ArenaSlice, plan_arena},
+    layouts::CudaPlan,
+    symbolic::{Bounds, capacity_bytes},
+};
+use anyhow::{Result, anyhow, ensure};
+
+#[cfg_attr(not(feature = "device"), allow(dead_code))]
+pub(crate) struct StoragePlan {
+    pub arena: ArenaPlan,
+    pub workspace: ArenaSlice,
+    pub staging_bytes: usize,
+}
+pub(crate) fn plan(plan: &CudaPlan, bounds: &Bounds) -> Result<StoragePlan> {
+    let mut arena = plan_arena(plan, |b| capacity_bytes(&b.layout, bounds))?;
+    let mut end = arena.slab_bytes;
+    let aligned = |v: usize| {
+        v.checked_add(ARENA_ALIGN - 1)
+            .map(|v| v / ARENA_ALIGN * ARENA_ALIGN)
+            .ok_or_else(|| anyhow!("arena size overflow"))
+    };
+    // Stable order makes per-bucket pointer layouts reproducible.
+    let mut ids: Vec<_> = arena
+        .standalone
+        .iter()
+        .chain(&arena.donated)
+        .cloned()
+        .collect();
+    ids.sort_by_key(|id| format!("{id:?}"));
+    for id in ids {
+        let bytes = capacity_bytes(&plan.buffers[&id].layout, bounds)?;
+        let offset = aligned(end)?;
+        end = offset
+            .checked_add(bytes.max(1))
+            .ok_or_else(|| anyhow!("arena size overflow"))?;
+        arena.slices.insert(id, ArenaSlice { offset, bytes });
+    }
+    let mut scratch = 0;
+    for node in plan.dag.node_weights() {
+        if let luminal::bufferize::BufferNode::Compute { op, .. } = node
+            && let Some(host) = crate::as_host_op(op.as_ref())
+        {
+            scratch = scratch.max(host.workspace_bytes(bounds)?);
+        }
+        if let luminal::bufferize::BufferNode::BufferOutput { slots } = node {
+            for slot in slots {
+                let buffer = plan
+                    .buffers
+                    .get(&slot.buffer)
+                    .ok_or_else(|| anyhow!("unknown output buffer"))?;
+                ensure!(
+                    buffer.freed_by == luminal::layout_ir::FreedBy::Caller,
+                    "output slot {} has NON-ESCAPING buffer {} (FreedBy::Program)",
+                    slot.index,
+                    buffer.label
+                );
+            }
+        }
+    }
+    let workspace = ArenaSlice {
+        offset: aligned(end)?,
+        bytes: scratch,
+    };
+    arena.slab_bytes = workspace
+        .offset
+        .checked_add(scratch)
+        .ok_or_else(|| anyhow!("arena workspace overflow"))?
+        .max(1);
+    let prefix = aligned(
+        bounds
+            .len()
+            .checked_mul(8)
+            .ok_or_else(|| anyhow!("parameter size overflow"))?
+            .max(8),
+    )?;
+    for slice in arena.slices.values_mut() {
+        slice.offset = slice
+            .offset
+            .checked_add(prefix)
+            .ok_or_else(|| anyhow!("arena offset overflow"))?;
+    }
+    let workspace = ArenaSlice {
+        offset: workspace
+            .offset
+            .checked_add(prefix)
+            .ok_or_else(|| anyhow!("arena offset overflow"))?,
+        bytes: workspace.bytes,
+    };
+    arena.slab_bytes = arena
+        .slab_bytes
+        .checked_add(prefix)
+        .ok_or_else(|| anyhow!("arena size overflow"))?;
+    let mut staging_bytes = (bounds.len() * 8).max(8);
+    let mut reserve = |bytes: usize| -> Result<()> {
+        staging_bytes = staging_bytes
+            .checked_add(bytes.max(1))
+            .ok_or_else(|| anyhow!("staging size overflow"))?;
+        Ok(())
+    };
+    for (id, buffer) in &plan.buffers {
+        if buffer.lit.is_some() {
+            reserve(arena.slices[id].bytes)?;
+        }
+    }
+    for node in plan.dag.node_weights() {
+        if let luminal::bufferize::BufferNode::BufferOutput { slots } = node {
+            for slot in slots {
+                reserve(arena.slices[&slot.buffer].bytes)?;
+            }
+        }
+    }
+    Ok(StoragePlan {
+        arena,
+        workspace,
+        staging_bytes,
+    })
+}

--- a/crates/luminal_cuda_lite/src/symbolic.rs
+++ b/crates/luminal_cuda_lite/src/symbolic.rs
@@ -1,0 +1,427 @@
+//! Runtime evaluation and capacity bounds for the shared layout vocabulary.
+//! This module evaluates metadata only; operation selection remains in egglog.
+use anyhow::{Result, anyhow, bail, ensure};
+use luminal::layouts::{self, IntExprTerm as T, LayoutFacts};
+use luminal::shape::{DynMap, Symbol};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+pub type Bounds = BTreeMap<Symbol, (usize, usize)>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Expr(pub T);
+impl From<usize> for Expr {
+    fn from(v: usize) -> Self {
+        Self(T::Lit(i64::try_from(v).expect("dimension exceeds i64")))
+    }
+}
+impl std::ops::Mul for Expr {
+    type Output = Self;
+    fn mul(self, rhs: Self) -> Self {
+        Self(T::Mul(Box::new(self.0), Box::new(rhs.0))).simplify()
+    }
+}
+impl std::iter::Product for Expr {
+    fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(1usize.into(), |a, b| a * b)
+    }
+}
+impl<'a> std::iter::Product<&'a Expr> for Expr {
+    fn product<I: Iterator<Item = &'a Expr>>(iter: I) -> Self {
+        iter.cloned().product()
+    }
+}
+impl Expr {
+    fn simplify(self) -> Self {
+        self.0
+            .eval_literal()
+            .map(|v| Self(T::Lit(v)))
+            .unwrap_or(self)
+    }
+    pub fn eval(&self, dims: &DynMap) -> Result<usize> {
+        usize::try_from(if let Some(value) = self.0.eval_literal() {
+            value
+        } else {
+            eval(&self.0, dims)?
+        })
+        .map_err(Into::into)
+    }
+    pub fn capacity(&self, bounds: &Bounds) -> Result<usize> {
+        let (lo, hi) = interval(&self.0, bounds)?;
+        ensure!(lo >= 0, "negative dimension bound {lo} for {:?}", self.0);
+        Ok(usize::try_from(hi)?)
+    }
+    pub fn literal(&self) -> Option<usize> {
+        self.0.eval_literal().and_then(|v| usize::try_from(v).ok())
+    }
+}
+impl fmt::Display for Expr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&cuda(&self.0, &|_| panic!("coordinate in dimension")))
+    }
+}
+
+pub fn variable(name: &str) -> String {
+    let mut s = String::from("luminal_dim_");
+    for b in name.bytes() {
+        use std::fmt::Write;
+        write!(s, "{b:02x}").unwrap();
+    }
+    s
+}
+pub fn cuda(t: &T, coord: &dyn Fn(i64) -> String) -> String {
+    let go = |e: &T| cuda(e, coord);
+    match t {
+        T::Lit(v) => integer_literal(*v),
+        T::Var(s) => variable(s),
+        T::Coord { axis_from_end } => coord(*axis_from_end),
+        T::Add(a, b) => format!("({}+{})", go(a), go(b)),
+        T::Mul(a, b) => format!("({}*{})", go(a), go(b)),
+        T::TruncDiv(a, b) => format!("({}/{})", go(a), go(b)),
+        T::TruncRem(a, b) => format!("({}%{})", go(a), go(b)),
+        T::CeilDiv(a, b) => format!("luminal_ceil_div({}, {})", go(a), go(b)),
+        T::Min(a, b) => format!("luminal_min({}, {})", go(a), go(b)),
+        T::Max(a, b) => format!("luminal_max({}, {})", go(a), go(b)),
+        T::LessThanCast(a, b) => format!("({}<{} ? 1LL:0LL)", go(a), go(b)),
+    }
+}
+pub const CUDA_HELPERS: &str = "__device__ long long luminal_min(long long a,long long b){return a<b?a:b;}\n__device__ long long luminal_max(long long a,long long b){return a>b?a:b;}\n__device__ long long luminal_ceil_div(long long a,long long b){return a/b + (a%b != 0 && ((a>0)==(b>0)));}\n";
+
+pub fn eval(t: &T, dims: &DynMap) -> Result<i64> {
+    let bounds = dims.iter().map(|(s, v)| (*s, (*v, *v))).collect();
+    let (lo, hi) = interval(t, &bounds)?;
+    ensure!(lo == hi, "expression did not evaluate exactly");
+    Ok(lo)
+}
+pub fn interval(t: &T, bounds: &Bounds) -> Result<(i64, i64)> {
+    let checked =
+        |v: i128| i64::try_from(v).map_err(|_| anyhow!("shape expression overflow: {t:?}"));
+    let (lo, hi) = match t {
+        T::Lit(v) => (*v, *v),
+        T::Var(s) => {
+            let (lo, hi) = bounds
+                .get(&Symbol::from(s.as_str()))
+                .ok_or_else(|| anyhow!("unbound dimension `{s}`"))?;
+            (i64::try_from(*lo)?, i64::try_from(*hi)?)
+        }
+        T::Coord { .. } => bail!("coordinate-dependent allocation span: {t:?}"),
+        T::Add(a, b) => {
+            let (a, z) = interval(a, bounds)?;
+            let (b, y) = interval(b, bounds)?;
+            (
+                checked(a as i128 + b as i128)?,
+                checked(z as i128 + y as i128)?,
+            )
+        }
+        T::Mul(a, b) => {
+            let (a, z) = interval(a, bounds)?;
+            let (b, y) = interval(b, bounds)?;
+            let v = [
+                a as i128 * b as i128,
+                a as i128 * y as i128,
+                z as i128 * b as i128,
+                z as i128 * y as i128,
+            ];
+            (
+                checked(*v.iter().min().unwrap())?,
+                checked(*v.iter().max().unwrap())?,
+            )
+        }
+        T::TruncDiv(a, b) | T::CeilDiv(a, b) => {
+            let (a, z) = interval(a, bounds)?;
+            let (b, y) = interval(b, bounds)?;
+            ensure!(b > 0 || y < 0, "divisor interval contains zero: {t:?}");
+            let mut v = vec![];
+            for n in [a, z] {
+                for d in [b, y] {
+                    let (n, d) = (n as i128, d as i128);
+                    let q = n / d;
+                    v.push(
+                        q + if matches!(t, T::CeilDiv(..)) && n % d != 0 && ((n > 0) == (d > 0)) {
+                            1
+                        } else {
+                            0
+                        },
+                    );
+                }
+            }
+            (
+                checked(*v.iter().min().unwrap())?,
+                checked(*v.iter().max().unwrap())?,
+            )
+        }
+        T::TruncRem(a, b) => {
+            let (a, z) = interval(a, bounds)?;
+            let (b, y) = interval(b, bounds)?;
+            ensure!(b > 0 || y < 0, "divisor interval contains zero: {t:?}");
+            if a == z && b == y {
+                let r = checked(a as i128 % b as i128)?;
+                (r, r)
+            } else {
+                let m = (b as i128).abs().max((y as i128).abs()) - 1;
+                (
+                    if a < 0 {
+                        checked((-m).max(a as i128))?
+                    } else {
+                        0
+                    },
+                    if z > 0 { checked(m.min(z as i128))? } else { 0 },
+                )
+            }
+        }
+        T::Min(a, b) => {
+            let (a, z) = interval(a, bounds)?;
+            let (b, y) = interval(b, bounds)?;
+            (a.min(b), z.min(y))
+        }
+        T::Max(a, b) => {
+            let (a, z) = interval(a, bounds)?;
+            let (b, y) = interval(b, bounds)?;
+            (a.max(b), z.max(y))
+        }
+        T::LessThanCast(a, b) => {
+            let (a, z) = interval(a, bounds)?;
+            let (b, y) = interval(b, bounds)?;
+            if z < b {
+                (1, 1)
+            } else if a >= y {
+                (0, 0)
+            } else {
+                (0, 1)
+            }
+        }
+    };
+    ensure!(lo <= hi, "invalid dimension interval {lo}..{hi}");
+    Ok((lo, hi))
+}
+pub fn vars(t: &T, out: &mut BTreeSet<Symbol>) {
+    match t {
+        T::Var(s) => {
+            out.insert(Symbol::from(s.as_str()));
+        }
+        T::Lit(_) | T::Coord { .. } => {}
+        T::Add(a, b)
+        | T::Mul(a, b)
+        | T::TruncDiv(a, b)
+        | T::TruncRem(a, b)
+        | T::CeilDiv(a, b)
+        | T::Min(a, b)
+        | T::Max(a, b)
+        | T::LessThanCast(a, b) => {
+            vars(a, out);
+            vars(b, out);
+        }
+    }
+}
+pub fn substitute(t: &T, dims: &DynMap) -> Result<T> {
+    let go = |t: &T| substitute(t, dims).map(Box::new);
+    Ok(match t {
+        T::Var(_) => T::Lit(eval(t, dims)?),
+        T::Lit(_) | T::Coord { .. } => t.clone(),
+        T::Add(a, b) => T::Add(go(a)?, go(b)?),
+        T::Mul(a, b) => T::Mul(go(a)?, go(b)?),
+        T::TruncDiv(a, b) => T::TruncDiv(go(a)?, go(b)?),
+        T::TruncRem(a, b) => T::TruncRem(go(a)?, go(b)?),
+        T::CeilDiv(a, b) => T::CeilDiv(go(a)?, go(b)?),
+        T::Min(a, b) => T::Min(go(a)?, go(b)?),
+        T::Max(a, b) => T::Max(go(a)?, go(b)?),
+        T::LessThanCast(a, b) => T::LessThanCast(go(a)?, go(b)?),
+    })
+}
+pub fn resolve_layout(l: &layouts::DecodedLayout, dims: &DynMap) -> Result<layouts::DecodedLayout> {
+    let shape = layouts::ShapeTerm(
+        l.shape()
+            .0
+            .iter()
+            .map(|e| substitute(e, dims))
+            .collect::<Result<_>>()?,
+    );
+    let mut spellings: Vec<std::sync::Arc<dyn LayoutFacts>> = vec![];
+    if let Some(s) = l.first::<layouts::RightMajorContiguousElementLayout>() {
+        spellings.push(std::sync::Arc::new(
+            layouts::RightMajorContiguousElementLayout {
+                shape: shape.clone(),
+                width: s.width,
+            },
+        ));
+    }
+    if let Some(s) = l.first::<layouts::LeftMajorContiguousElementLayout>() {
+        spellings.push(std::sync::Arc::new(
+            layouts::LeftMajorContiguousElementLayout {
+                shape: shape.clone(),
+                width: s.width,
+            },
+        ));
+    }
+    if let Some(s) = l.first::<layouts::StridedElementLayout>() {
+        spellings.push(std::sync::Arc::new(layouts::StridedElementLayout {
+            shape: shape.clone(),
+            width: s.width,
+            chain: s
+                .chain
+                .iter()
+                .map(|e| substitute(e, dims))
+                .collect::<Result<_>>()?,
+        }));
+    }
+    if let Some(s) = l.first::<layouts::ElementOffsetExpressionLayout>() {
+        spellings.push(std::sync::Arc::new(
+            layouts::ElementOffsetExpressionLayout {
+                shape: shape.clone(),
+                width: s.width,
+                offset: substitute(&s.offset, dims)?,
+            },
+        ));
+    }
+    if let Some(s) = l.first::<layouts::BitOffsetExpressionLayout>() {
+        spellings.push(std::sync::Arc::new(layouts::BitOffsetExpressionLayout {
+            shape,
+            width: s.width,
+            offset: substitute(&s.offset, dims)?,
+        }));
+    }
+    ensure!(
+        !spellings.is_empty(),
+        "unsupported layout {:?}",
+        l.present()
+    );
+    let mut out = layouts::DecodedLayout::of_spellings(spellings, l.dtype);
+    out.class = l.class.clone();
+    Ok(out)
+}
+pub fn span(l: &layouts::DecodedLayout) -> Result<Expr> {
+    l.spellings
+        .iter()
+        .find_map(|s| s.span_elements())
+        .map(Expr)
+        .ok_or_else(|| anyhow!("layout {:?} has no storage span", l.present()))
+}
+pub fn bytes(l: &layouts::DecodedLayout, dims: &DynMap) -> Result<usize> {
+    span(l)?
+        .eval(dims)?
+        .checked_mul(crate::host_buffer::dtype_bytes(
+            l.dtype.ok_or_else(|| anyhow!("layout has no dtype"))?,
+        )?)
+        .ok_or_else(|| anyhow!("buffer byte size overflow"))
+}
+pub fn capacity_bytes(l: &layouts::DecodedLayout, bounds: &Bounds) -> Result<usize> {
+    span(l)?
+        .capacity(bounds)?
+        .checked_mul(crate::host_buffer::dtype_bytes(
+            l.dtype.ok_or_else(|| anyhow!("layout has no dtype"))?,
+        )?)
+        .ok_or_else(|| anyhow!("buffer capacity overflow"))
+}
+
+/// Translate index metadata into the same expression vocabulary as layouts.
+pub fn iota_term(e: &luminal::index_expr::IotaExpr) -> Option<T> {
+    use luminal::index_expr::IotaExpr as I;
+    let go = |e: &I| iota_term(e).map(Box::new);
+    Some(match e {
+        I::Lit(v) => T::Lit(*v),
+        I::Var(s) => T::Var(s.clone()),
+        I::Coord(a) => T::Coord {
+            axis_from_end: *a as i64,
+        },
+        I::Add(a, b) => T::Add(go(a)?, go(b)?),
+        I::Mul(a, b) => T::Mul(go(a)?, go(b)?),
+        I::TruncDiv(a, b) => T::TruncDiv(go(a)?, go(b)?),
+        I::TruncRem(a, b) => T::TruncRem(go(a)?, go(b)?),
+        I::CeilDiv(a, b) => T::CeilDiv(go(a)?, go(b)?),
+        I::Min(a, b) => T::Min(go(a)?, go(b)?),
+        I::Max(a, b) => T::Max(go(a)?, go(b)?),
+        I::LessThanCast(a, b) => T::LessThanCast(go(a)?, go(b)?),
+    })
+}
+
+/// Capacity bounds and concrete dimensions used to prepare/profile a plan.
+#[derive(Debug, Clone, Default)]
+pub struct ShapeEnv {
+    pub bounds: Bounds,
+    pub values: DynMap,
+}
+
+/// C lexes a sign separately; spell i64::MIN without an out-of-range literal.
+pub fn integer_literal(v: i64) -> String {
+    if v == i64::MIN {
+        "(-9223372036854775807LL - 1LL)".into()
+    } else {
+        format!("{v}LL")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn var() -> T {
+        T::Var("n".into())
+    }
+    fn lit(v: i64) -> Box<T> {
+        Box::new(T::Lit(v))
+    }
+    #[test]
+    fn capacities_cover_interior_extrema_and_arithmetic() {
+        // n*(10-n) peaks inside [1,9]. Using endpoint sizes would underallocate.
+        let terms = [
+            T::Mul(
+                Box::new(var()),
+                Box::new(T::Add(lit(10), Box::new(T::Mul(lit(-1), Box::new(var()))))),
+            ),
+            T::TruncRem(Box::new(var()), lit(4)),
+            T::CeilDiv(Box::new(var()), lit(4)),
+            T::Min(Box::new(var()), lit(5)),
+            T::Max(Box::new(var()), lit(5)),
+            T::LessThanCast(Box::new(var()), lit(5)),
+        ];
+        let bounds = [('n'.into(), (1, 9))].into_iter().collect();
+        for term in terms {
+            let capacity = Expr(term.clone()).capacity(&bounds).unwrap();
+            for n in 1..=9 {
+                let dims = [('n'.into(), n)].into_iter().collect();
+                assert!(usize::try_from(eval(&term, &dims).unwrap()).unwrap() <= capacity);
+            }
+        }
+    }
+    #[test]
+    fn invalid_or_unbounded_allocations_refuse() {
+        assert!(Expr(var()).capacity(&Bounds::new()).is_err());
+        assert!(Expr(T::Lit(-1)).capacity(&Bounds::new()).is_err());
+        assert!(
+            Expr(T::Mul(lit(i64::MAX), lit(2)))
+                .capacity(&Bounds::new())
+                .is_err()
+        );
+        let bounds = [('n'.into(), (0, 9))].into_iter().collect();
+        assert!(
+            Expr(T::TruncDiv(lit(1), Box::new(var())))
+                .capacity(&bounds)
+                .is_err()
+        );
+        assert!(
+            Expr(T::Var("n".into()))
+                .capacity(&[('n'.into(), (9, 1))].into_iter().collect())
+                .is_err()
+        );
+    }
+    #[test]
+    fn runtime_division_agrees_with_integer_semantics() {
+        for a in -9i64..=9 {
+            for b in -4i64..=4 {
+                if b != 0 {
+                    assert_eq!(
+                        eval(&T::TruncDiv(lit(a), lit(b)), &Default::default()).unwrap(),
+                        a / b
+                    );
+                    assert_eq!(
+                        eval(&T::TruncRem(lit(a), lit(b)), &Default::default()).unwrap(),
+                        a % b
+                    );
+                    assert_eq!(
+                        eval(&T::CeilDiv(lit(a), lit(b)), &Default::default()).unwrap(),
+                        (a as f64 / b as f64).ceil() as i64
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/luminal_cuda_lite/tests/codegen_identity.rs
+++ b/crates/luminal_cuda_lite/tests/codegen_identity.rs
@@ -33,8 +33,13 @@ use std::collections::HashMap;
 /// An unlowerable layout answers `false` — it is certainly not a flat
 /// read.
 fn reads_flat(layout: &luminal_cuda_lite::layouts::DecodedLayout, dims: &[usize]) -> bool {
-    kernels::layout_read_index("probe", layout, dims, Coords::FlatIndex { prefix: "c" })
-        .is_ok_and(|(chain, idx)| chain.is_empty() && idx == "i")
+    kernels::layout_read_index(
+        "probe",
+        layout,
+        &dims.iter().copied().map(Into::into).collect::<Vec<_>>(),
+        Coords::FlatIndex { prefix: "c" },
+    )
+    .is_ok_and(|(chain, idx)| chain.is_empty() && idx == "i")
 }
 
 /// The PRE-Phase-3 construction, restated for the corrected contract:
@@ -90,9 +95,15 @@ fn sources_via_buffer_table(
         let kernel = luminal_cuda_lite::as_kernel_op(op.as_ref())
             .unwrap_or_else(|| panic!("elected op {label} has no kernel interface"));
         let ctx = kernels::CodegenCtx {
-            operand_dims: reads.iter().map(|id| geometry[id].0.clone()).collect(),
+            operand_dims: reads
+                .iter()
+                .map(|id| geometry[id].0.iter().copied().map(Into::into).collect())
+                .collect(),
             operand_dtypes: reads.iter().map(|id| geometry[id].1).collect(),
-            dest_dims: writes.iter().map(|id| geometry[id].0.clone()).collect(),
+            dest_dims: writes
+                .iter()
+                .map(|id| geometry[id].0.iter().copied().map(Into::into).collect())
+                .collect(),
             dest_dtypes: writes.iter().map(|id| geometry[id].1).collect(),
             // PROTOTYPE (Option B): the buffer table's layout is the
             // WRITER's (resident) layout — for a folded operand that is
@@ -397,8 +408,8 @@ mod strided {
             &source,
             &[
                 // out-coordinate prelude over [3,2]
-                "long long c1 = (long long)(rem % 2ULL); rem /= 2ULL;",
-                "long long c0 = (long long)(rem % 3ULL); rem /= 3ULL;",
+                "long long c1 = (long long)(rem % 2LL); rem /= 2LL;",
+                "long long c0 = (long long)(rem % 3LL); rem /= 3LL;",
                 // the layout's offset expression, lowered directly
                 "long long a_idx = (c1 * 3LL) + c0;",
                 "out[i] = a[a_idx];",
@@ -514,7 +525,7 @@ mod strided {
             &source,
             &[
                 // c0 (outside the reduced axis) rebuilt before the loop
-                "long long c0 = (long long)(rem % 2ULL); rem /= 2ULL;",
+                "long long c0 = (long long)(rem % 2LL); rem /= 2LL;",
                 // the reduced coordinate is the loop variable
                 "long long c1 = (long long)r;",
                 // the layout's expression, lowered directly
@@ -561,15 +572,19 @@ mod strided {
             chain: vec![coord(0), mul(coord(1), lit(2))],
             width: BitWidthTerm(32),
         });
-        let err = kernels::CodegenCtx::from_descriptors(
+        let ctx = kernels::CodegenCtx::from_descriptors(
             "Copy",
             &[slot_l(layout), slot(vec![3, 2])],
             &[slot(vec![3, 2])],
         )
-        .expect_err("symbolic layout extents must refuse");
+        .expect("symbolic domains are retained");
+        let err = luminal_cuda_lite::as_kernel_op(&op)
+            .unwrap()
+            .codegen(&ctx)
+            .unwrap_err();
         assert!(
-            err.to_string().contains("symbolic layout extents"),
-            "got: {err}"
+            err.to_string().contains("differ from dest extents"),
+            "{err}"
         );
         // An operand layout whose DOMAIN is not the destination's: the
         // template reads at the dest's coordinates, so this is a real
@@ -659,7 +674,8 @@ mod strided {
         );
         assert_eq!(
             source,
-            r#"extern "C" __global__ void k(const float* a, const float* b, float* out, unsigned long long n) {
+            r#"extern "C" __global__ void k(const float* a, const float* b, float* out, const long long* params) {
+    const unsigned long long n = 6LL;
     unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
     if (i < n) out[i] = a[i] + b[i];
 }"#
@@ -774,7 +790,8 @@ mod strided {
         // (b) THEREFORE: identical emitted source, and it is the flat
         //     read — the simplifier recognizes all five.
         let op = ops::materialize_layout_copy::MaterializeLayoutCopyDps;
-        let want = r#"extern "C" __global__ void k(const float* a, float* out, unsigned long long n) {
+        let want = r#"extern "C" __global__ void k(const float* a, float* out, const long long* params) {
+    const unsigned long long n = 6LL;
     unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
     if (i < n) out[i] = a[i];
 }"#;
@@ -809,7 +826,8 @@ mod strided {
         );
         assert_eq!(
             source,
-            r#"extern "C" __global__ void k(const float* a, float* out, unsigned long long n) {
+            r#"extern "C" __global__ void k(const float* a, float* out, const long long* params) {
+    const unsigned long long n = 6LL;
     unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
     if (i < n) out[i] = a[i];
 }"#
@@ -944,16 +962,13 @@ fn descriptor_ctx_bails_loudly_on_unusable_layouts() {
         ),
         ..filled.clone()
     };
-    let err = kernels::CodegenCtx::from_descriptors(
+    let symbolic_ctx = kernels::CodegenCtx::from_descriptors(
         "ProbeOp",
         &[symbolic],
         std::slice::from_ref(&filled),
     )
-    .expect_err("symbolic layout extents must refuse");
-    assert!(
-        err.to_string().contains("symbolic layout extents"),
-        "got: {err}"
-    );
+    .expect("symbolic layouts survive codegen");
+    assert!(symbolic_ctx.operand_dims[0][0].literal().is_none());
     let untyped = SlotDescriptor {
         layout: DecodedLayout::of(rm(lit_shape), None),
         ..filled.clone()
@@ -971,9 +986,9 @@ fn descriptor_ctx_bails_loudly_on_unusable_layouts() {
         std::slice::from_ref(&filled),
     )
     .expect("filled descriptors build");
-    assert_eq!(ok.operand_dims, vec![vec![2, 3]]);
+    assert_eq!(ok.operand_dims, vec![vec![2usize.into(), 3usize.into()]]);
     assert!(
-        reads_flat(ok.operand_layout(0), &ok.operand_dims[0]),
+        reads_flat(ok.operand_layout(0), &[2, 3]),
         "a dense layout's read simplifies to the bare `i` — no chain is emitted"
     );
 }

--- a/crates/luminal_cuda_lite/tests/composed_read_families.rs
+++ b/crates/luminal_cuda_lite/tests/composed_read_families.rs
@@ -248,12 +248,13 @@ fn gather_lowers_a_folded_coordinate_operand() {
     // one statement of it instead of two.
     assert_eq!(
         sources[0],
-        r#"extern "C" __global__ void k(const float* data, const int* coord0, const int* coord1, float* out, unsigned long long n) {
+        r#"extern "C" __global__ void k(const float* data, const int* coord0, const int* coord1, float* out, const long long* params) {
+    const unsigned long long n = 6LL;
     unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= n) return;
     unsigned long long rem = i;
-    long long c1 = (long long)(rem % 3ULL); rem /= 3ULL;
-    long long c0 = (long long)(rem % 2ULL); rem /= 2ULL;
+    long long c1 = (long long)(rem % 3LL); rem /= 3LL;
+    long long c0 = (long long)(rem % 2LL); rem /= 2LL;
     long long coord;
     long long coord0_idx = c0 + 0LL;
     coord = (long long)coord0[coord0_idx];
@@ -382,8 +383,8 @@ fn scatter_lowers_a_folded_coordinate_operand() {
         &sources[1],
         &[
             // src-coordinate prelude over (2,3)
-            "long long c1 = (long long)(rem % 3ULL); rem /= 3ULL;",
-            "long long c0 = (long long)(rem % 2ULL); rem /= 2ULL;",
+            "long long c1 = (long long)(rem % 3LL); rem /= 3LL;",
+            "long long c0 = (long long)(rem % 2LL); rem /= 2LL;",
             // the broadcast LAYOUT, lowered once
             "long long coord0_idx = c0 + 0LL;",
             "coord = (long long)coord0[coord0_idx];",

--- a/crates/luminal_cuda_lite/tests/cublaslt_contracts_cpu.rs
+++ b/crates/luminal_cuda_lite/tests/cublaslt_contracts_cpu.rs
@@ -25,6 +25,7 @@ fn cid(s: &str) -> ClassId {
 /// see `exec.rs`'s ROW CONVENTION), no decoration.
 fn base_spec(m: i64, n: i64, k: i64) -> LtMatmulSpec {
     LtMatmulSpec {
+        dim_exprs: Default::default(),
         form: CublasLtForm::Base,
         m: CuDim::Literal(m),
         n: CuDim::Literal(n),

--- a/crates/luminal_cuda_lite/tests/dim_buckets.rs
+++ b/crates/luminal_cuda_lite/tests/dim_buckets.rs
@@ -1,16 +1,4 @@
-//! BUCKETS ON THE CUDA LADDER (D7, 2026-09-03), CPU-side.
-//!
-//! The same bucket model as the reference runtime's
-//! (`luminal_reference::runtime::tests::bucketed_search_validates_searches_and_selects`),
-//! duplicated here because the ladders are duplicated: bind disjoint
-//! intervals per dim, search one Cartesian combination at a time — each
-//! validated bucket-wide over its whole range before its representative
-//! is searched — and select the covering plan from the runtime's dims.
-//!
-//! Everything here is device-free: this runtime ranks candidates with
-//! `luminal_cuda_lite::heuristic`, so a bucketed search needs no data and
-//! no device. Only `execute` would, and the static-plan refusal below
-//! fires before any of that.
+//! Bucket selection and range-valid compilation without a device.
 
 use luminal::dtype::DType;
 use luminal::graph::{DimBucket, Graph};
@@ -80,35 +68,23 @@ fn bucketed_search_validates_searches_and_selects() {
     }
 }
 
-/// THE PHASE 1 LIMITATION, pinned: each bucket's plan is STATIC at its
-/// representative (plan spans are literals), so executing it at another
-/// value inside the same bucket refuses by name and points at the
-/// symbolic-plan open item. This runtime cannot execute at all without a
-/// device, but the refusal is raised by plan SELECTION, before any
-/// device work — which is exactly the point: the wrong-geometry run is
-/// never even attempted.
+/// The selected physical plan retains the range variable instead of freezing
+/// geometry to the representative. GPU replay is covered in dynamic_graphs.
 #[test]
-fn a_non_representative_pin_refuses_loudly() {
-    let (cx, _out) = elementwise_graph();
-    let mut rt = CudaRuntime::load(&cx).expect("cuda load");
+fn bucket_plan_keeps_symbolic_capacity() {
+    let (cx, _) = elementwise_graph();
+    let mut rt = CudaRuntime::load(&cx).unwrap();
     rt.bind_dim_buckets('a', vec![DimBucket::new(2, 4)])
-        .expect("buckets bind");
+        .unwrap();
     rt.search(&Default::default(), &harness_search_options())
-        .expect("bucketed search completes");
-
-    // 3 is the representative of [2, 4]; 4 is inside the bucket and is
-    // NOT the pin the plan was searched at.
-    rt.set_dim('a', 4);
-    let err = rt
-        .execute()
-        .expect_err("a non-representative pin must refuse");
-    let text = format!("{err:#}");
-    assert!(text.contains("STATIC at that pin"), "{text}");
+        .unwrap();
     assert!(
-        text.contains("a = 3"),
-        "the message names the representative: {text}"
+        rt.bucket_plans()[0]
+            .plan
+            .buffers
+            .values()
+            .any(|b| b.layout.literal_extents().is_none())
     );
-    assert!(text.contains("symbolic plans"), "{text}");
 }
 
 /// Buckets must partition: overlap is refused, not resolved first-wins.

--- a/crates/luminal_cuda_lite/tests/dynamic_graphs.rs
+++ b/crates/luminal_cuda_lite/tests/dynamic_graphs.rs
@@ -1,0 +1,363 @@
+//! Numerical and resource-lifetime regressions for graph-only dynamic execution.
+#![cfg(feature = "device")]
+use luminal::{
+    dtype::DType,
+    graph::{DimBucket, Graph},
+    shape::IntExpr,
+};
+use luminal_cuda_lite::{CudaRuntime, harness_search_options};
+
+#[test]
+fn bucket_switches_overlay_one_arena_and_replay_cached_graphs() {
+    let mut g = Graph::new();
+    let x = g.tensor(('a', 2), DType::F32);
+    let y = g.tensor(('a', 2), DType::F32);
+    let out = (x * y + x).output();
+    let mut rt = CudaRuntime::load(&g).unwrap();
+    rt.bind_dim_buckets('a', vec![DimBucket::new(2, 4), DimBucket::new(5, 9)])
+        .unwrap();
+    rt.search(&Default::default(), &harness_search_options())
+        .unwrap();
+    let max = rt
+        .bucket_plans()
+        .iter()
+        .map(|p| p.slab_bytes)
+        .max()
+        .unwrap();
+    let mut base = None;
+    for (iteration, n) in [2, 4, 3, 9, 5, 7, 2, 9].into_iter().enumerate() {
+        rt.set_dim('a', n);
+        let xdata: Vec<f32> = (0..n * 2).map(|i| (i + iteration) as f32).collect();
+        let ydata: Vec<f32> = (0..n * 2).map(|i| i as f32 * 0.25 - 1.).collect();
+        let expected: Vec<_> = xdata.iter().zip(&ydata).map(|(x, y)| x * y + x).collect();
+        rt.set_data(x.id, xdata);
+        rt.set_data(y.id, ydata);
+        rt.execute().unwrap();
+        assert_eq!(rt.get_f32(out.id).unwrap(), expected);
+        let stats = rt.graph_stats().unwrap();
+        assert_eq!(stats.arena_bytes, max);
+        assert_eq!(*base.get_or_insert(stats.arena_base), stats.arena_base);
+        assert_eq!(stats.arena_generation, 1);
+    }
+    let stats = rt.graph_stats().unwrap();
+    assert_eq!(stats.instantiations, 2);
+    assert_eq!(stats.launches, 8);
+    rt.set_dim('a', 10);
+    assert!(rt.execute().is_err());
+}
+
+#[test]
+fn metadata_only_dimension_change_patches_no_nodes() {
+    let mut g = Graph::new();
+    let a = IntExpr::from('a');
+    let out = g.iota(5, |c| c[0] + a).output();
+    let mut rt = CudaRuntime::load(&g).unwrap();
+    rt.bind_dyn_range('a', 1, 19).unwrap();
+    rt.search(&Default::default(), &harness_search_options())
+        .unwrap();
+    for n in [1, 19, 7, 1] {
+        rt.set_dim('a', n);
+        rt.execute().unwrap();
+        assert_eq!(
+            rt.get_i32(out.id).unwrap(),
+            (n..n + 5).map(|v| v as i32).collect::<Vec<_>>()
+        );
+    }
+    let stats = rt.graph_stats().unwrap();
+    assert_eq!(stats.instantiations, 1);
+    assert_eq!(stats.node_updates, 0);
+    assert_eq!(stats.kernel_compilations, 1);
+}
+
+#[test]
+fn dynamic_transpose_and_reduction_use_live_strides() {
+    let mut g = Graph::new();
+    let x = g.tensor((3, 'a'), DType::F32);
+    let out = (x.permute((1, 0)) + 1.).sum(0).output();
+    let mut rt = CudaRuntime::load(&g).unwrap();
+    rt.bind_dyn_range('a', 2, 11).unwrap();
+    rt.search(&Default::default(), &harness_search_options())
+        .unwrap();
+    for n in [2, 11, 5, 2] {
+        let data: Vec<_> = (0..3 * n).map(|i| i as f32 / 2.).collect();
+        let expected: Vec<_> = (0..3)
+            .map(|row| {
+                data[row * n..(row + 1) * n]
+                    .iter()
+                    .map(|x| x + 1.)
+                    .sum::<f32>()
+            })
+            .collect();
+        rt.set_dim('a', n);
+        rt.set_data(x.id, data);
+        rt.execute().unwrap();
+        assert_eq!(rt.get_f32(out.id).unwrap(), expected);
+    }
+    assert_eq!(rt.graph_stats().unwrap().instantiations, 1);
+}
+
+#[test]
+fn cublas_geometry_changes_refresh_child_and_reuse_capture() {
+    let mut g = Graph::new();
+    let a = g.tensor(('m', 'k'), DType::F32);
+    let b = g.tensor(('k', 'n'), DType::F32);
+    let out = a.matmul(b).output();
+    let mut rt = CudaRuntime::load(&g).unwrap();
+    for s in ['m', 'k', 'n'] {
+        rt.bind_dyn_range(s, 2, 12).unwrap();
+    }
+    let mut options = harness_search_options();
+    options.generations = 4;
+    options.generation_size = 12;
+    rt.search(&Default::default(), &options).unwrap();
+    assert!(rt.plan().unwrap().dag.node_weights().any(|node|matches!(node,luminal::bufferize::BufferNode::Compute{op,..} if luminal_cuda_lite::as_host_op(op.as_ref()).is_some())));
+    for (m, n, k) in [(2, 3, 4), (12, 9, 7), (5, 2, 11), (2, 3, 4)] {
+        let av: Vec<_> = (0..m * k).map(|i| (i % 9) as f32 / 4. - 1.).collect();
+        let bv: Vec<_> = (0..k * n).map(|i| (i % 7) as f32 / 3. - 0.5).collect();
+        let expected: Vec<f32> = (0..m * n)
+            .map(|i| {
+                (0..k)
+                    .map(|j| av[(i / n) * k + j] * bv[j * n + i % n])
+                    .sum()
+            })
+            .collect();
+        for (s, v) in [('m', m), ('n', n), ('k', k)] {
+            rt.set_dim(s, v);
+        }
+        rt.set_data(a.id, av);
+        rt.set_data(b.id, bv);
+        rt.execute().unwrap();
+        let actual = rt.get_f32(out.id).unwrap();
+        assert_eq!(actual.len(), expected.len());
+        for (a, b) in actual.iter().zip(expected) {
+            assert!((a - b).abs() < 1e-4, "{a} != {b}");
+        }
+    }
+    let stats = rt.graph_stats().unwrap();
+    assert_eq!(stats.host_captures, 3);
+    assert_eq!(stats.host_cache_hits, 1);
+    assert_eq!(stats.arena_generation, 1);
+}
+
+#[test]
+fn profiling_and_serving_share_dynamic_graph_execution() {
+    let mut g = Graph::new();
+    let x = g.tensor('a', DType::F32);
+    let out = (x + 2.).output();
+    let mut rt = CudaRuntime::load(&g).unwrap();
+    rt.bind_dim_buckets('a', vec![DimBucket::new(2, 4), DimBucket::new(5, 9)])
+        .unwrap();
+    let data = [(x.id, vec![1f32, 2., 3.].into())].into_iter().collect();
+    let mut options = harness_search_options();
+    options.profile_on_device = true;
+    options.trials = 2;
+    let outcome = rt.search(&data, &options).unwrap();
+    assert!(outcome.plans_profiled > 0);
+    let before = rt.graph_stats().unwrap();
+    assert!(before.launches > before.instantiations);
+    rt.set_dim('a', 9);
+    rt.set_data(x.id, vec![7f32; 9]);
+    rt.execute().unwrap();
+    assert_eq!(rt.get_f32(out.id).unwrap(), vec![9f32; 9]);
+}
+
+#[test]
+fn zero_extents_disable_copies_and_restore_them() {
+    let mut g = Graph::new();
+    let x = g.tensor('a', DType::F32);
+    let out = (x + 3.).output();
+    let mut rt = CudaRuntime::load(&g).unwrap();
+    rt.bind_dyn_range('a', 0, 9).unwrap();
+    rt.search(&Default::default(), &harness_search_options())
+        .unwrap();
+    for n in [0, 9, 0, 2] {
+        rt.set_dim('a', n);
+        rt.set_data(x.id, vec![2f32; n]);
+        rt.execute().unwrap();
+        assert_eq!(rt.get_f32(out.id).unwrap(), vec![5f32; n]);
+    }
+    assert_eq!(rt.graph_stats().unwrap().instantiations, 1);
+}
+
+#[test]
+fn gather_scatter_update_symbolic_coordinates() {
+    let mut g = Graph::new();
+    let data = g.tensor(('a', 3), DType::F32);
+    let rows = g.tensor('a', DType::Int);
+    let cols = g.iota(('a', 3), |c| c[1]);
+    let coords = [rows.expand_dim(1, 3), cols];
+    let gathered = data.gather(&coords).output();
+    let scattered = (data * 0.).scatter(&coords, data + 1.).output();
+    let mut rt = CudaRuntime::load(&g).unwrap();
+    rt.bind_dyn_range('a', 2, 9).unwrap();
+    let mut opts = harness_search_options();
+    opts.generations = 4;
+    opts.generation_size = 8;
+    rt.search(&Default::default(), &opts).unwrap();
+    for n in [2, 9, 5, 2] {
+        let values: Vec<_> = (0..n * 3).map(|i| i as f32 / 4.).collect();
+        let indices: Vec<_> = (0..n).map(|i| ((i + 1) % n) as i32).collect();
+        let mut expected_gather = vec![0f32; n * 3];
+        let mut expected_scatter = vec![0f32; n * 3];
+        for i in 0..n {
+            for j in 0..3 {
+                expected_gather[i * 3 + j] = values[indices[i] as usize * 3 + j];
+                expected_scatter[indices[i] as usize * 3 + j] = values[i * 3 + j] + 1.;
+            }
+        }
+        rt.set_dim('a', n);
+        rt.set_data(data.id, values);
+        rt.set_data(rows.id, indices);
+        rt.execute().unwrap();
+        assert_eq!(rt.get_f32(gathered.id).unwrap(), expected_gather);
+        assert_eq!(rt.get_f32(scattered.id).unwrap(), expected_scatter);
+    }
+    assert_eq!(rt.graph_stats().unwrap().instantiations, 1);
+}
+
+#[test]
+fn installing_larger_plan_invalidates_graphs_before_arena_growth() {
+    use luminal_cuda_lite::device::CudaDevice;
+    fn plan(n: usize) -> luminal_cuda_lite::CudaPlan {
+        let mut g = Graph::new();
+        g.iota(n, |c| c[0]).output();
+        let mut rt = CudaRuntime::load(&g).unwrap();
+        rt.search(&Default::default(), &harness_search_options())
+            .unwrap();
+        rt.plan().unwrap().clone()
+    }
+    let mut device = CudaDevice::new(0).unwrap();
+    device.install(vec![(plan(4), Default::default())]).unwrap();
+    let retained = device
+        .execute(0, &Default::default(), &Default::default())
+        .unwrap();
+    let before = device.stats();
+    device
+        .install(vec![(plan(4097), Default::default())])
+        .unwrap();
+    let result = device
+        .execute(0, &Default::default(), &Default::default())
+        .unwrap();
+    assert_eq!(device.stats().arena_generation, before.arena_generation + 1);
+    assert!(device.stats().arena_bytes > before.arena_bytes);
+    assert_eq!(
+        result[&0].0.as_i32().unwrap(),
+        (0..4097).collect::<Vec<_>>()
+    );
+    assert_eq!(retained[&0].0.as_i32().unwrap(), vec![0, 1, 2, 3]);
+    device.release_slab();
+    assert_eq!(device.slab_bytes(), 0);
+    assert!(!device.is_installed());
+}
+
+#[test]
+fn ceil_division_in_dynamic_iota_is_evaluated_on_device() {
+    // The recorder currently rejects ceil_div in iota bodies; exercise the
+    // supported IntExpr IR directly at the buffer-plan/codegen boundary.
+    use luminal::index_expr::IotaExpr;
+    use luminal_cuda_lite::ops::iota::IotaDps;
+    let mut g = Graph::new();
+    let a = IntExpr::from('a');
+    g.iota(7, |c| c[0] + a).output();
+    let mut rt = CudaRuntime::load(&g).unwrap();
+    rt.bind_dyn_range('a', 1, 12).unwrap();
+    rt.search(&Default::default(), &harness_search_options())
+        .unwrap();
+    let mut plan = rt.plan().unwrap().clone();
+    let mut found = false;
+    for node in plan.dag.node_weights_mut() {
+        if let luminal::bufferize::BufferNode::Compute { op, .. } = node
+            && let Some(iota) = op.as_any().downcast_ref::<IotaDps>()
+        {
+            *op = Box::new(IotaDps {
+                expr: Some(IotaExpr::CeilDiv(
+                    Box::new(iota.expr.clone().unwrap()),
+                    Box::new(IotaExpr::Lit(3)),
+                )),
+            });
+            found = true;
+        }
+    }
+    assert!(found);
+    let mut device = luminal_cuda_lite::device::CudaDevice::new(0).unwrap();
+    device
+        .install(vec![(plan, [('a'.into(), (1, 12))].into_iter().collect())])
+        .unwrap();
+    for n in [1usize, 12, 2] {
+        let outputs = device
+            .execute(
+                0,
+                &Default::default(),
+                &[('a'.into(), n)].into_iter().collect(),
+            )
+            .unwrap();
+        assert_eq!(
+            outputs[&0].0.as_i32().unwrap(),
+            (n..n + 7).map(|i| i.div_ceil(3) as i32).collect::<Vec<_>>()
+        );
+    }
+    assert_eq!(device.stats().instantiations, 1);
+}
+
+#[test]
+fn bucketed_and_range_bound_dimensions_both_stay_symbolic() {
+    let mut g = Graph::new();
+    let x = g.tensor(('a', 'b'), DType::F32);
+    let out = (x + 1.).output();
+    let mut rt = CudaRuntime::load(&g).unwrap();
+    rt.bind_dyn_range('b', 2, 8).unwrap();
+    rt.bind_dim_buckets('a', vec![DimBucket::new(2, 4), DimBucket::new(5, 9)])
+        .unwrap();
+    rt.set_dim('b', 3); // This current value must not narrow the searched interval.
+    rt.search(&Default::default(), &harness_search_options())
+        .unwrap();
+    for (a, b) in [(2, 3), (4, 8), (5, 2), (9, 7)] {
+        rt.set_dim('a', a);
+        rt.set_dim('b', b);
+        rt.set_data(x.id, vec![2f32; a * b]);
+        rt.execute().unwrap();
+        assert_eq!(rt.get_f32(out.id).unwrap(), vec![3f32; a * b]);
+    }
+    assert_eq!(rt.graph_stats().unwrap().instantiations, 2);
+}
+
+#[test]
+fn dynamic_cublas_bias_epilogue_rebinds_geometry() {
+    let mut g = Graph::new();
+    let a = g.tensor(('m', 4), DType::F32);
+    let b = g.tensor((4, 'n'), DType::F32);
+    let bias = g.tensor('n', DType::F32);
+    let out = (a.matmul(b) + bias.expand_dim(0, 'm')).relu().output();
+    let mut rt = CudaRuntime::load(&g).unwrap();
+    for s in ['m', 'n'] {
+        rt.bind_dyn_range(s, 2, 9).unwrap();
+    }
+    let mut options = harness_search_options();
+    options.generations = 12;
+    options.generation_size = 16;
+    options.mutations = 4;
+    rt.search(&Default::default(), &options).unwrap();
+    assert!(rt.plan().unwrap().dag.node_weights().any(|node|matches!(node,luminal::bufferize::BufferNode::Compute{op,..} if luminal_cuda_lite::as_host_op(op.as_ref()).is_some()&&op.label().contains("Bias"))));
+    for (m, n) in [(2, 3), (9, 7), (4, 9), (2, 3)] {
+        let av: Vec<_> = (0..m * 4).map(|i| (i % 5) as f32 - 2.).collect();
+        let bv: Vec<_> = (0..4 * n).map(|i| (i % 7) as f32 * 0.25 - 0.5).collect();
+        let biasv: Vec<_> = (0..n).map(|i| i as f32 - 3.).collect();
+        let expected: Vec<f32> = (0..m * n)
+            .map(|i| {
+                ((0..4)
+                    .map(|j| av[i / n * 4 + j] * bv[j * n + i % n])
+                    .sum::<f32>()
+                    + biasv[i % n])
+                    .max(0.)
+            })
+            .collect();
+        rt.set_dim('m', m);
+        rt.set_dim('n', n);
+        rt.set_data(a.id, av);
+        rt.set_data(b.id, bv);
+        rt.set_data(bias.id, biasv);
+        rt.execute().unwrap();
+        assert_eq!(rt.get_f32(out.id).unwrap(), expected);
+    }
+    assert_eq!(rt.graph_stats().unwrap().host_captures, 3);
+}

--- a/crates/luminal_cuda_lite/tests/execution_traits.rs
+++ b/crates/luminal_cuda_lite/tests/execution_traits.rs
@@ -64,6 +64,10 @@ impl KernelOp for ExternalAdd {
     fn codegen(&self, ctx: &CodegenCtx) -> anyhow::Result<Vec<KernelSource>> {
         let mut launches = AddFunctionalDps.codegen(ctx)?;
         for launch in &mut launches {
+            launch.launch = Some(luminal_cuda_lite::kernels::KernelLaunch::linear(
+                launch.n.clone(),
+                128,
+            ));
             launch
                 .source
                 .push_str(&format!("\n// external {}\n", self.marker));
@@ -207,4 +211,249 @@ fn all_cublaslt_dps_forms_keep_the_host_interface_when_cloned() {
         assert_eq!(host.label(), functional.label());
         assert!(as_kernel_op(cloned.as_ref()).is_none());
     }
+}
+
+#[cfg(feature = "device")]
+mod host_graphs {
+    use super::*;
+    use cudarc::driver::{CudaFunction, CudaModule, LaunchConfig, PushKernelArg};
+    use luminal_cuda_lite::host::{CaptureCtx, HostOp, HostOpContext, PreparedHostOp};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    static RECORDS: AtomicUsize = AtomicUsize::new(0);
+    static DROPPED: AtomicUsize = AtomicUsize::new(0);
+    #[derive(Debug, Clone)]
+    struct ExternalHostAdd {
+        dps: bool,
+    }
+    impl OpSlotNames for ExternalHostAdd {}
+    impl BufferTensorIrOp for ExternalHostAdd {
+        fn label(&self) -> &str {
+            "ExternalHostAdd"
+        }
+        fn operand_reads_memory(&self, i: usize) -> bool {
+            !self.dps || i < 2
+        }
+        fn runtime_interface(&self) -> Option<&dyn std::any::Any> {
+            self.dps
+                .then(|| CudaOpInterface::host::<Self>() as &dyn std::any::Any)
+        }
+    }
+    impl Bufferizable for ExternalHostAdd {
+        fn alias_info(&self) -> Vec<AliasInfo> {
+            if self.dps {
+                AddFunctionalDps.alias_info()
+            } else {
+                vec![]
+            }
+        }
+    }
+    impl ToDps for ExternalHostAdd {
+        fn to_dps(&self) -> Option<Box<dyn LayoutIrOp>> {
+            (!self.dps).then(|| Box::new(Self { dps: true }) as Box<dyn LayoutIrOp>)
+        }
+    }
+    impl LayoutIrOp for ExternalHostAdd {}
+    struct Prepared {
+        dim: usize,
+        _module: Arc<CudaModule>,
+        function: CudaFunction,
+        inputs: [u64; 2],
+        dest: u64,
+        n: u64,
+        repeats: usize,
+    }
+    impl Drop for Prepared {
+        fn drop(&mut self) {
+            DROPPED.fetch_or(1 << self.dim, Ordering::SeqCst);
+        }
+    }
+    impl PreparedHostOp for Prepared {
+        unsafe fn record(&self, ctx: &CaptureCtx<'_>) -> anyhow::Result<()> {
+            RECORDS.fetch_add(1, Ordering::SeqCst);
+            for _ in 0..self.repeats {
+                let mut launch = ctx.stream().launch_builder(&self.function);
+                launch
+                    .arg(&self.inputs[0])
+                    .arg(&self.inputs[1])
+                    .arg(&self.dest)
+                    .arg(&self.n);
+                unsafe { launch.launch(LaunchConfig::for_num_elems(self.n as u32)) }?;
+            }
+            assert!(self.dim != 7, "injected recording panic");
+            Ok(())
+        }
+    }
+    impl HostOp for ExternalHostAdd {
+        unsafe fn prepare(
+            &self,
+            ctx: &HostOpContext<'_>,
+        ) -> anyhow::Result<Box<dyn PreparedHostOp>> {
+            let a = ctx.dims[&'a'.into()];
+            anyhow::ensure!(a != 6, "injected preparation failure");
+            let ptx = cudarc::nvrtc::compile_ptx(
+                r#"extern "C" __global__ void add(const float* a,const float* b,float* out,unsigned long long n){unsigned long long i=blockIdx.x*blockDim.x+threadIdx.x;if(i<n)out[i]=a[i]+b[i];}"#,
+            )?;
+            let module = ctx.stream.context().load_module(ptx)?;
+            let function = module.load_function("add")?;
+            Ok(Box::new(Prepared {
+                dim: a,
+                _module: module,
+                function,
+                inputs: [ctx.inputs[0].ptr, ctx.inputs[1].ptr],
+                dest: ctx.dest.ptr,
+                n: (ctx.dest.bytes / 4) as u64,
+                repeats: if a.is_multiple_of(2) { 2 } else { 1 },
+            }))
+        }
+    }
+    #[derive(Debug)]
+    struct Matcher;
+    impl OpMatcher for Matcher {
+        fn egglog_constructor(&self) -> &'static str {
+            "LayoutTensorOpExternalHostAdd"
+        }
+        fn metadata_slots(&self) -> &'static [(&'static str, usize)] {
+            AddFunctionalMatcher.metadata_slots()
+        }
+        fn snippets(&self) -> Vec<EgglogSnippet> {
+            static SNIPPETS: std::sync::OnceLock<
+                Vec<(luminal::egglog_snippet::SpliceCategory, String)>,
+            > = std::sync::OnceLock::new();
+            SNIPPETS
+                .get_or_init(|| {
+                    AddFunctionalMatcher
+                        .snippets()
+                        .into_iter()
+                        .map(|s| {
+                            (
+                                s.category,
+                                s.text.replace(
+                                    AddFunctionalMatcher.egglog_constructor(),
+                                    self.egglog_constructor(),
+                                ),
+                            )
+                        })
+                        .collect()
+                })
+                .iter()
+                .map(|(category, text)| EgglogSnippet {
+                    category: *category,
+                    text,
+                })
+                .collect()
+        }
+        fn extract(&self, _: &ExtractionSite<'_>) -> Box<dyn LayoutIrOp> {
+            Box::new(ExternalHostAdd { dps: false })
+        }
+    }
+    #[test]
+    fn external_host_topology_changes_cache_graphs_and_recover_from_errors() {
+        let mut g = luminal::graph::Graph::new();
+        let a = g.tensor(('a', 2), DType::F32);
+        let b = g.tensor(('a', 2), DType::F32);
+        let out = (a + b).output();
+        let mut registry = cuda_registry_without_cublaslt();
+        registry.retain(|e| e.constructor() != AddFunctionalMatcher.egglog_constructor());
+        registry.push(RegisteredOp::new(
+            Box::new(Matcher),
+            Box::new(ExternalHostAdd { dps: false }),
+        ));
+        let mut rt = CudaRuntime::load_with_registry(&g, registry).unwrap();
+        rt.bind_dyn_range('a', 2, 30).unwrap();
+        rt.search(&Default::default(), &harness_search_options())
+            .unwrap();
+        let initial = RECORDS.load(Ordering::SeqCst);
+        for n in [3, 4, 3, 4, 4] {
+            rt.set_dim('a', n);
+            rt.set_data(a.id, vec![n as f32; n * 2]);
+            rt.set_data(b.id, vec![1f32; n * 2]);
+            rt.execute().unwrap();
+            assert_eq!(rt.get_f32(out.id).unwrap(), vec![n as f32 + 1.; n * 2]);
+        }
+        let stats = rt.graph_stats().unwrap();
+        assert_eq!(stats.host_captures, 2);
+        assert_eq!(stats.instantiations, 2);
+        assert_eq!(stats.graph_cache_hits, 2);
+        assert_eq!(
+            RECORDS.load(Ordering::SeqCst) - initial,
+            2,
+            "record runs only during capture"
+        );
+        // More signatures than the capture cache holds. The parent source
+        // graphs still refer to the initial 3/4 captures, so those preparations
+        // (including their CUDA modules) must survive cache eviction.
+        for n in 9..=20 {
+            rt.set_dim('a', n);
+            rt.set_data(a.id, vec![n as f32; n * 2]);
+            rt.set_data(b.id, vec![1f32; n * 2]);
+            rt.execute().unwrap();
+            assert_eq!(rt.get_f32(out.id).unwrap(), vec![n as f32 + 1.; n * 2]);
+        }
+        assert_eq!(DROPPED.load(Ordering::SeqCst) & ((1 << 3) | (1 << 4)), 0);
+        rt.set_data(a.id, vec![4f32; 8]);
+        rt.set_data(b.id, vec![1f32; 8]);
+        rt.set_dim('a', 6);
+        assert!(
+            format!("{:#}", rt.execute().unwrap_err()).contains("injected preparation failure")
+        );
+        rt.set_dim('a', 4);
+        rt.execute().unwrap();
+        assert_eq!(rt.get_f32(out.id).unwrap(), vec![5f32; 8]);
+        let before = rt.graph_stats().unwrap().instantiations;
+        rt.set_dim('a', 7);
+        assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| rt.execute())).is_err());
+        rt.set_dim('a', 4);
+        rt.execute().unwrap();
+        assert_eq!(rt.get_f32(out.id).unwrap(), vec![5f32; 8]);
+        assert_eq!(rt.graph_stats().unwrap().instantiations, before + 1);
+        let captures = rt.graph_stats().unwrap().host_captures;
+        rt.set_dim("external_mode", 1);
+        rt.execute().unwrap();
+        assert_eq!(
+            rt.graph_stats().unwrap().host_captures,
+            captures + 1,
+            "default capture_dims covers newly supplied dimensions too"
+        );
+        drop(rt);
+        assert_eq!(
+            DROPPED.load(Ordering::SeqCst) & ((1 << 3) | (1 << 4)),
+            (1 << 3) | (1 << 4)
+        );
+    }
+}
+
+#[cfg(feature = "device")]
+#[test]
+fn external_kernel_launch_geometry_updates_without_reinstantiation() {
+    let mut graph = luminal::graph::Graph::new();
+    let a = graph.tensor('a', DType::F32);
+    let b = graph.tensor('a', DType::F32);
+    let out = (a + b).output();
+    let mut registry = cuda_registry_without_cublaslt();
+    registry.retain(|e| e.constructor() != AddFunctionalMatcher.egglog_constructor());
+    registry.push(RegisteredOp::new(
+        Box::new(ExternalAddMatcher),
+        Box::new(ExternalAdd {
+            dps: false,
+            marker: 0,
+        }),
+    ));
+    let mut rt = CudaRuntime::load_with_registry(&graph, registry).unwrap();
+    rt.bind_dyn_range('a', 0, 1025).unwrap();
+    rt.search(&Default::default(), &harness_search_options())
+        .unwrap();
+    for n in [0, 1025, 2, 0, 257] {
+        rt.set_dim('a', n);
+        rt.set_data(a.id, vec![2f32; n]);
+        rt.set_data(b.id, vec![3f32; n]);
+        rt.execute().unwrap();
+        assert_eq!(rt.get_f32(out.id).unwrap(), vec![5f32; n]);
+    }
+    let stats = rt.graph_stats().unwrap();
+    assert_eq!(stats.instantiations, 1);
+    assert_eq!(stats.kernel_compilations, 1);
+    assert!(stats.node_updates >= 4);
 }

--- a/crates/luminal_cuda_lite/tests/plan_smoke.rs
+++ b/crates/luminal_cuda_lite/tests/plan_smoke.rs
@@ -87,9 +87,13 @@ fn codegen_emits_wellformed_sources() {
         )
     }
     let ctx = kernels::CodegenCtx {
-        operand_dims: vec![vec![2, 3], vec![2, 3], vec![2, 3]],
+        operand_dims: vec![
+            vec![2usize.into(), 3usize.into()],
+            vec![2usize.into(), 3usize.into()],
+            vec![2usize.into(), 3usize.into()],
+        ],
         operand_dtypes: vec![PlanDtype::F32, PlanDtype::F32, PlanDtype::F32],
-        dest_dims: vec![vec![2, 3]],
+        dest_dims: vec![vec![2usize.into(), 3usize.into()]],
         dest_dtypes: vec![PlanDtype::F32],
         // The slot layouts ARE the read paths (the hop chain is retired):
         // all three are dense row-major, so every read simplifies to the
@@ -100,7 +104,7 @@ fn codegen_emits_wellformed_sources() {
     let kernel = luminal_cuda_lite::as_kernel_op(&add).expect("add implements KernelOp");
     let launches = kernel.codegen(&ctx).expect("codegen");
     assert_eq!(launches.len(), 1);
-    assert_eq!(launches[0].n, 6);
+    assert_eq!(launches[0].n.literal(), Some(6));
     assert!(launches[0].source.contains("__global__ void k("));
     assert!(launches[0].source.contains("a[i] + b[i]"));
 }

--- a/crates/luminal_cuda_lite/tests/view_admission.rs
+++ b/crates/luminal_cuda_lite/tests/view_admission.rs
@@ -139,7 +139,7 @@ fn audit(
                     let flat = luminal_cuda_lite::kernels::layout_read_index(
                         "probe",
                         &info.layout,
-                        &dims,
+                        &dims.into_iter().map(Into::into).collect::<Vec<_>>(),
                         luminal_cuda_lite::kernels::Coords::FlatIndex { prefix: "c" },
                     )
                     .is_ok_and(|(chain, idx)| chain.is_empty() && idx == "i");
@@ -165,7 +165,7 @@ fn audit(
                     let flat = luminal_cuda_lite::kernels::layout_read_index(
                         "probe",
                         &info.layout,
-                        &dims,
+                        &dims.into_iter().map(Into::into).collect::<Vec<_>>(),
                         luminal_cuda_lite::kernels::Coords::FlatIndex { prefix: "c" },
                     )
                     .is_ok_and(|(chain, idx)| chain.is_empty() && idx == "i");

--- a/src/index_expr.rs
+++ b/src/index_expr.rs
@@ -13,6 +13,8 @@ type BinaryIotaBuilder = fn(Box<IotaExpr>, Box<IotaExpr>) -> IotaExpr;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IotaExpr {
     Lit(i64),
+    /// A runtime dimension, retained when extraction uses interval bounds.
+    Var(String),
     /// CoordVar axis, zero-based from the END over the OUT coordinates.
     Coord(usize),
     Add(Box<IotaExpr>, Box<IotaExpr>),
@@ -21,6 +23,8 @@ pub enum IotaExpr {
     TruncDiv(Box<IotaExpr>, Box<IotaExpr>),
     /// Truncated remainder — the preamble's IntTruncRem.
     TruncRem(Box<IotaExpr>, Box<IotaExpr>),
+    /// Ceiling division, including symbolic shape arithmetic.
+    CeilDiv(Box<IotaExpr>, Box<IotaExpr>),
     Min(Box<IotaExpr>, Box<IotaExpr>),
     Max(Box<IotaExpr>, Box<IotaExpr>),
     /// The bool bridge's indicator: `(a < b) as i64` — IntCastFromBool
@@ -31,18 +35,34 @@ pub enum IotaExpr {
 impl IotaExpr {
     /// Evaluate at the given OUT coordinates (front-indexed).
     pub fn eval(&self, coords: &[usize]) -> i64 {
+        self.eval_with_dims(coords, &Default::default())
+    }
+
+    /// Evaluate coordinates and runtime dimension variables.
+    pub fn eval_with_dims(&self, coords: &[usize], dims: &crate::shape::DynMap) -> i64 {
+        let eval = |expr: &Self| expr.eval_with_dims(coords, dims);
         match self {
             IotaExpr::Lit(value) => *value,
+            IotaExpr::Var(name) => i64::try_from(
+                *dims
+                    .get(&crate::shape::Symbol::from(name.as_str()))
+                    .unwrap_or_else(|| panic!("unbound index-expression dimension `{name}`")),
+            )
+            .expect("dimension exceeds i64"),
             IotaExpr::Coord(axis_from_end) => coords[coords.len() - 1 - axis_from_end] as i64,
-            IotaExpr::Add(a, b) => a.eval(coords) + b.eval(coords),
-            IotaExpr::Mul(a, b) => a.eval(coords) * b.eval(coords),
+            IotaExpr::Add(a, b) => eval(a) + eval(b),
+            IotaExpr::Mul(a, b) => eval(a) * eval(b),
             // Divisors are literal strides/extents (>= 1 by construction);
             // a zero here is a translator bug and deserves the loud panic.
-            IotaExpr::TruncDiv(a, b) => a.eval(coords) / b.eval(coords),
-            IotaExpr::TruncRem(a, b) => a.eval(coords) % b.eval(coords),
-            IotaExpr::Min(a, b) => a.eval(coords).min(b.eval(coords)),
-            IotaExpr::Max(a, b) => a.eval(coords).max(b.eval(coords)),
-            IotaExpr::LessThanCast(a, b) => (a.eval(coords) < b.eval(coords)) as i64,
+            IotaExpr::TruncDiv(a, b) => eval(a) / eval(b),
+            IotaExpr::TruncRem(a, b) => eval(a) % eval(b),
+            IotaExpr::CeilDiv(a, b) => {
+                let (a, b) = (eval(a), eval(b));
+                a / b + i64::from(a % b != 0 && ((a > 0) == (b > 0)))
+            }
+            IotaExpr::Min(a, b) => eval(a).min(eval(b)),
+            IotaExpr::Max(a, b) => eval(a).max(eval(b)),
+            IotaExpr::LessThanCast(a, b) => (eval(a) < eval(b)) as i64,
         }
     }
 }
@@ -142,6 +162,18 @@ fn parse_int_expr_uncached(
         let value_class = site.class_of_child(lit, 0)?;
         return Some(IotaExpr::Lit(site.node_in_class_parse_i64(&value_class)?));
     }
+    for var in site.nodes_in_class_value(class, "IntVar") {
+        let name_class = site.class_of_child(var, 0)?;
+        if let Some(name) = site
+            .index
+            .nodes_of(&name_class)
+            .iter()
+            .filter_map(|id| site.egraph.nodes.get(id))
+            .find_map(|n| n.op.strip_prefix('"').and_then(|s| s.strip_suffix('"')))
+        {
+            return Some(IotaExpr::Var(name.to_string()));
+        }
+    }
     for coord in site.nodes_in_class_value(class, "CoordVar") {
         // Scoped coordinates: child 0 is the owner Shape, child 1 the
         // axis. The owner-shape guard: when the caller names its out
@@ -167,11 +199,12 @@ fn parse_int_expr_uncached(
     // a saturated class holds many equal spellings, and the first node of
     // a kind may have children outside the parsed subset while a sibling
     // spelling parses fine.
-    let binary_kinds: [(&str, BinaryIotaBuilder); 6] = [
+    let binary_kinds: [(&str, BinaryIotaBuilder); 7] = [
         ("IntAdd", |a, b| IotaExpr::Add(a, b)),
         ("IntMul", |a, b| IotaExpr::Mul(a, b)),
         ("IntTruncDiv", |a, b| IotaExpr::TruncDiv(a, b)),
         ("IntTruncRem", |a, b| IotaExpr::TruncRem(a, b)),
+        ("IntCeilDiv", |a, b| IotaExpr::CeilDiv(a, b)),
         ("IntMin", |a, b| IotaExpr::Min(a, b)),
         ("IntMax", |a, b| IotaExpr::Max(a, b)),
     ];


### PR DESCRIPTION
CUDA Lite now executes serving, candidate warmup, and profiling through CUDA graphs. Bucket plans preserve symbolic geometry across their full dimension ranges and share one capacity-planned device arena and one pinned host staging allocation.

- Pass live dimensions through a device parameter block and index node dependencies so shape changes patch only affected copy lengths and explicit launch geometry. Metadata-only changes require no graph node updates; zero-length operations are disabled and restored.
- Capture generic HostOps as opaque child graphs through separate preparation and recording interfaces. Adapt all cuBLASLt DPS forms and prepare descriptors and algorithms outside capture.
- Use one physical-lifetime planner for tensors, private boundary copies, escaping outputs, per-operation scratch, and pinned staging. Bufferizer alloc/free markers remain authoritative; uploads occur before first use, and output readbacks follow the same schedule consumed by graph construction. Donated copies and completed readbacks release device ranges, scratch overlaps non-live tensors, and completed uploads release staging space for outputs. Aliased output slots share a readback at each output boundary.
- Keep each bucket's offsets fixed across dimension changes. Reuse compatible child graphs and bounded capture/parent executable caches, retain resources referenced by both source graphs and live executables, invalidate partial updates on failure, and synchronize before shared allocations move.
- Add symbolic index-expression support, graph reuse statistics, architecture documentation, and regressions for bucket transitions, dynamic layouts and indexing, cuBLASLt geometry, external operation traits, topology changes, capture recovery, physical-range reuse, early outputs, late inputs, and scratch-backed graph replay.

Execution is serialized on one stream because buckets and graph nodes reuse arena and staging ranges. Operation selection remains in egglog. HostOp scratch contents are valid only during the owning operation's captured GPU work; preparations may retain addresses but cannot use scratch to preserve state across operations.

Validation on an NVIDIA H200:

- `cargo test -p luminal -p luminal_reference -p luminal_cuda_lite -p test_runtime -p luminal_nn --features luminal_cuda_lite/device --no-fail-fast` — 703 passed, 12 existing ignores, no failures.
- `cargo test -p luminal_cuda_lite --features device --test execution_traits --test dynamic_graphs` — 16 passed.
- `cargo test -p luminal_cuda_lite --features device --lib` — 21 passed, including the allocator and physical-lifetime GPU regressions.
- `cargo clippy -p luminal_cuda_lite --features device --all-targets -- -D warnings` — passed.
- `cargo clippy -p luminal_cuda_lite --all-targets -- -D warnings` — passed without the device feature.
- `cargo fmt --all --check` and `git diff --check` — passed.
