### PR TITLE
Model mutation with shared boundary buffer ids

### DIFF
--- a/crates/luminal_cuda_lite/src/bindings.rs
+++ b/crates/luminal_cuda_lite/src/bindings.rs
@@ -12,6 +12,7 @@
 //! (cuBLASLt descriptors). Divergence happens HERE, never in core.
 
 use luminal::dtype::DType;
+use luminal::layout_ir::Access;
 use luminal::runtime_binding::RuntimeBindingsGenerator;
 
 /// The CUDA-lite runtime's binding vocabulary.
@@ -36,8 +37,9 @@ impl RuntimeBindingsGenerator for CudaBindings {
         }
     }
 
-    /// Input boundary: contiguous row-major storage, read-only,
-    /// caller-owned, buffer id = the HLIR node index (set_data keying).
+    /// Input boundary: contiguous row-major storage, caller-owned,
+    /// buffer id = the HLIR node index (set_data keying). `access` is
+    /// ReadWrite when a `.output_into()` mutates this input in place.
     /// The buffer-tensor let is named `{stem}_buffer_tensor`.
     fn input_binding(
         &self,
@@ -46,12 +48,13 @@ impl RuntimeBindingsGenerator for CudaBindings {
         logical_name: &str,
         shape: &str,
         width: &str,
+        access: Access,
     ) -> String {
         format!(
             "(let {stem}_layout (RightMajorContiguousElementLayoutLit {shape} {width}))\n\
              (let {stem}_layout_tensor (LayoutTensorLit {logical_name} {stem}_layout))\n\
              (let {stem}_buffer_id (BufferLit {idx}))\n\
-             (set (buffer-access-of {stem}_buffer_id) (ReadOnly))\n\
+             (set (buffer-access-of {stem}_buffer_id) ({access:?}))\n\
              (set (buffer-freed-by {stem}_buffer_id) (CallerFrees))\n\
              (let {stem}_buffer_tensor (BufferTensorLit {stem}_layout_tensor {stem}_buffer_id))\n\n"
         )

--- a/crates/luminal_cuda_lite/src/device.rs
+++ b/crates/luminal_cuda_lite/src/device.rs
@@ -78,7 +78,6 @@ pub struct CudaDevice {
     stats: GraphStats,
     residents: BTreeMap<i64, ResidentHome>,
     resident_initialized: BTreeSet<i64>,
-    feedback: BTreeMap<usize, i64>,
 }
 impl CudaDevice {
     pub fn new(ordinal: usize) -> Result<Self> {
@@ -94,7 +93,6 @@ impl CudaDevice {
             stats: GraphStats::default(),
             residents: BTreeMap::new(),
             resident_initialized: BTreeSet::new(),
-            feedback: BTreeMap::new(),
         })
     }
     pub fn stats(&self) -> GraphStats {
@@ -143,7 +141,6 @@ impl CudaDevice {
         self.installed.clear();
         self.residents = allocation.homes;
         self.resident_initialized.clear();
-        self.feedback = allocation.feedback;
 
         let staging_bytes = installed
             .iter()
@@ -234,7 +231,6 @@ impl CudaDevice {
         self.installed.clear();
         self.residents.clear();
         self.resident_initialized.clear();
-        self.feedback.clear();
         self.slab = None;
         self.staging = None;
         self.stats.staging_bytes = 0;
@@ -275,7 +271,6 @@ impl CudaDevice {
                 &mut self.cache,
                 &mut self.stats,
                 &self.residents,
-                &self.feedback,
             )?);
         }
         // Move the executable out while updating it. An error or unwind drops
@@ -564,7 +559,6 @@ impl CompiledPlan {
         cache: &mut HashMap<String, Module>,
         stats: &mut GraphStats,
         residents: &BTreeMap<i64, ResidentHome>,
-        feedback: &BTreeMap<usize, i64>,
     ) -> Result<Self> {
         let schema: Vec<_> = bounds.keys().copied().collect();
         ensure!(
@@ -628,30 +622,18 @@ impl CompiledPlan {
                     let BufferNode::BufferOutput { slots } = &plan.dag[*node] else {
                         unreachable!()
                     };
+                    // A resident input's home IS this output's buffer: the
+                    // mutation wrote it in place, so there is nothing to
+                    // copy and nothing to stage for readback.
+                    if plan.buffers[id]
+                        .lit
+                        .is_some_and(|lit| residents.contains_key(&lit))
+                    {
+                        continue;
+                    }
                     let buffer = &plan.buffers[id];
                     let range = range(plan, storage, id, base, dims)?;
                     let size = size(&buffer.layout)?;
-                    for &i in indices {
-                        if let Some(lit) = feedback.get(&slots[i].index) {
-                            let next = residents[lit].next.unwrap();
-                            out.actions.push(Action::Copy {
-                                src: range.ptr,
-                                dst: base + next.offset as u64,
-                                kind: CopyKind::DtoD,
-                                size: size.clone(),
-                                other_size: None,
-                                bytes: range.bytes,
-                            });
-                        }
-                    }
-                    let host_indices: Vec<_> = indices
-                        .iter()
-                        .copied()
-                        .filter(|&i| !feedback.contains_key(&slots[i].index))
-                        .collect();
-                    if host_indices.is_empty() {
-                        continue;
-                    }
                     out.actions.push(Action::Copy {
                         src: range.ptr,
                         dst: pinned.ptr(staging),
@@ -660,7 +642,7 @@ impl CompiledPlan {
                         other_size: None,
                         bytes: range.bytes,
                     });
-                    for &i in &host_indices {
+                    for &i in indices {
                         let slot = &slots[i];
                         let mut resolved = slot.clone();
                         resolved.layout = symbolic::resolve_layout(&slot.layout, dims)?;
@@ -799,18 +781,6 @@ impl CompiledPlan {
                     }
                     _ => {}
                 },
-            }
-        }
-        for home in residents.values() {
-            if let Some(next) = home.next {
-                out.actions.push(Action::Copy {
-                    src: base + next.offset as u64,
-                    dst: base + home.data.offset as u64,
-                    kind: CopyKind::DtoD,
-                    size: home.data.bytes.into(),
-                    other_size: None,
-                    bytes: home.data.bytes,
-                });
             }
         }
         for (i, action) in out.actions.iter().enumerate() {

--- a/crates/luminal_cuda_lite/src/resident.rs
+++ b/crates/luminal_cuda_lite/src/resident.rs
@@ -1,4 +1,4 @@
-//! Shared resident input and feedback allocation with CUDA scratch sizing.
+//! Shared resident input allocation with CUDA scratch sizing.
 pub use luminal::resident::{ResidentBindings, ResidentHome};
 pub type ResidentPlan = luminal::resident::ResidentPlan<crate::symbolic::Bounds>;
 pub type ResidentAllocation = luminal::resident::ResidentAllocation<crate::symbolic::Bounds>;

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -746,8 +746,10 @@ impl CudaRuntime {
     }
 
     /// Keep this input in the shared device arena between executions. Its
-    /// shape must be static and its boundary must be read-only. Call after
-    /// search and before the first execute; set_data uploads it only when changed.
+    /// shape must be static. A `.output_into()` output targeting this input
+    /// shares its buffer, so the mutation lands in the arena home and is
+    /// neither copied nor read back. Call after search and before the first
+    /// execute; set_data uploads it only when changed.
     pub fn retain_input(&mut self, tensor: NodeIndex) -> Result<()> {
         #[cfg(feature = "device")]
         anyhow::ensure!(
@@ -759,28 +761,6 @@ impl CudaRuntime {
             .get(&tensor)
             .ok_or_else(|| anyhow!("no input binding for {tensor:?}"))?;
         self.residents.inputs.insert(lit);
-        Ok(())
-    }
-
-    /// Route an output into a resident input after each execution. Feedback
-    /// outputs stay on device and are unavailable through fetch. Their elected
-    /// layout must equal the static, contiguous input boundary layout.
-    pub fn bind_feedback(&mut self, input: NodeIndex, output: NodeIndex) -> Result<()> {
-        let slot = *self
-            .output_index
-            .get(&output)
-            .ok_or_else(|| anyhow!("no output binding for {output:?}"))?;
-        let lit = *self
-            .input_buffers
-            .get(&input)
-            .ok_or_else(|| anyhow!("no input binding for {input:?}"))?;
-        anyhow::ensure!(
-            !self.residents.feedback.contains_key(&slot)
-                && !self.residents.feedback.values().any(|v| *v == lit),
-            "duplicate feedback endpoint"
-        );
-        self.retain_input(input)?;
-        self.residents.feedback.insert(slot, lit);
         Ok(())
     }
 

--- a/crates/luminal_cuda_lite/src/storage.rs
+++ b/crates/luminal_cuda_lite/src/storage.rs
@@ -16,6 +16,24 @@ pub(crate) fn plan_resident(
     bounds: &Bounds,
     bindings: &crate::resident::ResidentBindings,
 ) -> Result<ArenaPlan> {
+    // Output slots whose buffer IS a resident input are mutation sinks:
+    // `.output_into()` pinned them to the input's buffer, so their writes
+    // already land in the arena home and they reserve no pinned staging.
+    let device_outputs: std::collections::BTreeSet<usize> = plan
+        .dag
+        .node_weights()
+        .filter_map(|node| match node {
+            luminal::bufferize::BufferNode::BufferOutput { slots } => Some(slots),
+            _ => None,
+        })
+        .flatten()
+        .filter(|slot| {
+            plan.buffers[&slot.buffer]
+                .lit
+                .is_some_and(|lit| bindings.inputs.contains(&lit))
+        })
+        .map(|slot| slot.index)
+        .collect();
     crate::arena::plan_resident_over(
         plan,
         |buffer| capacity_bytes(&buffer.layout, bounds),
@@ -32,7 +50,7 @@ pub(crate) fn plan_resident(
             .max(8),
         crate::arena::issue_order(plan)?,
         &bindings.inputs,
-        &bindings.feedback.keys().copied().collect(),
+        &device_outputs,
     )
 }
 

--- a/crates/luminal_cuda_lite/tests/resident_mutation.rs
+++ b/crates/luminal_cuda_lite/tests/resident_mutation.rs
@@ -6,13 +6,13 @@ fn dense(rt: &CudaRuntime, t: GraphTensor) -> Vec<f32> {
     luminal_cuda_lite::layouts::dense_f32(&data.as_f32().unwrap(), &binding.layout).unwrap()
 }
 #[test]
-fn resident_weights_and_feedback_survive_bucket_changes_and_explicit_updates() {
+fn resident_weights_and_in_place_state_survive_bucket_changes_and_explicit_updates() {
     let mut cx = Graph::new();
     let weights = cx.tensor(4, DType::F32);
     let state = cx.tensor(4, DType::F32);
     let input = cx.tensor('n', DType::F32);
     let previous = state.sum(0).output();
-    let next = (state + weights * input.sum(0).expand_dim(0, 4)).output();
+    let next = (state + weights * input.sum(0).expand_dim(0, 4)).output_into(&state);
     let mut rt = CudaRuntime::load(&cx).unwrap();
     rt.bind_dim_buckets(
         'n',
@@ -32,7 +32,7 @@ fn resident_weights_and_feedback_survive_bucket_changes_and_explicit_updates() {
     .collect();
     rt.search(&data, &harness_search_options()).unwrap();
     rt.retain_input(weights.id).unwrap();
-    rt.bind_feedback(state.id, next.id).unwrap();
+    rt.retain_input(state.id).unwrap();
     for (id, v) in data {
         rt.set_data(id, v);
     }

--- a/crates/luminal_metal/README.md
+++ b/crates/luminal_metal/README.md
@@ -39,16 +39,15 @@ execution. Buckets share one arena sized for the largest selected plan;
 staging, host payloads, or cached pipelines. Commands follow the buffer plan's
 data and anti-dependencies, and preserve outputs before recycling their storage.
 
-`retain_input(tensor)` keeps a static, read-only input in the arena after its
-initial upload. Call it after search and before execution; a later `set_data`
-explicitly updates that input. `bind_feedback(input, output)` routes a matching
-static, contiguous output into a retained input, snapshotting it at the output
-boundary and committing it after all previous-state reads finish. Feedback
-outputs stay on device and are not available through `fetch`. Dimension values
-may change between executions; re-searching or changing bounds requires a new
-runtime once residency is configured. Resident ranges and feedback snapshots
-count toward the arena budget and are shared across every bucket. Physical
-lifetimes and resident allocation use core's planner, also used by CUDA Lite.
+`retain_input(tensor)` keeps a static input in the arena after its initial
+upload. Call it after search and before execution; a later `set_data`
+explicitly updates that input. A `.output_into(&input)` output shares the
+input's buffer (one `BufferLit`), so the mutation writes the retained range in
+place; it is not copied to host and is not available through `fetch`. Dimension
+values may change between executions; re-searching or changing bounds requires
+a new runtime once residency is configured. Resident ranges count toward the
+arena budget and are shared across every bucket. Physical lifetimes and
+resident allocation use core's planner, also used by CUDA Lite.
 
 `fetch` returns an owned backing payload and its elected layout. For views, use
 `layouts::dense_f32` to interpret that layout; `get_f32` returns backing elements.

--- a/crates/luminal_metal/src/bindings.rs
+++ b/crates/luminal_metal/src/bindings.rs
@@ -1,6 +1,7 @@
 //! Metal boundary layouts and saturation schedule. Booleans use byte storage.
 
 use luminal::dtype::DType;
+use luminal::layout_ir::Access;
 use luminal::runtime_binding::RuntimeBindingsGenerator;
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -25,12 +26,13 @@ impl RuntimeBindingsGenerator for MetalBindings {
         logical_name: &str,
         shape: &str,
         width: &str,
+        access: Access,
     ) -> String {
         format!(
             "(let {stem}_layout (RightMajorContiguousElementLayoutLit {shape} {width}))\n\
              (let {stem}_layout_tensor (LayoutTensorLit {logical_name} {stem}_layout))\n\
              (let {stem}_buffer_id (BufferLit {idx}))\n\
-             (set (buffer-access-of {stem}_buffer_id) (ReadOnly))\n\
+             (set (buffer-access-of {stem}_buffer_id) ({access:?}))\n\
              (set (buffer-freed-by {stem}_buffer_id) (CallerFrees))\n\
              (let {stem}_buffer_tensor (BufferTensorLit {stem}_layout_tensor {stem}_buffer_id))\n\n"
         )

--- a/crates/luminal_metal/src/device.rs
+++ b/crates/luminal_metal/src/device.rs
@@ -53,7 +53,6 @@ pub struct MetalDevice {
     stats: GraphStats,
     residents: BTreeMap<i64, ResidentHome>,
     resident_initialized: BTreeSet<i64>,
-    feedback: BTreeMap<usize, i64>,
 }
 impl MetalDevice {
     pub fn new() -> Result<Self> {
@@ -70,7 +69,6 @@ impl MetalDevice {
             stats: GraphStats::default(),
             residents: BTreeMap::new(),
             resident_initialized: BTreeSet::new(),
-            feedback: BTreeMap::new(),
         })
     }
     pub fn stats(&self) -> GraphStats {
@@ -88,7 +86,6 @@ impl MetalDevice {
         self.staging = None;
         self.residents.clear();
         self.resident_initialized.clear();
-        self.feedback.clear();
         self.stats.arena_bytes = 0;
         self.stats.staging_bytes = 0;
     }
@@ -218,7 +215,6 @@ impl MetalDevice {
         self.installed = installed;
         self.residents = allocation.homes;
         self.resident_initialized.clear();
-        self.feedback = allocation.feedback;
         Ok(())
     }
     pub fn execute(
@@ -406,41 +402,33 @@ impl MetalDevice {
                 ArenaStep::Download {
                     buffer,
                     node,
-                    slots,
+                    slots: _,
                     staging: home,
                 } => {
                     let bytes = sizes[buffer];
                     if bytes == 0 {
                         continue;
                     }
-                    let blit = command.new_blit_command_encoder();
-                    let BufferNode::BufferOutput { slots: bindings } = &p.plan.dag[*node] else {
+                    // A resident input's home IS this output's buffer: the
+                    // mutation wrote it in place, so there is nothing to
+                    // copy and nothing to stage for readback.
+                    if p.plan.buffers[buffer]
+                        .lit
+                        .is_some_and(|lit| self.residents.contains_key(&lit))
+                    {
+                        continue;
+                    }
+                    let BufferNode::BufferOutput { .. } = &p.plan.dag[*node] else {
                         bail!("download without output node")
                     };
-                    let mut host_output = false;
-                    for index in slots {
-                        if let Some(lit) = self.feedback.get(&bindings[*index].index) {
-                            let next = self.residents[lit].next.unwrap();
-                            blit.copy_from_buffer(
-                                slab,
-                                p.storage.slices[buffer].offset as u64,
-                                slab,
-                                next.offset as u64,
-                                bytes as u64,
-                            );
-                        } else {
-                            host_output = true;
-                        }
-                    }
-                    if host_output {
-                        blit.copy_from_buffer(
-                            slab,
-                            p.storage.slices[buffer].offset as u64,
-                            staging,
-                            home.offset as u64,
-                            bytes as u64,
-                        );
-                    }
+                    let blit = command.new_blit_command_encoder();
+                    blit.copy_from_buffer(
+                        slab,
+                        p.storage.slices[buffer].offset as u64,
+                        staging,
+                        home.offset as u64,
+                        bytes as u64,
+                    );
                     blit.end_encoding();
                 }
                 ArenaStep::Node(node) => match &p.plan.dag[*node] {
@@ -557,23 +545,6 @@ impl MetalDevice {
                 },
             }
         }
-        // Feedback snapshots outlive output storage recycling. Commit only
-        // after every kernel has finished reading the previous input state.
-        for home in self.residents.values() {
-            if let Some(next) = home.next
-                && home.data.bytes > 0
-            {
-                let blit = command.new_blit_command_encoder();
-                blit.copy_from_buffer(
-                    slab,
-                    next.offset as u64,
-                    slab,
-                    home.data.offset as u64,
-                    home.data.bytes as u64,
-                );
-                blit.end_encoding();
-            }
-        }
         command.commit();
         command.wait_until_completed();
         if command.status() != MTLCommandBufferStatus::Completed {
@@ -592,10 +563,14 @@ impl MetalDevice {
                 let BufferNode::BufferOutput { slots: bindings } = &p.plan.dag[*node] else {
                     bail!("download without output node")
                 };
-                let slots: Vec<_> = slots
-                    .iter()
-                    .filter(|&&i| !self.feedback.contains_key(&bindings[i].index))
-                    .collect();
+                // A resident sink was never blitted to staging.
+                if p.plan.buffers[buffer]
+                    .lit
+                    .is_some_and(|lit| self.residents.contains_key(&lit))
+                {
+                    continue;
+                }
+                let slots: Vec<_> = slots.iter().collect();
                 if slots.is_empty() {
                     continue;
                 }

--- a/crates/luminal_metal/src/runtime.rs
+++ b/crates/luminal_metal/src/runtime.rs
@@ -482,8 +482,10 @@ impl MetalRuntime {
     }
 
     /// Keep this input in the shared device arena between executions. Its
-    /// shape must be static and its boundary must be read-only. Call after
-    /// search and before the first execute; set_data uploads it only when changed.
+    /// shape must be static. A `.output_into()` output targeting this input
+    /// shares its buffer, so the mutation lands in the arena home and is
+    /// neither copied nor read back. Call after search and before the first
+    /// execute; set_data uploads it only when changed.
     pub fn retain_input(&mut self, tensor: NodeIndex) -> Result<()> {
         #[cfg(target_os = "macos")]
         anyhow::ensure!(
@@ -495,28 +497,6 @@ impl MetalRuntime {
             .get(&tensor)
             .ok_or_else(|| anyhow!("no input binding for {tensor:?}"))?;
         self.residents.inputs.insert(lit);
-        Ok(())
-    }
-
-    /// Route an output into a resident input after each execution. Feedback
-    /// outputs stay on device and are unavailable through fetch. Their elected
-    /// layout must equal the static, contiguous input boundary layout.
-    pub fn bind_feedback(&mut self, input: NodeIndex, output: NodeIndex) -> Result<()> {
-        let slot = *self
-            .output_index
-            .get(&output)
-            .ok_or_else(|| anyhow!("no output binding for {output:?}"))?;
-        let lit = *self
-            .input_buffers
-            .get(&input)
-            .ok_or_else(|| anyhow!("no input binding for {input:?}"))?;
-        anyhow::ensure!(
-            !self.residents.feedback.contains_key(&slot)
-                && !self.residents.feedback.values().any(|v| *v == lit),
-            "duplicate feedback endpoint"
-        );
-        self.retain_input(input)?;
-        self.residents.feedback.insert(slot, lit);
         Ok(())
     }
 

--- a/crates/luminal_metal/src/storage.rs
+++ b/crates/luminal_metal/src/storage.rs
@@ -12,6 +12,24 @@ pub(crate) fn plan_resident(
     bounds: &Bounds,
     bindings: &luminal::resident::ResidentBindings,
 ) -> Result<ArenaPlan> {
+    // Output slots whose buffer IS a resident input are mutation sinks:
+    // `.output_into()` pinned them to the input's buffer, so their writes
+    // already land in the arena home and they reserve no pinned staging.
+    let device_outputs: std::collections::BTreeSet<usize> = plan
+        .dag
+        .node_weights()
+        .filter_map(|node| match node {
+            luminal::bufferize::BufferNode::BufferOutput { slots } => Some(slots),
+            _ => None,
+        })
+        .flatten()
+        .filter(|slot| {
+            plan.buffers[&slot.buffer]
+                .lit
+                .is_some_and(|lit| bindings.inputs.contains(&lit))
+        })
+        .map(|slot| slot.index)
+        .collect();
     crate::arena::plan_resident_over(
         plan,
         |buffer| capacity_bytes(&buffer.layout, bounds),
@@ -23,7 +41,7 @@ pub(crate) fn plan_resident(
             .max(8),
         crate::arena::issue_order(plan)?,
         &bindings.inputs,
-        &bindings.feedback.keys().copied().collect(),
+        &device_outputs,
     )
 }
 
@@ -34,12 +52,12 @@ mod tests {
     use luminal::{arena::ArenaStep, prelude::*, resident::ResidentBindings};
 
     #[test]
-    fn resident_ranges_and_feedback_share_the_arena_across_buckets() {
+    fn resident_ranges_and_mutation_sinks_share_the_arena_across_buckets() {
         let mut graph = Graph::new();
         let weights = graph.tensor(4, DType::F32);
         let state = graph.tensor(4, DType::F32);
         let input = graph.tensor('n', DType::F32);
-        let next = (state + weights * input.sum(0).expand_dim(0, 4)).output();
+        (state + weights * input.sum(0).expand_dim(0, 4)).output_into(&state);
         state.sum(0).output();
         let mut runtime = MetalRuntime::load(&graph).unwrap();
         runtime
@@ -56,10 +74,8 @@ mod tests {
             .unwrap();
         let weights = runtime.input_buffer(weights.id).unwrap();
         let state = runtime.input_buffer(state.id).unwrap();
-        let next = runtime.output_slot_index(next.id).unwrap();
         let bindings = ResidentBindings {
             inputs: [weights, state].into_iter().collect(),
-            feedback: [(next, state)].into_iter().collect(),
         };
         let plans = || {
             runtime
@@ -78,8 +94,6 @@ mod tests {
             .max()
             .unwrap();
         assert!(allocation.bytes > scratch);
-        assert!(allocation.homes[&state].next.is_some());
-        assert!(allocation.homes[&weights].next.is_none());
         for bucket in &allocation.plans {
             for (id, buffer) in &bucket.plan.buffers {
                 if let Some(home) = buffer.lit.and_then(|lit| allocation.homes.get(&lit)) {
@@ -98,22 +112,16 @@ mod tests {
                 bucket.storage.steps.iter().any(
                     |s| matches!(s, ArenaStep::Download { staging, .. } if staging.bytes == 0)
                 ),
-                "feedback does not reserve host staging"
+                "a resident mutation sink does not reserve host staging"
             );
         }
-        let mut invalid = bindings.clone();
+        let mut invalid = bindings;
         invalid
             .inputs
             .insert(runtime.input_buffer(input.id).unwrap());
         assert!(
             luminal::resident::allocate(plans(), invalid, plan_resident, capacity_bytes).is_err(),
             "resident geometry must be static across buckets"
-        );
-        let mut invalid = bindings;
-        invalid.feedback.insert(next + 100, state);
-        assert!(
-            luminal::resident::allocate(plans(), invalid, plan_resident, capacity_bytes).is_err(),
-            "two feedback outputs cannot overwrite the same state"
         );
     }
 }

--- a/crates/luminal_metal/tests/resident_mutation.rs
+++ b/crates/luminal_metal/tests/resident_mutation.rs
@@ -6,13 +6,13 @@ fn dense(rt: &MetalRuntime, t: GraphTensor) -> Vec<f32> {
     luminal_metal::layouts::dense_f32(&data.as_f32().unwrap(), &binding.layout).unwrap()
 }
 #[test]
-fn resident_weights_and_feedback_survive_bucket_changes_and_explicit_updates() {
+fn resident_weights_and_in_place_state_survive_bucket_changes_and_explicit_updates() {
     let mut cx = Graph::new();
     let weights = cx.tensor(4, DType::F32);
     let state = cx.tensor(4, DType::F32);
     let input = cx.tensor('n', DType::F32);
     let previous = state.sum(0).output();
-    let next = (state + weights * input.sum(0).expand_dim(0, 4)).output();
+    let next = (state + weights * input.sum(0).expand_dim(0, 4)).output_into(&state);
     let mut rt = MetalRuntime::load(&cx).unwrap();
     rt.bind_dim_buckets(
         'n',
@@ -32,7 +32,7 @@ fn resident_weights_and_feedback_survive_bucket_changes_and_explicit_updates() {
     .collect();
     rt.search(&data, &harness_search_options()).unwrap();
     rt.retain_input(weights.id).unwrap();
-    rt.bind_feedback(state.id, next.id).unwrap();
+    rt.retain_input(state.id).unwrap();
     for (id, v) in data {
         rt.set_data(id, v);
     }

--- a/crates/luminal_reference/src/bindings.rs
+++ b/crates/luminal_reference/src/bindings.rs
@@ -12,6 +12,7 @@
 //! caller-owned buffers.
 
 use luminal::dtype::DType;
+use luminal::layout_ir::Access;
 use luminal::runtime_binding::RuntimeBindingsGenerator;
 
 /// The reference runtime's binding vocabulary.
@@ -37,8 +38,9 @@ impl RuntimeBindingsGenerator for ReferenceBindings {
     }
 
     /// Input boundary: contiguous row-major storage of the declared
-    /// dtype, read-only, caller-owned, buffer id = the HLIR node index
-    /// (their set_data keying). `stem` namespaces the lets; the
+    /// dtype, caller-owned, buffer id = the HLIR node index (their
+    /// set_data keying). `access` is ReadWrite when a `.output_into()`
+    /// mutates this input in place. `stem` namespaces the lets; the
     /// buffer-tensor let is named `{stem}_buffer_tensor`.
     fn input_binding(
         &self,
@@ -47,12 +49,13 @@ impl RuntimeBindingsGenerator for ReferenceBindings {
         logical_name: &str,
         shape: &str,
         width: &str,
+        access: Access,
     ) -> String {
         format!(
             "(let {stem}_layout (RightMajorContiguousElementLayoutLit {shape} {width}))\n\
              (let {stem}_layout_tensor (LayoutTensorLit {logical_name} {stem}_layout))\n\
              (let {stem}_buffer_id (BufferLit {idx}))\n\
-             (set (buffer-access-of {stem}_buffer_id) (ReadOnly))\n\
+             (set (buffer-access-of {stem}_buffer_id) ({access:?}))\n\
              (set (buffer-freed-by {stem}_buffer_id) (CallerFrees))\n\
              (let {stem}_buffer_tensor (BufferTensorLit {stem}_layout_tensor {stem}_buffer_id))\n\n"
         )

--- a/examples/llm_chat/README.md
+++ b/examples/llm_chat/README.md
@@ -117,7 +117,7 @@ cargo test -p llm_chat --features metal
 The shared device test compares prefill and decode against ReferenceRuntime
 using a small zoo model. Other tests cover namespace mappings, sharded
 checkpoints, dtype/layout conversion, templates, sampling, prefix reuse, and
-cache reset. Both runtime suites check resident feedback across buckets.
+cache reset. Both runtime suites check in-place resident state across buckets.
 
 For real-checkpoint comparisons against Transformers across prompts, follow-ups,
 prefill chunk sizes, and resets, see the [validation tools](validation/README.md).

--- a/examples/llm_chat/src/backend/gpu.rs
+++ b/examples/llm_chat/src/backend/gpu.rs
@@ -41,7 +41,7 @@ impl GpuBackend {
             runtime.retain_input(id)?;
         }
         for state in &graph.state {
-            runtime.bind_feedback(state.input, state.output)?;
+            runtime.retain_input(state.input)?;
         }
         for (id, data) in data {
             runtime.set_data(id, data);

--- a/examples/llm_chat/src/graph.rs
+++ b/examples/llm_chat/src/graph.rs
@@ -380,15 +380,19 @@ impl LlmGraph {
             .zip(caches)
             .zip(widths)
             .flat_map(|(((ki, vi), (ko, vo)), w)| {
+                // The cache outputs MUTATE their cache inputs in place:
+                // one boundary buffer, stated in the SSA graph itself.
+                let ko = ko.output_into(ki);
+                let vo = vo.output_into(vi);
                 [
                     StateBinding {
                         input: ki.id,
-                        output: ko.output().id,
+                        output: ko.id,
                         elements: capacity * w,
                     },
                     StateBinding {
                         input: vi.id,
-                        output: vo.output().id,
+                        output: vo.id,
                         elements: capacity * w,
                     },
                 ]

--- a/src/frontend/tensor.rs
+++ b/src/frontend/tensor.rs
@@ -106,6 +106,31 @@ impl GraphTensor {
         source
     }
 
+    /// Mark this tensor as an observable output that MUTATES `target` in
+    /// place: the value stays SSA, and the binding pins this output and
+    /// `target` to one buffer id (target must be a graph input). This is
+    /// PyTorch's functionalized in-place contract — `x.copy_(y)`.
+    pub fn output_into(&self, target: &GraphTensor) -> GraphTensor {
+        let source = *self;
+        let dims = source.dims();
+        let target_dims = target.dims();
+        self.graph()
+            .logical
+            .output_into(&(source.id, dims), &(target.id, target_dims), None);
+        source
+    }
+
+    /// `.output_into()` with an authored interface name.
+    pub fn output_into_named(&self, name: &str, target: &GraphTensor) -> GraphTensor {
+        let source = *self;
+        let dims = source.dims();
+        let target_dims = target.dims();
+        self.graph()
+            .logical
+            .output_into(&(source.id, dims), &(target.id, target_dims), Some(name));
+        source
+    }
+
     pub fn dims(&self) -> Vec<IntExpr> {
         self.dims.to_vec()
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -9,10 +9,11 @@ use petgraph::{
     stable_graph::{NodeIndex, StableDiGraph},
     visit::EdgeRef,
 };
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::dtype::DType;
 use crate::frontend::GraphTensor;
+use crate::layout_ir::Access;
 use crate::shape::ToShape;
 
 /// A bucket for a dynamic dimension, defining a range of valid values.
@@ -358,10 +359,14 @@ pub struct LogicalNode {
 }
 
 /// One `.output()` designation: the value and optional authored name.
+/// `storage` is `Some(input)` when the output is a MUTATION of that input
+/// (`.output_into()`): the two share one boundary buffer, so the value
+/// stays SSA and storage identity lives in the binding.
 #[derive(Debug)]
 struct OutputRecord {
     value: ValueId,
     label: Option<String>,
+    storage: Option<ValueId>,
 }
 
 /// One bound input of the recorded model: the pristine label, the
@@ -1273,6 +1278,60 @@ impl LogicalGraph {
         self.outputs.push(OutputRecord {
             value: id,
             label: label.map(str::to_string),
+            storage: None,
+        });
+    }
+
+    /// Record an output that WRITES INTO an input's storage — the
+    /// mutation contract (PyTorch's functionalized `x.copy_(...)`), kept
+    /// SSA: the value is a fresh SSA value; only its boundary storage is
+    /// stated. The binding layer pins both the input and this output to
+    /// one `BufferLit` and marks the input `ReadWrite`, so the
+    /// bufferizer's conflict engine orders the read-modify-write — or
+    /// repairs with a copy — exactly as it does for any tied pair.
+    ///
+    /// The target must be a graph input, and the value must carry the
+    /// target's dtype (a mutation writes the caller's bytes).
+    pub fn output_into(&mut self, operand: &Operand, target: &Operand, label: Option<&str>) {
+        if self.poisoned.is_some() {
+            return;
+        }
+        if let Some(name) = label
+            && self
+                .outputs
+                .iter()
+                .any(|record| record.label.as_deref() == Some(name))
+        {
+            return self.poison(format!("duplicate output name \"{name}\""));
+        }
+        let id = match self.resolve(operand, "output_into") {
+            Ok(id) => id,
+            Err(reason) => return self.poison(reason),
+        };
+        let target_id = match self.resolve(target, "output_into target") {
+            Ok(id) => id,
+            Err(reason) => return self.poison(reason),
+        };
+        if !matches!(self.graph[target_id].op, LogicalOp::Input { .. }) {
+            return self.poison(format!(
+                "output_into target t{}: mutation targets must be graph inputs",
+                target_id.index()
+            ));
+        }
+        let (value, target_value) = (&self.graph[id], &self.graph[target_id]);
+        if value.dtype != target_value.dtype {
+            return self.poison(format!(
+                "output_into at t{}: a {:?} value cannot overwrite the {:?} input t{}",
+                id.index(),
+                value.dtype,
+                target_value.dtype,
+                target_id.index()
+            ));
+        }
+        self.outputs.push(OutputRecord {
+            value: id,
+            label: label.map(str::to_string),
+            storage: Some(target_id),
         });
     }
 
@@ -1442,8 +1501,17 @@ impl LogicalGraph {
         String,
     > {
         let mut text = self.model_text()?;
+        // Inputs that some `.output_into()` writes into: their boundary
+        // becomes ReadWrite, admitting in-place lowerings (the writability
+        // veto only fires on ReadOnly storage).
+        let mutable_inputs: FxHashSet<ValueId> = self
+            .outputs
+            .iter()
+            .filter_map(|record| record.storage)
+            .collect();
         let mut input_slots = Vec::new();
         let mut input_buffer_tensors = Vec::new();
+        let mut input_buffers: FxHashMap<ValueId, i64> = FxHashMap::default();
         let mut next_buffer: i64 = 0;
         for id in self.graph.node_indices() {
             let value = &self.graph[id];
@@ -1460,14 +1528,21 @@ impl LogicalGraph {
             } else {
                 format!("v{}", id.index())
             };
+            let access = if mutable_inputs.contains(&id) {
+                Access::ReadWrite
+            } else {
+                Access::ReadOnly
+            };
             text.push_str(&bindings.input_binding(
                 &stem,
                 buffer as usize,
                 &value_name,
                 &shape,
                 &bindings.width_term(value.dtype),
+                access,
             ));
             input_buffer_tensors.push(format!("{stem}_buffer_tensor"));
+            input_buffers.insert(id, buffer);
             input_slots.push(InputSlot {
                 tensor: id,
                 buffer,
@@ -1483,8 +1558,17 @@ impl LogicalGraph {
             let value = &self.graph[id];
             let shape = Self::shape_term(&value.dims)?;
             let stem = format!("natout{key}");
-            let buffer = next_buffer;
-            next_buffer += 1;
+            // A mutation output shares its target input's BufferLit; any
+            // other output mints a fresh boundary. (Boundary values
+            // pinned to one buffer are pre-unioned by the bufferizer.)
+            let buffer = match record.storage.and_then(|target| input_buffers.get(&target)) {
+                Some(&shared) => shared,
+                None => {
+                    let buffer = next_buffer;
+                    next_buffer += 1;
+                    buffer
+                }
+            };
             text.push_str(&bindings.output_binding(
                 &stem,
                 buffer as usize,
@@ -1532,7 +1616,8 @@ impl LogicalGraph {
 
 /// One bound input: the graph tensor it carries, the buffer the runtime
 /// allocated for it, and its declared size. Buffer ids are an internal,
-/// sequential, binding-time allocation — inputs first, outputs after —
+/// binding-time allocation — inputs first, outputs after, except that a
+/// mutation output (`.output_into()`) shares its target input's id —
 /// never derived from graph node indices (the retired HLIR keyspace).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputSlot {
@@ -1677,5 +1762,95 @@ mod logical_petgraph_tests {
 
         assert_eq!(cx.logical.input_specs()[0].id, lhs.id);
         assert_eq!(cx.logical.output_specs()[0].id, viewed.id);
+    }
+
+    /// A `.output_into()` output shares its target input's `BufferLit`
+    /// and marks that input `ReadWrite`; every other boundary keeps the
+    /// fresh-buffer + `ReadOnly` default. This is the mutation contract
+    /// the runtimes key on (resident sinks, no readback).
+    #[test]
+    fn output_into_shares_the_input_buffer_and_marks_it_writable() {
+        struct TestBindings;
+        impl crate::runtime_binding::RuntimeBindingsGenerator for TestBindings {
+            fn width_term(&self, dtype: DType) -> String {
+                format!("(bits-of ({dtype:?}))")
+            }
+            fn input_binding(
+                &self,
+                stem: &str,
+                idx: usize,
+                _logical_name: &str,
+                _shape: &str,
+                _width: &str,
+                access: Access,
+            ) -> String {
+                format!("(let {stem}_buffer_id (BufferLit {idx}))\n(access {access:?} {stem})\n")
+            }
+            fn output_binding(
+                &self,
+                stem: &str,
+                key: usize,
+                _value_name: &str,
+                _shape: &str,
+                _dtype: DType,
+            ) -> String {
+                format!("(let {stem}_buffer_id (BufferLit {key}))\n(access ReadWrite {stem})\n")
+            }
+            fn schedule(&self) -> &str {
+                ""
+            }
+        }
+
+        let mut cx = Graph::new();
+        let x = cx.named_tensor("x", (2usize,), DType::F32);
+        let y = cx.named_tensor("y", (2usize,), DType::F32);
+        let z = (x + y).output_into(&x);
+        let (text, inputs, outputs, _, _) = cx.logical.bound_parts(&TestBindings).unwrap();
+        assert_eq!(inputs.len(), 2);
+        assert_eq!(outputs.len(), 1);
+        let x_buffer = inputs[0].buffer;
+        let y_buffer = inputs[1].buffer;
+        assert_ne!(x_buffer, y_buffer);
+        assert_eq!(
+            outputs[0].buffer, x_buffer,
+            "the mutation output shares x's boundary buffer"
+        );
+        assert_eq!(outputs[0].tensor, z.id);
+        assert!(
+            text.contains(&format!("(access ReadWrite nat{})", x.id.index())),
+            "x must be writable:\n{text}"
+        );
+        assert!(
+            text.contains(&format!("(access ReadOnly nat{})", y.id.index())),
+            "y stays read-only:\n{text}"
+        );
+    }
+
+    /// `output_into` refuses non-input targets and dtype mismatches at
+    /// authoring time (fail closed, never mistranslate).
+    #[test]
+    fn output_into_rejects_non_input_targets_and_dtype_mismatch() {
+        let mut cx = Graph::new();
+        let x = cx.named_tensor("x", (2usize,), DType::F32);
+        let y = cx.named_tensor("y", (2usize,), DType::F32);
+        let sum = x + y;
+        sum.output_into(&sum);
+        assert!(
+            cx.logical.poisoned().is_some_and(|r| r.contains("inputs")),
+            "non-input target must poison: {:?}",
+            cx.logical.poisoned()
+        );
+
+        let mut cx = Graph::new();
+        let x = cx.named_tensor("x", (2usize,), DType::F32);
+        let i = cx.named_tensor("i", (2usize,), DType::Int);
+        (x + x).output_into(&i);
+        assert!(
+            cx.logical
+                .poisoned()
+                .is_some_and(|r| r.contains("cannot overwrite")),
+            "dtype mismatch must poison: {:?}",
+            cx.logical.poisoned()
+        );
     }
 }

--- a/src/resident.rs
+++ b/src/resident.rs
@@ -1,23 +1,20 @@
-//! Opt-in device-resident input boundaries and output-to-input feedback.
-//! Names are runtime buffer/slot IDs; this layer knows nothing about models.
+//! Opt-in device-resident input boundaries. Names are runtime buffer/slot
+//! IDs; this layer knows nothing about models. A resident input may be
+//! MUTATED in place: a `.output_into()` output shares the input's BufferId,
+//! so its writes land in the home and need no host readback — the state is
+//! still SSA, only its boundary storage is shared.
 use crate::arena::{ArenaPlan, ArenaSlice};
-use crate::{
-    bufferize::{BufferIrGraph, BufferNode},
-    layouts::DecodedLayout,
-};
+use crate::{bufferize::BufferIrGraph, layouts::DecodedLayout};
 use anyhow::{Result, anyhow, ensure};
 use std::collections::{BTreeMap, BTreeSet};
 #[derive(Clone, Debug, Default)]
 pub struct ResidentBindings {
     pub inputs: BTreeSet<i64>,
-    /// Output slot -> resident input BufferLit. Every destination is unique.
-    pub feedback: BTreeMap<usize, i64>,
 }
-/// Session-lived storage; `next` snapshots feedback before old state is retired.
+/// Session-lived storage for one resident input boundary.
 #[derive(Clone, Debug)]
 pub struct ResidentHome {
     pub data: ArenaSlice,
-    pub next: Option<ArenaSlice>,
     pub dtype: crate::dtype::PlanDtype,
     pub shape: Vec<usize>,
 }
@@ -30,7 +27,6 @@ pub struct ResidentAllocation<B> {
     pub plans: Vec<ResidentPlan<B>>,
     pub homes: BTreeMap<i64, ResidentHome>,
     pub bytes: usize,
-    pub feedback: BTreeMap<usize, i64>,
 }
 /// One physical planning implementation for native GPU executors. Resident
 /// ranges are identical across buckets; temporaries overlay the largest plan.
@@ -57,21 +53,13 @@ pub fn allocate<B>(
         .max()
         .unwrap_or(1);
     let mut residents = BTreeMap::new();
-    let mut feedback_inputs = BTreeSet::new();
-    for lit in bindings.feedback.values() {
-        ensure!(
-            bindings.inputs.contains(lit) && feedback_inputs.insert(*lit),
-            "invalid/duplicate resident feedback destination {lit}"
-        );
-    }
     for &lit in &bindings.inputs {
         let mut geometry = None;
         for bucket in &installed {
             for buffer in bucket.plan.buffers.values().filter(|b| b.lit == Some(lit)) {
                 ensure!(
-                    buffer.access == crate::layout_ir::Access::ReadOnly
-                        && buffer.freed_by == crate::layout_ir::FreedBy::Caller,
-                    "resident input {lit} must be read-only and caller-owned"
+                    buffer.freed_by == crate::layout_ir::FreedBy::Caller,
+                    "resident input {lit} must be caller-owned"
                 );
                 ensure!(
                     buffer
@@ -112,27 +100,7 @@ pub fn allocate<B>(
         bytes = bytes
             .checked_add(data.reserved())
             .ok_or_else(|| anyhow!("resident size overflow"))?;
-        let next = if feedback_inputs.contains(&lit) {
-            let next = ArenaSlice {
-                offset: bytes,
-                bytes: size,
-            };
-            bytes = bytes
-                .checked_add(next.reserved())
-                .ok_or_else(|| anyhow!("feedback size overflow"))?;
-            Some(next)
-        } else {
-            None
-        };
-        residents.insert(
-            lit,
-            ResidentHome {
-                data,
-                next,
-                dtype,
-                shape,
-            },
-        );
+        residents.insert(lit, ResidentHome { data, dtype, shape });
     }
     for bucket in &mut installed {
         for (id, buffer) in &bucket.plan.buffers {
@@ -140,41 +108,10 @@ pub fn allocate<B>(
                 bucket.storage.slices.insert(id.clone(), home.data);
             }
         }
-        let mut seen = BTreeSet::new();
-        for node in bucket.plan.dag.node_weights() {
-            if let BufferNode::BufferOutput { slots } = node {
-                for slot in slots {
-                    if let Some(lit) = bindings.feedback.get(&slot.index) {
-                        let home = &residents[lit];
-                        ensure!(
-                            slot.layout
-                                .has::<crate::layouts::RightMajorContiguousElementLayout>()
-                                && slot.layout.literal_extents().as_ref() == Some(&home.shape)
-                                && slot.layout.dtype == Some(home.dtype),
-                            "feedback slot {} must match its static contiguous input boundary",
-                            slot.index
-                        );
-                        ensure!(
-                            capacity_bytes(
-                                &bucket.plan.buffers[&slot.buffer].layout,
-                                &bucket.bounds
-                            )? == home.data.bytes,
-                            "feedback backing span differs from input"
-                        );
-                        seen.insert(slot.index);
-                    }
-                }
-            }
-        }
-        ensure!(
-            seen.len() == bindings.feedback.len(),
-            "feedback output absent from a bucket"
-        );
     }
     Ok(ResidentAllocation {
         plans: installed,
         homes: residents,
         bytes,
-        feedback: bindings.feedback,
     })
 }

--- a/src/runtime_binding.rs
+++ b/src/runtime_binding.rs
@@ -13,16 +13,19 @@
 //! runtime without touching core.
 
 use crate::dtype::DType;
+use crate::layout_ir::Access;
 
 /// Per-runtime boundary vocabulary: how a runtime states its
 /// representation contract in egglog at load time.
 pub trait RuntimeBindingsGenerator {
     /// The boundary element width term for a dtype under this binding
-    /// (e.g. whether booleans cross as Bool8).
+    /// (e.g., whether booleans cross as Bool8).
     fn width_term(&self, dtype: DType) -> String;
 
     /// Input boundary text. `stem` namespaces the lets; the produced
-    /// buffer-tensor let must be named `{stem}_buffer_tensor`.
+    /// buffer-tensor let must be named `{stem}_buffer_tensor`. `access`
+    /// is `ReadWrite` when some `.output_into()` targets this input (a
+    /// caller-storage mutation), `ReadOnly` otherwise.
     fn input_binding(
         &self,
         stem: &str,
@@ -30,6 +33,7 @@ pub trait RuntimeBindingsGenerator {
         logical_name: &str,
         shape: &str,
         width: &str,
+        access: Access,
     ) -> String;
 
     /// Output boundary text. Same `{stem}_buffer_tensor` naming

--- a/tests/test_runtime/src/bindings.rs
+++ b/tests/test_runtime/src/bindings.rs
@@ -20,6 +20,7 @@
 //! those, it changes HERE and the reference contract does not move.
 
 use luminal::dtype::DType;
+use luminal::layout_ir::Access;
 use luminal::runtime_binding::RuntimeBindingsGenerator;
 
 /// The TestRuntime's binding vocabulary.
@@ -45,8 +46,9 @@ impl RuntimeBindingsGenerator for TestRuntimeBindings {
     }
 
     /// Input boundary: contiguous row-major storage of the declared
-    /// dtype, read-only, caller-owned, buffer id = the HLIR node index
-    /// (their set_data keying). `stem` namespaces the lets; the
+    /// dtype, caller-owned, buffer id = the HLIR node index (their
+    /// set_data keying). `access` is ReadWrite when a `.output_into()`
+    /// mutates this input in place. `stem` namespaces the lets; the
     /// buffer-tensor let is named `{stem}_buffer_tensor`.
     fn input_binding(
         &self,
@@ -55,12 +57,13 @@ impl RuntimeBindingsGenerator for TestRuntimeBindings {
         logical_name: &str,
         shape: &str,
         width: &str,
+        access: Access,
     ) -> String {
         format!(
             "(let {stem}_layout (RightMajorContiguousElementLayoutLit {shape} {width}))\n\
              (let {stem}_layout_tensor (LayoutTensorLit {logical_name} {stem}_layout))\n\
              (let {stem}_buffer_id (BufferLit {idx}))\n\
-             (set (buffer-access-of {stem}_buffer_id) (ReadOnly))\n\
+             (set (buffer-access-of {stem}_buffer_id) ({access:?}))\n\
              (set (buffer-freed-by {stem}_buffer_id) (CallerFrees))\n\
              (let {stem}_buffer_tensor (BufferTensorLit {stem}_layout_tensor {stem}_buffer_id))\n\n"
         )


### PR DESCRIPTION
## Summary
- Add `GraphTensor::output_into(&input)` / `output_into_named`: an SSA output that writes into a graph input's storage. `bound_parts` pins the pair to one `BufferLit` and marks the input `ReadWrite`, so bufferization's conflict engine orders the read-modify-write (or repairs with a copy). `RuntimeBindingsGenerator::input_binding` now takes `Access`.
- Delete `bind_feedback` and the resident double-buffer (`ResidentBindings.feedback`, `ResidentHome.next`) from core, CUDA Lite and Metal. Output slots whose buffer is a resident input are mutation sinks: writes land in the arena home with no host staging or readback. Non-resident mutation outputs are still read back normally.
- Migrate `llm_chat` KV cache state to `output_into` + `retain_input`; rename the `resident_feedback` tests to `resident_mutation`; update Metal/llm_chat docs.

## Tests
- `cargo test -p luminal` (267 lib + integration), `-p test_runtime`, `-p luminal_reference`, `-p luminal_cuda_lite`, `-p luminal_nn`, `-p llm_chat`
- Metal device: `cargo test -p luminal_metal --test resident_mutation`, `cargo test -p luminal_metal --lib storage::tests`, and `cargo test -p llm_chat --features metal --test backend_chat` (prefill/decode + reset vs ReferenceRuntime)
- `cargo clippy --workspace --all-targets` and `cargo clippy -p luminal_cuda_lite --features device --all-targets` clean; `cargo fmt --all` run

CUDA device suite not run (no Nvidia GPU on this host); CUDA plan-level tests pass and the adapter compiles with `device`.