### PR TITLE
qwen3_moe: expert banks enter as two stacked rank-3 inputs per layer

### DIFF
--- a/crates/model_zoo/src/qwen3_moe/model.rs
+++ b/crates/model_zoo/src/qwen3_moe/model.rs
@@ -5,6 +5,18 @@
 //! experts, top-8, NO shared expert, router in F32 with the Qwen3
 //! scoring order (softmax over all experts FIRST, then top-k, then
 //! renormalize — norm_topk_prob).
+//!
+//! THE EXPERT BANKS ARE TWO RANK-3 INPUTS PER LAYER, not 3×E rank-2
+//! ones: `mlp.experts.gate_up_proj` [E, 2I, H] and
+//! `mlp.experts.down_proj` [E, H, I] — the fused form transformers v5
+//! gives this model, and the form `gemma4_moe`'s checkpoint stores
+//! natively. The Qwen3 checkpoint on disk stores every expert
+//! separately (`mlp.experts.{e}.gate_proj|up_proj|down_proj.weight`),
+//! so the LOADER stacks them, a pure byte relayout with no arithmetic
+//! and no dtype change: `gate_up_proj[e, ..I, :]` = expert e's gate
+//! rows, `gate_up_proj[e, I.., :]` = its up rows, `down_proj[e]` = its
+//! down matrix. (Stacking in-graph instead would put 3×E inputs on the
+//! boundary and build the bank by pad+add.)
 
 use crate::model_support::{
     AttentionGeometry, CacheAccess, Embedding, KvCache, KvCachePool, LayerNorm, Linear, Namespace,
@@ -55,46 +67,42 @@ impl Qwen3MoeDims {
     }
 }
 
-/// Qwen3's model-specific routed SwiGLU feed-forward network.
+/// Qwen3's model-specific routed SwiGLU feed-forward network over the
+/// stacked expert banks (see the module doc for their layout).
 pub struct Qwen3MoeFfn {
     pub router: Linear,
+    /// `[E, 2I, H]`: gate rows then up rows per expert.
     pub gate_up: GraphTensor,
+    /// `[E, H, I]`.
     pub down: GraphTensor,
     pub top_k: usize,
     pub intermediate: usize,
 }
 
 impl Qwen3MoeFfn {
-    fn from_per_expert(
-        router: Linear,
-        parts: &[(GraphTensor, GraphTensor, GraphTensor)],
-        top_k: usize,
-    ) -> Self {
-        let (gate, _, _) = parts.first().expect("Qwen3 MoE requires an expert");
-        let intermediate = gate.dims()[0]
-            .to_usize()
-            .expect("Qwen3 expert intermediate size must be static");
-        let mut gate_up: Option<GraphTensor> = None;
-        let mut down: Option<GraphTensor> = None;
-        for (gate_part, up_part, down_part) in parts {
-            let gate_up_part = gate_part.concat_along(*up_part, 0).expand_dim(0, 1);
-            let down_part = down_part.expand_dim(0, 1);
-            gate_up = Some(match gate_up {
-                Some(stack) => stack.concat_along(gate_up_part, 0),
-                None => gate_up_part,
-            });
-            down = Some(match down {
-                Some(stack) => stack.concat_along(down_part, 0),
-                None => down_part,
-            });
-        }
-
+    fn new(mlp: &Namespace, d: &Qwen3MoeDims, cx: &mut Graph) -> Self {
+        let experts = mlp.child("experts");
         Self {
-            router,
-            gate_up: gate_up.expect("Qwen3 MoE requires an expert"),
-            down: down.expect("Qwen3 MoE requires an expert"),
-            top_k,
-            intermediate,
+            router: Linear::new(
+                d.hidden,
+                d.experts,
+                false,
+                DType::F32,
+                &mlp.child("gate"),
+                cx,
+            ),
+            gate_up: cx.named_tensor(
+                experts.leaf("gate_up_proj"),
+                (d.experts, 2 * d.moe_intermediate, d.hidden),
+                DType::F32,
+            ),
+            down: cx.named_tensor(
+                experts.leaf("down_proj"),
+                (d.experts, d.hidden, d.moe_intermediate),
+                DType::F32,
+            ),
+            top_k: d.top_k,
+            intermediate: d.moe_intermediate,
         }
     }
 
@@ -123,9 +131,6 @@ impl Qwen3MoeFfn {
 }
 
 pub struct Qwen3MoeBlock {
-    /// Per-expert (gate, up, down) handles — the HF checkpoint
-    /// anatomy; the Qwen3 feed-forward network stacks them in-graph.
-    pub expert_parts: Vec<(GraphTensor, GraphTensor, GraphTensor)>,
     pub attn_norm: LayerNorm,
     pub wq: Linear,
     pub wk: Linear,
@@ -145,29 +150,6 @@ impl Qwen3MoeBlock {
         let ns = Namespace::root().child("model").child("layers").index(l);
         let attn = ns.child("self_attn");
         let mlp = ns.child("mlp");
-        let experts = mlp.child("experts");
-        let expert_parts: Vec<(GraphTensor, GraphTensor, GraphTensor)> = (0..d.experts)
-            .map(|e| {
-                let expert = experts.index(e);
-                (
-                    cx.named_tensor(
-                        expert.child("gate_proj").leaf("weight"),
-                        (d.moe_intermediate, d.hidden),
-                        DType::F32,
-                    ),
-                    cx.named_tensor(
-                        expert.child("up_proj").leaf("weight"),
-                        (d.moe_intermediate, d.hidden),
-                        DType::F32,
-                    ),
-                    cx.named_tensor(
-                        expert.child("down_proj").leaf("weight"),
-                        (d.hidden, d.moe_intermediate),
-                        DType::F32,
-                    ),
-                )
-            })
-            .collect();
         Self {
             attn_norm: LayerNorm::new(
                 d.hidden,
@@ -223,19 +205,7 @@ impl Qwen3MoeBlock {
                 &ns.child("post_attention_layernorm"),
                 cx,
             ),
-            moe: Qwen3MoeFfn::from_per_expert(
-                Linear::new(
-                    d.hidden,
-                    d.experts,
-                    false,
-                    DType::F32,
-                    &mlp.child("gate"),
-                    cx,
-                ),
-                &expert_parts,
-                d.top_k,
-            ),
-            expert_parts,
+            moe: Qwen3MoeFfn::new(&mlp, d, cx),
             n_heads: d.n_heads,
             n_kv_heads: d.n_kv_heads,
             head_dim: d.head_dim,

--- a/crates/model_zoo/tests/qwen3_moe.rs
+++ b/crates/model_zoo/tests/qwen3_moe.rs
@@ -61,4 +61,30 @@ fn qwen3_30b_a3b_full_forward_contract_builds() {
     assert_eq!(static_dims(logits), vec![1, d.vocab]);
     assert_eq!(cache_out.len(), d.layers);
     assert_eq!(static_dims(cache_out[0].0), vec![SLOTS, d.kv_dim()]);
+
+    // The expert banks enter stacked (two rank-3 inputs per layer); the
+    // loader relayouts the checkpoint's per-expert tensors into them.
+    let moe = &model.blocks[0].moe;
+    assert_eq!(
+        static_dims(moe.gate_up),
+        vec![d.experts, 2 * d.moe_intermediate, d.hidden]
+    );
+    assert_eq!(
+        static_dims(moe.down),
+        vec![d.experts, d.hidden, d.moe_intermediate]
+    );
+    let labels: Vec<String> = cx
+        .logical
+        .input_specs()
+        .into_iter()
+        .map(|spec| spec.label)
+        .filter(|label| label.starts_with("model.layers.0.mlp.experts"))
+        .collect();
+    assert_eq!(
+        labels,
+        vec![
+            "model.layers.0.mlp.experts.gate_up_proj",
+            "model.layers.0.mlp.experts.down_proj",
+        ]
+    );
 }


### PR DESCRIPTION
## What

`examples/qwen3_moe` declared 3×E rank-2 expert inputs per layer (one per checkpoint key) and rebuilt the `[E, 2I, H]` / `[E, H, I]` banks in-graph with a 127-deep `concat_along` fold (pad + add). This PR declares the two stacked banks directly, as `gemma4_moe` already does:

- `model.layers.{l}.mlp.experts.gate_up_proj` `[E, 2I, H]` — gate rows then up rows per expert
- `model.layers.{l}.mlp.experts.down_proj` `[E, H, I]`

These are the transformers-v5 fused parameter names for this model. `Qwen3MoeFfn::from_per_expert` and `Qwen3MoeBlock::expert_parts` are removed; `forward` is unchanged. The stacking contract (a pure byte relayout of the per-expert checkpoint tensors, no dtype change) is documented at the declaration for the loader; no loader exists in the tree since the model/runtime split.

## Why

Ruling 2026-09-10 (Austin): a load-time pipeline may concatenate experts into one bank; dtype changes and value transforms stay out. At full scale the in-graph form put 18,432 expert inputs on the boundary (18,970 total), which overflowed egglog's recursive parser on the nested `BufferTensorCons` list (LUM-819) and routed every bank through ~12k rank-3 pads per forward.

## Effect

| | before | after |
|---|---|---|
| graph inputs (Qwen3-30B-A3B) | 18,970 | 634 |
| full 48-layer graph construction, Mac release | 6.79 s | 5.63 s |

The remaining construction time is not the fold; that is under separate study.

## Gate

- `cargo test -p qwen3_moe --release`: 2/2 (spec test now pins bank shapes + labels)
- `cargo clippy -p qwen3_moe --all-targets`: clean; `cargo fmt --check`: clean
- `cargo check -p luminal_cuda_lite --features device --example qwen3_moe`: compiles
- `cargo check --tests` for luminal_reference and luminal_cuda_lite: compile (their qwen3 MoE uses are the mini crate)
- Not run: device end-to-end on the A100 (the 30B model does not fit the 40 GB card); a host-only re-measure is the follow-up to LUM-819.

🤖 Generated with [Claude Code](https://claude.com/claude-code)