### PR TITLE
IntExpr::egglog_equal: structurally equal spellings short-circuit

### DIFF
--- a/src/shape/expression.rs
+++ b/src/shape/expression.rs
@@ -626,11 +626,19 @@ impl IntegerExpression {
             .collect();
         IntegerExpression::new(new_terms)
     }
+    /// Equality under the expression algebra. Structurally equal spellings
+    /// are equal without egglog; only differing spellings pay for a
+    /// saturation (a fresh e-graph per call).
+    pub fn egglog_equal(self, rhs: impl Into<IntegerExpression>) -> bool {
+        let rhs = rhs.into();
+        self == rhs || self.egglog_equal_saturating(rhs)
+    }
+
     /// Run proper equality check inside egglog
     #[tracing::instrument(skip_all)]
-    pub fn egglog_equal(self, rhs: impl Into<IntegerExpression>) -> bool {
+    fn egglog_equal_saturating(self, rhs: IntegerExpression) -> bool {
         let lhs_expr = self.to_egglog();
-        let rhs_expr = rhs.into().to_egglog();
+        let rhs_expr = rhs.to_egglog();
         let mut program = String::new();
         program.push_str(&egglog_utils::base::base_expression_egglog());
         program.push('\n');


### PR DESCRIPTION
## What

`IntExpr::egglog_equal` now returns `true` immediately when the two expressions are structurally equal, and only differing spellings reach the egglog saturation (moved into the private `egglog_equal_saturating`). One function, every caller benefits: `matmul::assert_dims_eq`, both `split_dims` forms, `dims_agree`, luminal_nn's MoE shape checks, and the Python translator's comparisons.

## Why

Each saturating call builds a fresh `egglog::EGraph`, string-assembles and parses the 11 KB base expression program, saturates three rulesets, and drops it: a flat ~4 ms whatever the operands. The matmul contraction check and the split divisibility check call it once per op on extents that are already structurally identical after `simplify`, so on full-size models recording time was almost entirely e-graph construction to learn that 2048 equals 2048. Structural equality is reflexive under the algebra, so the short-circuit changes no answer.

## Measured (Mac, release, full-size graphs, `Graph::new` + `init` + `forward` + `output()`)

| model | before | egglog_equal saturations before | after | saturations after |
|---|---|---|---|---|
| qwen3-4B, 36 layers, 7,125 values | 3.18 s | 829 calls, 3.16 s | 16.8 ms | 0 |
| gemma4_moe 26B-A4B, 30 layers, 14,628 values | 3.63 s | 956 calls, 3.61 s | 23.5 ms | 0 |

Recorded `model_text` is byte-identical before and after (1,487,508 and 2,509,732 bytes). The A100 box's host CPU is ~2.6× slower, so its 8.8 s / 10.1 s recordings should land near 45 / 60 ms.

## Not in this PR

- A memo on the saturating path plus caching the base program strings, for graphs with symbolic dims whose spellings differ (the only case that still pays the 4 ms).
- `LogicalGraph::input`'s duplicate-label scan is quadratic in input count (175 ms at 16k inputs); irrelevant at today's counts.

## Gate

- `cargo test -p luminal --lib --release`: all pass (matmul / movement / expression subsets incl. proptests: 38/38)
- `cargo test -p luminal_nn --lib -- moe`: 4/4
- full-model spec tests for qwen3, gemma4_moe, qwen3_moe, llama3, gemma3, whisper: pass
- `cargo build --release -p luminal_cuda_lite --examples`: ok; `cargo fmt --check` and lib clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)