### PR TITLE
Logical helpers: MatrixTranspose and BroadcastAxis spellings of view patterns

### DIFF
--- a/src/egglog_snippet.rs
+++ b/src/egglog_snippet.rs
@@ -149,6 +149,9 @@ pub fn assembled_program_for(matchers: &[Box<dyn crate::layout_ir::OpMatcher>]) 
     for op in crate::logical_op::built_in_logical_ops() {
         snippets.extend(op.snippets());
     }
+    for helper in crate::logical_helper::built_in_logical_helpers() {
+        snippets.extend(helper.snippets());
+    }
     for matcher in matchers {
         snippets.extend(matcher.snippets());
     }

--- a/src/extraction.rs
+++ b/src/extraction.rs
@@ -2565,7 +2565,10 @@ impl<'a> ClassRenderer<'a> {
 
     fn choose_logical_node(&self, class: &ClassId) -> Option<&NodeId> {
         let node_ids = self.class_nodes.get(class)?;
-        for op in crate::logical_op::built_in_logical_ops() {
+        for op in crate::logical_op::built_in_logical_ops()
+            .iter()
+            .chain(crate::logical_helper::built_in_logical_helpers())
+        {
             if let Some(node_id) = node_ids.iter().find(|node_id| {
                 self.egraph
                     .nodes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub mod subst_primitive;
 // (Austin's fold-into-core amendment, resident-geometry cleanup
 // 2026-08-31).
 pub mod layouts;
+pub mod logical_helper;
 pub mod logical_op;
 pub mod search_support;
 pub mod test_support;

--- a/src/logical_helper/broadcast_axis/constructor.egg
+++ b/src/logical_helper/broadcast_axis/constructor.egg
@@ -1,0 +1,5 @@
+; A logical tensor with one NEW axis of the given extent inserted at the
+; given from-end position of the output; identity on every existing axis.
+; Rank grows by one. A helper spelling of one LogicalIndexMapApply pattern,
+; unioned into the same class, so rules can match and mint it by name.
+(constructor LogicalHelperBroadcastAxis (LogicalTensor i64 IntExpr) LogicalTensor)

--- a/src/logical_helper/broadcast_axis/expand_rank1_pos0.egg
+++ b/src/logical_helper/broadcast_axis/expand_rank1_pos0.egg
@@ -1,0 +1,13 @@
+; BroadcastAxis, parent rank 1, new axis at from-end position 0: expand
+; the helper into the apply it names, tagged with the parent's shape.
+(rule
+  (
+    (= ?h (LogicalHelperBroadcastAxis ?p 0 ?e))
+    (= ?ishape (shape-of ?p))
+    (= ?ishape (ShapeLit (IntExprCons ?d0 (IntExprNil))))
+  )
+  (
+    (let oshape (ShapeLit (IntExprCons ?d0 (IntExprCons ?e (IntExprNil)))))
+    (union ?h (LogicalIndexMapApply ?p (IndexMapLit (IntExprCons (CoordVar oshape 1) (IntExprNil)) ?ishape) oshape))
+  )
+)

--- a/src/logical_helper/broadcast_axis/expand_rank1_pos1.egg
+++ b/src/logical_helper/broadcast_axis/expand_rank1_pos1.egg
@@ -1,0 +1,13 @@
+; BroadcastAxis, parent rank 1, new axis at from-end position 1: expand
+; the helper into the apply it names, tagged with the parent's shape.
+(rule
+  (
+    (= ?h (LogicalHelperBroadcastAxis ?p 1 ?e))
+    (= ?ishape (shape-of ?p))
+    (= ?ishape (ShapeLit (IntExprCons ?d0 (IntExprNil))))
+  )
+  (
+    (let oshape (ShapeLit (IntExprCons ?e (IntExprCons ?d0 (IntExprNil)))))
+    (union ?h (LogicalIndexMapApply ?p (IndexMapLit (IntExprCons (CoordVar oshape 0) (IntExprNil)) ?ishape) oshape))
+  )
+)

--- a/src/logical_helper/broadcast_axis/expand_rank2_pos0.egg
+++ b/src/logical_helper/broadcast_axis/expand_rank2_pos0.egg
@@ -1,0 +1,13 @@
+; BroadcastAxis, parent rank 2, new axis at from-end position 0: expand
+; the helper into the apply it names, tagged with the parent's shape.
+(rule
+  (
+    (= ?h (LogicalHelperBroadcastAxis ?p 0 ?e))
+    (= ?ishape (shape-of ?p))
+    (= ?ishape (ShapeLit (IntExprCons ?d1 (IntExprCons ?d0 (IntExprNil)))))
+  )
+  (
+    (let oshape (ShapeLit (IntExprCons ?d1 (IntExprCons ?d0 (IntExprCons ?e (IntExprNil))))))
+    (union ?h (LogicalIndexMapApply ?p (IndexMapLit (IntExprCons (CoordVar oshape 2) (IntExprCons (CoordVar oshape 1) (IntExprNil))) ?ishape) oshape))
+  )
+)

--- a/src/logical_helper/broadcast_axis/expand_rank2_pos1.egg
+++ b/src/logical_helper/broadcast_axis/expand_rank2_pos1.egg
@@ -1,0 +1,13 @@
+; BroadcastAxis, parent rank 2, new axis at from-end position 1: expand
+; the helper into the apply it names, tagged with the parent's shape.
+(rule
+  (
+    (= ?h (LogicalHelperBroadcastAxis ?p 1 ?e))
+    (= ?ishape (shape-of ?p))
+    (= ?ishape (ShapeLit (IntExprCons ?d1 (IntExprCons ?d0 (IntExprNil)))))
+  )
+  (
+    (let oshape (ShapeLit (IntExprCons ?d1 (IntExprCons ?e (IntExprCons ?d0 (IntExprNil))))))
+    (union ?h (LogicalIndexMapApply ?p (IndexMapLit (IntExprCons (CoordVar oshape 2) (IntExprCons (CoordVar oshape 0) (IntExprNil))) ?ishape) oshape))
+  )
+)

--- a/src/logical_helper/broadcast_axis/expand_rank2_pos2.egg
+++ b/src/logical_helper/broadcast_axis/expand_rank2_pos2.egg
@@ -1,0 +1,13 @@
+; BroadcastAxis, parent rank 2, new axis at from-end position 2: expand
+; the helper into the apply it names, tagged with the parent's shape.
+(rule
+  (
+    (= ?h (LogicalHelperBroadcastAxis ?p 2 ?e))
+    (= ?ishape (shape-of ?p))
+    (= ?ishape (ShapeLit (IntExprCons ?d1 (IntExprCons ?d0 (IntExprNil)))))
+  )
+  (
+    (let oshape (ShapeLit (IntExprCons ?e (IntExprCons ?d1 (IntExprCons ?d0 (IntExprNil))))))
+    (union ?h (LogicalIndexMapApply ?p (IndexMapLit (IntExprCons (CoordVar oshape 1) (IntExprCons (CoordVar oshape 0) (IntExprNil))) ?ishape) oshape))
+  )
+)

--- a/src/logical_helper/broadcast_axis/mod.rs
+++ b/src/logical_helper/broadcast_axis/mod.rs
@@ -1,0 +1,83 @@
+use egraph_serialize::Node;
+
+use crate::egglog_snippet::{EgglogSnippet, SpliceCategory};
+use crate::logical_op::{LogicalOp, LogicalRender};
+
+/// One new axis inserted at a from-end position (see `constructor.egg`).
+/// Instances cover parents of rank 1 and 2 at every insertion position.
+#[derive(Debug, Clone, Copy)]
+pub struct LogicalHelperBroadcastAxis;
+
+impl LogicalOp for LogicalHelperBroadcastAxis {
+    fn egglog_constructor(&self) -> &'static str {
+        "LogicalHelperBroadcastAxis"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "broadcast_axis"
+    }
+
+    fn child_ports(&self) -> &'static [(&'static str, usize)] {
+        &[("input", 0)]
+    }
+
+    fn readable_expr(&self, node: &Node, ctx: &mut dyn LogicalRender) -> String {
+        let input = ctx.child_expr(node, 0);
+        let axis = ctx
+            .child_short(node, 1, 1, None)
+            .unwrap_or_else(|| "?".to_string());
+        let extent = ctx
+            .child_int_expr(node, 2)
+            .unwrap_or_else(|| "?".to_string());
+        format!("LogicalHelperBroadcastAxis(input={input}, axis_from_end={axis}, extent={extent})")
+    }
+
+    fn snippets(&self) -> Vec<EgglogSnippet> {
+        vec![
+            EgglogSnippet {
+                category: SpliceCategory::LogicalConstructors,
+                text: include_str!("constructor.egg"),
+            },
+            EgglogSnippet {
+                category: SpliceCategory::Rewrites,
+                text: include_str!("recognize_rank1_pos0.egg"),
+            },
+            EgglogSnippet {
+                category: SpliceCategory::Rewrites,
+                text: include_str!("expand_rank1_pos0.egg"),
+            },
+            EgglogSnippet {
+                category: SpliceCategory::Rewrites,
+                text: include_str!("recognize_rank1_pos1.egg"),
+            },
+            EgglogSnippet {
+                category: SpliceCategory::Rewrites,
+                text: include_str!("expand_rank1_pos1.egg"),
+            },
+            EgglogSnippet {
+                category: SpliceCategory::Rewrites,
+                text: include_str!("recognize_rank2_pos0.egg"),
+            },
+            EgglogSnippet {
+                category: SpliceCategory::Rewrites,
+                text: include_str!("expand_rank2_pos0.egg"),
+            },
+            EgglogSnippet {
+                category: SpliceCategory::Rewrites,
+                text: include_str!("recognize_rank2_pos1.egg"),
+            },
+            EgglogSnippet {
+                category: SpliceCategory::Rewrites,
+                text: include_str!("expand_rank2_pos1.egg"),
+            },
+            EgglogSnippet {
+                category: SpliceCategory::Rewrites,
+                text: include_str!("recognize_rank2_pos2.egg"),
+            },
+            EgglogSnippet {
+                category: SpliceCategory::Rewrites,
+                text: include_str!("expand_rank2_pos2.egg"),
+            },
+        ]
+    }
+}

--- a/src/logical_helper/broadcast_axis/recognize_rank1_pos0.egg
+++ b/src/logical_helper/broadcast_axis/recognize_rank1_pos0.egg
@@ -1,0 +1,12 @@
+; BroadcastAxis, parent rank 1, new axis at from-end position 0: recognize
+; the apply whose out dims are the parent's dims with one extent inserted
+; and whose entries read every parent axis from its own coordinate.
+(rule
+  (
+    (= ?v (LogicalIndexMapApply ?p ?map ?oshape))
+    (= ?map (IndexMapLit (IntExprCons (CoordVar ?oshape 1) (IntExprNil)) ?tag))
+    (= ?tag    (ShapeLit (IntExprCons ?d0 (IntExprNil))))
+    (= ?oshape (ShapeLit (IntExprCons ?d0 (IntExprCons ?e (IntExprNil)))))
+  )
+  ((union ?v (LogicalHelperBroadcastAxis ?p 0 ?e)))
+)

--- a/src/logical_helper/broadcast_axis/recognize_rank1_pos1.egg
+++ b/src/logical_helper/broadcast_axis/recognize_rank1_pos1.egg
@@ -1,0 +1,12 @@
+; BroadcastAxis, parent rank 1, new axis at from-end position 1: recognize
+; the apply whose out dims are the parent's dims with one extent inserted
+; and whose entries read every parent axis from its own coordinate.
+(rule
+  (
+    (= ?v (LogicalIndexMapApply ?p ?map ?oshape))
+    (= ?map (IndexMapLit (IntExprCons (CoordVar ?oshape 0) (IntExprNil)) ?tag))
+    (= ?tag    (ShapeLit (IntExprCons ?d0 (IntExprNil))))
+    (= ?oshape (ShapeLit (IntExprCons ?e (IntExprCons ?d0 (IntExprNil)))))
+  )
+  ((union ?v (LogicalHelperBroadcastAxis ?p 1 ?e)))
+)

--- a/src/logical_helper/broadcast_axis/recognize_rank2_pos0.egg
+++ b/src/logical_helper/broadcast_axis/recognize_rank2_pos0.egg
@@ -1,0 +1,12 @@
+; BroadcastAxis, parent rank 2, new axis at from-end position 0: recognize
+; the apply whose out dims are the parent's dims with one extent inserted
+; and whose entries read every parent axis from its own coordinate.
+(rule
+  (
+    (= ?v (LogicalIndexMapApply ?p ?map ?oshape))
+    (= ?map (IndexMapLit (IntExprCons (CoordVar ?oshape 2) (IntExprCons (CoordVar ?oshape 1) (IntExprNil))) ?tag))
+    (= ?tag    (ShapeLit (IntExprCons ?d1 (IntExprCons ?d0 (IntExprNil)))))
+    (= ?oshape (ShapeLit (IntExprCons ?d1 (IntExprCons ?d0 (IntExprCons ?e (IntExprNil))))))
+  )
+  ((union ?v (LogicalHelperBroadcastAxis ?p 0 ?e)))
+)

--- a/src/logical_helper/broadcast_axis/recognize_rank2_pos1.egg
+++ b/src/logical_helper/broadcast_axis/recognize_rank2_pos1.egg
@@ -1,0 +1,12 @@
+; BroadcastAxis, parent rank 2, new axis at from-end position 1: recognize
+; the apply whose out dims are the parent's dims with one extent inserted
+; and whose entries read every parent axis from its own coordinate.
+(rule
+  (
+    (= ?v (LogicalIndexMapApply ?p ?map ?oshape))
+    (= ?map (IndexMapLit (IntExprCons (CoordVar ?oshape 2) (IntExprCons (CoordVar ?oshape 0) (IntExprNil))) ?tag))
+    (= ?tag    (ShapeLit (IntExprCons ?d1 (IntExprCons ?d0 (IntExprNil)))))
+    (= ?oshape (ShapeLit (IntExprCons ?d1 (IntExprCons ?e (IntExprCons ?d0 (IntExprNil))))))
+  )
+  ((union ?v (LogicalHelperBroadcastAxis ?p 1 ?e)))
+)

--- a/src/logical_helper/broadcast_axis/recognize_rank2_pos2.egg
+++ b/src/logical_helper/broadcast_axis/recognize_rank2_pos2.egg
@@ -1,0 +1,12 @@
+; BroadcastAxis, parent rank 2, new axis at from-end position 2: recognize
+; the apply whose out dims are the parent's dims with one extent inserted
+; and whose entries read every parent axis from its own coordinate.
+(rule
+  (
+    (= ?v (LogicalIndexMapApply ?p ?map ?oshape))
+    (= ?map (IndexMapLit (IntExprCons (CoordVar ?oshape 1) (IntExprCons (CoordVar ?oshape 0) (IntExprNil))) ?tag))
+    (= ?tag    (ShapeLit (IntExprCons ?d1 (IntExprCons ?d0 (IntExprNil)))))
+    (= ?oshape (ShapeLit (IntExprCons ?e (IntExprCons ?d1 (IntExprCons ?d0 (IntExprNil))))))
+  )
+  ((union ?v (LogicalHelperBroadcastAxis ?p 2 ?e)))
+)

--- a/src/logical_helper/matrix_transpose/constructor.egg
+++ b/src/logical_helper/matrix_transpose/constructor.egg
@@ -1,0 +1,4 @@
+; The rank-2 transpose of a logical tensor: the view whose two axes trade
+; places. A helper spelling of one LogicalIndexMapApply pattern, unioned
+; into the same class, so rules can match and mint the pattern by name.
+(constructor LogicalHelperMatrixTranspose (LogicalTensor) LogicalTensor)

--- a/src/logical_helper/matrix_transpose/expand.egg
+++ b/src/logical_helper/matrix_transpose/expand.egg
@@ -1,0 +1,19 @@
+; Expand: a transpose helper over a [d1, d0] parent is the apply reading it
+; through (c0 c1) into [d0, d1]. The map is tagged with the parent's shape,
+; as the recorder tags it, so both spellings land on one apply row.
+(rule
+  (
+    (= ?h (LogicalHelperMatrixTranspose ?p))
+    (= ?ishape (shape-of ?p))
+    (= ?ishape (ShapeLit (IntExprCons ?d1 (IntExprCons ?d0 (IntExprNil)))))
+  )
+  (
+    (let oshape (ShapeLit (IntExprCons ?d0 (IntExprCons ?d1 (IntExprNil)))))
+    (union ?h (LogicalIndexMapApply ?p
+      (IndexMapLit
+        (IntExprCons (CoordVar oshape 0)
+          (IntExprCons (CoordVar oshape 1) (IntExprNil)))
+        ?ishape)
+      oshape))
+  )
+)

--- a/src/logical_helper/matrix_transpose/involution.egg
+++ b/src/logical_helper/matrix_transpose/involution.egg
@@ -1,0 +1,8 @@
+; The transpose of a transpose is the tensor itself.
+(rule
+  (
+    (= ?w (LogicalHelperMatrixTranspose ?v))
+    (= ?v (LogicalHelperMatrixTranspose ?x))
+  )
+  ((union ?w ?x))
+)

--- a/src/logical_helper/matrix_transpose/mod.rs
+++ b/src/logical_helper/matrix_transpose/mod.rs
@@ -1,0 +1,47 @@
+use egraph_serialize::Node;
+
+use crate::egglog_snippet::{EgglogSnippet, SpliceCategory};
+use crate::logical_op::{LogicalOp, LogicalRender};
+
+/// The rank-2 transpose view (see `constructor.egg`).
+#[derive(Debug, Clone, Copy)]
+pub struct LogicalHelperMatrixTranspose;
+
+impl LogicalOp for LogicalHelperMatrixTranspose {
+    fn egglog_constructor(&self) -> &'static str {
+        "LogicalHelperMatrixTranspose"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "matrix_transpose"
+    }
+
+    fn child_ports(&self) -> &'static [(&'static str, usize)] {
+        &[("input", 0)]
+    }
+
+    fn readable_expr(&self, node: &Node, ctx: &mut dyn LogicalRender) -> String {
+        format!("LogicalHelperMatrixTranspose({})", ctx.child_expr(node, 0))
+    }
+
+    fn snippets(&self) -> Vec<EgglogSnippet> {
+        vec![
+            EgglogSnippet {
+                category: SpliceCategory::LogicalConstructors,
+                text: include_str!("constructor.egg"),
+            },
+            EgglogSnippet {
+                category: SpliceCategory::Rewrites,
+                text: include_str!("recognize.egg"),
+            },
+            EgglogSnippet {
+                category: SpliceCategory::Rewrites,
+                text: include_str!("expand.egg"),
+            },
+            EgglogSnippet {
+                category: SpliceCategory::Rewrites,
+                text: include_str!("involution.egg"),
+            },
+        ]
+    }
+}

--- a/src/logical_helper/matrix_transpose/recognize.egg
+++ b/src/logical_helper/matrix_transpose/recognize.egg
@@ -1,0 +1,15 @@
+; Recognize: the apply reading a [d1, d0] parent through (c0 c1) into
+; [d0, d1] is its transpose. The out dims are the parent's dims swapped,
+; tied by shared variables: a shrinking or widening read is not a transpose.
+(rule
+  (
+    (= ?v (LogicalIndexMapApply ?p ?map ?oshape))
+    (= ?map (IndexMapLit
+        (IntExprCons (CoordVar ?oshape 0)
+          (IntExprCons (CoordVar ?oshape 1) (IntExprNil)))
+        ?tag))
+    (= ?tag    (ShapeLit (IntExprCons ?d1 (IntExprCons ?d0 (IntExprNil)))))
+    (= ?oshape (ShapeLit (IntExprCons ?d0 (IntExprCons ?d1 (IntExprNil)))))
+  )
+  ((union ?v (LogicalHelperMatrixTranspose ?p)))
+)

--- a/src/logical_helper/mod.rs
+++ b/src/logical_helper/mod.rs
@@ -1,0 +1,134 @@
+//! Helper spellings of common `LogicalIndexMapApply` patterns.
+//!
+//! A helper is a `LogicalTensor` constructor that names one view pattern
+//! and carries every field needed to rebuild it. Each instance has two
+//! rules: recognize (the apply's class gains the helper) and expand (the
+//! helper's class gains the apply), so rewrite rules can match and mint
+//! the pattern by name. Helpers own no shape or dtype rules: the union
+//! with the apply carries both. They live beside the core logical-op
+//! vocabulary, not inside it, and register through their own list.
+
+use crate::logical_op::LogicalOp;
+
+mod broadcast_axis;
+mod matrix_transpose;
+
+pub use broadcast_axis::LogicalHelperBroadcastAxis;
+pub use matrix_transpose::LogicalHelperMatrixTranspose;
+
+/// THE registration list for logical helpers, kept apart from
+/// [`crate::logical_op::built_in_logical_ops`] so the core vocabulary
+/// stays small. Consulted after the ops wherever a constructor is looked
+/// up by name.
+pub fn built_in_logical_helpers() -> &'static [Box<dyn LogicalOp + Send + Sync>] {
+    static HELPERS: std::sync::OnceLock<Vec<Box<dyn LogicalOp + Send + Sync>>> =
+        std::sync::OnceLock::new();
+    HELPERS.get_or_init(|| {
+        vec![
+            Box::new(LogicalHelperMatrixTranspose),
+            Box::new(LogicalHelperBroadcastAxis),
+        ]
+    })
+}
+
+/// Registry lookup by egglog constructor name.
+pub fn logical_helper_for(constructor: &str) -> Option<&'static (dyn LogicalOp + Send + Sync)> {
+    built_in_logical_helpers()
+        .iter()
+        .find(|helper| helper.egglog_constructor() == constructor)
+        .map(|helper| helper.as_ref())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::egglog_snippet::{assembled_program_for, new_egraph};
+
+    const SCHEDULE: &str = "(run-schedule (saturate (run prop)) (saturate (saturate (run) (run prop)) (run subst-walk)))";
+
+    /// Run `script` under the core program (no runtime matchers) — its
+    /// `check`s are the assertions.
+    fn run(script: &str) {
+        let program = format!("{}\n\n{script}", assembled_program_for(&[]));
+        new_egraph()
+            .parse_and_run_program(None, &program)
+            .unwrap_or_else(|err| panic!("helper script: {err}"));
+    }
+
+    #[test]
+    fn matrix_transpose_recognizes_expands_and_involutes() {
+        run(&format!(
+            r#"
+(let pshape (ShapeLit (IntExprCons (IntLit 5) (IntExprCons (IntLit 3) (IntExprNil)))))
+(let oshape (ShapeLit (IntExprCons (IntLit 3) (IntExprCons (IntLit 5) (IntExprNil)))))
+(let x (LogicalTensorInputLit (LogicalIdLit "x") pshape (F32)))
+; the recorder's spelling of x.permute((1, 0))
+(let xt (LogicalIndexMapApply x
+  (IndexMapLit (IntExprCons (CoordVar oshape 0) (IntExprCons (CoordVar oshape 1) (IntExprNil))) pshape)
+  oshape))
+; a helper minted directly, as a rewrite would
+(let ht (LogicalHelperMatrixTranspose x))
+(let htt (LogicalHelperMatrixTranspose (LogicalHelperMatrixTranspose x)))
+; a shrinking read through the same entries is NOT a transpose
+(let sshape (ShapeLit (IntExprCons (IntLit 2) (IntExprCons (IntLit 5) (IntExprNil)))))
+(let xs (LogicalIndexMapApply x
+  (IndexMapLit (IntExprCons (CoordVar sshape 0) (IntExprCons (CoordVar sshape 1) (IntExprNil))) pshape)
+  sshape))
+; an extent-1 axis: the transpose still saturates without a shape conflict
+(let p14 (ShapeLit (IntExprCons (IntLit 1) (IntExprCons (IntLit 4) (IntExprNil)))))
+(let y (LogicalTensorInputLit (LogicalIdLit "y") p14 (F32)))
+(let yt (LogicalHelperMatrixTranspose y))
+{SCHEDULE}
+(check (= xt (LogicalHelperMatrixTranspose x)))
+(check (= ht xt))
+(check (= (shape-of ht) oshape))
+(check (= (dtype-of ht) (F32)))
+(check (= htt x))
+(fail (check (= xs (LogicalHelperMatrixTranspose x))))
+(check (= (shape-of yt) (ShapeLit (IntExprCons (IntLit 4) (IntExprCons (IntLit 1) (IntExprNil))))))
+"#
+        ));
+    }
+
+    #[test]
+    fn broadcast_axis_recognizes_and_expands_every_instance() {
+        run(&format!(
+            r#"
+(let pshape (ShapeLit (IntExprCons (IntLit 5) (IntExprCons (IntLit 3) (IntExprNil)))))
+(let a (LogicalTensorInputLit (LogicalIdLit "a") pshape (F32)))
+(let n (IntLit 7))
+; the matmul A leg: a[m,k] read through (c2 c0) into P = [m, n, k]
+(let p3 (ShapeLit (IntExprCons (IntLit 5) (IntExprCons n (IntExprCons (IntLit 3) (IntExprNil))))))
+(let a_b (LogicalIndexMapApply a
+  (IndexMapLit (IntExprCons (CoordVar p3 2) (IntExprCons (CoordVar p3 0) (IntExprNil))) pshape)
+  p3))
+; helpers minted directly at every position of a rank-2 parent
+(let h0 (LogicalHelperBroadcastAxis a 0 n))
+(let h1 (LogicalHelperBroadcastAxis a 1 n))
+(let h2 (LogicalHelperBroadcastAxis a 2 n))
+; a rank-1 parent, both positions
+(let vshape (ShapeLit (IntExprCons (IntLit 4) (IntExprNil))))
+(let v (LogicalTensorInputLit (LogicalIdLit "v") vshape (F32)))
+(let v_out (ShapeLit (IntExprCons n (IntExprCons (IntLit 4) (IntExprNil)))))
+(let v_b (LogicalIndexMapApply v (IndexMapLit (IntExprCons (CoordVar v_out 0) (IntExprNil)) vshape) v_out))
+(let g0 (LogicalHelperBroadcastAxis v 0 n))
+; the same entries over a shrunk out shape is NOT an insertion (shape tie)
+(let bshape (ShapeLit (IntExprCons (IntLit 5) (IntExprCons n (IntExprCons (IntLit 2) (IntExprNil))))))
+(let bad (LogicalIndexMapApply a
+  (IndexMapLit (IntExprCons (CoordVar bshape 2) (IntExprCons (CoordVar bshape 0) (IntExprNil))) pshape)
+  bshape))
+{SCHEDULE}
+(check (= a_b (LogicalHelperBroadcastAxis a 1 n)))
+(check (= h1 a_b))
+(check (= (shape-of h1) p3))
+(check (= (dtype-of h1) (F32)))
+(check (= (shape-of h0) (ShapeLit (IntExprCons (IntLit 5) (IntExprCons (IntLit 3) (IntExprCons n (IntExprNil)))))))
+(check (= (shape-of h2) (ShapeLit (IntExprCons n (IntExprCons (IntLit 5) (IntExprCons (IntLit 3) (IntExprNil)))))))
+(check (= v_b (LogicalHelperBroadcastAxis v 1 n)))
+(check (= (shape-of g0) (ShapeLit (IntExprCons (IntLit 4) (IntExprCons n (IntExprNil))))))
+(fail (check (= bad (LogicalHelperBroadcastAxis a 0 n))))
+(fail (check (= bad (LogicalHelperBroadcastAxis a 1 n))))
+(fail (check (= bad (LogicalHelperBroadcastAxis a 2 n))))
+"#
+        ));
+    }
+}

--- a/src/logical_op/mod.rs
+++ b/src/logical_op/mod.rs
@@ -218,10 +218,11 @@ pub fn built_in_logical_ops() -> &'static [Box<dyn LogicalOp + Send + Sync>] {
     })
 }
 
-/// Registry lookup by egglog constructor name.
+/// Registry lookup by egglog constructor name — the ops, then the helpers.
 pub fn logical_op_for(constructor: &str) -> Option<&'static (dyn LogicalOp + Send + Sync)> {
     built_in_logical_ops()
         .iter()
         .find(|op| op.egglog_constructor() == constructor)
         .map(|op| op.as_ref())
+        .or_else(|| crate::logical_helper::logical_helper_for(constructor))
 }

--- a/tests/test_runtime/tests/r11_collapse_revert_probe.rs
+++ b/tests/test_runtime/tests/r11_collapse_revert_probe.rs
@@ -1,27 +1,24 @@
-//! ROUND-11 REVERT PROBE (permanent): the double-transpose collapse rule
-//! is the sandwich's termination anchor.
+//! ROUND-11 REVERT PROBE (permanent): the transpose sandwich needs a
+//! termination anchor, and the probe pins that one is in force.
 //!
 //! The canonical-form sandwich mints a sibling whose operands are rank-2
 //! transpose VIEWS, and the sibling is itself canonical, so the sandwich
-//! fires on it too. WITH the collapse rule, generation-3 operands
-//! (views-of-views) union back into generation 1 and every rebuilt chain
-//! hash-conses into the original — saturation closes. WITHOUT it, each
-//! generation's views are NEW values and the main ruleset never
-//! saturates.
+//! fires on it too. Unless views-of-views union back into the original
+//! tensor, each generation's views are NEW values and the main ruleset
+//! never saturates (measured 2026-08-26 with no anchor: 3729 / 4616 /
+//! 5386 / 6156 nodes at K = 40/60/80/100, ~38 nodes per iteration).
 //!
-//! The default schedule ((saturate ...)) would simply HANG without the
-//! collapse rule, so this probe runs a BOUNDED schedule ((run-schedule
-//! (repeat K (run)))) at increasing K and prints node counts:
-//!   * collapse REMOVED:  counts grow strictly with every added
-//!     iteration block — unbounded growth (measured 2026-08-26: 3729 /
-//!     4616 / 5386 / 6156 at K = 40/60/80/100, ~38 nodes per iteration
-//!     with no plateau);
-//!   * collapse PRESENT:  the count reaches the main ruleset's fixed
-//!     point and stays flat (measured: 3022 at K = 60, 80, and 100).
-//!
-//! The rule text is removed by exact string surgery on the assembled
-//! program (a marker-comment slice), so what runs without the rule is
-//! byte-identical everywhere else.
+//! Two anchors exist. The cuBLASLt estate's double-transpose collapse
+//! rule (cublaslt_marker_canonicalize.egg) unions an apply-of-apply
+//! transpose with its base directly. Core's `LogicalHelperMatrixTranspose`
+//! recognizer names every rank-2 transpose view, and its involution rule
+//! unions a transpose of a transpose with the base, so core anchors the
+//! sandwich on its own. The probe runs a BOUNDED schedule ((run-schedule
+//! (repeat K (run)))) at increasing K WITH and WITHOUT the collapse rule
+//! (removed by exact string surgery on the assembled program) and
+//! requires both to reach the same flat node count inside the range: the
+//! collapse rule is redundant, and if this ever grows again the anchor
+//! has been lost.
 
 use luminal::dtype::DType;
 use luminal::graph::Graph;
@@ -96,36 +93,34 @@ fn node_count(program: &str) -> usize {
 }
 
 #[test]
-fn r11_collapse_removed_diverges_and_present_saturates() {
-    // WITHOUT the collapse rule: strictly growing node counts — every
-    // added iteration mints a fresh generation of views-of-views.
-    let mut without = Vec::new();
-    for iters in [40usize, 60, 80, 100] {
-        let n = node_count(&bounded_program(iters, false));
-        println!("collapse REMOVED, run {iters}: {n} nodes");
-        without.push(n);
-    }
-    for pair in without.windows(2) {
-        assert!(
-            pair[1] > pair[0],
-            "without the collapse rule the count must grow every added \
-             iteration block (got {without:?}) — if this ever plateaus, the \
-             divergence closed some other way and the collapse rule may be \
-             re-litigated"
-        );
-    }
-
-    // WITH the collapse rule: the same K range is DEEP saturation — the
-    // count reaches its fixed point and stays flat.
-    let mut with = Vec::new();
-    for iters in [60usize, 80, 100] {
-        let n = node_count(&bounded_program(iters, true));
-        println!("collapse PRESENT, run {iters}: {n} nodes");
-        with.push(n);
-    }
+fn r11_sandwich_terminates_with_and_without_the_collapse_rule() {
+    let counts = |with_collapse: bool| -> Vec<usize> {
+        [60usize, 80, 100]
+            .into_iter()
+            .map(|iters| {
+                let n = node_count(&bounded_program(iters, with_collapse));
+                println!(
+                    "collapse {}, run {iters}: {n} nodes",
+                    if with_collapse { "PRESENT" } else { "REMOVED" }
+                );
+                n
+            })
+            .collect()
+    };
+    let without = counts(false);
+    let with = counts(true);
+    assert!(
+        without.windows(2).all(|p| p[0] == p[1]),
+        "without the collapse rule the main ruleset must still saturate inside \
+         the probe range — core's transpose involution is the anchor (got {without:?})"
+    );
     assert!(
         with.windows(2).all(|p| p[0] == p[1]),
         "with the collapse rule the main ruleset must saturate inside the \
          probe range (got {with:?})"
+    );
+    assert_eq!(
+        without[0], with[0],
+        "the two anchors must close at the same fixed point"
     );
 }


### PR DESCRIPTION
## What

Round 1 of the helper vocabulary: core `LogicalTensor` constructors that name common `LogicalIndexMapApply` patterns, each with a recognize rule (apply → helper) and an expand rule (helper → apply), unioned into one class so rewrite rules can match and mint the pattern by name.

- `LogicalHelperMatrixTranspose (LogicalTensor) LogicalTensor`: rank-2 transpose; recognize, expand, and the involution `T(T(x)) = x`.
- `LogicalHelperBroadcastAxis (LogicalTensor i64 IntExpr) LogicalTensor`: one new axis of the given extent at the given from-end position; instances for parents of rank 1 (positions 0, 1) and rank 2 (positions 0, 1, 2), generated from one template. The rank-2 / position-1 instance is byte-for-byte the cuBLASLt site rule's A-leg spelling.
- New folder `src/logical_helper/` with its own registry (`built_in_logical_helpers`), kept apart from the core logical-op list; `logical_op_for`, `assembled_program_for` and the extractor's node chooser consult it after the ops.
- No helper shape or dtype rules: the union with the expanded apply carries both (decision: one propagation pathway).
- Recognizers tie out dims to parent dims by shared variables; all rules are equality joins, no `!=`.

## Measured (gemma3, real CUDA Lite program, Mac release)

| layers | wall before → after | iterations | rows added | helper rule time |
|---|---|---|---|---|
| 8 | 2,356 → 2,385 ms | 2,818 → 2,818 | +487 (294 transpose, 193 broadcast) | 15 ms |
| 16 | 4,481 → 4,493 ms | 5,346 → 5,346 | +951 | 20 ms |
| 34 | 12,005 → 12,424 ms | 11,034 → 11,034 | +1,995 | 29 ms |

Every non-helper table is identical at every depth (per-table size dumps diff clean); the added rows are exactly the two helper tables. The cuBLASLt rules and their timings are untouched.

## Finding: the transpose sandwich's termination anchor

The r11 revert probe pinned that removing the cuBLASLt double-transpose collapse rule makes the sandwich diverge. With the helpers, the recognizer names the sandwich's transpose views and the involution unions views-of-views back to the base, so the "removed" arm now plateaus at the same fixed point as the "present" arm (2,624 nodes from K=60 on, both arms). The probe is rewritten to pin that both anchors close identically. The collapse rule in `cublaslt_marker_canonicalize.egg` is now redundant on this fixture but is not modified here; removing it is a separate decision.

## Tests / gate

- New: `logical_helper::tests` (egglog scripts under the core program): recorder spellings recognized, directly minted helpers expand and get shape/dtype through the union, involution, shrunk-read negatives unmatched, extent-1 parent saturates.
- `cargo test --release`: luminal lib 259 pass (incl. the prop-ruleset hygiene test), luminal_nn 31, luminal_reference 44, luminal_cuda_lite host suites all pass, test_runtime all pass after the probe update; fmt and lib clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)